### PR TITLE
Tries to fix #864 substitutions wrongly placed inside notes and tips

### DIFF
--- a/themes/qgis-theme/static/qgis-style.css
+++ b/themes/qgis-theme/static/qgis-style.css
@@ -879,7 +879,6 @@ section.menu nav.subnav ul li a:hover {
 }
 .admonition p img,
 .bordered-block p img {
-  float: left;
   margin: 0 15px 0 0;
 }
 .guilabel {


### PR DESCRIPTION
This pull request is a test, not sure how it would affect other parts of the documentation. A further inspection might be necessary. And someone with HTML/CSS knowledge can better infer the implications of this change.