### PR TITLE
Fix QgsColorButtonV2 call in PyQGIS Cookbook

### DIFF
--- a/source/docs/pyqgis_developer_cookbook/vector.rst
+++ b/source/docs/pyqgis_developer_cookbook/vector.rst
@@ -1114,7 +1114,7 @@ first symbol
       else:
         self.r = renderer
       # setup UI
-      self.btn1 = QgsColorButtonV2("Color 1")
+      self.btn1 = QgsColorButtonV2()
       self.btn1.setColor(self.r.syms[0].color())
       self.vbox = QVBoxLayout()
       self.vbox.addWidget(self.btn1)


### PR DESCRIPTION
Try to execute in the Python QGIS console

```python
from qgis.gui import QgsColorButtonV2

btn = QgsColorButtonV2("Color 1")
```

You will get an issue like below:

> Traceback (most recent call last):
>   File "<input>", line 1, in <module>
> TypeError: QgsColorButtonV2(QWidget parent=None, QString cdt="", QgsColorSchemeRegistry registry=None): argument 1 has unexpected type 'str'

It seems previously the string for `QgsColorButtonV2` was the first arg whereas it's not true anymore.
Removing the string `"Color 1"` make the class constructor uses the default parameters.