### PR TITLE
two typos corrected

### DIFF
--- a/source/docs/user_manual/working_with_vector/query_builder.rst
+++ b/source/docs/user_manual/working_with_vector/query_builder.rst
@@ -60,7 +60,7 @@ window without changing the current selection.
 
 |qg| treats the resulting subset acts as if it where the entire layer. 
 For example if you applied the filter above for 'Borough', you can not 
-display, query, save or edit Ankorage, because that is a 'Manicpality' 
+display, query, save or edit Anchorage, because that is a 'Municipality' 
 and therefore not part of the subset.
 
 The only exception is that unless your layer is part of a database, using a subset will prevent you from editing the layer.


### PR DESCRIPTION
line 63: edit Ankorage, because that is a 'Manicpality' --> 'Ankorage' = 'Anchorage" ;  'Manicpality' = 'Municipality'
