### PR TITLE
Update translation process and rules description

### DIFF
--- a/source/docs/documentation_guidelines/do_translations.rst
+++ b/source/docs/documentation_guidelines/do_translations.rst
@@ -8,119 +8,134 @@ Translation Guidelines
    :local:
 
 This manual is aiming to help the translator.
-First the general process of how technically a translation is done 
-is explained. Later the translation is explained from an actual English 
+First the general process of how technically a translation is done
+is explained. Later the translation is explained from an actual English
 rst document that is translated to Dutch.
-Finally a summary of "Rules of translation" is given.
-
-Foreword
-========
-
-**A first important note:** If you want to translate content within 
-the docs folder (not web), never do this in the master branch. For translations 
-there are always translation branches available, once a document is fully 
-updated in english for a certain version. As an example the branch to translate 
-the manual of QGIS 1.8, you have to use the manual_en_v1.8 branch. For questions, 
-please contact the qgis-community-team at http://lists.osgeo.org/mailman/listinfo/qgis-community-team.
+Finally a summary of `Rules of translation <translation_summary>`_ is given.
 
 
-.. _translation_general:
+Although these guidelines focus on QGIS documentation, the methods and
+the rules described below are also applicable to QGIS applications and
+website translation.
 
-General information
+.. _translation_process:
+
+Translation process
 ===================
 
-To explain how translation works, we will use the heatmap plugin as an example. 
-In this example we will translate it from English to Dutch, but it will 
-be practically the same for other documents in all languages.
+To create documentation first ``.rst`` documents are created.
+A prebuild script creates translation files named ``.po`` files for the english
+language in the folder :file:`/QGIS-Documentation/i18n/en`.
 
-.. _first_translation:
+These "originals" are copied by the script to the i18n folders for other languages.
 
-First translation
-.................
+The sentences in the ``.po`` files need to be translated from english to the
+language with a translation tool editor.
 
+When you want to contribute, first get a ``.po`` file and add
+translations for the sentences in the ``.po`` file.
+When you are finished the ``.po`` file is placed back in the right place and
+during the next build the buildscript now creates ``.mo`` files next to
+the ``.po`` files.
+These ``.mo`` files are actually used by the script to create translated output.
 
-To create documentation first rst documents are created.
-A prebuild script creates translation files named .po files for the english 
-language in the folder /QGIS-Documentation/i18n/en. 
-
-These "originals" are copied by the script to the i18n folders for other languages. 
-
-The sentences in the .po files needs to be translated from english to the 
-language with a translation tool editor. There is a web translation tool called 
-pootle we would like to use, but it is not activated yet. However there is an 
-excellent tool supplied with the qt development tools named Qt Linguist.
-
-When you want to contribute, first get a .po file and add 
-translations for the sentences in the .po file. 
-
-When you are finished the .po file is placed back in the right place and during the next 
-build the buildscript now creates .mo files next to the .po files.
-
-These .mo files are actually used by the script to create translated output.
-
-.. _update_translation:
-
-
-Update translations
-...................
-
- 
-When afterwards an rst document is updated a new .po file is created in the 
-english part. The contents of this new file will be merged with already existing .po 
-files for each language. This means that when a new line is added to 
-an rst document that was allready translated, only the new/updated sentences are 
-added in the translated .po file and needs to be translated. The amount of 
-work for updating translations for next versions of |QG| should be relative 
+When afterwards an rst document is updated a new ``.po`` file is created in the
+english part. The contents of this new file will be merged with already existing
+``.po`` files for each language. This means that when a new line is added to
+an rst document that was already translated, only the new/updated sentences are
+added in the translated ``.po`` file and needs to be translated. The amount of
+work for updating translations for next versions of QGIS should be relative
 small.
 
-.. _translate_po_file:
+Two different tools are currently used to do translations in QGIS:
+
+* the Transifex web platform, the easiest and recommanded way to translate QGIS,
+  transparently does the process described above and pulls all the translatable
+  texts in one place for the translator. He then just picks the files he wants
+  and does the translation
+* Qt Linguist, a Qt development tool that requires the translator to pick and
+  replace the ``.po`` files from the source code.
+
+Note that whatever tool you choose, rules of translations are the same.
+
+.. warning::
+
+   **An important note:** If you want to translate content within
+   the docs folder (not web), never do this in the master branch. For translations
+   there are always translation branches available, once a document is fully
+   updated in english for a certain version. As an example, to translate
+   the manual of QGIS 2.8, you have to use the manual_en_v2.8 branch.
 
 
-Translate a .po-file
-====================
+.. _translate_file:
 
