### PR TITLE
Fix cosmetics in the "Draw effects" section

### DIFF
--- a/source/docs/user_manual/working_with_vector/vector_properties.rst
+++ b/source/docs/user_manual/working_with_vector/vector_properties.rst
@@ -253,15 +253,29 @@ The function is activated by checking the |checkbox| :guilabel:`Draw effects` op
 and clicking the |PaintEffects| :sup:`Customize effects` button.
 The effects include the following categories, with the following options:
 
-* **Blur:** Adds a blur effect on the vector layer. The options that someone can change are the
-  :menuselection:`Blur type` (:menuselection:`Stack` or :menuselection:`Gaussian blur`),
-  the strength and transparency of the blur effect.
+* **Source:** Implements the feature in the drawing menu, with its style as selected in the
+  layer properties. The transparency of its style can be adjusted.
 
   .. _figure_effects_1:
 
   .. only:: html
 
      **Figure Effects 1:**
+
+  .. figure:: /static/user_manual/working_with_vector/source.png
+     :align: center
+
+     Draw Effects: Source dialog
+
+* **Blur:** Adds a blur effect on the vector layer. The options that someone can change are the
+  :menuselection:`Blur type` (:menuselection:`Stack` or :menuselection:`Gaussian blur`),
+  the strength and transparency of the blur effect.
+
+  .. _figure_effects_2:
+
+  .. only:: html
+
+     **Figure Effects 2:**
 
   .. figure:: /static/user_manual/working_with_vector/blur.png
      :align: center
@@ -274,30 +288,16 @@ The effects include the following categories, with the following options:
   the :menuselection:`grayscale` effect selected, which actually converts the color of the feature
   to grayscale, based on 3 options: lightness, luminosity and average.
 
-  .. _figure_effects_2:
-
-  .. only:: html
-
-     **Figure Effects 2:**
-
-  .. figure:: /static/user_manual/working_with_vector/colorise.png
-     :align: center
-
-     Draw Effects: Colorize dialog
-
-* **Source:** Implements the feature in the drawing menu, with its style as selected in the layer properties.
-  The transparency of its style can be adjusted.
-
   .. _figure_effects_3:
 
   .. only:: html
 
      **Figure Effects 3:**
 
-  .. figure:: /static/user_manual/working_with_vector/source.png
+  .. figure:: /static/user_manual/working_with_vector/colorise.png
      :align: center
 
-     Draw Effects: Source dialog
+     Draw Effects: Colorize dialog
 
 * **Drop Shadow:** Using this effect adds a shadow on the feature, which looks like adding an
   extra dimension. This effect can be customized by changing the :menuselection:`offset`
@@ -316,10 +316,9 @@ The effects include the following categories, with the following options:
 
      Draw Effects: Drop Shadow dialog
 
-* **Inner Glow:** Adds a glow effect inside the feature. This effect can be customized by adjusting
-  the :menuselection:`spread` (width) of the glow, or the :menuselection:`Blur radius`.
-  The latter specifies the proximity from the edge of the feature where you want any blurring to happen.
-  Additionally, there are options to customize the color of the glow, with a single color or a color ramp.
+* **Inner Shadow:** This effect is similar to the :menuselection:`Drop Shadow` effect, but it adds
+  the shadow effect on the inside of the edges of the feature. The available options for customization
+  are the same as the :menuselection:`Drop Shadow` effect.
 
   .. _figure_effects_5:
 
@@ -327,14 +326,15 @@ The effects include the following categories, with the following options:
 
      **Figure Effects 5:**
 
-  .. figure:: /static/user_manual/working_with_vector/inner_glow.png
+  .. figure:: /static/user_manual/working_with_vector/inner_shadow.png
      :align: center
 
-     Draw Effects: Inner Glow dialog
+     Draw Effects: Inner Shadow dialog
 
