### PR TITLE
Fixing #557 - correct to QgsRectangle class - rebased

### DIFF
--- a/source/docs/pyqgis_developer_cookbook/composer.rst
+++ b/source/docs/pyqgis_developer_cookbook/composer.rst
@@ -43,7 +43,7 @@ and do the rendering
   render.setLayerSet(lst)
 
   # set extent
-  rect = QgsRect(render.fullExtent())
+  rect = QgsRectangle(render.fullExtent())
   rect.scale(1.1)
   render.setExtent(rect)
 


### PR DESCRIPTION
See issue #557 - use QgsRectangle rather than QgsRect (it appears QgsRect was the correct class in much older pre 2.0 QGIS versions).