### PR TITLE
Some fixes to get the snippet code working

### DIFF
--- a/source/docs/pyqgis_developer_cookbook/vector.rst
+++ b/source/docs/pyqgis_developer_cookbook/vector.rst
@@ -42,6 +42,8 @@ Iterating over the features in a vector layer is one of the most common tasks. B
 
       # fetch attributes
       attrs = feature.attributes()
+
+      # attrs is a list. It contains all the attribute values of this feature
       print attrs
 
 


### PR DESCRIPTION
After reading and trying some snippet codes here, there are some invalid points:
1) QgsFeature.attributes() returns a list, not dictionary. So, this code:
`attrs = feature.attributes()` 
will return a list, not a dictionary. From reading this (http://www.qgis.org/api/qgsfeature_8h_source.html), it makes sense: QgsFeature.attributes() returns QgsAttributes which is a QVector.
For the same reason, we can not do:
`print feature.attributes()['name']`

2) Get rid of QVariant constructor as the consequence of SIP API changes. This code:
`attrs = { 0 : QVariant("hello"), 1 : QVariant(123) }`
will raise an error: "TypeError: PyQt4.QtCore.QVariant represents a mapped type and cannot be instantiated"
