### PR TITLE
Guidelines: Add rule for button labels

### DIFF
--- a/source/docs/documentation_guidelines/writing.rst
+++ b/source/docs/documentation_guidelines/writing.rst
@@ -73,12 +73,17 @@ You can use some tags inside the text to emphasize some items.
      :menuselection:`menu --> submenu`
 
 * **Dialog and Tab title**: Labels presented as part of an interactive user interface
-  including button labels, window titles, field names, menu and menu selection names,
-  and even values in selection lists.
+  including window title, tab title and option labels.
 
   ::
 
      :guilabel:`title`
+
+* **Button labels**
+
+  ::
+
+     **[Apply]**
 
 * **Filename or directory**
 
@@ -86,7 +91,7 @@ You can use some tags inside the text to emphasize some items.
 
      :file:`README.rst`
 
-* **Icon with popup text belonging to Icon**:
+* **Icon with popup text belonging to Icon**
 
   ::
 

--- a/source/docs/user_manual/working_with_vector/editing_geometry_attributes.rst
+++ b/source/docs/user_manual/working_with_vector/editing_geometry_attributes.rst
@@ -547,7 +547,7 @@ First, drag a rectangle over the feature. The vertices will be highlighted in re
 feature will change and a dialog where you can define a tolerance in map units or pixels
 will appear. QGIS calculates the amount of vertices that can be deleted while maintaining the
 geometry using the given tolerance. The higher the tolerance is the more vertices can be deleted. After
-gaining the statistics about the simplification just klick the :guilabel:`OK` button.
+gaining the statistics about the simplification just click the **[OK]** button.
 The tolerance you used will be saved when leaving a project or when leaving an edit session.
 So you can go back to the same tolerance the next time when simplifying a feature.
 


### PR DESCRIPTION
Add rule for writing button label (picked from http://docs.qgis.org/testing/en/docs/user_manual/preamble/conventions.html#gui-conventions e.g., **[OK]**)
Apply the rule to the doc (there was a single mistake in the user manual)
The training manual seems to not follow that rule given that it's full of `:guilabel:OK` or `:guilabel:Apply` and no **[...]**. I'm not sure it's worth fixing this. @pcav @timlinux ?