### PR TITLE
Refine warning about estimated metadata

### DIFF
--- a/source/docs/user_manual/working_with_vector/supported_data.rst
+++ b/source/docs/user_manual/working_with_vector/supported_data.rst
@@ -411,6 +411,16 @@ Optionally, you can activate the following checkboxes:
 Once all parameters and options are set, you can test the connection
 by clicking on the **[Test Connect]** button.
 
+**Note on :guilabel:`Use estimated table metadata`:** When initializing layers,
+various queries may be needed to establish the characteristics of the
+geometries stored in the database table. When this option is checked, these
+queries examine only a sample of the rows and use the table statistics, rather
+than the entire table. This can drastically speed up operations on large
+datasets, but may result in incorrect characterization of layers (eg. the
+feature count of filtered layers will not be accurately determined) and may
+even cause strange behaviour in case columns that are supposed to be unique
+actually are not.
+
 .. _vector_loading_postgis:
 
 Loading a PostGIS Layer


### PR DESCRIPTION
Fix #703 (Text from the QGIS warning).

[Documentation fix funded by Camptocamp]