### PR TITLE
Adds fasthtml job to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -225,3 +225,10 @@ gettext:
 #	make springclean
 #	make pretranslate
 #	tx push -f -s --no-interactive
+
+fasthtml:
+	# This build is just for fast previewing changes in EN documentation
+	# Instead of fully copy the english images to static folder, it sync it
+	# No internationalization is preformed
+	rsync -uthvr --delete $(RESOURCEDIR)/en/docs/ $(SOURCEDIR)/static
+	$(SPHINXBUILD) -n -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html/$(LANG)

--- a/Makefile
+++ b/Makefile
@@ -228,7 +228,7 @@ gettext:
 
 fasthtml:
 	# This build is just for fast previewing changes in EN documentation
-	# Instead of fully copy the english images to static folder, it sync it
-	# No internationalization is preformed
+	# Instead of fully copy the english images to static folder, it syncs it
+	# No internationalization is performed
 	rsync -uthvr --delete $(RESOURCEDIR)/en/docs/ $(SOURCEDIR)/static
 	$(SPHINXBUILD) -n -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html/$(LANG)


### PR DESCRIPTION
This allows much faster build for EN language to preview changes.
It skips internationalization and used rsync to update the static folder.
I also removed the W option so that it does not break on warnings

@rduivenvoorde , @DelazJ and @yjacolin can you please try it out?