### PR TITLE
Update restoring toolbar tip

### DIFF
--- a/source/docs/user_manual/introduction/qgis_configuration.rst
+++ b/source/docs/user_manual/introduction/qgis_configuration.rst
@@ -661,6 +661,8 @@ from the destination computer in order to import the ``.ini`` file.
 You can also run :ref:`command line tools <custom_commandline>` and save various
 setups for different use cases as well.
 
+.. _tip_restoring_configuration:
+
 .. tip:: **Easily restore predefined QGIS**
 
    The initial QGIS GUI configuration can be restored by one of the methods below:
@@ -668,8 +670,11 @@ setups for different use cases as well.
    * unchecking |checkbox| :guilabel:`Enable customization` option in the
      Customization dialog or click the |selectAllTree| :sup:`Check All` button
    * pressing the **[Reset]** button in the **QSettings** frame under
-     :menuselection:`Settings --> Options... --> System` menu
+     :menuselection:`Settings --> Options` menu, :guilabel:`System` tab
    * launching QGIS at a command prompt with the following command line
      ``qgis --nocustomization``
-   * setting to ``false`` the value of :guilabel:`UI --> Customization --> Enabled` variable
-     under :menuselection:`Settings --> Options... --> Advanced` menu.
+   * setting to ``false`` the value of :guilabel:`UI --> Customization --> Enabled`
+     variable under :menuselection:`Settings --> Options` menu, :guilabel:`Advanced` tab.
+
+   In most cases, you need to restart QGIS in order to have the change applied.
+     

--- a/source/docs/user_manual/introduction/qgis_gui.rst
+++ b/source/docs/user_manual/introduction/qgis_gui.rst
@@ -355,12 +355,11 @@ holding the mouse over the toolbars (read also :ref:`sec_panels_and_toolbars`).
 .. tip::
         **Restoring toolbars**
 
-        If you have accidentally hidden all your toolbars, you can get them
-        back by choosing menu option :menuselection:`Settings --> Toolbars -->`.
-        If a toolbar disappears under Windows, you have to remove key
-        ``\HKEY_CURRENT_USER\Software\QGIS\qgis\UI\state`` in the registry.
-        When you restart QGIS, the key is written again with the default state,
-        and all toolbars are visible again.
+        If you have accidentally hidden a toolbar, you can get it
+        back by choosing menu option :menuselection:`View --> Toolbars -->`.
+        If for some reason a toolbar (or any other widget) totally disappears
+        from the interface, you'll find tips to get it back at :ref:`restoring
+        initial GUI <tip_restoring_configuration>`.
 
 .. _`label_legend`:
 


### PR DESCRIPTION
I've been using QGIS under Windows for years and never had a toolbar disappeared magically so I remove that comment that sounds like a bashing. I also remove the manipulation of the registry which imho should not be advised to anybody (an advanced setting) and there are simpler tips to solve that issue

fix #934