### PR TITLE
Hide TOC in html only

### DIFF
--- a/source/docs/user_manual/grass_integration/grass_integration.rst
+++ b/source/docs/user_manual/grass_integration/grass_integration.rst
@@ -6,33 +6,35 @@
 GRASS GIS Integration
 *********************
 
-.. contents::
-   :local:
+.. only:: html
+
+   .. contents::
+      :local:
 
 :index:`GRASS` integration provides access to GRASS GIS databases and functionalities
-(see GRASS-PROJECT in :ref:`literature_and_web`). The integration consists of two parts: 
-provider and plugin. The provider allows to browse, manage and visualize GRASS raster 
-and vector layers. The plugin can be used to create new GRASS locations and mapsets, 
-change GRASS region, create and edit vector layers and analyze GRASS 2-D and 3-D data 
-with more than 400 GRASS modules. In this section, we'll introduce the provider and plugin 
-functionalities and give some examples of managing and working with GRASS data. 
+(see GRASS-PROJECT in :ref:`literature_and_web`). The integration consists of two parts:
+provider and plugin. The provider allows to browse, manage and visualize GRASS raster
+and vector layers. The plugin can be used to create new GRASS locations and mapsets,
+change GRASS region, create and edit vector layers and analyze GRASS 2-D and 3-D data
+with more than 400 GRASS modules. In this section, we'll introduce the provider and plugin
+functionalities and give some examples of managing and working with GRASS data.
 
 The provider supports GRASS version 6 and 7, the plugin supports GRASS 6 and 7
-(starting from QGIS 2.12). QGIS distribution may contain provider/plugin for either 
-GRASS 6 or GRASS 7 or for both versions at the same time 
-(binaries have different file names). Only one version of the provider/plugin may be 
+(starting from QGIS 2.12). QGIS distribution may contain provider/plugin for either
+GRASS 6 or GRASS 7 or for both versions at the same time
+(binaries have different file names). Only one version of the provider/plugin may be
 loaded on runtime however.
 
 Demo dataset
 ============
 
-As an example, we will use the QGIS Alaska dataset (see section :ref:`label_sampledata`). 
-It includes a small sample GRASS :file:`LOCATION` with three vector layers and one 
-raster elevation map. Create a new folder called :file:`grassdata`, download 
-the QGIS 'Alaska' dataset :file:`qgis\_sample\_data.zip` from 
+As an example, we will use the QGIS Alaska dataset (see section :ref:`label_sampledata`).
+It includes a small sample GRASS :file:`LOCATION` with three vector layers and one
+raster elevation map. Create a new folder called :file:`grassdata`, download
+the QGIS 'Alaska' dataset :file:`qgis\_sample\_data.zip` from
 http://download.osgeo.org/qgis/data/ and unzip the file into :file:`grassdata`.
 
-More sample GRASS :file:`LOCATIONs` are available at the GRASS website at 
+More sample GRASS :file:`LOCATIONs` are available at the GRASS website at
 http://grass.osgeo.org/download/sample-data/.
 
 .. _sec_load_grassdata:
@@ -40,18 +42,18 @@ http://grass.osgeo.org/download/sample-data/.
 Loading GRASS raster and vector layers
 ======================================
 
-If the provider is loaded in QGIS, the location item with GRASS |grassLocation| 
+If the provider is loaded in QGIS, the location item with GRASS |grassLocation|
 icon is added in the browser tree under each folder item which contains GRASS location.
-Go to the folder :file:`grassdata` and expand location :file:`alaska` and 
+Go to the folder :file:`grassdata` and expand location :file:`alaska` and
 mapset :file:`demo`.
 
-You can load GRASS raster and vector layers like any other layer from the browser either 
+You can load GRASS raster and vector layers like any other layer from the browser either
 by double click on layer item or by dragging and dropping to map canvas or legend.
 
 .. tip:: **GRASS Data Loading**
 
-   If you don't see GRASS location item, verify in 
-   :menuselection:`Help -->` :menuselection:`About` :guilabel:`Providers` if 
+   If you don't see GRASS location item, verify in
+   :menuselection:`Help -->` :menuselection:`About` :guilabel:`Providers` if
    GRASS vector provider is loaded.
 
 .. _import_data_dnd:
@@ -59,24 +61,24 @@ by double click on layer item or by dragging and dropping to map canvas or legen
 Importing data into a GRASS LOCATION via drag and drop
 ======================================================
 
-This section gives an example of how to import raster and vector data into a GRASS mapset. 
+This section gives an example of how to import raster and vector data into a GRASS mapset.
 
 #. In QGIS browser navigate to the mapset you want to import data into.
-#. In QGIS browser find a layer you want to import to GRASS, note that you can 
-   open another instance of the browser (:guilabel:`Browser Panel (2)`) if 
+#. In QGIS browser find a layer you want to import to GRASS, note that you can
+   open another instance of the browser (:guilabel:`Browser Panel (2)`) if
    source data are too far from the mapset in the tree.
-#. Drag a layer and drop it on the target mapset. The imported may take some time for 
+#. Drag a layer and drop it on the target mapset. The imported may take some time for
    larger layers, you will see animated icon |import| in front of new layer item
    until the import finishes.
-   
-Where raster data are in different CRS, they can be reprojected using an :guilabel:`Approximate` 
-(fast) or :guilabel:`Exact` (precise) transformation. If a link to the source raster 
-is created (using r.external), the source data are in the same CRS and the format 
-is known to GDAL, the source data CRS will be used. You can set these options in the 
+
+Where raster data are in different CRS, they can be reprojected using an :guilabel:`Approximate`
+(fast) or :guilabel:`Exact` (precise) transformation. If a link to the source raster
+is created (using r.external), the source data are in the same CRS and the format
+is known to GDAL, the source data CRS will be used. You can set these options in the
 :guilabel:`Browser` tab in :ref:`grass_options`.
 
 If a source raster has more bands, a new GRASS map is created for each layer with **.<band number>**
-suffix and group of all maps with |rasterGroup| icon is created. External rasters 
+suffix and group of all maps with |rasterGroup| icon is created. External rasters
 have a different icon |rasterLink|.
 
 .. _managing_grass_data:
@@ -93,7 +95,7 @@ Managing GRASS data in QGIS browser
 GRASS Options
 =============
 
-GRASS options may be set in :guilabel:`GRASS Options` dialog, which can be opened by right 
+GRASS options may be set in :guilabel:`GRASS Options` dialog, which can be opened by right
 clicking on the location or mapset item in the browser and then choosing :guilabel:`GRASS Options`.
 
 .. _sec_starting_grass:
@@ -101,7 +103,7 @@ clicking on the location or mapset item in the browser and then choosing :guilab
 Starting the GRASS plugin
 =========================
 
-To use GRASS functionalities in QGIS, you must select and load the GRASS plugin using the 
+To use GRASS functionalities in QGIS, you must select and load the GRASS plugin using the
 Plugin Manager. To do this, go to the menu :menuselection:`Plugins -->` |showPluginManager|
 :menuselection:`Manage Plugins`, select |checkbox| :guilabel:`GRASS` and click
 **[OK]**.
@@ -136,10 +138,10 @@ by its coordinate system, map projection and geographical boundaries. Each
 :file:`LOCATION`) that are used to subdivide the project into different topics or
 subregions, or as workspaces for individual team members (see Neteler & Mitasova
 2008 in :ref:`literature_and_web`). In order to analyse vector and raster layers
-with GRASS modules, you generally have to import them into a GRASS :file:`LOCATION`. 
+with GRASS modules, you generally have to import them into a GRASS :file:`LOCATION`.
 (This is not strictly true -- with the GRASS modules :file:`r.external` and :file:`v.external`
 you can create read-only links to external GDAL/OGR-supported datasets without
-importing them. This is not the usual way for beginners to work with GRASS, therefore 
+importing them. This is not the usual way for beginners to work with GRASS, therefore
 this functionality will not be described here.)
 
 .. _figure_grass_location_1:
@@ -158,11 +160,11 @@ this functionality will not be described here.)
 Importing data into a GRASS LOCATION
 ====================================
 
-See section :ref:`import_data_dnd` to find how data can be easily imported 
+See section :ref:`import_data_dnd` to find how data can be easily imported
 by dragging and dropping in the browser.
 
 This section gives an example of how to import raster and vector data into the
-'alaska' GRASS :file:`LOCATION` provided by the QGIS 'Alaska' dataset in traditional 
+'alaska' GRASS :file:`LOCATION` provided by the QGIS 'Alaska' dataset in traditional
 way, using standard GRASS modules.
 Therefore, we use the landcover raster map :file:`landcover.img` and the vector GML
 file :file:`lakes.gml` from the QGIS 'Alaska' dataset (see :ref:`label_sampledata`).
@@ -208,9 +210,9 @@ Creating a new GRASS LOCATION
 -----------------------------
 
 As an example, here is the sample GRASS :file:`LOCATION alaska`, which is
-projected in the Albers Equal Area projection using feet as units. 
-This sample GRASS :file:`LOCATION alaska` will be used for all examples and 
-exercises in the following GRASS-related sections. It is useful to download and 
+projected in the Albers Equal Area projection using feet as units.
+This sample GRASS :file:`LOCATION alaska` will be used for all examples and
+exercises in the following GRASS-related sections. It is useful to download and
 install the dataset on your computer (see :ref:`label_sampledata`).
 
 #. Start QGIS and make sure the GRASS plugin is loaded.
@@ -277,9 +279,9 @@ section :ref:`label_vectmodel`.
 Adding a new MAPSET
 -------------------
 
-A user has write access only to a GRASS :file:`MAPSET` which he or she created. This 
+A user has write access only to a GRASS :file:`MAPSET` which he or she created. This
 means that besides access to your own :file:`MAPSET`, you can read maps in other users'
-:file:`MAPSETs` (and they can read yours), but you can modify or remove only the maps in 
+:file:`MAPSETs` (and they can read yours), but you can modify or remove only the maps in
 your own :file:`MAPSET`.
 
 All :file:`MAPSETs` include a :file:`WIND` file that stores the current boundary
@@ -327,7 +329,7 @@ different layers.)
 It is possible to store several 'layers' in one vector dataset. For example,
 fields, forests and lakes can be stored in one vector. An adjacent forest and lake
 can share the same boundary, but they have separate attribute tables. It is also
-possible to attach attributes to boundaries. An example might be the case where the boundary 
+possible to attach attributes to boundaries. An example might be the case where the boundary
 between a lake and a forest is a road, so it can have a different attribute table.
 
 The 'layer' of the feature is defined by the 'layer' inside GRASS. 'Layer' is the
@@ -365,7 +367,7 @@ used as the link to one key column in the database table.
 Creating a new GRASS vector layer
 =================================
 
-To create a new GRASS vector layer, select one of following items from mapset context 
+To create a new GRASS vector layer, select one of following items from mapset context
 menu in the browser:
 
 * New Point Layer
@@ -373,9 +375,9 @@ menu in the browser:
 * New Polygon Layer
 
 and enter a name in the dialog. A new vector map will be created and layer will be added