-* **Inner Shadow:** This effect is similar to the :menuselection:`Drop Shadow` effect, but it adds
-  the shadow effect on the inside of the edges of the feature. The available options for customization
-  are the same as the :menuselection:`Drop Shadow` effect.
+* **Inner Glow:** Adds a glow effect inside the feature. This effect can be customized by adjusting
+  the :menuselection:`spread` (width) of the glow, or the :menuselection:`Blur radius`.
+  The latter specifies the proximity from the edge of the feature where you want any blurring to happen.
+  Additionally, there are options to customize the color of the glow, with a single color or a color ramp.
 
   .. _figure_effects_6:
 
@@ -342,10 +342,10 @@ The effects include the following categories, with the following options:
 
      **Figure Effects 6:**
 
-  .. figure:: /static/user_manual/working_with_vector/inner_shadow.png
+  .. figure:: /static/user_manual/working_with_vector/inner_glow.png
      :align: center
 
-     Draw Effects: Inner Shadow dialog
+     Draw Effects: Inner Glow dialog
 
 * **Outer Glow:** This effect is similar to the :menuselection:`Inner Glow` effect, but it adds
   the glow effect on the outside of the edges of the feature. The available options for customization

--- a/source/docs/user_manual/working_with_vector/vector_properties.rst
+++ b/source/docs/user_manual/working_with_vector/vector_properties.rst
@@ -364,14 +364,15 @@ The effects include the following categories, with the following options:
 
 * **Transform:** Adds the possibility of transforming the shape of the source feature.
   The first options available for customization are the :menuselection:`Reflect horizontal`
-  and :menuselection:`Reflect horizontal`, which actually create a reflection on the
-  horizontal and/or vertical axes. The 4 other options are the :menuselection:`Shear`,
-  :menuselection:`Scale`, :menuselection:`Rotation` and :menuselection:`Translate` effects.
-  The :menuselection:`Shear` effect slants the feature along the x and/or y axis, the
-  :menuselection:`Scale` enlarges or minimizes the feature along the x and/or y axis,
-  by the percentage given, while the :menuselection:`Rotation` effect turns the feature
-  around its center point and the :menuselection:`Translate` effect changes the position
-  of the item based on a distance given on the x and/or the y axis.
+  and :menuselection:`Reflect vertical`, which actually create a reflection on the
+  horizontal and/or vertical axes. The 4 other options are:
+  
+  * :menuselection:`Shear`: slants the feature along the x and/or y axis
+  * :menuselection:`Scale`: enlarges or minimizes the feature along the x and/or y axis
+    by the percentage given
+  * :menuselection:`Rotation`: turns the feature around its center point
+  * and :menuselection:`Translate` changes the position of the item based on a distance
+    given on the x and/or the y axis.
 
   .. _figure_effects_8:
 

--- a/source/docs/user_manual/working_with_vector/vector_properties.rst
+++ b/source/docs/user_manual/working_with_vector/vector_properties.rst
@@ -250,19 +250,23 @@ or at the whole layer level. It adds :index:`paint effects` for customizing the 
 of vector files.
 
 The function is activated by checking the |checkbox| :guilabel:`Draw effects` option
-and clicking the |PaintEffects| :guilabel:`Customize effects` button.
+and clicking the |PaintEffects| :sup:`Customize effects` button.
 The effects include the following categories, with the following options:
 
 * **Blur:** Adds a blur effect on the vector layer. The options that someone can change are the
   :menuselection:`Blur type` (:menuselection:`Stack` or :menuselection:`Gaussian blur`),
   the strength and transparency of the blur effect.
 
-  **Figure Effects 1:**
+  .. _figure_effects_1:
+
+  .. only:: html
+
+     **Figure Effects 1:**
 
   .. figure:: /static/user_manual/working_with_vector/blur.png
      :align: center
 
-  Draw Effects: Blur dialog
+     Draw Effects: Blur dialog
 
 * **Colorize:** This effect can be used by someone who wants to adjust the :menuselection:`brightness`,
   :menuselection:`contrast` and :menuselection:`saturation` levels of the feature. It also offers
