### PR TITLE
Fix reference to enexistent setProjectionEnable()

### DIFF
--- a/source/docs/pyqgis_developer_cookbook/geometry.rst
+++ b/source/docs/pyqgis_developer_cookbook/geometry.rst
@@ -135,7 +135,7 @@ parameters are used for calculations.
 ::
 
   d = QgsDistanceArea()
-  d.setProjectionsEnabled(True)
+  d.setEllipsoidalMode(True)
 
   print "distance in meters: ", d.measureLine(QgsPoint(10,10),QgsPoint(11,11))
 


### PR DESCRIPTION
As I can see, QgsDistanceArea setProjectionEnable() method no longer works. It was replaced by setEllipsoidalMode()