### PR TITLE
screenshot file is showing old location of the toolbar panels activation list (fix #120).

### DIFF
--- a/source/docs/user_manual/introduction/qgis_configuration.rst
+++ b/source/docs/user_manual/introduction/qgis_configuration.rst
@@ -60,8 +60,8 @@ and off icon groups in the |qg| toolbar (see figure_panels_toolbars_).
 Project Properties
 ==================
 
-In the properties window for the project under |nix|
-:menuselection:`Settings --> Project Properties` (kde) or |nix| |win|
+In the properties window for the project under |nix| 
+:menuselection:`Settings --> Project Properties` (kde) or |nix| |win| 
 :menuselection:`Project --> Project Properties` (Gnome), you can set 
 project-specific options. These include:
 


### PR DESCRIPTION
This is not a screenshot issue, rather a wrong description related to OS guidelines as
KDE is the only one showing project properties, panels and toolbard in Settings menu.