+Translate a file
+================
 
-For this example we will use the relative smaller rst document 
-for the heatmap plugin. The source of the document can be found here:
+To explain how translation works, we will use the heatmap plugin as an example.
+In this example we will translate it from English to Dutch, but it will
+be practically the same for other documents in all languages.
+
+The source of the document can be found here:
+
+::
 
   QGIS-Documentation/source/docs/user_manual/plugins/plugins_heatmap.rst
 
-So why did I choose this document? 
+So why did I choose this document?
 
-1. It is considered finished for the current release.
-   If it is not yet completed the following statement followed by an empty line 
+#. It is considered finished for the current release.
+   If it is not yet completed the following statement followed by an empty line
    can be found in the top of the document.
 
-   ``|updatedisclamer|``
+   ``|updatedisclaimer|``
 
-   This will produce a visible disclaimer in the output product. 
-   To start translating a document with an update disclaimer there is a good 
+   This will produce a visible disclaimer in the output product.
+   To start translating a document with an update disclaimer there is a good
    chance that later on it needs another finishing touch.
 
-2. It also includes images, captions, headers, references and replacements.
-3. I wrote it so it is easier for me to translate ;-)
+#. It also includes images, captions, headers, references and replacements.
+#. I wrote it so it is easier for me to translate ;-)
 
-The build process has created the English .po file which can be found here:
+The build process has created the English ``.po`` file which can be found here::
 
-  QGIS-Documentation/i18n/en/LC_MESSAGES/docs/user_manual/plugins/plugins_heatmap.po
+ QGIS-Documentation/i18n/en/LC_MESSAGES/docs/user_manual/plugins/plugins_heatmap.po
 
-The equivalent Dutch .po file (basically a copy) can be found here:
+The equivalent Dutch ``.po`` file (basically a copy) can be found here::
 
-  QGIS-Documentation/i18n/nl/LC_MESSAGES/docs/user_manual/plugins/plugins_heatmap.po
+ QGIS-Documentation/i18n/nl/LC_MESSAGES/docs/user_manual/plugins/plugins_heatmap.po
 
-Along this file you will see a tiny .mo file which indicates that it 
-does not hold any translations yet. 
+Along this file you will see a tiny ``.mo`` file which indicates that it
+does not hold any translations yet.
 
-Now I will grab this .po file and start translating it. During this translation 
-session I will point out which parts (rst statements) need translation.
+
+.. _translation_transifex:
+
+Translation in Transifex
+........................
+
+In order to translate QGIS with Transifex, you first need to `join the project
+<http://qgis.org/en/site/getinvolved/translate.html#join-a-project>`_. Once
+you got a team, click on the corresponding project and your language.
+You get a list of all translatable ``.po`` files. Click on the
+``docs_user-manual_plugins_plugins-heatmap`` to select the heatmap plugin file
+and choose ``Translate`` in the prompted dialog.
+Note that you can also choose to download the file and translate it
+with tools like Qt Linguist.
+The next page lists all the sentences in the file. All you need to do is select
+the text and translate following the `guidelines <translate_manual>`_.
+
+For further information on the use of Transifex Web Editor, see
+http://docs.transifex.com/tutorials/txeditor/.
+
 
 .. _translation_linguist:
 
 Translation in Qt Linguist
 ..........................
 
-
-When you open the .po file in Qt Linguist for the first time you will see the 
+With Qt Linguist, you need to manually grab the ``.po`` file.
+When you open the file in Qt Linguist for the first time you will see the
 following dialog:
 
 .. _figure_translation_1:
@@ -135,11 +150,11 @@ following dialog:
    Select language for translation in linguist menu |osx|
 
 
-The Target language should be filled correctly. The Source language can be left 
-as is with language POSIX and Country/Region on Any Country. 
- 
-When you press the **[OK]** button Qt Linguist is filled with sentences and 
-you can start translating, see Figure translation 2.
+The Target language should be filled correctly. The Source language can be left
+as is with language POSIX and Country/Region on Any Country.
+
+When you press the **[OK]** button Qt Linguist is filled with sentences and
+you can start translating, see Figure_translation_2_.
 
 
 .. _figure_translation_2:
@@ -147,12 +162,12 @@ you can start translating, see Figure translation 2.
 .. only:: html
 
    **Figure Translation 2:**
-  
+
 .. figure:: /static/documentation_guidelines/linguist_menu.png
    :align: center
    :width: 50em
 
-   Translate using the linguist menu |osx|
+   Translate using the linguist menu
 
 
 .. |linguist_done_next| image:: /static/documentation_guidelines/linguist_done_next.png
