### PR TITLE
Typo in menu entry

### DIFF
--- a/source/docs/training_manual/vector_analysis/basic_analysis.rst
+++ b/source/docs/training_manual/vector_analysis/basic_analysis.rst
@@ -59,7 +59,7 @@ data from OSM using QGIS' built-in OSM download tool.
 
 * Start a new QGIS project.
 * Use the OpenStreetMap data download tool found in the :guilabel:`Vector` ->
-  :guilabel:`OpenStreeMap` menu to download the data for your chosen region.
+  :guilabel:`OpenStreetMap` menu to download the data for your chosen region.
 * Save the data as :kbd:`osm_data.osm` in your :kbd:`exercise_data` folder.
 
 * Note that the :guilabel:`osm` format is a type of vector data. Add this data as a vector


### PR DESCRIPTION
Row 62 :   :guilabel:`OpenStreeMap` menu to download the data for your chosen region.

missed a letter "t" in "OpenStreeMap".

Corrected the typo to "OpenStreetMap"
