### PR TITLE
Fix spelling errors in PyQGIS cookbook

### DIFF
--- a/source/docs/pyqgis_developer_cookbook/canvas.rst
+++ b/source/docs/pyqgis_developer_cookbook/canvas.rst
@@ -244,11 +244,11 @@ applies as for the rubber bands.
 Writing Custom Map Tools
 ========================
 
-You can write your custom tools, to implement a custom behaviour to actions perfored by users on the canvas.
+You can write your custom tools, to implement a custom behaviour to actions performed by users on the canvas.
 
 Map tools should inherit from the :class:`QgsMapTool` class or any derived class, and selected as active tools in the canvas using the :func:`setMapTool` method as we have already seen.
 
-Here is an example of a map tool that allows to define a rectangular extent by clicking and draggin on the canvas. When the rectangle is defined, it prints its boundary coordinates in the console. It uses the rubber band elements described before to show the selected rectangle as it is being defined.
+Here is an example of a map tool that allows to define a rectangular extent by clicking and dragging on the canvas. When the rectangle is defined, it prints its boundary coordinates in the console. It uses the rubber band elements described before to show the selected rectangle as it is being defined.
 
 ::
 

--- a/source/docs/pyqgis_developer_cookbook/communicating.rst
+++ b/source/docs/pyqgis_developer_cookbook/communicating.rst
@@ -7,7 +7,7 @@ This section shows some methods and elements that should be used to communicate 
 Showing messages. The QgsMessageBar class.
 ==========================================
 
-Using mesages boxes can be a bad idea from a user experience point of view. For showing a small info line or a warning/error messages, the QGIS message bar is usually a better option
+Using message boxes can be a bad idea from a user experience point of view. For showing a small info line or a warning/error messages, the QGIS message bar is usually a better option
 
 
 Using the reference to the QGIS interface object, you can show a message in the message bar with the following code.
@@ -39,7 +39,7 @@ You can set a duration to show it for a limited time.
    QGIS Message bar with timer
 
 
-The examples above show an error bar, but the ``level`` parameter can be used to creating warning messages or info messages, using the ``QgsMessageBar.WARNING`` and ``QgsMessageBar.INFO`` constants repectively.
+The examples above show an error bar, but the ``level`` parameter can be used to creating warning messages or info messages, using the ``QgsMessageBar.WARNING`` and ``QgsMessageBar.INFO`` constants respectively.
 
 .. figure:: /static/pyqgis_developer_cookbook/warningbar.png
    :align: center

--- a/source/docs/pyqgis_developer_cookbook/composer.rst
+++ b/source/docs/pyqgis_developer_cookbook/composer.rst
@@ -66,7 +66,7 @@ then exported to PDF, raster images or directly printed on a printer.
 
 The composer consists of a bunch of classes. They all belong to the core
 library. QGIS application has a convenient GUI for placement of the elements,
-though it is not available in the gui library. If you are not familiar with
+though it is not available in the GUI library. If you are not familiar with
 `Qt Graphics View framework <http://doc.qt.nokia.com/stable/graphicsview.html>`_,
 then you are encouraged to check the documentation now, because the composer
 is based on it.

--- a/source/docs/pyqgis_developer_cookbook/crs.rst
+++ b/source/docs/pyqgis_developer_cookbook/crs.rst
@@ -45,7 +45,7 @@ created by several different ways:
 It's wise to check whether creation (i.e. lookup in the database) of the CRS
 has been successful: :func:`isValid` must return :const:`True`.
 
-Note that for initialization of spatial reference systems QGIS needs to lookup
+Note that for initialization of spatial reference systems QGIS needs to look up
 appropriate values in its internal database :file:`srs.db`. Thus in case you
 create an independent application you need to set paths correctly with
 :func:`QgsApplication.setPrefixPath` otherwise it will fail to find the database.

