### PR TITLE
install markerlib prior to pip install -r

### DIFF
--- a/REQUIREMENTS.txt
+++ b/REQUIREMENTS.txt
@@ -3,7 +3,6 @@ MarkupSafe==0.18
 Pygments==1.6
 Sphinx==1.2
 argparse==1.2.1
-distribute==0.7.3
 docutils==0.11
 polib==1.0.3
 six==1.5.2


### PR DESCRIPTION
Fixes an error when doing pip install -r REQUIREMENTS:
```
      from _markerlib import compile as compile_marker
  ImportError: No module named _markerlib
```

I tried embedding the markerlib in REQUIREMENTS but for some reasons I get the same error.
If you have better ideas, glad to hear them.