### PR TITLE
Change deactivate method in RectangleMapTool, calling deactivate of supe...

### DIFF
--- a/source/docs/pyqgis_developer_cookbook/canvas.rst
+++ b/source/docs/pyqgis_developer_cookbook/canvas.rst
@@ -335,7 +335,7 @@ described before to show the selected rectangle as it is being defined.
         return QgsRectangle(self.startPoint, self.endPoint)
 
     def deactivate(self):
-        QgsMapTool.deactivate(self)
+        super(RectangleMapTool, self).deactivate()
         self.emit(SIGNAL("deactivated()"))
 
 .. index:: map canvas; writing custom canvas items


### PR DESCRIPTION
...r class (tested on QGIS 2.2., Linux)

The original call to "QgsMapTool.deactivate(self)" failed, there is no such static function with one parameter.