### PR TITLE
clean file sample rendering

### DIFF
--- a/readme.rst
+++ b/readme.rst
@@ -115,8 +115,8 @@ Or use the fullhtml target of make (which will checkout the branch)::
     # to build eg dutch:
     make LANG=nl fullhtml
 
-Trying to build a fullhtml you might get an Exception: No user credentials found for host https://www.transifex.com.
-To fix this, add a ~/.transifexrc file stored in the user's home directory with following information.
+Trying to build a fullhtml you might get an Exception: ``No user credentials found for host https://www.transifex.com``.
+To fix this, add a ``~/.transifexrc`` file stored in the user's home directory with following information::
 
     [https://www.transifex.com]
     username = user


### PR DESCRIPTION
The content of the file sample below was one-line text instead of multiline