### PR TITLE
Layer fields should be updated after changes in the data provider.

### DIFF
--- a/source/docs/pyqgis_developer_cookbook/vector.rst
+++ b/source/docs/pyqgis_developer_cookbook/vector.rst
@@ -175,6 +175,11 @@ For deletion of fields just provide a list of field indexes.
   if caps & QgsVectorDataProvider.DeleteAttributes:
     res = layer.dataProvider().deleteAttributes( [ 0 ] )
 
+After adding or removing fields in the data provider the layer's fields need
+to be updated because the changes are not automatically propagated.
+::
+
+  layer.updateFields()
 
 .. _editing-buffer:
 


### PR DESCRIPTION
After modifying a layer's fields in the data provider the cache of the fields in the layer need to be updated as they are not automatically propagated.

This commit adds a comment and code example to this effect in the pyqgis cookbook in the section on modifying vector layers.
