### PR TITLE
set a dynamic title

### DIFF
--- a/source/docs/user_manual/preamble/whats_new.rst
+++ b/source/docs/user_manual/preamble/whats_new.rst
@@ -3,7 +3,7 @@
 .. _qgis.documentation.whatsnew:
 
 ****************************
-What's new in |qg| |CURRENT|
+What's new in QGIS |version|
 ****************************
 
 This release contains new features and extends the programmatic


### PR DESCRIPTION
It's weird to have `what's new in QGIS 2.8` as title while comment is about 2.14.
This commit uses the |version| substitution (set in `conf.py` file) so that this title is automatically updated according to the branch used (testing or numbered) to generate the doc.