@@ -168,24 +183,24 @@ you can start translating, see Figure translation 2.
 
 In the menu you see the following buttons which are convenient to use.
 
-   * |linguist_done_next| The Translation Done Next button, is the most important 
-     button. If the item needs translation, you enter a translation in the text 
-     field, then hit this button. If the item does not translation just leave the 
-     text field for translation empty and also hit this button which indicates the 
-     item is done and you continue with the next item.  
+* |linguist_done_next| The Translation Done Next button, is the most important
+  button. If the item needs translation, you enter a translation in the text
+  field, then hit this button. If the item does not translation just leave the
+  text field for translation empty and also hit this button which indicates the
+  item is done and you continue with the next item.
 
-   * |linguist_previous| The Goto Previous button, can be used to go to the 
-     previous translation item. 
+* |linguist_previous| The Goto Previous button, can be used to go to the
+  previous translation item.
 
-   * |linguist_next| The Goto Next button, can be used to go to the next 
-     translation item.
+* |linguist_next| The Goto Next button, can be used to go to the next
+  translation item.
 
-   * |linguist_next_todo| The Next Todo button, jumps to the first translation 
-     item that still needs a translation. Handy when the original document has 
-     changed and only several new/changed sentences need to be translated.  
+* |linguist_next_todo| The Next Todo button, jumps to the first translation
+  item that still needs a translation. Handy when the original document has
+  changed and only several new/changed sentences need to be translated.
 
-   * |linguist_previous_todo| The Previous Todo button, searches backward and 
-     jumps to the first translation item it finds that still needs a translation.
+* |linguist_previous_todo| The Previous Todo button, searches backward and
+  jumps to the first translation item it finds that still needs a translation.
 
 
 .. _translate_manual:
@@ -193,67 +208,75 @@ In the menu you see the following buttons which are convenient to use.
 Translate a manual
 ..................
 
-
 Now we start to translate the plugin_heatmap manual!
 
-The first two items do not need translation, just push the toolbar button which 
-considers the translation finished and jump to the next item.
+Translating most of the sentences should be straightforward.
+During this translation session I will point out which parts (rst statements)
+need special translation.
 
-When I get to the third item we see a more interesting sentence to translate:
+Below we see an interesting sentence to translate:
 
 ::
 
-   The |heatmap| :sup:`Heatmap` plugin allows to create a heatmap from a point vector map. A heatmap is a raster map showing the density or magnitude of point related information. From the result "hotspots" can easily be identified. 
-  
+   The |heatmap| :sup:`Heatmap` plugin allows to create a heatmap from a
+   point vector map. A heatmap is a raster map showing the density or
+   magnitude of point related information. From the result "hotspots" can
+   easily be identified.
+
 
 This sentence contains two rst statements:
-  #. ``|heatmap|`` words between ``|`` are replacements and these should never 
-     be translated! This will be replaced by the heatmap plugin icon!
-  #. ``:sup:`Heatmap` `` the ``:sup:`` statement is a superposition statement 
-     and prints the following text a bit higher. This is used to show the popup 
-     texts that appear when you hover above the toolbar item and this may be 
-     different when it is actually translated in the QGIS application. In this 
-     case it is not!
+
+#. ``|heatmap|`` words between ``|`` are replacements and these should never
+   be translated! This will be replaced by the heatmap plugin icon!
+#. ``:sup:`Heatmap```,  the ``:sup:`` statement is a superposition statement
+   and prints the following text a bit higher. This is used to show the popup
+   texts that appear when you hover above the toolbar item and this may be
+   different when it is actually translated in the QGIS application. In this
+   case it is not!
 
 All other plain text in this sentence can be translated!
-  
-The fifth translation item contains the ``:ref:`` rst statement that is 
-commonly used to refer to another section somewhere in het manual! The text 
-following a ``:ref:`` statement should never be changed because it is a unique 
+
+The next translation item contains the ``:ref:`` statement that is
+commonly used to refer to another section somewhere in the manual! The text
+following a ``:ref:`` statement should never be changed because it is a unique
 identifier!
 
 ::
 
-   First this core plugin needs to be activated using the Plugin Manager (see Section :ref:`load_core_plugin`). After activation the heatmap icon |heatmap| can be found in the Raster Toolbar.
+   First this core plugin needs to be activated using the Plugin Manager
+   (see Section :ref:`load_core_plugin`). After activation the heatmap icon
+   |heatmap| can be found in the Raster Toolbar.
 
