### PR TITLE
Rename menu-option in doc.

### DIFF
--- a/source/docs/user_manual/processing/modeler.rst
+++ b/source/docs/user_manual/processing/modeler.rst
@@ -283,7 +283,7 @@ as part of the model.
    Model With Deactivated Algorithms
 
 When right-clicking on an algorithm that is not active, you will instead see a
-:guilabel:`Deactivate` menu option that you can use to activate it back.
+:guilabel:`Activate` menu option that you can use to activate it back.
 
 Editing model help files and meta-information
 ---------------------------------------------


### PR DESCRIPTION
Line 285  :  When right-clicking on an algorithm that is not active, you will instead see a
Line 286  :  :guilabel:`Deactivate` menu option that you can use to activate it back.

This seems not correct to me. Expected value for the menu option should be  :guilabel:`Activate`.
Checked the option against a  deactivated model and the option says:  Activate

Please change for this case wording in doc from Deactivate to Activate