### PR TITLE
Update link for translation status fixes #359

### DIFF
--- a/source/docs/user_manual/introduction/getting_started.rst
+++ b/source/docs/user_manual/introduction/getting_started.rst
@@ -247,8 +247,7 @@ be added after ``--snapshot``.
 Based on your locale, |qg| selects the correct localization. If you would like
 to change your language, you can specify a language code. For example,
 ``--lang=it`` starts |qg| in italian localization. A list of currently supported
-languages with language code and status is provided at
-http://hub.qgis.org/wiki/quantum-gis/GUI_Translation_Progress.
+languages and status is provided at https://www.transifex.com/projects/p/QGIS/.
 
 **Command line option** ``--project``
 


### PR DESCRIPTION
I have updated the link to the transifex qgis desktop page. Note that there is no longer a list of available languages codes.