-In this case "load_core_plugin" is a unique reference identifier placed before 
-an rst item that has a caption. The ref statement will be replaced with the text 
-of the header and turned into a hyerlink. When the header this reference is 
-refering to is translated, all references to this header will be automatically 
-translated as well. 
+In this case ``load_core_plugin`` is a unique reference identifier placed before
+an rst item that has a caption. The ref statement will be replaced with the text
+of the header and turned into a hyperlink. When the header this reference is
+refering to is translated, all references to this header will be automatically
+translated as well.
 
-The next item contains the rst-tag ``:menuselection:`` followed by text 
-actually displayed in a menu in QGIS application, this may be translated in the 
+The next item contains the rst-tag ``:menuselection:`` followed by text
+actually displayed in a menu in QGIS application, this may be translated in the
 application and therefore should be changed when this is the case.
 
 ::
 
-   Select from menu :menuselection:`View -->` :menuselection:`Toolbars -->` :menuselection:`Raster` to activate the Raster Toolbar when it is not yet activated.
-  
-In above item "View -->" is actually translated to "Beeld -->" because this is 
-the translation used in the Dutch localized QGIS application. 
+   Select from menu :menuselection:`View --> Toolbars --> Raster` to activate
+   the Raster Toolbar when it is not yet activated.
+
+In above item "View -->" is actually translated to "Beeld -->" because this is
+the translation used in the Dutch localized QGIS application.
 
 A bit further we meet the following tricky translation item:
 
 ::
 
-   The |heatmap| :sup:`Heatmap` toolbutton starts the Dialog of the Heatmap plugin (see figure_heatmap_2_).
+   The |heatmap| :sup:`Heatmap` tool button starts the Dialog of the Heatmap
+   plugin (see figure_heatmap_2_).
 
-It holds a reference to a figure ``figure_heatmap_2_``, and like a reference 
-to section this reference should not be changed!! The reference definition 
-itself from the rst-document is not included in the .po file and can therefore 
-not be changed. This means the reference to figures can not be translated. When 
-HTML is created you will see ``figure_heatmap_2``. When a PDF document is 
+It holds a reference to a figure ``figure_heatmap_2_``, and like a reference
+to section this reference should not be changed!! The reference definition
+itself from the rst-document is not included in the ``.po`` file and can therefore
+not be changed. This means the reference to figures can not be translated. When
+HTML is created you will see ``figure_heatmap_2``. When a PDF document is
 created ``figure_heatmap_2_`` is replaced with a figure number.
 
 The next translation item with rst attributes is the following item:
@@ -262,53 +285,63 @@ The next translation item with rst attributes is the following item:
 
     **Input Point dialog**: Provides a selection of loaded point vector maps.
 
-Do not remove the stars in above line. It will print the text it holds in bold. 
-The text itself is often text included in the dialog itself and may wel be 
-translated in the application. 
+Do not remove the stars in above line. It will print the text it holds in bold.
+The text itself is often text included in the dialog itself and may well be
+translated in the application.
 
 The following translation item contains the ``:guilabel:`` rst tag.
 
 ::
-    
-    When the |checkbox| :guilabel:`Advanced` checkbox is checked it will give acces to additional advanced options.
 
-The text `Advanced` of the guilabel tag may wel be translated in the QGIS 
+    When the |checkbox| :guilabel:`Advanced` checkbox is checked it will
+    give access to additional advanced options.
+
+The text ``Advanced`` of the guilabel tag may well be translated in the QGIS
 application and probably needs to be changed!
 
-The following translation item contains \`\`airports\`\`. The apostrophs are 
-used this to give text another textfont. In this case it is a literal value and
-does not need translation. 
+The following translation item contains \``airports\``. The quotes are
+used to give the text another text font. In this case it is a literal value and
+does not need translation.
 
 ::
 
-    For the following example, we will use the ``airports`` vector point layer from the QGIS sample dataset (see :ref:`label_sampledata`). Another exellent QGIS tutorial on making heatmaps can be found on `http://qgis.spatialthoughts.com <http://qgis.spatialthoughts.com/2012/07/tutorial-making-heatmaps-using-qgis-and.html>`_.
+    For the following example, we will use the ``airports`` vector point
+    layer from the QGIS sample dataset (see :ref:`label_sampledata`).
+    Another excellent QGIS tutorial on making heatmaps can be found on
+    `http://qgis.spatialthoughts.com
+    <http://qgis.spatialthoughts.com/2012/07/tutorial-making-heatmaps-using-qgis-and.html>`_.
 
 
-This item also includes a hyperlink with a url and an external presentation. 
-The url should ofcourse be left intact, you are allowed to change the external 
-text "http://qgis.spatialthoughts.com" which is visible by the reader. Never 
-remove the underscore at the end of the hyperlink which forms an essential 
+This item also includes a hyperlink with an url and an external presentation.
+The url should of course be left intact, you are allowed to change the external
+text ``http://qgis.spatialthoughts.com`` which is visible by the reader. Never
+remove the underscore at the end of the hyperlink which forms an essential
 part of it!!
