### PR TITLE
added information about using different GPS devices and notes about using Bluetooth units for live tracking

### DIFF
--- a/source/docs/user_manual/working_with_gps/live_GPS_tracking.rst
+++ b/source/docs/user_manual/working_with_gps/live_GPS_tracking.rst
@@ -129,3 +129,114 @@ and a file where log messages about the GPS tracking are logged.
 
 If you want to set a feature manually, you have to go back to |mActionToggleEditing|
 :sup:`Position` and click on **[Add Point]** or **[Add track point]**.
+
+Connect to a Bluetooth GPS for live tracking
+--------------------------------------------
+
+With QGIS you can connect a Bluetooth GPS for field data collection. To perform
+this task you need a GPS Bluetooth device and a Bluetooth receiver on your
+computer.
+
+At first you must let your GPS device be recognized and paired to the computer.
+Turn on the GPS, go to the Bluetooth icon on your notification area and search
+for a New Device.
+
+On the right side of the Device selection mask make sure that all devices are
+selected so your GPS unit will probably appear among those available. In the
+next step a serial connection service should be available, select it and click
+on **[Configure]** button.
+
+Remember the number of the COM port assigned to the GPS connection as resulting
+by the Bluetooth properties.
+
+After the GPS has been recognized, make the pairing for the connection. Usually
+the autorization code is ``0000``.
+
+Now open :guilabel:`GPS information`panel and switch to |mActionOptions| GPS
+options screen. Select the COM port assigned to the GPS connection and click
+the **[Connect]**. After a while a cursor indicating your position should
+appear.
+
+If QGIS can't receive GPS data, then you should restart your GPS device, wait
+5-10 seconds then try to connect again. Usually this solution work. If you
+receive again a connection error make sure you don't have another Bluetooth
+receiver near you, paired with the same GPS unit.
+
+Using GPSMAP 60cs
+-----------------
+
+MS Windows
+..........
+
+Easiest way to make it work is to use a middleware (freeware, not open) called
+`GPSGate <http://update.gpsgate.com/install/GpsGateClient.exe>`_.
+
+Launch the program, make it scan for GPS devices (works for both USB and BT
+ones) and then in QGIS just click **[Connect]** in the Live tracking panel
+using the |radiobuttonon| :guilabel:`Autodetect` mode.
+
+Ubuntu/Mint GNU/Linux
+.....................
+
+As for Windows the easiest way is to use a server in the middle, in this case
+GPSD, so
+
+::
+
+  sudo apt-get install gpsd
+
+Then load the ``garmin_gps`` kernel module
+
+::
+
+  sudo modprobe garmin_gps
+
+And then connect the unit. Then check with ``dmesg`` the actual device being
+used bu the unit, for example ``/dev/ttyUSB0``. Now you can launch gpsd
+
+::
+
+  gpsd /dev/ttyUSB0
+
+And finally connect with the QGIS live tracking tool.
+
+Using BTGP-38KM datalogger (only Bluetooth)
+-------------------------------------------
+
+Using GPSD (under Linux) or GPSGate (under Windows) is effortless.
+
+Using BlueMax GPS-4044 datalogger (both BT and USB)
+---------------------------------------------------
+
+MS Windows
+..........
+
+The live tracking works for both USB and BT modes, by using GPSGate or even
+without it, just use the |radiobuttonon| :guilabel:`Autodetect` mode, or point
+the tool the right port.
+
+
+Ubuntu/Mint GNU/Linux
+.....................
+
+**For USB**
+
+The live tracking works both with GPSD
+
+::
+
+  gpsd /dev/ttyACM3
+
+or without it, by connecting the QGIS live tracking tool directly to the
+device (for example ``/dev/ttyACM3``).
+
+**For Bluetooth**
+
+The live tracking works both with GPSD
+
+::
+
+  gpsd /dev/rfcomm0
+
+or without it, by connecting the QGIS live tracking tool directly to the device
+(for example ``/dev/rfcomm0``).

--- a/source/docs/user_manual/working_with_gps/plugins_gps.rst
+++ b/source/docs/user_manual/working_with_gps/plugins_gps.rst
@@ -191,3 +191,111 @@ http://www.gpsbabel.org.
 
 Once you have created a new device type, it will appear in the device lists for
 the download and upload tools.
