### PR TITLE
Allow user to save vector and raster file

### DIFF
--- a/source/docs/user_manual/introduction/general_tools.rst
+++ b/source/docs/user_manual/introduction/general_tools.rst
@@ -936,7 +936,7 @@ Clicking the |dataDefined| :sup:`Data defined override` icon shows:
 * :guilabel:`Clear` button to remove the setup.
 
 When the :index:`data-defined override` option is setup correctly the icon is yellow,
-|dataDefineOn| or |dataDefineExpressionOn| if it is broken, the icon is red, 
+|dataDefineOn| or |dataDefineExpressionOn| if it is broken, the icon is red,
 |dataDefineError| or |dataDefineExpressionError|.
 
 Parameters that can be used with data-defined tools are:
@@ -956,8 +956,68 @@ connection profiles and encrypt their passowrd in their project files.
 
 A master password should be set up when adding a new authentication definition.
 
-.. todo: 
-    * Add information where settings files are saved, 
+.. todo:
+    * Add information where settings files are saved,
     * authentication options,
     * Authentication Methods Plugins
+
+.. _general_saveas:
+
+Save layer into file
+=====================
+
+Layers (raster or vector) can be saved in another format with the
+:guilabel:`save as ...` feature in the layer contextual menu (by right-clicking
+in the layer in the layer tree) or in the :menuselection:`Layer -> Save As ...`
+menu.
+
+The :guilabel:`save as` dialog shows several parameters to change the behaviour
+when saving the layer. Common parameters (raster and vector) are:
+
+* Format
+* Filename
+* CRS
+* Add save file to map to add the new layer to the canvas
+* Extent (possible values are layer, Map view or custom extent)
+* Create (for raster), Layer or Custom (for vector) Options which allow you to
+  change some advanced options. Advanced user can see the driver documentation
+  in `gdal-ogr <http://gdal.org>`_ documentation.
+
+However, some parameters are specific to raster and vector formats:
+
+* Raster specific parameters:
+
+  * Resolution (horizontal and vertical)
+  * Pyramid creation
+  * Output mode (raw data or rendered image)
+
+* Vector specific parameters:
+
+  * Encoding
+  * Save only selected features
+  * Skip attribute creation
+  * Symbology export: can be used mainly for DXF export and for all file
+    formats who manage OGR feature styles (see note below) as DXF, KML, tab
+    file formats:
+
+    * No symbology: default style of the application that reads the data
+    * Feature symbology: save style with OGR Feature Styles (see note below)
+    * Symbol Layer symbology: save with OGR Feature Styles (see note below) but
+      export the same geometry multiple times if there are multiple symbology
+      symbol layers used
+
+  * Geometry:
+
+    * force to multi-geometry,
+    * add z-dimension,
+    * add or remove a geometry column with the drop-down list. This is not
+      linked with the current geometry type of the layer. You can add an empty
+      geometry column to an attribute table, remove the geometry column of
+      a spatial layer.
+
+.. note:: **Note:** *OGR Feature Styles* are a way to store style directly in
+   the data as a hidden attribute. Only some format can handle this kind of
+   information. KML, DXF and TAB files format are such format. For advanced
+   user, you can read the `OGR Feature Styles specification 
+   <http://www.gdal.org/ogr_feature_style.html>`_ document.
 

--- a/source/docs/user_manual/working_with_vector/supported_data.rst
+++ b/source/docs/user_manual/working_with_vector/supported_data.rst
@@ -704,7 +704,7 @@ right clicking the layer in the legend. Then, click on :menuselection:`Save as..
 define the name of the output file, and select 'SpatiaLite' as format and the CRS.
 Also, you can select 'SQLite' as format and then add ``SPATIALITE=YES`` in the
 OGR data source creation option field. This tells OGR to create a SpatiaLite
-database. See also http://www.gdal.org/ogr/drv_sqlite.html.
+database. See :ref:`general_saveas` and http://www.gdal.org/ogr/drv_sqlite.html.
 
 QGIS also supports editable views in SpatiaLite.
 


### PR DESCRIPTION
Fix #682 Allow overide of geometry type in vector save as dialog

[Documentation fix funded by Camptocamp]