### PR TITLE
two typos

### DIFF
--- a/source/docs/user_manual/introduction/qgis_configuration.rst
+++ b/source/docs/user_manual/introduction/qgis_configuration.rst
@@ -287,9 +287,9 @@ Colors Menu
 ------------
 
 This menu allows you to add some custom color that you can find in each color dialog 
-window of the renderes. You will see a set of predefined colors in the tab: you can 
+window of the renderers. You will see a set of predefined colors in the tab: you can 
 delete or edit all of them. Moreover you can add the color you want and perform some copy 
-and paste operation. Finally you can export the color set as a :file:`gpl` file or import
+and paste operations. Finally you can export the color set as a :file:`gpl` file or import
 them.
 
 


### PR DESCRIPTION
line 290:  in each color dialog window of the renderes ---> 'renderes' should be 'renderers'

line 292: and paste operations -----> 'operation" should be plural 'operations' since we are talking about 'some copy and paste' (plural)