-to canvas and editing started. Selecting type of the layer does not restrict geometry 
-types which can be digitized in the vector map. In GRASS, it is possible to organize all sorts 
-of geometry types (point, line and polygon) in one vector map. The type is only used to add 
+to canvas and editing started. Selecting type of the layer does not restrict geometry
+types which can be digitized in the vector map. In GRASS, it is possible to organize all sorts
+of geometry types (point, line and polygon) in one vector map. The type is only used to add
 the layer to the canvas, because QGIS requires a layer to have a specific type.
 
 It is also possible to add layers to existing vector maps selecting one of the items
@@ -395,35 +397,35 @@ Digitizing and editing a GRASS vector layer
 .. index::
    single:GRASS;digitizing tools
 
-GRASS vector layers can be digitized using the standard QGIS digitizing tools. 
-There are however some particularities, which you should know about, due to 
+GRASS vector layers can be digitized using the standard QGIS digitizing tools.
+There are however some particularities, which you should know about, due to
 
 * GRASS topological model versus QGIS simple feature
 * complexity of GRASS model
-  
+
   * multiple layers in single maps
   * multiple geometry types in single map
   * geometry sharing by multiple features from multiple layers
 
 The particularities are discussed in the following sections.
-    
+
 **Save, discard changes, undo, redo**
 
 .. warning:: All the changes done during editing are immediately written to vector map and related attribute tables.
 
-Changes are written after each operation, it is however, possible to do undo/redo 
+Changes are written after each operation, it is however, possible to do undo/redo
 or discard all changes when closing editing. If undo or discard changes is used, original state
-is rewritten in vector map and attribute tables. 
+is rewritten in vector map and attribute tables.
 
 There are two main reasons for this behaviour:
 
 * It is the nature of GRASS vectors coming from conviction that user wants to do what he is