+
+Download of points/tracks from GPS units
+----------------------------------------
+
+As described in previous sections QGIS uses GPSBabel to download points/tracks
+directly in the project. QGIS comes out of the box with a pre-defined profile
+to download from Garmin devices. Unfortunately there is a `bug
+<http://hub.qgis.org/issues/6318>`_ that does not allow create other profiles,
+so downloading directly in QGIS using the GPS Tools is at the moment limited to
+Garmin USB units.
+
+Garmin GPSMAP 60cs
+..................
+
+**MS Windows**
+
+Install the Garmin USB drivers ​from
+http://www8.garmin.com/support/download_details.jsp?id=591
+
+Connect the unit. Open GPS Tools and use ``type=garmin serial`` and ``port=usb:``
+Fill the fields :guilabel:`Layer name` and :guilabel:`Output file`. Sometimes
+it seems to have problems saving in a certain folder, using something like
+``c:\temp`` usually works.
+
+**Ubuntu/Mint GNU/Linux**
+
+It is first needed an issue about the permissions of the device, as described
+at https://wiki.openstreetmap.org/wiki/USB_Garmin_on_GNU/Linux. You can try to
+create a file :file:`/etc/udev/rules.d/51-garmin.rules` containing this rule
+
+::
+
+  ATTRS{idVendor}=="091e", ATTRS{idProduct}=="0003", MODE="666"
+
+After that is necessary to be sure that the ``garmin_gps`` kernel module is not
+loaded
+
+::
+
+  rmmod garmin_gps
+
+and then you can use the GPS Tools. Unfortunately there seems to be a `bug
+<http://hub.qgis.org/issues/7182>`_ and usually QGIS freezes several times
+before the operation work fine.
+
+BTGP-38KM datalogger (only Bluetooth)
+.....................................
+
+**MS Windows**
+
+The already referred bug does not allow to download the data from within QGIS,
+so it is needed to use GPSBabel from the command line or using its interface.
+The working command is
+
+::
+
+  gpsbabel -t -i skytraq,baud=9600,initbaud=9600 -f COM9 -o gpx -F C:/GPX/aaa.gpx
+
+**Ubuntu/Mint GNU/Linux**
+
+Use same command (or settings if you use GPSBabel GUI) as in Windows. On Linux
+it maybe somehow common to get a message like
+
+::
+
+  skytraq: Too many read errors on serial port
+
+it is just a matter to turn off and on the datalogger and try again.
+
+BlueMax GPS-4044 datalogger (both BT and USB)
+.............................................
+
+**MS Windows**
+
+.. note::
+
+   It needs to install its drivers before using it on Windows 7. See in the
+   manufacturer site for the proper download.
+
+Downloading with GPSBabel, both with USB and BT returns always an error like
+
+::
+
+  gpsbabel -t -i mtk -f COM12 -o gpx -F C:/temp/test.gpx
+  mtk_logger: Can't create temporary file data.bin
+  Error running gpsbabel: Process exited unsucessfully with code 1
+
+**Ubuntu/Mint GNU/Linux**
+
+**With USB**
+
+After having connected the cable use the ``dmesg`` command to understand what
+port is being used, for example ``/dev/ttyACM3``. Then as usual use GPSBabel
+from the CLI or GUI
+
+::
+
+  gpsbabel -t -i mtk -f /dev/ttyACM3 -o gpx -F /home/user/bluemax.gpx
+
+**With Bluetooth**
+
+Use Blueman Device Manager to pair the device and make it available through a
+system port, then run GPSBabel
+
+::
+
+  gpsbabel -t -i mtk -f /dev/rfcomm0 -o gpx -F /home/user/bluemax_bt.gpx
+


### PR DESCRIPTION
This adds information from wiki pages found during cleanup. See
http://hub.qgis.org/wiki/quantum-gis/Connect_to_a_Bluetooth_GPS_for_live_tracking and http://hub.qgis.org/wiki/quantum-gis/Gps_units_download_data_and_live_tracking
