### PR TITLE
Save readonly mode of vector layers in project

### DIFF
--- a/source/docs/user_manual/introduction/general_tools.rst
+++ b/source/docs/user_manual/introduction/general_tools.rst
@@ -1293,13 +1293,19 @@ should be identified:
   identify features from. Operates like a right-click. Only the chosen features
   will be shown in the result panel.
 
-The :guilabel:`View` can be set as **Tree**, **Table** or **Graph**.
+.. note:: **Identify configuration**
+   You can configure the identify feature in :menuselection:`Project -->
+   Project Properties` in the :guilabel:`Identify layers` tab. The table allow
+   user to select layer that can be used by this tools to find features
+   (column :guilabel:`Identifiable`). You can also put this layer in read-only
+   mode with the checkbox in the last column.
+
+    The :guilabel:`View` can be set as **Tree**, **Table** or **Graph**.
 'Table' and 'Graph' views can only be set for raster layers.
 
 The identify tool allows you to |checkbox|:guilabel:`Auto open a form`.
 If checked, each time a single feature is identified QGIS will open a form
 showing its attributes. This is a handy way to quickly edit a feature's attributes.
-
 
 Other functions can be found in the context menu of the identified item. For
 example, from the context menu you can:

--- a/source/docs/user_manual/introduction/general_tools.rst
+++ b/source/docs/user_manual/introduction/general_tools.rst
@@ -1293,14 +1293,15 @@ should be identified:
   identify features from. Operates like a right-click. Only the chosen features
   will be shown in the result panel.
 
-.. note:: **Identify configuration**
+.. note:: **Identify tool configuration**
+
    You can configure the identify feature in :menuselection:`Project -->
-   Project Properties` in the :guilabel:`Identify layers` tab. The table allow
-   user to select layer that can be used by this tools to find features
+   Project Properties` in the :guilabel:`Identify layers` tab. The table allows
+   user to select layer(s) that can be used by this tool to identify features
    (column :guilabel:`Identifiable`). You can also put this layer in read-only
    mode with the checkbox in the last column.
 
-    The :guilabel:`View` can be set as **Tree**, **Table** or **Graph**.
+The :guilabel:`View` can be set as **Tree**, **Table** or **Graph**.
 'Table' and 'Graph' views can only be set for raster layers.
 
 The identify tool allows you to |checkbox|:guilabel:`Auto open a form`.


### PR DESCRIPTION
- Add a section on Identify configuration dialog
- Add information on read-only for fields via widget configuration

Fix #937