-  doing and it is better to have data saved when the work is suddenly interrupted (for example, 
+  doing and it is better to have data saved when the work is suddenly interrupted (for example,
   blackout)
 * Necessity for effective editing of topological data is visualized information about topological
-  correctness, such information can only be acquired from GRASS vector map if changes are 
+  correctness, such information can only be acquired from GRASS vector map if changes are
   written to the map.
-    
+
 **Toolbar**
 
 The 'Digitizing Toolbar' has some specific tools when a GRASS layer is edited:
@@ -454,15 +456,15 @@ Table GRASS Digitizing 1: GRASS Digitizing Tools
    The reason for this is that a topological vector model links the attribute information of
    a polygon always to the centroid and not to the boundary.
 
-   
+
 **Category**
 
 Category, often called cat, is sort of ID. The name comes from times when GRASS vectors
 had only singly attribute "category". Category is used as a link between geometry and attributes.
 A single geometry may have multiple categories and thus represent multiple features in different
 layers. Currently it is possible to assign only one category per layer using QGIS editing tools.
-New features have automatically assigned new unique category, except boundaries. 
-Boundaries usually only form areas and do not represent linear features, it is however 
+New features have automatically assigned new unique category, except boundaries.
+Boundaries usually only form areas and do not represent linear features, it is however
 possible to define attributes for a boundary later, for example in different layer.
 
 New categories are always created only in currently being edited layer.
@@ -474,17 +476,17 @@ even from different layers, may be deleted.
 **Attributes**
 
 Attributes of currently edited layer can only be modified. If the vector map contains more layers,
-features of other layers will have all attributes set to '<not editable (layer #)>' to warn you that 
+features of other layers will have all attributes set to '<not editable (layer #)>' to warn you that
 such attribute is not editable. The reason is, that other layers may have and usually have different
 set of fields while QGIS only supports one fixed set of fields per layer.
 
-If a geometry primitive does not have a category assigned, a new unique category is automatically 
+If a geometry primitive does not have a category assigned, a new unique category is automatically
 assigned and new record in attribute table is created when an attribute of that geometry is changed.
 
 .. tip::
 
-   If you want to do bulk update of attributes in table, for example using 'Field Calculator' 
-   (:ref:`vector_field_calculator`), and there are features without category which you don't want 
+   If you want to do bulk update of attributes in table, for example using 'Field Calculator'
+   (:ref:`vector_field_calculator`), and there are features without category which you don't want
    to update (typically boundaries), you can filter them out by setting 'Advanced Filter' to ``cat is not null``.
 
 
@@ -492,46 +494,46 @@ assigned and new record in attribute table is created when an attribute of that 
 
 .. index::
    single:GRASS;style
-   
-The topological symbology is essential for effective editing of topological data. When editing 
+
+The topological symbology is essential for effective editing of topological data. When editing
 starts, a specialized 'GRASS Edit' renderer is set on the layer automatically and original renderer
 is restored when editing is closed. The style may be customized in layer properties 'Style' tab.
-The style can also be stored in project file or in separate file as any other style. 
-If you customize the style, do not change its name, because it is used to reset the style 
+The style can also be stored in project file or in separate file as any other style.
+If you customize the style, do not change its name, because it is used to reset the style
 when editing is started again.
 
-.. tip::  Do not save project file when the layer is edited, the layer would be stored with 
+.. tip::  Do not save project file when the layer is edited, the layer would be stored with
    'Edit Style' which has no meaning if layer is not edited.
 
-The style is based on topological information which is temporarily added to attribute table 
+The style is based on topological information which is temporarily added to attribute table
 as field 'topo_symbol'. The field is automatically removed when editing is closed.
 
-.. tip::  Do not remove 'topo_symbol' field from attribute table, that would make features 
+.. tip::  Do not remove 'topo_symbol' field from attribute table, that would make features
    invisible because the renderer is based on that column.
 
 
 **Snapping**
- 
-To form an area, vertices of connected boundaries must have **exactly** the same coordinates. 
-This can be achieved using snapping tool only if canvas and vector map have the same CRS. 
-Otherwise, due conversion from map coordinates to canvas and back, the coordinate may become 
+
+To form an area, vertices of connected boundaries must have **exactly** the same coordinates.
+This can be achieved using snapping tool only if canvas and vector map have the same CRS.
+Otherwise, due conversion from map coordinates to canvas and back, the coordinate may become
 slightly different due to representation error and CRS transformations.
-   
+
 .. tip:: Use layer's CRS also for canvas when editing.
 
 
 **Limitations**
 
-Simultaneous editing of multiple layers within the same vector at the same time is not 
-supported. This is mainly due to the impossibility of handling multiple undo stacks for 
+Simultaneous editing of multiple layers within the same vector at the same time is not
+supported. This is mainly due to the impossibility of handling multiple undo stacks for
 a single data source.
 
-|nix| |osx| On Linux and Mac OSX only one GRASS layer can be edited at time. This is 
-due to a bug in GRASS which does not allow to close database drivers in random order. 
+|nix| |osx| On Linux and Mac OSX only one GRASS layer can be edited at time. This is
+due to a bug in GRASS which does not allow to close database drivers in random order.
 This is being solved with GRASS developers.
 
 
-.. tip:: **GRASS Edit Permissions** 
+.. tip:: **GRASS Edit Permissions**
 
    You must be the owner of the GRASS :file:`MAPSET` you want to edit. It is
    impossible to edit data layers in a :file:`MAPSET` that is not yours, even
@@ -560,8 +562,8 @@ canvas using the |grassRegion| :sup:`Display current GRASS region` button.
    single:GRASS;region display
 
 The region can be modified in 'Region' tab in 'GRASS Tolls' dock widget.
-Type in the new region bounds and resolution, and click **[Apply]**. 
-If you click on **[Select the extent by dragging on canvas]** you can select 
+Type in the new region bounds and resolution, and click **[Apply]**.
+If you click on **[Select the extent by dragging on canvas]** you can select
 a new region interactively with your mouse on the QGIS canvas dragging a rectangle.
 
 .. index::

--- a/source/docs/user_manual/introduction/general_tools.rst
+++ b/source/docs/user_manual/introduction/general_tools.rst
@@ -6,8 +6,10 @@
 General Tools
 *************
 
-.. contents::
-   :local:
+.. only:: html
+
+   .. contents::
+      :local:
 
 .. _`shortcuts`:
 

--- a/source/docs/user_manual/introduction/getting_started.rst
+++ b/source/docs/user_manual/introduction/getting_started.rst
@@ -6,8 +6,10 @@
 Getting Started
 ***************
 
-.. contents::
-   :local:
+.. only:: html
+
+   .. contents::
+      :local:
 
 This chapter gives a quick overview of installing QGIS, some sample data from
 the QGIS web page, and running a first and simple session visualizing raster

--- a/source/docs/user_manual/introduction/qgis_configuration.rst
+++ b/source/docs/user_manual/introduction/qgis_configuration.rst
@@ -4,8 +4,10 @@
 QGIS Configuration
 ******************
 
-.. contents::
-   :local:
+.. only:: html
+
+   .. contents::
+      :local:
 
 QGIS is highly configurable through the :menuselection:`Settings` menu. Choose
 between Panels, Toolbars, Project Properties, Options and Customization.

--- a/source/docs/user_manual/introduction/qgis_gui.rst
+++ b/source/docs/user_manual/introduction/qgis_gui.rst
@@ -6,8 +6,10 @@
 QGIS GUI
 ********
 
-.. contents::
-   :local:
+.. only:: html
+
+   .. contents::
+      :local:
 
 .. index::
    single:main window

--- a/source/docs/user_manual/plugins/plugins.rst
+++ b/source/docs/user_manual/plugins/plugins.rst
@@ -9,8 +9,10 @@
 QGIS Plugins
 *************
 
-.. contents::
-   :local:
+.. only:: html
+
+   .. contents::
+      :local:
 
 QGIS has been designed with a plugin architecture. This allows many new
 features and functions to be easily added to the application. Many of the features
@@ -18,7 +20,7 @@ in QGIS are actually implemented as plugins.
 
 Core and External plugins
 =========================
-   
+
 QGIS plugins are implemented either as **Core Plugins** or **External Plugins**.
 
 :ref:`Core Plugins <core_plugins>` are maintained by the QGIS Development Team and are
@@ -27,7 +29,7 @@ languages: C++ or Python.
 
 Most of External Plugins are currently written in Python. They are stored either in the
 'Official' QGIS Repository at http://plugins.qgis.org/plugins/ or in external
-repositories and are maintained by the individual authors. 
+repositories and are maintained by the individual authors.
 Detailed documentation about the usage, minimum QGIS version, home page, authors,
 and other important information are provided for the plugins in the Official repository.
 For other external repositories, documentation might
@@ -39,14 +41,14 @@ folder. Home directory (denoted by above ``~``) on Windows is usually something
 like :file:`C:\\Documents and Settings\\(user)` (on Windows XP or earlier)
 or :file:`C:\\Users\\(user)`.
 
-Paths to Custom C++ plugins libraries can also be added under 
+Paths to Custom C++ plugins libraries can also be added under
 :menuselection:`Settings --> Options --> System`.
 
-You can manage your plugins in the plugin dialog which can be opened with 
+You can manage your plugins in the plugin dialog which can be opened with
 :guilabel:`Plugins > Manage and install plugins ...`.
 
-When a plugin needs to be updated, and if plugins settings have been set up 
-accordingly, QGIS main interface will display a blue link in the status bar 
+When a plugin needs to be updated, and if plugins settings have been set up
+accordingly, QGIS main interface will display a blue link in the status bar
 to inform you that there are updates for your plugins waiting to be applied.
 
 .. :index::
@@ -54,7 +56,7 @@ to inform you that there are updates for your plugins waiting to be applied.
 
 .. _managing_plugins:
 
-The Plugins Dialog 
+The Plugins Dialog
 ===================
 
 The menus in the Plugins dialog allow the user to install, uninstall and upgrade plugins in
@@ -72,8 +74,8 @@ You can use the filter to find a specific plugin.
 
 |showPluginManager| :guilabel:`All`
 
-Here, all the available plugins are listed, including both core and external plugins. 
-Use **[Upgrade all]** to look for new versions of the plugins. Furthermore, 
+Here, all the available plugins are listed, including both core and external plugins.
+Use **[Upgrade all]** to look for new versions of the plugins. Furthermore,
 you can use **[Install plugin]** if a plugin is listed but not installed,
 **[Uninstall plugin]** as well as **[Reinstall plugin]** if a plugin is installed.
 An installed plugin can be temporarily de/activated using the checkbox.
@@ -129,7 +131,7 @@ You can use the **[Install plugin]** button to implement a plugin into QGIS.
 
 If you activated |checkbox| :guilabel:`Show also experimental plugins` in the
 |transformSettings| :guilabel:`Settings` menu, you can use this menu
-to look for more recent plugin versions. This can be done with the **[Upgrade plugin]** or 
+to look for more recent plugin versions. This can be done with the **[Upgrade plugin]** or
 **[Upgrade all]** buttons.
 
 .. _figure_plugins_4:
@@ -145,14 +147,14 @@ to look for more recent plugin versions. This can be done with the **[Upgrade pl
 
 .. _setting_plugins:
 
-|transformSettings| :guilabel:`Settings` 
+|transformSettings| :guilabel:`Settings`
 
 In this menu, you can use the following options:
 
 * |checkbox| :guilabel:`Check for updates on startup`. Whenever a new plugin or
   a plugin update is available, QGIS will inform you 'every time QGIS starts', 'once a day',
   'every 3 days', 'every week', 'every 2 weeks' or 'every month'.
-* |checkbox| :guilabel:`Show also experimental plugins`. QGIS will show you 
+* |checkbox| :guilabel:`Show also experimental plugins`. QGIS will show you
   plugins in early stages of development, which are generally unsuitable for production
   use.
 * |checkbox| :guilabel:`Show also deprecated plugins`. These plugins are deprecated

--- a/source/docs/user_manual/plugins/plugins_evis.rst
+++ b/source/docs/user_manual/plugins/plugins_evis.rst
@@ -5,8 +5,10 @@
 eVis Plugin
 ===========
 
-.. contents::
-   :local:
+.. only:: html
+
+   .. contents::
+      :local:
 
 (This section is derived
 from Horning, N., K. Koy, P. Ersts. 2009. eVis (v1.1.0) User's Guide. American
@@ -14,7 +16,7 @@ Museum of Natural History, Center for Biodiversity and Conservation. Available
 from http://biodiversityinformatics.amnh.org/, and released under the GNU FDL.)
 
 The Biodiversity Informatics Facility at the American Museum of Natural History's
-(AMNH) Center for Biodiversity and Conservation (CBC) 
+(AMNH) Center for Biodiversity and Conservation (CBC)
 has developed the Event Visualization Tool (eVis), another software tool to add
 to the suite of conservation monitoring and decision support tools for guiding
 protected area and landscape planning. This plugin enables users to easily link

--- a/source/docs/user_manual/plugins/plugins_ftools.rst
+++ b/source/docs/user_manual/plugins/plugins_ftools.rst
@@ -5,8 +5,10 @@
 fTools Plugin
 =============
 
-.. contents::
-   :local:
+.. only:: html
+
+   .. contents::
+      :local:
 
 The goal of the fTools Python plugin is to provide a one-stop resource for many
 common vector-based GIS tasks, without the need for additional software,

--- a/source/docs/user_manual/plugins/plugins_gdaltools.rst
+++ b/source/docs/user_manual/plugins/plugins_gdaltools.rst
@@ -5,8 +5,10 @@
 GDAL Tools Plugin
 =================
 
-.. contents::
-   :local:
+.. only:: html
+
+   .. contents::
+      :local:
 
 .. _`whatsgdal`:
 

--- a/source/docs/user_manual/plugins/plugins_georeferencer.rst
+++ b/source/docs/user_manual/plugins/plugins_georeferencer.rst
@@ -5,8 +5,10 @@
 Georeferencer Plugin
 ====================
 
-.. contents::
-   :local:
+.. only:: html
+
+   .. contents::
+      :local:
 
 The Georeferencer Plugin is a tool for generating world files for rasters. It
 allows you to reference rasters to geographic or projected coordinate systems by

--- a/source/docs/user_manual/plugins/plugins_heatmap.rst
+++ b/source/docs/user_manual/plugins/plugins_heatmap.rst
@@ -5,8 +5,10 @@
 Heatmap Plugin
 ==============
 
-.. contents::
-   :local:
+.. only:: html
+
+   .. contents::
+      :local:
 
 The `Heatmap` plugin uses Kernel Density Estimation to create a density (heatmap)
 raster of an input point vector layer. The density is calculated based on the

--- a/source/docs/user_manual/plugins/plugins_metasearch.rst
+++ b/source/docs/user_manual/plugins/plugins_metasearch.rst
@@ -5,8 +5,10 @@
 MetaSearch Catalogue Client
 ===========================
 
-.. contents::
-   :local:
+.. only:: html
+
+   .. contents::
+      :local:
 
 
 Introduction

--- a/source/docs/user_manual/plugins/plugins_oracle_raster.rst
+++ b/source/docs/user_manual/plugins/plugins_oracle_raster.rst
@@ -5,8 +5,10 @@
 Oracle Spatial GeoRaster Plugin
 ===============================
 
-.. contents::
-   :local:
+.. only:: html
+
+   .. contents::
+      :local:
 
 In Oracle databases, raster data can be stored in SDO_GEORASTER objects available
 with the Oracle Spatial extension. In QGIS, the |oracleRaster|

--- a/source/docs/user_manual/preamble/conventions.rst
+++ b/source/docs/user_manual/preamble/conventions.rst
@@ -6,13 +6,15 @@
 Conventions
 ***********
 
-.. contents::
-   :local:
+.. only:: html
+
+   .. contents::
+      :local:
 
 This section describes the uniform styles that will be used throughout
 this manual.
 
-GUI Conventions 
+GUI Conventions
 ---------------
 
 The GUI convention styles are intended to mimic the appearance of the
@@ -40,7 +42,7 @@ instruction in the manual.
 
 A shadow indicates a clickable GUI component.
 
-Text or Keyboard Conventions 
+Text or Keyboard Conventions
 ----------------------------
 
 This manual also includes styles related to text, keyboard commands
@@ -70,7 +72,7 @@ Lines of code are indicated by a fixed-width font:
     PROJCS["NAD_1927_Albers",
       GEOGCS["GCS_North_American_1927",
 
-Platform-specific instructions 
+Platform-specific instructions
 ------------------------------
 
 GUI sequences and small amounts of text may be formatted inline: Click

--- a/source/docs/user_manual/preamble/features.rst
+++ b/source/docs/user_manual/preamble/features.rst
@@ -6,8 +6,10 @@
 Features
 ********
 
-.. contents::
-   :local:
+.. only:: html
+
+   .. contents::
+      :local:
 
 QGIS offers many common GIS functionalities provided by core features
 and plugins. A short summary of six general categories of features and

--- a/source/docs/user_manual/preamble/help_and_support.rst
+++ b/source/docs/user_manual/preamble/help_and_support.rst
@@ -6,10 +6,12 @@
 Help and Support
 ****************
 
-.. contents::
-   :local:
+.. only:: html
 
-Mailing lists 
+   .. contents::
+      :local:
+
+Mailing lists
 =============
 
 QGIS is under active development and as such it won't always work like
@@ -17,7 +19,7 @@ you expect it to. The preferred way to get help is by joining the
 qgis-users mailing list. Your questions will reach a broader audience
 and answers will benefit others.
 
-qgis-users 
+qgis-users
 ----------
 
 This mailing list is used for discussion of QGIS in general, as well
@@ -25,7 +27,7 @@ as specific questions regarding its installation and use. You can
 subscribe to the qgis-users mailing list by visiting the following
 URL: http://lists.osgeo.org/mailman/listinfo/qgis-user
 
-fossgis-talk-liste 
+fossgis-talk-liste
 ------------------
 
 For the German-speaking audience, the German FOSSGIS e.V. provides the
@@ -35,7 +37,7 @@ subscribe to the fossgis-talk-liste mailing list by visiting the
 following URL:
 https://lists.fossgis.de/mailman/listinfo/fossgis-talk-liste
 
-qgis-developer 
+qgis-developer
 --------------
 
 If you are a developer facing problems of a more technical nature, you
@@ -50,7 +52,7 @@ related UX (User Experience) / usability issues.
 
 http://lists.osgeo.org/mailman/listinfo/qgis-ux
 
-qgis-commit 
+qgis-commit
 -----------
 
 Each time a commit is made to the QGIS code repository, an email is
@@ -58,14 +60,14 @@ posted to this list. If you want to be up-to-date with every change to
 the current code base, you can subscribe to this list at:
 http://lists.osgeo.org/mailman/listinfo/qgis-commit
 
-qgis-trac 
+qgis-trac
 ---------
 
 This list provides email notification related to project management,
 including bug reports, tasks, and feature requests. You can subscribe
 to this list at: http://lists.osgeo.org/mailman/listinfo/qgis-trac
 
-qgis-community-team 
+qgis-community-team
 -------------------
 
 This list deals with topics like documentation, context help, user
@@ -75,7 +77,7 @@ list is a good starting point to ask your questions. You can subscribe
 to this list at:
 http://lists.osgeo.org/mailman/listinfo/qgis-community-team
 
-qgis-release-team 
+qgis-release-team
 -----------------
 
 This list deals with topics like the release process, packaging
@@ -83,7 +85,7 @@ binaries for various OSs and announcing new releases to the world at
 large. You can subscribe to this list at:
 http://lists.osgeo.org/mailman/listinfo/qgis-release-team
 
-qgis-tr 
+qgis-tr
 -------
 
 This list deals with the translation efforts. If you like to work on
@@ -92,7 +94,7 @@ this list is a good starting point to ask your questions. You can
 subscribe to this list at:
 http://lists.osgeo.org/mailman/listinfo/qgis-tr
 
-qgis-edu 
+qgis-edu
 --------
 
 This list deals with QGIS education efforts. If you would like to work
@@ -100,7 +102,7 @@ on QGIS education materials, this list is a good starting point to ask
 your questions. You can subscribe to this list at:
 http://lists.osgeo.org/mailman/listinfo/qgis-edu
 
-qgis-psc 
+qgis-psc
 --------
 
 This list is used to discuss Steering Committee issues related to
@@ -112,7 +114,7 @@ contribute to the list by answering questions and sharing your
 experiences. Note that the qgis-commit and qgis-trac lists are
 designed for notification only and are not meant for user postings.
 
-IRC 
+IRC
 ===
 
 We also maintain a presence on IRC - visit us by joining the #qgis
@@ -126,7 +128,7 @@ IRC-logs.
 Commercial support for QGIS is also available. Check the website
 http://qgis.org/en/commercial-support.html for more information.
 
-BugTracker 
+BugTracker
 ==========
 
 While the qgis-users mailing list is useful for general 'How do I do
@@ -144,19 +146,19 @@ available for this.
 Feature requests can be submitted as well using the same ticket system
 as for bugs. Please make sure to select the type ``Feature``.
 
-If you have found a bug and fixed it yourself, you can submit either a 
-Pull Request on the Github QGIS Project (prefered) or a patch also. 
-The lovely redmine ticketsystem at 
+If you have found a bug and fixed it yourself, you can submit either a
+Pull Request on the Github QGIS Project (prefered) or a patch also.
+The lovely redmine ticketsystem at
 http://hub.qgis.org/wiki/quantum-gis/issues has this type as well.
 Check the ``Patch supplied`` checkbox and attach your patch before
 submitting your bug. One of the developers will review it and apply it
 to QGIS. Please don't be alarmed if your patch is not applied straight
-away -- developers may be tied up with other commitments. 
+away -- developers may be tied up with other commitments.
 
-Note that if you supply a Pull Request, your change would be more 
+Note that if you supply a Pull Request, your change would be more
 likely be merged into the source code!
 
-Blog 
+Blog
 ====
 
 The QGIS community also runs a weblog at
@@ -164,14 +166,14 @@ http://planet.qgis.org/planet/, which has some interesting articles
 for users and developers as well provided by other blogs in the
 community. You are invited to contribute your own QGIS blog!
 
-Plugins 
+Plugins
 =======
 
 The website http://plugins.qgis.org provides the official QGIS plugins
 web portal. Here, you find a list of all stable and experimental QGIS
 plugins available via the 'Official QGIS Plugin Repository'.
 
-Wiki 
+Wiki
 ====
 
 Lastly, we maintain a WIKI web site at

--- a/source/docs/user_manual/print_composer/composer_items/composer_arrow.rst
+++ b/source/docs/user_manual/print_composer/composer_items/composer_arrow.rst
@@ -5,19 +5,21 @@
 The Arrow Item
 ===============
 
-.. contents::
-   :local:
+.. only:: html
 
-To add an arrow, click the |addArrow| :sup:`Add Arrow` icon, place the element holding 
-down the left mouse button and drag a line to draw the arrow on the Print Composer canvas and 
+   .. contents::
+      :local:
+
+To add an arrow, click the |addArrow| :sup:`Add Arrow` icon, place the element holding
+down the left mouse button and drag a line to draw the arrow on the Print Composer canvas and
 position and customize the appearance in the scale bar :guilabel:`Item Properties` tab.
 
-When you also hold down the :kbd:`Shift` key while placing the arrow, it is placed in an angle 
+When you also hold down the :kbd:`Shift` key while placing the arrow, it is placed in an angle
 of exactly 45\ |degrees| .
 
-The arrow item can be used to add a line or a simple arrow that can be used, for example, to 
-show the relation between other print composer items. To create a north arrow, the image item should 
-be considered first. QGIS has a set of North arrows in SVG format. Furthermore you can connect 
+The arrow item can be used to add a line or a simple arrow that can be used, for example, to
+show the relation between other print composer items. To create a north arrow, the image item should
+be considered first. QGIS has a set of North arrows in SVG format. Furthermore you can connect
 an image item with a map so it can rotate automatically with the map (see :ref:`image_item`).
 
 .. _figure_composer_arrow:
@@ -39,8 +41,8 @@ The :guilabel:`Arrow` item properties tab allows you to configure an arrow item.
 The  **[Line style ...]** button can be used to set the line style using the line style symbol editor.
 
 In :guilabel:`Arrows markers` you can select one of three radio buttons.
- 
-* :guilabel:`Default`: To draw a regular arrow, gives you options to style the arrow head 
+
+* :guilabel:`Default`: To draw a regular arrow, gives you options to style the arrow head
 * :guilabel:`None`: To draw a line without arrow head
 * :guilabel:`SVG Marker`: To draw a line with an SVG :guilabel:`Start marker` and/or :guilabel:`End marker`
 
@@ -50,8 +52,8 @@ For :guilabel:`Default` Arrow marker you can use following options to style the 
 * :guilabel:`Arrow fill color`: Set the fill color of the arrow head
 * :guilabel:`Arrow outline width`: Set the outline width of the arrow head
 * :guilabel:`Arrow head width`: Set the size of the arrow head
-  
-For :guilabel:`SVG Marker` you can use following options. 
+
+For :guilabel:`SVG Marker` you can use following options.
 
 * :guilabel:`Start marker`: Choose an SVG image to draw at the beginning of the line
 * :guilabel:`End marker`: Choose an SVG image to draw at the end of the line

--- a/source/docs/user_manual/print_composer/composer_items/composer_attribute_table.rst
+++ b/source/docs/user_manual/print_composer/composer_items/composer_attribute_table.rst
@@ -6,12 +6,14 @@
 The Attribute Table Item
 ========================
 
-.. contents::
-   :local:
+.. only:: html
+
+   .. contents::
+      :local:
 
 It is possible to add parts of a vector attribute table to the Print Composer
-canvas: Click the |openTable| :sup:`Add attribute table` icon, click and drag 
-with the left mouse button on the Print Composer canvas to place and size the item. 
+canvas: Click the |openTable| :sup:`Add attribute table` icon, click and drag
+with the left mouse button on the Print Composer canvas to place and size the item.
 You can better position and customize its appearance in the :guilabel:`Item Properties` tab.
 
 The :guilabel:`Item properties` tab of an attribute table provides the following
@@ -32,7 +34,7 @@ functionalities (see figure_composer_table_1_):
 Main properties
 ---------------
 
-The :guilabel:`Main properties` dialog of the attribute table` provides the 
+The :guilabel:`Main properties` dialog of the attribute table` provides the
 following functionalities (see figure_composer_table_2_):
 
 .. _Figure_composer_table_2:
@@ -46,19 +48,19 @@ following functionalities (see figure_composer_table_2_):
 
    Attribute table Main properties Dialog |nix|
 
-* For :guilabel:`Source` you can normally select only 'Layer features'. 
+* For :guilabel:`Source` you can normally select only 'Layer features'.
 * With :guilabel:`Layer` you can choose from the vector layers loaded in the project.
-* In case you activated the |checkbox|:guilabel:`Generate an atlas` option in the 
+* In case you activated the |checkbox|:guilabel:`Generate an atlas` option in the
   :guilabel:`Atlas generation` tab, there are two additional :guilabel:`Source` possible:
   'Current atlas feature' (see figure_composer_table_2b_) and 'Relation children'
   (see figure_composer_table_2c_). Choosing the 'Current atlas feature'
-  you won't see any option to choose the layer, and the table item will only 
-  show a row with the attributes from the current feature of the atlas coverage layer. 
+  you won't see any option to choose the layer, and the table item will only
+  show a row with the attributes from the current feature of the atlas coverage layer.
   Choosing 'Relation children', an option with the relation names will show up.
-  The 'Relation children' option can only be used if you have defined a relation using 
-  your atlas coverage layer as parent, and the table will show the children rows of 
+  The 'Relation children' option can only be used if you have defined a relation using
+  your atlas coverage layer as parent, and the table will show the children rows of
   the atlas coverage layer's current feature (for further information about the atlas generation, see :ref:`atlas_generation`).
-* The button **[Refresh table data]** can be used to refresh the table when the actual 
+* The button **[Refresh table data]** can be used to refresh the table when the actual
   contents of the table has changed.
 
 
@@ -70,7 +72,7 @@ following functionalities (see figure_composer_table_2_):
 
 .. figure:: /static/user_manual/print_composer/attribute_mainatlas.png
    :align: center
-  
+
    Attribute table Main properties for 'Current atlas feature' |nix|
 
 
@@ -86,9 +88,9 @@ following functionalities (see figure_composer_table_2_):
    Attribute table Main properties for 'Relation children' |nix|
 
 
-* The button **[Attributes...]** starts the :guilabel:`Select attributes` menu, see 
+* The button **[Attributes...]** starts the :guilabel:`Select attributes` menu, see
   figure_composer_table_3_, that can be used to change the visible contents of the table.
-  After making changes use the **[OK]** button to apply changes to the table. The upper part of 
+  After making changes use the **[OK]** button to apply changes to the table. The upper part of
   the window shows the list of the attributes to display and the lower part helps to set the way the data is sorted.
 
   .. _Figure_composer_table_3:
@@ -103,34 +105,34 @@ following functionalities (see figure_composer_table_2_):
      Attribute table Select attributes Dialog |nix|
 
   In the :guilabel:`Columns` section you can:
-  
-  * Remove an attribute, just select an attribute row by clicking anywhere in the row 
-    and press the minus button to remove the selected attribute. 
-  * Add a new attribute use the plus button. At the end a new empty row appears and you can 
-    select empty cell of the column :guilabel:`Attribute`. You can select a field attribute from 
-    the list or you can select to build a new attribute using a regular expression 
-    (|expression| button). Of course you can modify every already existing attribute 
+
+  * Remove an attribute, just select an attribute row by clicking anywhere in the row
+    and press the minus button to remove the selected attribute.
+  * Add a new attribute use the plus button. At the end a new empty row appears and you can
+    select empty cell of the column :guilabel:`Attribute`. You can select a field attribute from
+    the list or you can select to build a new attribute using a regular expression
+    (|expression| button). Of course you can modify every already existing attribute
     by means of a regular expression.
   * Use the up and down arrows to change the order of the attributes in the table.
   * Select a cell in the Headings column and, to change the heading, just type in a new name.
   * set a precise Alignment (mixing vertical and horizontal alignment options) for each column.
-  * Select a cell in the Width column and change it from Automatic to a width in mm, just 
+  * Select a cell in the Width column and change it from Automatic to a width in mm, just
     type a number. When you want to change it back to Automatic, use the cross.
   * The **[Reset]** button can always be used to restore it to the original attribute settings.
 
   In the :guilabel:`Sorting` section you can:
-  
-  * Add an attribute to sort the table with. Select an attribute and set the sorting order 
+
+  * Add an attribute to sort the table with. Select an attribute and set the sorting order
     to 'Ascending' or 'Descending' and press the plus button. A new line is added to the sort order list.
-  * select a row in the list and use the up and down button to change the sort priority on attribute level. 
-    Selecting a cell in the Sort Order column helps you change the sorting order of the attribute field. 
+  * select a row in the list and use the up and down button to change the sort priority on attribute level.
+    Selecting a cell in the Sort Order column helps you change the sorting order of the attribute field.
   * use the minus button to remove an attribute from the sort order list.
 
 
 Feature filtering
 -----------------
 
-The :guilabel:`Feature filtering` dialog of the attribute table provides 
+The :guilabel:`Feature filtering` dialog of the attribute table provides
 the following functionalities (see figure_composer_table_4_):
 
 .. _Figure_composer_table_4:
@@ -144,33 +146,33 @@ the following functionalities (see figure_composer_table_4_):
 
    Attribute table Feature filtering Dialog |nix|
 
-You can: 
+You can:
 
 * Define the :guilabel:`Maximum rows` to be displayed.
-* Activate |checkbox| :guilabel:`Remove duplicate rows from table` to show unique records only. 
-* Activate |checkbox| :guilabel:`Show only visible features within a map` and select the 
-  corresponding :guilabel:`Composer map` to display the attributes of features only visible 
-  on selected map. 
-* Activate |checkbox| :guilabel:`Show only features intersecting Atlas feature` is only 
+* Activate |checkbox| :guilabel:`Remove duplicate rows from table` to show unique records only.
+* Activate |checkbox| :guilabel:`Show only visible features within a map` and select the
+  corresponding :guilabel:`Composer map` to display the attributes of features only visible
+  on selected map.
+* Activate |checkbox| :guilabel:`Show only features intersecting Atlas feature` is only
   available when |checkbox| :guilabel:`Generate an atlas` is activated. When activated it will
   show a table with only the features shown on the map of that particular page of the atlas.
-* Activate |checkbox| :guilabel:`Filter with` and provide a filter by typing in the input line 
-  or insert a regular expression using the given |expression| expression button. 
-  A few examples of filtering statements you can use when you have loaded the airports 
+* Activate |checkbox| :guilabel:`Filter with` and provide a filter by typing in the input line
+  or insert a regular expression using the given |expression| expression button.
+  A few examples of filtering statements you can use when you have loaded the airports
   layer from the Sample dataset:
 
   * ``ELEV > 500``
-  * ``NAME = 'ANIAK'`` 
-  * ``NAME NOT LIKE 'AN%'`` 
+  * ``NAME = 'ANIAK'``
+  * ``NAME NOT LIKE 'AN%'``
   * ``regexp_match( attribute( $currentfeature, 'USE' )  , '[i]')``
 
-  The last regular expression will include only the airports that have a letter 'i' 
-  in the attribute field 'USE'. 
+  The last regular expression will include only the airports that have a letter 'i'
+  in the attribute field 'USE'.
 
 Appearance
 ----------
 
-The :guilabel:`Appearance` dialog of the attribute table provides 
+The :guilabel:`Appearance` dialog of the attribute table provides
 the following functionalities  (see figure_composer_table_5_):
 
 .. _Figure_composer_table_5:
@@ -184,25 +186,25 @@ the following functionalities  (see figure_composer_table_5_):
 
    Attribute table appearance Dialog |nix|
 
-* Click |checkbox| :guilabel:`Show empty rows` to fill the attribute table with empty cells. 
+* Click |checkbox| :guilabel:`Show empty rows` to fill the attribute table with empty cells.
   This option can also be used to provide additional empty cells when you have a result to show!
 * With :guilabel:`Cell margins` you can define the margin around text in each cell of the table.
-* With :guilabel:`Display header` you can select from a list one of 'On first frame', 
+* With :guilabel:`Display header` you can select from a list one of 'On first frame',
   'On all frames' default option, or 'No header'.
 * The option :guilabel:`Empty table` controls what will be displayed when the result selection is empty.
 
   * **Draw headers only**, will only draw the header except if you have chosen 'No header' for :guilabel:`Display header`.
-  * **Hide entire table**, will only draw the background of the table. You can 
-    activate |checkbox| :guilabel:`Don't draw background if frame is empty` in :guilabel:`Frames` 
+  * **Hide entire table**, will only draw the background of the table. You can
+    activate |checkbox| :guilabel:`Don't draw background if frame is empty` in :guilabel:`Frames`
     to completely hide the table.
-  * **Show set message**, will draw the header and adds a cell spanning all columns and 
-    display a message like 'No result' that can be provided in the option :guilabel:`Message to display`  
+  * **Show set message**, will draw the header and adds a cell spanning all columns and
+    display a message like 'No result' that can be provided in the option :guilabel:`Message to display`
 
-* The option :guilabel:`Message to display` is only activated when you have selected 
-  **Show set message** for :guilabel:`Empty table`. The message provided will be shown in 
+* The option :guilabel:`Message to display` is only activated when you have selected
+  **Show set message** for :guilabel:`Empty table`. The message provided will be shown in
   the table in the first row, when the result is an empty table.
-* With :guilabel:`Background color` you can set the background color of the table. 
-  The :guilabel:`Advanced customization` option helps you define different background colors 
+* With :guilabel:`Background color` you can set the background color of the table.
+  The :guilabel:`Advanced customization` option helps you define different background colors
   for each cell (see figure_composer_table_6_)
 
    .. _Figure_composer_table_6:
@@ -216,16 +218,16 @@ the following functionalities  (see figure_composer_table_5_):
 
    Attribute table Advanced Background Dialog |nix|
 
-* With the :guilabel:`Wrap text on` option, you can define a character on which 
+* With the :guilabel:`Wrap text on` option, you can define a character on which
   the cell content will be wraped each time it is met
-* With :guilabel:`Oversized text` you define the behaviour when the width set for a column is 
+* With :guilabel:`Oversized text` you define the behaviour when the width set for a column is
   smaller than its content's length. It can be **Wrap text** or **Truncate text**.
 
 
 Show grid
 ---------
 
-The :guilabel:`Show grid` dialog of the attribute table provides 
+The :guilabel:`Show grid` dialog of the attribute table provides
 the following functionalities (see figure_composer_table_7_):
 
    .. _Figure_composer_table_7:
@@ -239,15 +241,15 @@ the following functionalities (see figure_composer_table_7_):
 
    Attribute table Show grid Dialog |nix|
 
-* Activate |checkbox| :guilabel:`Show grid` when you want to display the grid, the outlines of the table cells. 
+* Activate |checkbox| :guilabel:`Show grid` when you want to display the grid, the outlines of the table cells.
 * With :guilabel:`Line width` you can set the thickness of the lines used in the grid.
-* The :guilabel:`Color` of the grid can be set using the color selection dialog. 
+* The :guilabel:`Color` of the grid can be set using the color selection dialog.
 
 
 Fonts and text styling
 ----------------------
 
-The :guilabel:`Fonts and text styling` dialog of the attribute table 
+The :guilabel:`Fonts and text styling` dialog of the attribute table
 provides the following functionalities (see figure_composer_table_8_):
 
    .. _Figure_composer_table_8:
@@ -262,15 +264,15 @@ provides the following functionalities (see figure_composer_table_8_):
    Attribute table Fonts and text styling Dialog |nix|
 
 * You can define :guilabel:`Font` and :guilabel:`Color` for :guilabel:`Table heading` and :guilabel:`Table contents`.
-* For :guilabel:`Table heading` you can additionally set the :guilabel:`Alignment` to 
-  `Follow column alignment` or override this setting by choosing `Left`, `Center` or `Right`. 
-  The column alignment is set using the :guilabel:`Select Attributes` dialog (see Figure_composer_table_3_ ).  
+* For :guilabel:`Table heading` you can additionally set the :guilabel:`Alignment` to
+  `Follow column alignment` or override this setting by choosing `Left`, `Center` or `Right`.
+  The column alignment is set using the :guilabel:`Select Attributes` dialog (see Figure_composer_table_3_ ).
 
 
 Frames
 -------
 
-The :guilabel:`Frames` dialog of the attribute table provides 
+The :guilabel:`Frames` dialog of the attribute table provides
 the following functionalities (see figure_composer_table_9_):
 
    .. _Figure_composer_table_9:
@@ -287,19 +289,19 @@ the following functionalities (see figure_composer_table_9_):
 * With :guilabel:`Resize mode` you can select how to render the attribute table contents:
 
   * `Use existing frames` displays the result in the first frame and added frames only.
-  * `Extend to next page` will create as many frames (and corresponding pages) as necessary 
-    to display the full selection of attribute table. Each frame can be moved around on the layout. 
-    If you resize a frame, the resulting table will be divided up between the other frames. 
+  * `Extend to next page` will create as many frames (and corresponding pages) as necessary
+    to display the full selection of attribute table. Each frame can be moved around on the layout.
+    If you resize a frame, the resulting table will be divided up between the other frames.
     The last frame will be trimmed to fit the table.
-  * `Repeat until finished` will also create as many frames as the `Extend to next page` option, 
+  * `Repeat until finished` will also create as many frames as the `Extend to next page` option,
     except all frames will have the same size.
 
-* Use the **[Add Frame]** button to add another frame with the same size as selected frame. 
-  The result of the table that will not fit in the first frame will continue in the next frame 
-  when you use the Resize mode `Use existing frames`. 
-* Activate |checkbox| :guilabel:`Don't export page if frame is empty` prevents the page 
-  to be exported when the table frame has no contents. This means all other composer items, 
-  maps, scalebars, legends etc. will not be visible in the result.  
-* Activate |checkbox| :guilabel:`Don't draw background if frame is empty` prevents the background 
+* Use the **[Add Frame]** button to add another frame with the same size as selected frame.
+  The result of the table that will not fit in the first frame will continue in the next frame
+  when you use the Resize mode `Use existing frames`.
+* Activate |checkbox| :guilabel:`Don't export page if frame is empty` prevents the page
+  to be exported when the table frame has no contents. This means all other composer items,
+  maps, scalebars, legends etc. will not be visible in the result.
+* Activate |checkbox| :guilabel:`Don't draw background if frame is empty` prevents the background
   to be drawn when the table frame has no contents.
 

--- a/source/docs/user_manual/print_composer/composer_items/composer_html_frame.rst
+++ b/source/docs/user_manual/print_composer/composer_items/composer_html_frame.rst
@@ -5,15 +5,17 @@
 The HTML Frame Item
 ====================
 
-.. contents::
-   :local:
+.. only:: html
+
+   .. contents::
+      :local:
 
 It is possible to add a frame that displays the contents of a website or even create and style
 your own HTML page and display it!
- 
-Click the |addHtml| :sup:`Add HTML frame` icon, place the element by dragging a 
-rectangle holding down the left mouse button on the Print Composer canvas and position 
-and customize the appearance in the :guilabel:`Item Properties` tab 
+
+Click the |addHtml| :sup:`Add HTML frame` icon, place the element by dragging a
+rectangle holding down the left mouse button on the Print Composer canvas and position
+and customize the appearance in the :guilabel:`Item Properties` tab
 (see figure_composer_html_1_).
 
 .. _Figure_composer_html_1:
@@ -31,8 +33,8 @@ and customize the appearance in the :guilabel:`Item Properties` tab
 HTML Source
 ------------
 
-As an HTML source, you can either set a URL and activate the URL radiobutton or 
-enter the HTML source directly in the textbox provided and activate the Source radiobutton. 
+As an HTML source, you can either set a URL and activate the URL radiobutton or
+enter the HTML source directly in the textbox provided and activate the Source radiobutton.
 
 The :guilabel:`HTML Source` dialog of the HTML frame :guilabel:`Item Properties` tab
 provides the following functionalities (see figure_composer_html_2_):
@@ -48,19 +50,19 @@ provides the following functionalities (see figure_composer_html_2_):
 
    HTML frame, the HTML Source properties |nix|
 
-* In :guilabel:`URL` you can enter the URL of a webpage you copied from your internet 
-  browser or select an HTML file using the browse button |browseButton|. There is also the 
-  option to use the Data defined override button, to provide an URL from the contents of an 
-  attribute field of a table or using a regular expression. 
-* In :guilabel:`Source` you can enter text in the textbox with some HTML tags or provide a full 
+* In :guilabel:`URL` you can enter the URL of a webpage you copied from your internet
+  browser or select an HTML file using the browse button |browseButton|. There is also the
+  option to use the Data defined override button, to provide an URL from the contents of an
+  attribute field of a table or using a regular expression.
+* In :guilabel:`Source` you can enter text in the textbox with some HTML tags or provide a full
   HTML page.
-* The **[insert an expression]** button can be used to insert an expression like 
-  ``[%Year($now)%]`` in the Source textbox to display the current year. This button is only 
-  activated when radiobutton :guilabel:`Source` is selected. After inserting the expression 
-  click somewhere in the textbox before refreshing the HTML frame, otherwise you will 
+* The **[insert an expression]** button can be used to insert an expression like
+  ``[%Year($now)%]`` in the Source textbox to display the current year. This button is only
+  activated when radiobutton :guilabel:`Source` is selected. After inserting the expression
+  click somewhere in the textbox before refreshing the HTML frame, otherwise you will
   lose the expression.
-* Activate |checkbox| :guilabel:`Evaluate QGIS expressions in HTML code` to see the result of 
-  the expression you have included, otherwise you will see the expression instead. 
+* Activate |checkbox| :guilabel:`Evaluate QGIS expressions in HTML code` to see the result of
+  the expression you have included, otherwise you will see the expression instead.
 * Use the **[Refresh HTML]** button to refresh the HTML frame(s) to see the result of
   changes.
 
@@ -85,32 +87,32 @@ provides the following functionalities (see figure_composer_html_3_):
 * With :guilabel:`Resize mode` you can select how to render the HTML contents:
 
   * `Use existing frames` displays the result in the first frame and added frames only.
-  * `Extend to next page` will create as many frames (and corresponding pages) as 
-    necessary to render the height of the web page. Each frame can be moved around on 
-    the layout. If you resize a frame, the webpage will be divided up between the 
+  * `Extend to next page` will create as many frames (and corresponding pages) as
+    necessary to render the height of the web page. Each frame can be moved around on
+    the layout. If you resize a frame, the webpage will be divided up between the
     other frames. The last frame will be trimmed to fit the web page.
-  * `Repeat on every page` will repeat the upper left of the web page on every page 
+  * `Repeat on every page` will repeat the upper left of the web page on every page
     in frames of the same size.
-  * `Repeat until finished` will also create as many frames as the 
+  * `Repeat until finished` will also create as many frames as the
     `Extend to next page` option, except all frames will have the same size.
 
-* Use the **[Add Frame]** button to add another frame with the same size as selected 
-  frame. If the HTML page that will not fit in the first frame it will continue 
-  in the next frame when you use :guilabel:`Resize mode` or :guilabel:`Use 
-  existing frames`. 
-* Activate |checkbox| :guilabel:`Don't export page if frame is empty` prevents 
-  the map layout from being exported when the frame has no HTML contents. This 
-  means all other composer items, 
-  maps, scalebars, legends etc. will not be visible in the result.  
-* Activate |checkbox| :guilabel:`Don't draw background if frame is empty` 
+* Use the **[Add Frame]** button to add another frame with the same size as selected
+  frame. If the HTML page that will not fit in the first frame it will continue
+  in the next frame when you use :guilabel:`Resize mode` or :guilabel:`Use
+  existing frames`.
+* Activate |checkbox| :guilabel:`Don't export page if frame is empty` prevents
+  the map layout from being exported when the frame has no HTML contents. This
+  means all other composer items,
+  maps, scalebars, legends etc. will not be visible in the result.
+* Activate |checkbox| :guilabel:`Don't draw background if frame is empty`
   prevents the HTML frame being drawn if the frame is empty.
 
 
 Use smart page breaks and User style sheet
 -------------------------------------------
 
-The :guilabel:`Use smart page breaks` dialog and :guilabel:`Use style sheet` dialog of 
-the HTML frame :guilabel:`Item Properties` tab provides the following functionalities 
+The :guilabel:`Use smart page breaks` dialog and :guilabel:`Use style sheet` dialog of
+the HTML frame :guilabel:`Item Properties` tab provides the following functionalities
 (see figure_composer_html_4_):
 
 .. _Figure_composer_html_4:
@@ -124,19 +126,19 @@ the HTML frame :guilabel:`Item Properties` tab provides the following functional
 
    HTML frame, Use smart page breaks and User stylesheet properties |nix|
 
-* Activate |checkbox| :guilabel:`Use smart page breaks` to prevent the html frame contents 
-  from breaking mid-way a line of text so it continues nice and smooth in the next frame. 
-* Set the :guilabel:`Maximum distance` allowed when calculating where to place page 
-  breaks in the html. This distance is the maximum amount of empty space allowed at the 
-  bottom of a frame after calculating the optimum break location. Setting a larger value 
-  will result in better choice of page break location, but more wasted space at the bottom 
+* Activate |checkbox| :guilabel:`Use smart page breaks` to prevent the html frame contents
+  from breaking mid-way a line of text so it continues nice and smooth in the next frame.
+* Set the :guilabel:`Maximum distance` allowed when calculating where to place page
+  breaks in the html. This distance is the maximum amount of empty space allowed at the
+  bottom of a frame after calculating the optimum break location. Setting a larger value
+  will result in better choice of page break location, but more wasted space at the bottom
   of frames. This is only used when :guilabel:`Use smart page breaks` is activated.
-* Activate |checkbox| :guilabel:`User stylesheet` to apply HTML styles that often is provided 
+* Activate |checkbox| :guilabel:`User stylesheet` to apply HTML styles that often is provided
   in cascading style sheets. An example of style code is provide below to set the color of
-  ``<h1>`` header tag to green and set the font and fontsize of text included in paragraph 
+  ``<h1>`` header tag to green and set the font and fontsize of text included in paragraph
   tags ``<p>``.
 
-  .. code-block:: css 
+  .. code-block:: css
 
      h1 {color: #00ff00;
      }

--- a/source/docs/user_manual/print_composer/composer_items/composer_items_options.rst
+++ b/source/docs/user_manual/print_composer/composer_items/composer_items_options.rst
@@ -4,8 +4,10 @@
 Composer Items Common Options
 ==============================
 
-.. contents::
-   :local:
+.. only:: html
+
+   .. contents::
+      :local:
 
 Composer items have a set of common properties you will find on the bottom of
 the :guilabel:`Item Properties` tab: Position and size, Rotation, Frame,

--- a/source/docs/user_manual/print_composer/composer_items/composer_label.rst
+++ b/source/docs/user_manual/print_composer/composer_items/composer_label.rst
@@ -3,14 +3,16 @@
 The Label Item
 ===============
 
-.. contents::
-   :local:
+.. only:: html
+
+   .. contents::
+      :local:
 
 To add a label, click the |label| :sup:`Add label` icon, place the element
 with the left mouse button on the Print Composer canvas and position and customize
 its appearance in the label :guilabel:`Item Properties` tab.
 
-The :guilabel:`Item Properties` tab of a label item provides the following functionality 
+The :guilabel:`Item Properties` tab of a label item provides the following functionality
 for the label item (see Figure_composer_label_):
 
 .. _Figure_composer_label:
@@ -27,26 +29,26 @@ for the label item (see Figure_composer_label_):
 Main properties
 ----------------
 
-* The main properties dialog is where the text (HTML or not) or the expression 
+* The main properties dialog is where the text (HTML or not) or the expression
   needed to fill the label is added to the Composer canvas.
-* Labels can be interpreted as HTML code: check |checkbox| :guilabel:`Render as HTML`. 
+* Labels can be interpreted as HTML code: check |checkbox| :guilabel:`Render as HTML`.
   You can now insert a URL, a clickable image that links to a web page or something more complex.
-* You can also insert an expression. Click on **[Insert an expression]** to open a new dialog. 
-  Build an expression by clicking the functions available in the left side of the panel. 
-  Two special categories can be useful, particularly associated with the atlas functionality: 
+* You can also insert an expression. Click on **[Insert an expression]** to open a new dialog.
+  Build an expression by clicking the functions available in the left side of the panel.
+  Two special categories can be useful, particularly associated with the atlas functionality:
   geometry functions and records functions. At the bottom, a preview of the expression is shown.
 
 Appearance
 ----------
 
-* Define :guilabel:`Font` by clicking on the **[Font...]** button or a :guilabel:`Font color` 
+* Define :guilabel:`Font` by clicking on the **[Font...]** button or a :guilabel:`Font color`
   selecting a color using the color selection tool.
 * You can specify different horizontal and vertical margins in mm.
-  This is the margin from the edge of the composer item. The label can be positioned outside 
+  This is the margin from the edge of the composer item. The label can be positioned outside
   the bounds of the label e.g. to align label items with other items. In this case you have to
-  use negative values for the margin. 
+  use negative values for the margin.
 * Using the :guilabel:`Alignment` is another way to position your label. Note that when e.g. using
-  the :guilabel:`Horizontal alignment` in |radioButtonOn|:guilabel:`Center` Position the 
+  the :guilabel:`Horizontal alignment` in |radioButtonOn|:guilabel:`Center` Position the
   :guilabel:`Horizontal margin` feature is disabled.
 
 

--- a/source/docs/user_manual/print_composer/composer_items/composer_legend.rst
+++ b/source/docs/user_manual/print_composer/composer_items/composer_legend.rst
@@ -1,13 +1,15 @@
 |updatedisclaimer|
-  
-.. index:: 
+
+.. index::
    single: legend_composer; Map_Legend
 
 The Legend Item
 ================
 
-.. contents::
-   :local:
+.. only:: html
+
+   .. contents::
+      :local:
 
 To add a map legend, click the |addLegend| :sup:`Add new legend` icon,
 place the element with the left mouse button on the Print Composer canvas and
@@ -49,7 +51,7 @@ In Main properties you can:
 
 * Change the title of the legend.
 * Set the title alignment to Left, Center or Right.
-* You can choose which :guilabel:`Map` item the current legend will refer to 
+* You can choose which :guilabel:`Map` item the current legend will refer to
   in the select list.
 * You can wrap the text of the legend title on a given character.
 
@@ -76,27 +78,27 @@ provides the following functionalities (see figure_composer_legend_3_):
   The icons below the legend items list will be activated.
 * The legend items window lists all legend items and allows you to change item order,
   group layers, remove and restore items in the list, edit layer names and add a filter.
-  
+
   * The item order can be changed using the **[Up]** and **[Down]** buttons or with 'drag-and-drop'
     functionality. The order can not be changed for WMS legend graphics.
   * Use the **[Add group]** button to add a legend group.
   * Use the **[plus]** and **[minus]** button to add or remove layers.
-  * The **[Edit]** button is used to edit the layer, groupname or title. 
+  * The **[Edit]** button is used to edit the layer, groupname or title.
     First you need to select the legend item.
   * The **[Sigma]** button adds a feature count for each vector layer.
-  * Use the **[filter]** button to filter the legend by map content, only the 
+  * Use the **[filter]** button to filter the legend by map content, only the
     legend items visible in the map will be listed in the legend.
 
-  After changing the symbology in the QGIS main window, you can click on **[Update All]** to 
-  adapt the changes in the legend element of the Print Composer. 
+  After changing the symbology in the QGIS main window, you can click on **[Update All]** to
+  adapt the changes in the legend element of the Print Composer.
 
 
 
 Fonts, Columns, Symbol
 ----------------------
 
-The :guilabel:`Fonts`, :guilabel:`Columns` and :guilabel:`Symbol` dialogs of the legend 
-:guilabel:`Item Properties` tab provide the following functionalities 
+The :guilabel:`Fonts`, :guilabel:`Columns` and :guilabel:`Symbol` dialogs of the legend
+:guilabel:`Item Properties` tab provide the following functionalities
 (see figure_composer_legend_4_):
 
 .. _Figure_composer_legend_4:
@@ -110,26 +112,26 @@ The :guilabel:`Fonts`, :guilabel:`Columns` and :guilabel:`Symbol` dialogs of the
 
    Legend Fonts, Columns and Symbol Dialogs
 
-* You can change the font of the legend title, group, subgroup and item (layer) in the legend item. 
+* You can change the font of the legend title, group, subgroup and item (layer) in the legend item.
   Click on a category button to open a **Select font** dialog.
-* You provide the labels with a **Color** using the advanced color picker, however the selected 
+* You provide the labels with a **Color** using the advanced color picker, however the selected
   color will be given to all font items in the legend..
-* Legend items can be arranged over several columns. Set the number of columns in 
+* Legend items can be arranged over several columns. Set the number of columns in
   the :guilabel:`Count` |selectNumber| field.
 
   * |checkbox| :guilabel:`Equal column widths` sets how legend columns should be adjusted.
-  * The |checkbox| :guilabel:`Split layers` option allows a categorized or a graduated layer 
+  * The |checkbox| :guilabel:`Split layers` option allows a categorized or a graduated layer
     legend to be divided between columns.
 
-* You can also change the width and height of the legend symbol,set a color and 
+* You can also change the width and height of the legend symbol,set a color and
   a thickness in case of raster layer symbol.
 
 
 WMS LegendGraphic and Spacing
 ------------------------------
 
-The :guilabel:`WMS LegendGraphic` and :guilabel:`Spacing` dialogs of the legend 
-:guilabel:`Item Properties` tab provide the following functionalities (see 
+The :guilabel:`WMS LegendGraphic` and :guilabel:`Spacing` dialogs of the legend
+:guilabel:`Item Properties` tab provide the following functionalities (see
 figure_composer_legend_5_):
 
 .. _Figure_composer_legend_5:
@@ -143,14 +145,14 @@ figure_composer_legend_5_):
 
    WMS LegendGraphic and Spacing Dialogs
 
-When you have added a WMS layer and you insert a legend composer item, a request 
-will be sent to the WMS server to provide a WMS legend. This Legend will only be 
-shown if the WMS server provides the GetLegendGraphic capability. 
+When you have added a WMS layer and you insert a legend composer item, a request
+will be sent to the WMS server to provide a WMS legend. This Legend will only be
+shown if the WMS server provides the GetLegendGraphic capability.
 The WMS legend content will be provided as a raster image.
 
-:guilabel:`WMS LegendGraphic` is used to be able to adjust the :guilabel:`Legend width` 
+:guilabel:`WMS LegendGraphic` is used to be able to adjust the :guilabel:`Legend width`
 and the :guilabel:`Legend height` of the WMS legend raster image.
 
-Spacing around title, group, subgroup, symbol, icon label, box space 
+Spacing around title, group, subgroup, symbol, icon label, box space
 or column space can be customized through this dialog.
 

--- a/source/docs/user_manual/print_composer/composer_items/composer_map.rst
+++ b/source/docs/user_manual/print_composer/composer_items/composer_map.rst
@@ -5,8 +5,10 @@
 The Map Item
 =============
 
-.. contents::
-   :local:
+.. only:: html
+
+   .. contents::
+      :local:
 
 Click on the |addMap| :sup:`Add new map` toolbar button in the Print
 Composer toolbar to add the QGIS map canvas. Now, drag a rectangle onto the Composer
@@ -93,7 +95,7 @@ following functionalities (see figure_composer_map_1_):
   by ``|`` character.
   The following example locks the map item to use only layers ``layer 1`` and
   ``layer 2``::
-  
+
     concat ('layer 1', '|', 'layer 2')
 
 

--- a/source/docs/user_manual/print_composer/composer_items/composer_scale_bar.rst
+++ b/source/docs/user_manual/print_composer/composer_items/composer_scale_bar.rst
@@ -6,8 +6,10 @@
 The Scale Bar Item
 ==================
 
-.. contents::
-   :local:
+.. only:: html
+
+   .. contents::
+      :local:
 
 To add a scale bar, click the |scaleBar| :sup:`Add new scalebar` icon, place
 the element with the left mouse button on the Print Composer canvas and position
@@ -54,8 +56,8 @@ provides the following functionalities (see figure_composer_scalebar_2_):
 Units and Segments
 ------------------
 
-The :guilabel:`Units` and :guilabel:`Segments` dialogs of the scale bar 
-:guilabel:`Item Properties` tab provide the following functionalities 
+The :guilabel:`Units` and :guilabel:`Segments` dialogs of the scale bar
+:guilabel:`Item Properties` tab provide the following functionalities
 (see figure_composer_scalebar_3_):
 
 .. _Figure_composer_scalebar_3:
@@ -71,24 +73,24 @@ The :guilabel:`Units` and :guilabel:`Segments` dialogs of the scale bar
 
 In these two dialogs, you can set how the scale bar will be represented.
 
-* Select the units you want to use with :guilabel:`Scalebar units`. 
-  There are four possible choices: **Map Units**, the default one and **Meters**, 
+* Select the units you want to use with :guilabel:`Scalebar units`.
+  There are four possible choices: **Map Units**, the default one and **Meters**,
   **Feet** or **Nautical Miles** which may force unit conversions.
-* The :guilabel:`Label unit multiplier` specifies how many scalebar units per labeled unit. 
+* The :guilabel:`Label unit multiplier` specifies how many scalebar units per labeled unit.
   Eg, if your scalebar units are set to "meters", a multiplier of 1000 will result
   in the scale bar labels in "kilometers".
-* The :guilabel:`Label for units` field defines the text used to describe the units 
+* The :guilabel:`Label for units` field defines the text used to describe the units
   of the scale bar, eg "m" or "km". This should be matched to reflect the multiplier above.
 * You can define how many :guilabel:`Segments` will be drawn on the left and on the right side of the scale bar.
-* You can set how long each segment will be (:guilabel:`fixed width`), or limit the scale bar size in mm 
-  with :guilabel:`Fit segment width` option. In the latter case, each time the map scale changes, 
+* You can set how long each segment will be (:guilabel:`fixed width`), or limit the scale bar size in mm
+  with :guilabel:`Fit segment width` option. In the latter case, each time the map scale changes,
   the scale bar is resized (and its label updated) to fit the range set.
 * :guilabel:`Height` is used to define the height of the bar.
 
 Display
 --------
 
-The :guilabel:`Display` dialog of the scale bar :guilabel:`Item Properties` tab provide 
+The :guilabel:`Display` dialog of the scale bar :guilabel:`Item Properties` tab provide
 the following functionalities (see figure_composer_scalebar_4_):
 
 .. _Figure_composer_scalebar_4:
@@ -102,22 +104,22 @@ the following functionalities (see figure_composer_scalebar_4_):
 
    Scale Bar Display |nix|
 
-You can define how the scale bar will be displayed in its frame. 
+You can define how the scale bar will be displayed in its frame.
 
 * :guilabel:`Box margin` : space between text and frame borders
 * :guilabel:`Labels margin` :  space between text and scale bar drawing
 * :guilabel:`Line width` : line width of the scale bar drawing
-* :guilabel:`Join style` : Corners at the end of scalebar in style Bevel, Rounded or Square 
-  (only available for Scale bar style Single Box & Double Box)  
+* :guilabel:`Join style` : Corners at the end of scalebar in style Bevel, Rounded or Square
+  (only available for Scale bar style Single Box & Double Box)
 * :guilabel:`Cap style` : End of all lines in style Square, Round or Flat
-  (only available for Scale bar style Line Ticks Up, Down and Middle)  
+  (only available for Scale bar style Line Ticks Up, Down and Middle)
 * :guilabel:`Alignment` : Puts text on the left, middle or right side of the frame
-  (works only for Scale bar style Numeric) 
+  (works only for Scale bar style Numeric)
 
 Fonts and colors
 -----------------
 
-The :guilabel:`Fonts and colors` dialog of the scale bar :guilabel:`Item Properties` tab 
+The :guilabel:`Fonts and colors` dialog of the scale bar :guilabel:`Item Properties` tab
 provide the following functionalities (see figure_composer_scalebar_5_):
 
 .. _Figure_composer_scalebar_5:
@@ -135,12 +137,12 @@ You can define the fonts and colors used for the scale bar.
 
 * Use the **[Font]** button to set the font of scale bar label
 * :guilabel:`Font color`: set the font color
-* :guilabel:`Fill color`: set the first fill color 
-* :guilabel:`Secondary fill color`: set the second fill color 
+* :guilabel:`Fill color`: set the first fill color
+* :guilabel:`Secondary fill color`: set the second fill color
 * :guilabel:`Stroke color`: set the color of the lines of the Scale Bar
 
-Fill colors are only used for scale box styles Single Box and Double Box. 
-To select a color you can use the list option using the dropdown arrow to open 
-a simple color selection option or the more advanced color selection option, that is 
-started when you click in the colored box in the dialog. 
+Fill colors are only used for scale box styles Single Box and Double Box.
+To select a color you can use the list option using the dropdown arrow to open
+a simple color selection option or the more advanced color selection option, that is
+started when you click in the colored box in the dialog.
 

--- a/source/docs/user_manual/print_composer/create_output.rst
+++ b/source/docs/user_manual/print_composer/create_output.rst
@@ -9,8 +9,10 @@
  Creating an Output
 ********************
 
-.. contents::
-   :local:
+.. only:: html
+
+   .. contents::
+      :local:
 
 Figure_composer_output_1_ shows the Print Composer with an example print layout,
 including each type of map item described in the previous section.
@@ -90,7 +92,7 @@ the exported image.
    Exporting big rasters can sometimes fail, even if there seems to be
    enough memory. This is a problem with the underlying Qt management of rasters.
 
-Export as SVG 
+Export as SVG
 ==============
 
 With |saveAsSVG| :sup:`Export as SVG`, you also need to fill the filename
@@ -231,7 +233,7 @@ or, another combination:
 
 .. code::
 
-   The area of [% upper(CITY_NAME)%],[%ZIPCODE%] is 
+   The area of [% upper(CITY_NAME)%],[%ZIPCODE%] is
    [%format_number($area/1000000,2) %] km2
 
 The information ``[% upper(CITY_NAME) || ',' || ZIPCODE || ' is ' format_number($area/1000000,2) %]``

--- a/source/docs/user_manual/print_composer/overview_composer.rst
+++ b/source/docs/user_manual/print_composer/overview_composer.rst
@@ -6,9 +6,10 @@
  Overview of the Print Composer
 ********************************
 
-.. contents::
-   :local:
+.. only:: html
 
+   .. contents::
+      :local:
 
 The Print Composer provides growing layout and printing capabilities. It allows
 you to add elements such as the QGIS map canvas, text labels, images, legends,

--- a/source/docs/user_manual/processing/3rdParty.rst
+++ b/source/docs/user_manual/processing/3rdParty.rst
@@ -5,8 +5,10 @@
 Configuring external applications
 =================================
 
-.. contents::
-   :local:
+.. only:: html
+
+   .. contents::
+      :local:
 
 The processing framework can be extended using additional applications.
 Currently, SAGA, GRASS, OTB (Orfeo Toolbox) and R are supported, along

--- a/source/docs/user_manual/processing/batch.rst
+++ b/source/docs/user_manual/processing/batch.rst
@@ -3,8 +3,10 @@
 The batch processing interface
 ===============================
 
-.. contents::
-   :local:
+.. only:: html
+
+   .. contents::
+      :local:
 
 Introduction
 ------------

--- a/source/docs/user_manual/processing/commander.rst
+++ b/source/docs/user_manual/processing/commander.rst
@@ -5,8 +5,10 @@
 The QGIS Commander
 ======================
 
-.. contents::
-   :local:
+.. only:: html
+
+   .. contents::
+      :local:
 
 Processing includes a practical tool that allows you to run algorithms without
 having to use the toolbox, but just by typing the name of the algorithm you want to

--- a/source/docs/user_manual/processing/console.rst
+++ b/source/docs/user_manual/processing/console.rst
@@ -3,8 +3,10 @@
 Using processing algorithms from the console
 ==============================================
 
-.. contents::
-   :local:
+.. only:: html
+
+   .. contents::
+      :local:
 
 The console allows advanced users to increase their productivity and perform
 complex operations that cannot be performed using any of the other GUI elements of

--- a/source/docs/user_manual/processing/history.rst
+++ b/source/docs/user_manual/processing/history.rst
@@ -5,8 +5,10 @@
 The history manager
 ============================
 
-.. contents::
-   :local:
+.. only:: html
+
+   .. contents::
+      :local:
 
 The processing history
 ------------------------

--- a/source/docs/user_manual/processing/modeler.rst
+++ b/source/docs/user_manual/processing/modeler.rst
@@ -5,8 +5,10 @@
 The graphical modeler
 =====================
 
-.. contents::
-   :local:
+.. only:: html
+
+   .. contents::
+      :local:
 
 The *graphical modeler* allows you to create complex models using a simple and
 easy-to-use interface. When working with a GIS, most analysis operations are not

--- a/source/docs/user_manual/processing/scripts.rst
+++ b/source/docs/user_manual/processing/scripts.rst
@@ -1,6 +1,8 @@
 
-.. contents::
-   :local:
+.. only:: html
+
+   .. contents::
+      :local:
 
 Writing new Processing algorithms as python scripts
 ---------------------------------------------------

--- a/source/docs/user_manual/processing/toolbox.rst
+++ b/source/docs/user_manual/processing/toolbox.rst
@@ -5,8 +5,10 @@
 The toolbox
 ============
 
-.. contents::
-   :local:
+.. only:: html
+
+   .. contents::
+      :local:
 
 The *Toolbox* is the main element of the processing GUI, and the one that you are
 more likely to use in your daily work. It shows the list of all available

--- a/source/docs/user_manual/working_with_gps/live_GPS_tracking.rst
+++ b/source/docs/user_manual/working_with_gps/live_GPS_tracking.rst
@@ -5,8 +5,10 @@
 Live GPS tracking
 ==================
 
-.. contents::
-   :local:
+.. only:: html
+
+   .. contents::
+      :local:
 
 To activate live GPS tracking in QGIS, you need to select :menuselection:`Settings --> Panels`
 |checkbox| :guilabel:`GPS information`. You will get a new docked window on the

--- a/source/docs/user_manual/working_with_gps/plugins_gps.rst
+++ b/source/docs/user_manual/working_with_gps/plugins_gps.rst
@@ -5,8 +5,10 @@
 GPS Plugin
 ==========
 
-.. contents::
-   :local:
+.. only:: html
+
+   .. contents::
+      :local:
 
 .. _`whatsgps`:
 

--- a/source/docs/user_manual/working_with_ogc/ogc_client_support.rst
+++ b/source/docs/user_manual/working_with_ogc/ogc_client_support.rst
@@ -6,8 +6,10 @@
 QGIS as OGC Data Client
 ***********************
 
-.. contents::
-   :local:
+.. only:: html
+
+   .. contents::
+      :local:
 
 
 .. index:: Open_Geospatial_Consortium, OGC

--- a/source/docs/user_manual/working_with_ogc/ogc_server_support.rst
+++ b/source/docs/user_manual/working_with_ogc/ogc_server_support.rst
@@ -9,8 +9,10 @@
 QGIS as OGC Data Server
 ***********************
 
-.. contents::
-   :local:
+.. only:: html
+
+   .. contents::
+      :local:
 
 QGIS Server is an open source WMS 1.3, WFS 1.0.0 and WCS 1 1.1.1
 implementation that, in addition, implements advanced cartographic features for

--- a/source/docs/user_manual/working_with_projections/working_with_projections.rst
+++ b/source/docs/user_manual/working_with_projections/working_with_projections.rst
@@ -6,8 +6,10 @@
 Working with Projections
 ************************
 
-.. contents::
-   :local:
+.. only:: html
+
+   .. contents::
+      :local:
 
 .. index:: Projections, CRS, Coordinate_Reference_System
 

--- a/source/docs/user_manual/working_with_raster/raster_analysis.rst
+++ b/source/docs/user_manual/working_with_raster/raster_analysis.rst
@@ -5,8 +5,10 @@
 Raster Analysis
 ================
 
-.. contents::
-   :local:
+.. only:: html
+
+   .. contents::
+      :local:
 
 .. _label_raster_calc:
 

--- a/source/docs/user_manual/working_with_raster/raster_properties.rst
+++ b/source/docs/user_manual/working_with_raster/raster_properties.rst
@@ -3,8 +3,10 @@
 Raster Properties Dialog
 ========================
 
-.. contents::
-   :local:
+.. only:: html
+
+   .. contents::
+      :local:
 
 To view and set the properties for a raster layer, double click on the layer name
 in the map legend, or right click on the layer name and choose :guilabel:`Properties`
@@ -41,13 +43,13 @@ Layer Info
 
 The :guilabel:`General` menu displays basic information about the selected raster,
 including the layer source path, the display name in the legend (which can be
-modified), and the number of columns, rows and no-data values of the raster. 
+modified), and the number of columns, rows and no-data values of the raster.
 
 Coordinate reference system
 ...........................
 
-Here, you find the coordinate reference system (CRS) information printed as a 
-PROJ.4 string. If this setting is not correct, it can be modified by clicking 
+Here, you find the coordinate reference system (CRS) information printed as a
+PROJ.4 string. If this setting is not correct, it can be modified by clicking
 the **[Specify]** button.
 
 Scale Dependent visibility

--- a/source/docs/user_manual/working_with_raster/supported_data.rst
+++ b/source/docs/user_manual/working_with_raster/supported_data.rst
@@ -8,8 +8,10 @@
 Working with Raster Data
 *************************
 
-.. contents::
-   :local:
+.. only:: html
+
+   .. contents::
+      :local:
 
 .. % when the revision of a section has been finalized,
 .. % comment out the following line:

--- a/source/docs/user_manual/working_with_vector/attribute_table.rst
+++ b/source/docs/user_manual/working_with_vector/attribute_table.rst
@@ -5,8 +5,10 @@
  Working with the Attribute Table
 **********************************
 
-.. contents::
-   :local:
+.. only:: html
+
+   .. contents::
+      :local:
 
 The :index:`attribute table` displays features of a selected layer. Each row
 in the table represents one map feature, and each column contains a particular
@@ -216,8 +218,10 @@ also to features from another source defined using well-known text (WKT).
 Editing attribute values
 =========================
 
-.. contents::
-   :local:
+.. only:: html
+
+   .. contents::
+      :local:
 
 The |calculateField| :sup:`Field Calculator` button in the attribute
 table allows you to perform calculations on the basis of existing attribute values or

--- a/source/docs/user_manual/working_with_vector/editing_geometry_attributes.rst
+++ b/source/docs/user_manual/working_with_vector/editing_geometry_attributes.rst
@@ -3,8 +3,10 @@
 Editing
 =======
 
-.. contents::
-   :local:
+.. only:: html
+
+   .. contents::
+      :local:
 
 QGIS supports various capabilities for :index:`editing` OGR,
 SpatiaLite, PostGIS, MSSQL Spatial and Oracle Spatial vector layers and tables.

--- a/source/docs/user_manual/working_with_vector/expression.rst
+++ b/source/docs/user_manual/working_with_vector/expression.rst
@@ -8,8 +8,10 @@
 Expressions
 ************
 
-.. contents::
-   :local:
+.. only:: html
+
+   .. contents::
+      :local:
 
 The :index:`Expressions` feature is available from many parts in QGIS. It can be
 accessed using the |expression| :sup:`Expression Builder`, the

--- a/source/docs/user_manual/working_with_vector/style_library.rst
+++ b/source/docs/user_manual/working_with_vector/style_library.rst
@@ -5,8 +5,10 @@
 The Symbol Library
 ==================
 
-.. contents::
-   :local:
+.. only:: html
+
+   .. contents::
+      :local:
 
 .. index::
     single:Style

--- a/source/docs/user_manual/working_with_vector/supported_data.rst
+++ b/source/docs/user_manual/working_with_vector/supported_data.rst
@@ -3,8 +3,10 @@
 Supported Data Formats
 ======================
 
-.. contents::
-   :local:
+.. only:: html
+
+   .. contents::
+      :local:
 
 QGIS uses the OGR library to read and write vector data formats,
 including ESRI shapefiles, MapInfo and MicroStation file formats, AutoCAD DXF,

--- a/source/docs/user_manual/working_with_vector/vector_properties.rst
+++ b/source/docs/user_manual/working_with_vector/vector_properties.rst
@@ -6,8 +6,10 @@
 The Vector Properties Dialog
 *****************************
 
-.. contents::
-   :local:
+.. only:: html
+
+   .. contents::
+      :local:
 
 The :guilabel:`Layer Properties` dialog for a vector layer provides general
 settings to manage appearance of layer features in the map (symbology, labeling,

--- a/source/docs/user_manual/working_with_vector/virtual_layers.rst
+++ b/source/docs/user_manual/working_with_vector/virtual_layers.rst
@@ -7,8 +7,10 @@
 Virtual layers
 ==============
 
-.. contents::
-   :local:
+.. only:: html
+
+   .. contents::
+      :local:
 
 A special kind of vector layer allows you to define a layer as the result of an
 advanced query, using the SQL language on any number of other vector layers that


### PR DESCRIPTION
This is a PR to go ahead for #1138 and #988. Feel free to comment :+1: or :-1:.

The PR main changes are:
* add `.. only:: html` before each `.. contents::` 
* remove trailing space when they are present