+
 
 .. _translation_summary:
 
 Summary Rules for translation
 .............................
 
-
-#. Do not change replacements like ``|nix|``
-#. Do not change references that start with the tag ``:ref:``
+#. Do not change replacements like ``|checkbox|``, ``|selectstring|``, ``|mActionAddLayer|`` ...
+#. Do not change references that start with the tag ``:ref:`` or ``:file:``
 #. Do not change references that end with an underscore like ``figure_1_``
-#. Do not change the url in hyperlinks, but you may change the external 
+#. Do not change the url in hyperlinks, but you may change the external
    description. Leave the underscore at the end of the hyperlink
-#. Change the contents of ``:sup:``, ``:guilabel:`` and ``:menuselection:``,
+#. Change the contents of ``:index:``, ``:sup:``, ``:guilabel:`` and ``:menuselection:``,
    Check if/how it is translated in the QGIS Application.
-#. Text between Double Stars and double apostrophes often indicate values or 
+#. Text between double stars and double quotes often indicate values or
    fieldnames, sometimes they need translation sometimes not.
-#. Be aware to use exactly the same apostrophes of the source text.
-#. Don't end the translated strings with a new paragraph, otherwise the 
+#. Be aware to use exactly the same (number of) special characters of the source
+   text such as \`, \``, \*, \**, \::
+#. Do not begin nor end the text hold by special characters or tags with a space
+#. Do not end the translated strings with a new paragraph, otherwise the
    text will not be translated during the html generation.
 
-
 Stick to above presented rules and the translated document will look fine!
+
+For any question, please contact the `QGIS Community Team
+<qgis-community-team@lists.osgeo.org>`_ or the
+`QGIS Translation Team <qgis-tr@lists.osgeo.org>`_.
 

--- a/source/docs/documentation_guidelines/do_translations.rst
+++ b/source/docs/documentation_guidelines/do_translations.rst
@@ -13,7 +13,6 @@ is explained. Later the translation is explained from an actual English
 rst document that is translated to Dutch.
 Finally a summary of `Rules of translation <translation_summary>`_ is given.
 
-
 Although these guidelines focus on QGIS documentation, the methods and
 the rules described below are also applicable to QGIS applications and
 website translation.
@@ -35,7 +34,7 @@ language with a translation tool editor.
 When you want to contribute, first get a ``.po`` file and add
 translations for the sentences in the ``.po`` file.
 When you are finished the ``.po`` file is placed back in the right place and
-during the next build the buildscript now creates ``.mo`` files next to
+during the next build the build script now creates ``.mo`` files next to
 the ``.po`` files.
 These ``.mo`` files are actually used by the script to create translated output.
 
@@ -185,7 +184,7 @@ In the menu you see the following buttons which are convenient to use.
 
 * |linguist_done_next| The Translation Done Next button, is the most important
   button. If the item needs translation, you enter a translation in the text
-  field, then hit this button. If the item does not translation just leave the
+  field, then hit this button. If the item does not need translation just leave the
   text field for translation empty and also hit this button which indicates the
   item is done and you continue with the next item.
 
@@ -231,8 +230,8 @@ This sentence contains two rst statements:
 #. ``:sup:`Heatmap```,  the ``:sup:`` statement is a superposition statement
    and prints the following text a bit higher. This is used to show the popup
    texts that appear when you hover above the toolbar item and this may be
-   different when it is actually translated in the QGIS application. In this
-   case it is not!
+   different when it is actually translated in the QGIS application. In the
+   Dutch case it is not!
 
 All other plain text in this sentence can be translated!
 


### PR DESCRIPTION
Following the recent build errors related to translation errors (http://osgeo-org.1560.x6.nabble.com/Qgis-community-team-Translated-websites-td5253677.html) this PR updates the translation rules in order to integrate Transifex process. Thus, it :
- mentions Transifex
- reorders the description so that it fits Qt Linguist and Transifex
- complete the list of rules, according to @rduivenvoorde comment above
- fix some typo errors

I just wonder if I didn't make an excessive use of the \`` character :)
@rduivenvoorde @dassau @yjacolin 