### PR TITLE
Updated announcement of memory layers

### DIFF
--- a/source/docs/user_manual/preamble/whats_new.rst
+++ b/source/docs/user_manual/preamble/whats_new.rst
@@ -41,7 +41,11 @@ Data Providers
 
 * **DXF Export tool improvements**: Improved marker symbol export
 * **WMS Layers**: Support for contextual WMS legend graphics
-* **Temporary Scratch Layers**: It is possible to create empty editable memory layers
+* **Temporary Scratch Layers**:
+
+  * It is possible to create empty editable memory layers, with or without geometries.
+  * Adding and removing fields is supported.
+  * The layer - without the features - will be saved to project files or layer definition files.
 
 Digitizing
 ----------


### PR DESCRIPTION
Pointed out the possibility of 
* creating __geometryless__ memory layers (qgis/QGIS#2653) (fixes #746)
* adding and removing fields

and that that all of these changes will be saved to projects/qlr files (qgis/QGIS#2624).

Of course the user would expect these features to be there anyways, but because they were absent in previous versions it might be worth documenting their addition now.