--- a/source/docs/pyqgis_developer_cookbook/geometry.rst
+++ b/source/docs/pyqgis_developer_cookbook/geometry.rst
@@ -101,7 +101,7 @@ QGIS uses GEOS library for advanced geometry operations such as geometry
 predicates (:func:`contains`, :func:`intersects`, ...) and set operations
 (:func:`union`, :func:`difference`, ...). It can also compute geometric properties of geometries, such as area (in the case of polygons) or lengths (for polygons and lines)
 
-Here you have a small example that combines iterating over the features in a given layer and perfoming some geometric computations based on their geometries.
+Here you have a small example that combines iterating over the features in a given layer and performing some geometric computations based on their geometries.
 
 ::
 

--- a/source/docs/pyqgis_developer_cookbook/ide_debugging.rst
+++ b/source/docs/pyqgis_developer_cookbook/ide_debugging.rst
@@ -2,7 +2,7 @@
 IDE settings for writing and debugging plugins
 ***********************************************
 
-Although each programmer has his prefered IDE/Text editor, here are some recommendations for setting up popular IDE's for writing and debugging QGIS Python plugins.
+Although each programmer has his preferred IDE/Text editor, here are some recommendations for setting up popular IDE's for writing and debugging QGIS Python plugins.
 
 
 
@@ -17,14 +17,14 @@ way to do this, is to modify the startup batch file of QGIS.
 If you used the OSGeo4W Installer, you can find this under the bin folder
 of your OSGoeW install. Look for something like :file:`C:\\OSGeo4W\\bin\\qgis-unstable.bat`.
 
-For using `Pyscripter IDE <http://code.google.com/p/pyscripter>`_, here's what ou have to do:
+For using `Pyscripter IDE <http://code.google.com/p/pyscripter>`_, here's what you have to do:
 
 * Make a copy of qgis-unstable.bat and rename it pyscripter.bat.
-* Open it in an editor. And remove the last line, the one that starts qgis.
-* Add a line that points to the your pyscripter executable and add the
-  commandline argument that sets the version of python to be used (2.7 in the case of QGIs 2.0)
-* Also add the argument that points to the folder where pyscripter can
-  find the python dll used by qgis, you can find this under the bin folder
+* Open it in an editor. And remove the last line, the one that starts QGIS.
+* Add a line that points to the your Pyscripter executable and add the
+  commandline argument that sets the version of Python to be used (2.7 in the case of QGIS 2.0)
+* Also add the argument that points to the folder where Pyscripter can
+  find the Python dll used by QGIS, you can find this under the bin folder
   of your OSGeoW install::
 
     @echo off
@@ -35,15 +35,15 @@ For using `Pyscripter IDE <http://code.google.com/p/pyscripter>`_, here's what o
     path %PATH%;%GISBASE%\bin
     Start C:\pyscripter\pyscripter.exe --python25 --pythondllpath=C:\OSGeo4W\bin
 
-Now when you double click this batch file it will start pyscripter, with the correct path.
+Now when you double click this batch file it will start Pyscripter, with the correct path.
 
-More popular that Pyscripter, Eclipse is a common choice among developers. In the following sections, we will be explaining how to configure it for depelopping and testing plugins. To prepare your environment for using Eclipse in windows, you should also create a batch file and use it to start Eclipse. 
+More popular that Pyscripter, Eclipse is a common choice among developers. In the following sections, we will be explaining how to configure it for developing and testing plugins. To prepare your environment for using Eclipse in windows, you should also create a batch file and use it to start Eclipse.
 
 To create that batch file, follow these steps.
 
-- Locate the folder where ``qgis_core.dll`` resides in. Normally this is ``C:\OSGeo4W\apps\qgis\bin`` , but if you compiled your own qgis application this is in your build folder in ``output/bin/RelWithDebInfo``
+- Locate the folder where ``qgis_core.dll`` resides in. Normally this is ``C:\OSGeo4W\apps\qgis\bin``, but if you compiled your own QGIS application this is in your build folder in ``output/bin/RelWithDebInfo``
 - Locate your eclipse.exe executable. 