@@ -270,7 +274,11 @@ The effects include the following categories, with the following options:
   the :menuselection:`grayscale` effect selected, which actually converts the color of the feature
   to grayscale, based on 3 options: lightness, luminosity and average.
 
-  **Figure Effects 2:**
+  .. _figure_effects_2:
+
+  .. only:: html
+
+     **Figure Effects 2:**
 
   .. figure:: /static/user_manual/working_with_vector/colorise.png
      :align: center
@@ -280,7 +288,11 @@ The effects include the following categories, with the following options:
 * **Source:** Implements the feature in the drawing menu, with its style as selected in the layer properties.
   The transparency of its style can be adjusted.
 
-  **Figure Effects 3:**
+  .. _figure_effects_3:
+
+  .. only:: html
+
+     **Figure Effects 3:**
 
   .. figure:: /static/user_manual/working_with_vector/source.png
      :align: center
@@ -293,7 +305,11 @@ The effects include the following categories, with the following options:
   the source object. :menuselection:`Drop Shadow` also has the option to change the blur radius,
   the transparency and the color of the effect.
 
-  **Figure Effects 4:**
+  .. _figure_effects_4:
+
+  .. only:: html
+
+     **Figure Effects 4:**
 
   .. figure:: /static/user_manual/working_with_vector/drop_shadow.png
      :align: center
@@ -305,7 +321,11 @@ The effects include the following categories, with the following options:
   The latter specifies the proximity from the edge of the feature where you want any blurring to happen.
   Additionally, there are options to customize the color of the glow, with a single color or a color ramp.
 
-  **Figure Effects 5:**
+  .. _figure_effects_5:
+
+  .. only:: html
+
+     **Figure Effects 5:**
 
   .. figure:: /static/user_manual/working_with_vector/inner_glow.png
      :align: center
@@ -316,7 +336,11 @@ The effects include the following categories, with the following options:
   the shadow effect on the inside of the edges of the feature. The available options for customization
   are the same as the :menuselection:`Drop Shadow` effect.
 
-  **Figure Effects 6:**
+  .. _figure_effects_6:
+
+  .. only:: html
+
+     **Figure Effects 6:**
 
   .. figure:: /static/user_manual/working_with_vector/inner_shadow.png
      :align: center
@@ -327,7 +351,11 @@ The effects include the following categories, with the following options:
   the glow effect on the outside of the edges of the feature. The available options for customization
   are the same as the :menuselection:`Inner Glow` effect.
 
-  **Figure Effects 7:**
+  .. _figure_effects_7:
+
+  .. only:: html
+
+     **Figure Effects 7:**
 
   .. figure:: /static/user_manual/working_with_vector/outer_glow.png
      :align: center
@@ -345,7 +373,11 @@ The effects include the following categories, with the following options:
   around its center point and the :menuselection:`Translate` effect changes the position
   of the item based on a distance given on the x and/or the y axis.
 
-  **Figure Effects 8:**
+  .. _figure_effects_8:
+
+  .. only:: html
+
+     **Figure Effects 8:**
 
   .. figure:: /static/user_manual/working_with_vector/transform.png
      :align: center
@@ -354,9 +386,10 @@ The effects include the following categories, with the following options:
 
 In each of the Draw effect types, the :menuselection:`Blend mode` and :menuselection:`Draw mode`
 can be adjusted to match the user needs. The Blend mode follows the same methods as the ones
-included for the layers (link here) and cannot be used for the transform effect.
+included for the layers and cannot be used for the transform effect.
 You can find more information in the :ref:`blend-modes`.
 The Draw mode can apply a render and/or modify mode for each of the effects.
+
 One or more draw effects can be selected at the same time, which can also be
 moved up and down, in order to finally get the desired result.
 


### PR DESCRIPTION
reorder description of effects (see #994)
apply the ".. only:: html" directive in order to remove `Figure Effects ...` title in the PDF doc