### PR TITLE
Typo in word "metres"

### DIFF
--- a/source/docs/training_manual/vector_analysis/basic_analysis.rst
+++ b/source/docs/training_manual/vector_analysis/basic_analysis.rst
@@ -369,7 +369,7 @@ of a restaurant.
 |basic| |FA| Select Buildings of the Right Size
 -------------------------------------------------------------------------------
 
-To see which buildings are the correct size (more than 100 square metres), we
+To see which buildings are the correct size (more than 100 square meters), we
 first need to calculate their size.
 
 * Open the attribute table for the :guilabel:`houses_restaurants_500m` layer.


### PR DESCRIPTION
Row 372: To see which buildings are the correct size (more than 100 square metres), we

The word "metres" should be "meters"