-- Create the following script and use this to start eclipse when developping QGIS plugins.
+- Create the following script and use this to start eclipse when developing QGIS plugins.
 
 ::
 
@@ -74,7 +74,7 @@ There is some preparation to be done on QGIS itself. Two plugins are of interest
 
 Setting up Eclipse
 -------------------
-In Eclipse, create a new project. You can select *General Project* and link your real sources later on, so it does not really mather where you place this project.
+In Eclipse, create a new project. You can select *General Project* and link your real sources later on, so it does not really matter where you place this project.
 
 .. figure:: /static/pyqgis_developer_cookbook/eclipsenewproject.png
    :align: center
@@ -115,7 +115,7 @@ Open the Console view (*Window => Show view*). It will show the Debug Server con
 
 You have now an interactive console which let's you test any commands from within the current context. You can manipulate variables or make API calls or whatever you like.
 
-A little bit annoying is, that everytime you enter a command, the console switches back to the Debug Server. To stop this behavior, you can click the *Pin Console* button when on the Debug Server page and it should remember this decision at least for the current debug session.
+A little bit annoying is, that every time you enter a command, the console switches back to the Debug Server. To stop this behavior, you can click the *Pin Console* button when on the Debug Server page and it should remember this decision at least for the current debug session.
 
 Making eclipse understand the API
 -----------------------------------
@@ -133,24 +133,24 @@ You will see your configured python interpreter in the upper part of the window 
 
    PyDev Debug Console
 
