### PR TITLE
added link to a post about rule based renderer

### DIFF
--- a/source/docs/pyqgis_developer_cookbook/vector.rst
+++ b/source/docs/pyqgis_developer_cookbook/vector.rst
@@ -896,12 +896,12 @@ can be loaded from a `Qt resource <http://qt.nokia.com/doc/4.5/resources.html>`_
 
 Further Topics
 ..............
-
+re
 **TODO:**
  * creating/modifying symbols
  * working with style (:class:`QgsStyleV2`)
  * working with color ramps (:class:`QgsVectorColorRampV2`)
- * rule-based renderer
+ * rule-based renderer (see .. _this blogpost: http://snorf.net/blog/2014/03/04/symbology-of-vector-layers-in-qgis-python-plugins)
  * exploring symbol layer and renderer registries
 
 .. index:: symbology; old


### PR DESCRIPTION
add a link to http://snorf.net/blog/2014/03/04/symbology-of-vector-layers-in-qgis-python-plugins/ as there is basically no doc about rule based renderers
Hope the rst is correct
