### PR TITLE
Typo in sentence

### DIFF
--- a/source/docs/training_manual/vector_analysis/reproject_transform.rst
+++ b/source/docs/training_manual/vector_analysis/reproject_transform.rst
@@ -206,7 +206,7 @@ in square meters
    :align: center
 
 Look at the new values in your attribute table. This is much more useful, as
-people actually quote building size in metres, not in degrees. This is why it's
+people actually quote building size in meters, not in degrees. This is why it's
 a good idea to reproject your data, if necessary, before calculating areas,
 distances, and other values that are dependent on the spatial properties of the
 layer.


### PR DESCRIPTION
The word "metres" in the sentence containing ..."actually quote building size in metres, not in degrees. ".... should in fact be "meters"