-First open the Libraries tab. Add a New Folder and choose the python folder of your QGIS installation. If you do not know where this folder is (it's not the plugins folder) open QGIS, start a python console and simply enter ``qgis`` and press enter. It will show you which qgis module it uses and its path. Strip the trailing ``/qgis/__init__.pyc`` from this path and you've got the path you are looking for.
+First open the Libraries tab. Add a New Folder and choose the python folder of your QGIS installation. If you do not know where this folder is (it's not the plugins folder) open QGIS, start a python console and simply enter ``qgis`` and press enter. It will show you which QGIS module it uses and its path. Strip the trailing ``/qgis/__init__.pyc`` from this path and you've got the path you are looking for.
 
-You should also add your plugins folder here (on linux its ~/.qgis/python/plugins ).
+You should also add your plugins folder here (on Linux it is ~/.qgis/python/plugins ).
 
-Next jump to the *Forced Builtins* tab, click on *New...* and enter ``qgis``. This will make eclipse parse the QGIS API. You probably also want eclipse to know about the PyQt4 API. Therefore also add PyQt4 as forced builtin. That should probably already be present in your libraries tab 
+Next jump to the *Forced Builtins* tab, click on *New...* and enter ``qgis``. This will make eclipse parse the QGIS API. You probably also want eclipse to know about the PyQt4 API. Therefore also add PyQt4 as forced builtin. That should probably already be present in your libraries tab.
 
 Click *OK* and you're done.
 
-Note: everytime the QGIS API changes (e.g. if you're compiling QGIS master and the sip file changed), you should go back to this page and simply click *Apply*. This will let Eclipse parse all the libraries again.
+Note: every time the QGIS API changes (e.g. if you're compiling QGIS master and the sip file changed), you should go back to this page and simply click *Apply*. This will let Eclipse parse all the libraries again.
 
 
 For another possible setting of Eclipse to work with QGIS Python plugins, check `this link <http://linfiniti.com/2011/12/remote-debugging-qgis-python-plugins-with-pydev>`_
 
 
 Debugging using PDB
-=================================
+===================
 
-If you do not use an IDE such as Eclipse, you can debug using PDB, following this steps.
+If you do not use an IDE such as Eclipse, you can debug using PDB, following these steps.
 
 First add this code in the spot where you would like to debug::
 
@@ -175,6 +175,6 @@ And when the application hits your breakpoint you can type in the console!
 .. index:: plugins; testing
 
 .. todo::
-    Add testing informations
+    Add testing information
 
 .. index:: plugins; releasing

--- a/source/docs/pyqgis_developer_cookbook/loadlayer.rst
+++ b/source/docs/pyqgis_developer_cookbook/loadlayer.rst
@@ -51,7 +51,7 @@ providers:
     uri = QgsDataSourceURI()
     # set host name, port, database name, username and password
     uri.setConnection("localhost", "5432", "dbname", "johny", "xxx")
-    # set database schema, table name, geometry column and optionaly 
+    # set database schema, table name, geometry column and optionally
     # subset (WHERE clause)
     uri.setDataSource("public", "roads", "the_geom", "cityid = 2643")
 
@@ -70,7 +70,7 @@ providers:
 
   Note: from QGIS version 1.7 the provider string is structured as a URL, so 
   the path must be prefixed with *file://*. Also it allows WKT (well known
-  text) formatted geomtries as an alternative to "x" and "y" fields, and allows
+  text) formatted geometries as an alternative to "x" and "y" fields, and allows
   the coordinate reference system to be specified. For example
   ::
 
@@ -101,7 +101,7 @@ providers:
     schema = ''
     table = 'Towns'
     geom_column = 'Geometry'
-    uri.setDataSource(schema, table, geom_colum)
+    uri.setDataSource(schema, table, geom_column)
     
     display_name = 'Towns'
     vlayer = QgsVectorLayer(uri.uri(), display_name, 'spatialite')

--- a/source/docs/pyqgis_developer_cookbook/plugins.rst
+++ b/source/docs/pyqgis_developer_cookbook/plugins.rst
@@ -12,13 +12,13 @@ understand, maintain and distribute due the dynamic nature of the Python
 language.
 
 Python plugins are listed together with C++ plugins in QGIS plugin manager.
-They're being searched for in these paths:
+They are searched for in these paths:
 
     * UNIX/Mac: :file:`~/.qgis/python/plugins` and :file:`(qgis_prefix)/share/qgis/python/plugins`
     * Windows: :file:`~/.qgis/python/plugins` and :file:`(qgis_prefix)/python/plugins`
 
 Home directory (denoted by above :file:`~`) on Windows is usually something like :file:`C:\\Documents and Settings\\(user)` (on Windows XP or earlier) or :file:`C:\\Users\\(user)`. Since Quantum GIS is using Python 2.7, subdirectories of these
-paths have to contain an __init__.py fily to be considered Python packages that can be imported as plugins.
+paths have to contain an __init__.py file to be considered Python packages that can be imported as plugins.
 
 Steps:
 
@@ -28,7 +28,7 @@ Steps:
    Is there already another plugin for that problem?
 
 2. *Create files*: Create the files described next.
-   A starting point (:file:`__init.py__`).
+   A starting point (:file:`__init__.py`).
    Fill in the :ref:`plugin_metadata` (:file:`metadata.txt`)
    A main python plugin body (:file:`mainplugin.py`).
    A form in QT-Designer (:file:`form.ui`), with its :file:`resources.qrc`.
@@ -39,18 +39,18 @@ Steps:
    everything is OK.
 
 5. *Publish*: Publish your plugin in QGIS repository or make your own
-   repository as an "arsenal" of personal "GIS weapons"
+   repository as an "arsenal" of personal "GIS weapons".
 
 .. index:: plugins; writing
 
 Writing a plugin
 ================
 
-Since the introduction of python plugins in QGIS, a number of plugins have
+Since the introduction of Python plugins in QGIS, a number of plugins have
 appeared - on `Plugin Repositories wiki page <http://www.qgis.org/wiki/Python_Plugin_Repositories>`_
 you can find some of them, you can use their source to learn more about
 programming with PyQGIS or find out whether you are not duplicating development
-effort. QGIS team also maintains an :ref:`official_pyqgis_repository`.
+effort. The QGIS team also maintains an :ref:`official_pyqgis_repository`.
 Ready to create a plugin but no idea what to do? `Python Plugin Ideas wiki page <http://www.qgis.org/wiki/Python_Plugin_Ideas>`_ lists wishes from the community!
 
 
@@ -134,7 +134,7 @@ email                  True      email of the author, will *not* be shown on the
 changelog              False     string, can be multiline, no HTML allowed
 experimental           False     boolean flag, `True` or `False`
 deprecated             False     boolean flag, `True` or `False`, applies to the whole plugin and not just to the uploaded version
-tags                   False     comma separated list, spaces are allowe inside individual tags
+tags                   False     comma separated list, spaces are allowed inside individual tags
 homepage               False     a valid URL pointing to the homepage of your plugin
 repository             False     a valid URL for the source code repository
 tracker                False     a valid URL for tickets and bug reports
@@ -190,8 +190,8 @@ An example for this metadata.txt::
 
   ; Tags are in comma separated value format, spaces are allowed within the 
   ; tag name.
-  ; Tags should be in english language. Please also check for existing tags and
-  ; synoninms before creating a new one.
+  ; Tags should be in English language. Please also check for existing tags and
+  ; synonyms before creating a new one.
   tags=wkt,raster,hello world
 
   ; these metadata can be empty, they will eventually become mandatory.
@@ -237,7 +237,7 @@ This is where the magic happens and this is how magic looks like:
   from PyQt4.QtGui import *
   from qgis.core import *
 
-  # initialize Qt resources from file resouces.py
+  # initialize Qt resources from file resources.py
   import resources
 
   class TestPlugin:
@@ -376,12 +376,4 @@ and section, which is the name of an html anchor tag in the document
 on which the browser will be positioned.
 
 .. index:: plugins; code snippets
-
-
-
-
-
-
-
-
 

--- a/source/docs/pyqgis_developer_cookbook/raster.rst
+++ b/source/docs/pyqgis_developer_cookbook/raster.rst
@@ -50,7 +50,7 @@ Index   Constant: QgsRasterLater.X     Comment
   2     SingleBandPseudoColor          Single band image drawn using a pseudocolor algorithm
   3     PalettedColor                  "Palette" image drawn using color table
   4     PalettedSingleBandGray         "Palette" layer drawn in gray scale
-  5     PalettedSingleBandPseudoColor  "Palette" layerdrawn using a pseudocolor algorithm
+  5     PalettedSingleBandPseudoColor  "Palette" layer drawn using a pseudocolor algorithm
   7     MultiBandSingleBandGray        Layer containing 2 or more bands, but a single band drawn as a range of gray colors
   8     MultiBandSingleBandPseudoColor Layer containing 2 or more bands, but a single band drawn using a pseudocolor algorithm
   9     MultiBandColor                 Layer containing 2 or more bands, mapped to RGB color space.
@@ -85,7 +85,7 @@ pseudocolor:
   >>> rlayer.setDrawingStyle(QgsRasterLayer.SingleBandPseudoColor)
   >>> rlayer.setColorShadingAlgorithm(QgsRasterLayer.PseudoColorShader)
 
-The ``PseudoColorShader`` is a basic shader that highlighs low values in blue
+The ``PseudoColorShader`` is a basic shader that highlights low values in blue
 and high values in red. Another, ``FreakOutShader`` uses more fancy colors and
 according to the documentation, it will frighten your granny and make your dogs
 howl.
@@ -160,7 +160,7 @@ The second call emits signal that will force any map canvas containing the
 layer to issue a refresh.
 
 With WMS raster layers, these commands do not work. In this case, you have
-to do it explicitily::
+to do it explicitly::
 
   layer.dataProvider().reloadData()
   layer.triggerRepaint()
@@ -185,7 +185,7 @@ To do a query on value of bands of raster layer at some specified point::
   if ident.isValid():
     print ident.results()
 
-The ``results`` method in this case returs a dictionary, with band indices as keys, and band values as values.
+The ``results`` method in this case returns a dictionary, with band indices as keys, and band values as values.
 
 ::
 

--- a/source/docs/pyqgis_developer_cookbook/releasing.rst
+++ b/source/docs/pyqgis_developer_cookbook/releasing.rst
@@ -69,7 +69,7 @@ Plugin structure
 Following the validation rules the compressed (.zip) package of your plugin must have a specific structure
 to validate as a functional plugin.
 As the plugin will be unzipped inside the users plugins folder it must have it's own directory inside the .zip file to not interfere with other plugins.
-Mandatory files are: netadata.txt and __init__.py
+Mandatory files are: metadata.txt and __init__.py
 But it would be nice to have a README.py and of course an icon to represent the plugin (resources.qrc).
 Following is an example of how a plugin.zip should look like.
 ::

--- a/source/docs/pyqgis_developer_cookbook/vector.rst
+++ b/source/docs/pyqgis_developer_cookbook/vector.rst
@@ -19,7 +19,7 @@ Iterating over the features in a vector layer is one of the most common tasks. B
 
   iter = layer.getFeatures()
   for feature in iter:
-    # retreive every feature with its geometry and attributes
+    # retrieve every feature with its geometry and attributes
       # fetch geometry
       geom = feature.geometry()
       print "Feature ID %d: " % feature.id()
@@ -47,7 +47,7 @@ Iterating over the features in a vector layer is one of the most common tasks. B
       print attrs
 
 
-Attributes can be refered by index.
+Attributes can be referred by index.
 
 ::
 
@@ -62,7 +62,7 @@ Iterating over selected features
 Convenience methods
 --------------------
 
-For the above cases, and in case you need to consider selection in a vector layer in case it exist, you can use the :func:`features` method from the buil-in processing plugin, as follows:
+For the above cases, and in case you need to consider selection in a vector layer in case it exist, you can use the :func:`features` method from the built-in processing plugin, as follows:
 
 ::
 
@@ -163,7 +163,7 @@ then it changes the feature's geometry::
 Adding and Removing Fields
 --------------------------
 
-To add fields (attributes), you need to specify a list of field defnitions.
+To add fields (attributes), you need to specify a list of field definitions.
 For deletion of fields just provide a list of field indexes.
 ::
 
@@ -251,9 +251,9 @@ by the user.
 Using Spatial Index
 ===================
 
-Spatial indexes can dramatically improve the performance of your code if you need to do frequent queries to a vector layer. Imagin, for instance, that you are writing an interpolation algorithm, and that for a given location you need to know the 10 closest point from a points layer,, in order to use those point for calculating the interpolated value. Without a spatial index, the only way for QGIS to find those 10 points is to compute the distance from each and every point to the specified location and then compare those distances. This can be a very time consuming task, specilly if it needs to be repeated fro several locations. If a spatial index exists for the layer, the operation is much more effective.
+Spatial indexes can dramatically improve the performance of your code if you need to do frequent queries to a vector layer. Imagine, for instance, that you are writing an interpolation algorithm, and that for a given location you need to know the 10 closest points from a points layer, in order to use those point for calculating the interpolated value. Without a spatial index, the only way for QGIS to find those 10 points is to compute the distance from each and every point to the specified location and then compare those distances. This can be a very time consuming task, especially if it needs to be repeated fro several locations. If a spatial index exists for the layer, the operation is much more effective.
 
-Think of a layer withou a spatial index as a telephone book in which telephone number are not orderer or indexed. The only way to find the telephone number of a given person is to read from the beginning until you find it.
+Think of a layer without a spatial index as a telephone book in which telephone numbers are not ordered or indexed. The only way to find the telephone number of a given person is to read from the beginning until you find it.
 
 Spatial indexes are not created by default for a QGIS vector layer, but you can create them easily. This is what you have to do.
 


### PR DESCRIPTION
Correct mispelled words. Also correct a few other minor typos.
Do not change between US or UK spelling variants, both of which are
used (sometimes in the same sentence).
