### PR TITLE
Wrong name for window, should be GRASS not GDAL

### DIFF
--- a/source/docs/training_manual/grass/grass_setup.rst
+++ b/source/docs/training_manual/grass/grass_setup.rst
@@ -114,7 +114,7 @@ vectors already loaded into QGIS.
 * When it's done, click the :guilabel:`View output` button to see the newly
   imported GRASS layer in the map.
 * Close first the import tool (click the :guilabel:`Close` button to the
-  immediate right of :guilabel:`View output`), then close the :guilabel:`GDAL
+  immediate right of :guilabel:`View output`), then close the :guilabel:`GRASS
   Tools` window.
 * Remove the original :guilabel:`roads` layer.
 


### PR DESCRIPTION
row 117 :  immediate right of :guilabel:`View output`), then close the :guilabel:`GDAL Tools` window.

Lesson is about GRASS, not about GDAL. The window that is opened is the "GRASS Tools" window,
not the "GDAL Tools" window.
