### PR TITLE
Remove |updatedisclaimer| reference from 2.14 doc

### DIFF
--- a/source/docs/user_manual/appendices/appendices.rst
+++ b/source/docs/user_manual/appendices/appendices.rst
@@ -1,4 +1,3 @@
-|updatedisclaimer|
 
 Appendix
 ========

--- a/source/docs/user_manual/auth_system/index.rst
+++ b/source/docs/user_manual/auth_system/index.rst
@@ -1,4 +1,3 @@
-|updatedisclaimer|
 
 .. _authentication_index:
 

--- a/source/docs/user_manual/grass_integration/grass_integration.rst
+++ b/source/docs/user_manual/grass_integration/grass_integration.rst
@@ -1,4 +1,3 @@
-|updatedisclaimer|
 
 .. _sec_grass:
 

--- a/source/docs/user_manual/index.rst
+++ b/source/docs/user_manual/index.rst
@@ -1,6 +1,3 @@
-|updatedisclaimer|
-
-.. comment out this Section (by putting '|updatedisclaimer|' on top) if file is not up-to-date with release
 
 .. _QGIS-manual-index-reference:
 

--- a/source/docs/user_manual/introduction/general_tools.rst
+++ b/source/docs/user_manual/introduction/general_tools.rst
@@ -1,4 +1,3 @@
-|updatedisclaimer|
 
 .. _general_tools:
 

--- a/source/docs/user_manual/introduction/getting_started.rst
+++ b/source/docs/user_manual/introduction/getting_started.rst
@@ -1,4 +1,3 @@
-|updatedisclaimer|
 
 .. _`label.getstarted`:
 

--- a/source/docs/user_manual/introduction/qgis_configuration.rst
+++ b/source/docs/user_manual/introduction/qgis_configuration.rst
@@ -1,4 +1,3 @@
-|updatedisclaimer|
 
 ******************
 QGIS Configuration

--- a/source/docs/user_manual/introduction/qgis_gui.rst
+++ b/source/docs/user_manual/introduction/qgis_gui.rst
@@ -1,4 +1,3 @@
-|updatedisclaimer|
 
 .. _`label_qgismainwindow`:
 

--- a/source/docs/user_manual/literature_web/literature_and_web_references.rst
+++ b/source/docs/user_manual/literature_web/literature_and_web_references.rst
@@ -1,4 +1,3 @@
-|updatedisclaimer|
 
 .. _literature_and_web:
 

--- a/source/docs/user_manual/plugins/core_plugins.rst
+++ b/source/docs/user_manual/plugins/core_plugins.rst
@@ -1,4 +1,3 @@
-|updatedisclaimer|
 
 .. :index::
     single:core plugins

--- a/source/docs/user_manual/plugins/plugins.rst
+++ b/source/docs/user_manual/plugins/plugins.rst
@@ -1,4 +1,3 @@
-|updatedisclaimer|
 
 .. index::
    single:plugins

--- a/source/docs/user_manual/plugins/plugins_coordinate_capture.rst
+++ b/source/docs/user_manual/plugins/plugins_coordinate_capture.rst
@@ -1,6 +1,3 @@
-|updatedisclaimer|
-
-.. comment out this Section (by putting '|updatedisclaimer|' on top) if file is not up to date with release
 
 .. _coordcapt:
 

--- a/source/docs/user_manual/plugins/plugins_db_manager.rst
+++ b/source/docs/user_manual/plugins/plugins_db_manager.rst
@@ -1,4 +1,3 @@
-|updatedisclaimer|
 
 .. _dbmanager:
 

--- a/source/docs/user_manual/plugins/plugins_dxf2shape_converter.rst
+++ b/source/docs/user_manual/plugins/plugins_dxf2shape_converter.rst
@@ -1,6 +1,3 @@
-|updatedisclaimer|
-
-.. comment out this Section (by putting '|updatedisclaimer|' on top) if file is not uptodate with release
 
 .. _dxf2shape:
 

--- a/source/docs/user_manual/plugins/plugins_evis.rst
+++ b/source/docs/user_manual/plugins/plugins_evis.rst
@@ -1,4 +1,3 @@
-|updatedisclaimer|
 
 .. _`evis`:
 

--- a/source/docs/user_manual/plugins/plugins_ftools.rst
+++ b/source/docs/user_manual/plugins/plugins_ftools.rst
@@ -1,4 +1,3 @@
-|updatedisclaimer|
 
 .. _ftools:
 

--- a/source/docs/user_manual/plugins/plugins_gdaltools.rst
+++ b/source/docs/user_manual/plugins/plugins_gdaltools.rst
@@ -1,4 +1,3 @@
-|updatedisclaimer|
 
 .. _label_plugingdaltools:
 

--- a/source/docs/user_manual/plugins/plugins_geometry_checker.rst
+++ b/source/docs/user_manual/plugins/plugins_geometry_checker.rst
@@ -1,4 +1,3 @@
-|updatedisclaimer|
 
 .. index:: Digitizing, Geometry Checker, Topology, Geometry validity, Errors
 

--- a/source/docs/user_manual/plugins/plugins_geometry_snapper.rst
+++ b/source/docs/user_manual/plugins/plugins_geometry_snapper.rst
@@ -1,4 +1,3 @@
-|updatedisclaimer|
 
 .. index:: Geometry, Topology, Snapping, Plugin, Geometry snapper plugin
 

--- a/source/docs/user_manual/plugins/plugins_georeferencer.rst
+++ b/source/docs/user_manual/plugins/plugins_georeferencer.rst
@@ -1,4 +1,3 @@
-|updatedisclaimer|
 
 .. _`georef`:
 

--- a/source/docs/user_manual/plugins/plugins_heatmap.rst
+++ b/source/docs/user_manual/plugins/plugins_heatmap.rst
@@ -1,4 +1,3 @@
-|updatedisclaimer|
 
 .. _heatmap_plugin:
 

--- a/source/docs/user_manual/plugins/plugins_index.rst
+++ b/source/docs/user_manual/plugins/plugins_index.rst
@@ -1,4 +1,3 @@
-|updatedisclaimer|
 
 .. _qgis.manual.introduction.index:
 

--- a/source/docs/user_manual/plugins/plugins_interpolation.rst
+++ b/source/docs/user_manual/plugins/plugins_interpolation.rst
@@ -1,4 +1,3 @@
-|updatedisclaimer|
 
 .. _`interpol`:
 

--- a/source/docs/user_manual/plugins/plugins_metasearch.rst
+++ b/source/docs/user_manual/plugins/plugins_metasearch.rst
@@ -1,4 +1,3 @@
-|updatedisclaimer|
 
 .. _metasearch:
 

--- a/source/docs/user_manual/plugins/plugins_offline_editing.rst
+++ b/source/docs/user_manual/plugins/plugins_offline_editing.rst
@@ -1,4 +1,3 @@
-|updatedisclaimer|
 
 .. _`offlinedit`:
 

--- a/source/docs/user_manual/plugins/plugins_oracle_raster.rst
+++ b/source/docs/user_manual/plugins/plugins_oracle_raster.rst
@@ -1,4 +1,3 @@
-|updatedisclaimer|
 
 .. _oracle_raster:
 

--- a/source/docs/user_manual/plugins/plugins_raster_terrain.rst
+++ b/source/docs/user_manual/plugins/plugins_raster_terrain.rst
@@ -1,4 +1,3 @@
-|updatedisclaimer|
 
 .. _`rasterrain`:
 

--- a/source/docs/user_manual/plugins/plugins_road_graph.rst
+++ b/source/docs/user_manual/plugins/plugins_road_graph.rst
@@ -1,4 +1,3 @@
-|updatedisclaimer|
 
 .. _roadgraph:
 

--- a/source/docs/user_manual/plugins/plugins_spatial_query.rst
+++ b/source/docs/user_manual/plugins/plugins_spatial_query.rst
@@ -1,4 +1,3 @@
-|updatedisclaimer|
 
 .. _spatial_query:
 

--- a/source/docs/user_manual/plugins/plugins_topology_checker.rst
+++ b/source/docs/user_manual/plugins/plugins_topology_checker.rst
@@ -1,4 +1,3 @@
-|updatedisclaimer|
 
 .. _`topology`:
 

--- a/source/docs/user_manual/plugins/plugins_zonal_statistics.rst
+++ b/source/docs/user_manual/plugins/plugins_zonal_statistics.rst
@@ -1,4 +1,3 @@
-|updatedisclaimer|
 
 .. _zonal_statistics:
 

--- a/source/docs/user_manual/preamble/conventions.rst
+++ b/source/docs/user_manual/preamble/conventions.rst
@@ -1,4 +1,3 @@
-|updatedisclaimer|
 
 .. _label_conventions:
 

--- a/source/docs/user_manual/preamble/features.rst
+++ b/source/docs/user_manual/preamble/features.rst
@@ -1,4 +1,3 @@
-|updatedisclaimer|
 
 .. _qgis.documentation.features:
 

--- a/source/docs/user_manual/preamble/foreword.rst
+++ b/source/docs/user_manual/preamble/foreword.rst
@@ -1,4 +1,3 @@
-|updatedisclaimer|
 
 .. _`label_forward`:
 

--- a/source/docs/user_manual/preamble/help_and_support.rst
+++ b/source/docs/user_manual/preamble/help_and_support.rst
@@ -1,4 +1,3 @@
-|updatedisclaimer|
 
 .. _`label_helpsupport`:
 

--- a/source/docs/user_manual/preamble/preamble.rst
+++ b/source/docs/user_manual/preamble/preamble.rst
@@ -1,6 +1,3 @@
-|updatedisclaimer|
-
-.. comment out this Section (by putting '|updatedisclaimer|' on top) if file is not up-to-date with release
 
 .. _qgis.documentation.preamble:
 

--- a/source/docs/user_manual/preamble/whats_new.rst
+++ b/source/docs/user_manual/preamble/whats_new.rst
@@ -1,4 +1,3 @@
-|updatedisclaimer|
 
 .. _qgis.documentation.whatsnew:
 

--- a/source/docs/user_manual/print_composer/composer_items/composer_arrow.rst
+++ b/source/docs/user_manual/print_composer/composer_items/composer_arrow.rst
@@ -1,4 +1,3 @@
-|updatedisclaimer|
 
 .. _arrow_item:
 

--- a/source/docs/user_manual/print_composer/composer_items/composer_attribute_table.rst
+++ b/source/docs/user_manual/print_composer/composer_items/composer_attribute_table.rst
@@ -1,4 +1,3 @@
-|updatedisclaimer|
 
 .. index:: Attribute_Table
 

--- a/source/docs/user_manual/print_composer/composer_items/composer_basic_shape.rst
+++ b/source/docs/user_manual/print_composer/composer_items/composer_basic_shape.rst
@@ -1,5 +1,3 @@
-|updatedisclaimer|
-
 
 The Basic Shape Items
 =====================

--- a/source/docs/user_manual/print_composer/composer_items/composer_html_frame.rst
+++ b/source/docs/user_manual/print_composer/composer_items/composer_html_frame.rst
@@ -1,4 +1,3 @@
-|updatedisclaimer|
 
 .. index:: HTML_Frame
 

--- a/source/docs/user_manual/print_composer/composer_items/composer_image.rst
+++ b/source/docs/user_manual/print_composer/composer_items/composer_image.rst
@@ -1,4 +1,3 @@
-|updatedisclaimer|
 
 .. _image_item:
 

--- a/source/docs/user_manual/print_composer/composer_items/composer_items_options.rst
+++ b/source/docs/user_manual/print_composer/composer_items/composer_items_options.rst
@@ -1,5 +1,3 @@
-|updatedisclaimer|
-
 
 Composer Items Common Options
 ==============================

--- a/source/docs/user_manual/print_composer/composer_items/composer_label.rst
+++ b/source/docs/user_manual/print_composer/composer_items/composer_label.rst
@@ -1,4 +1,3 @@
-|updatedisclaimer|
 
 The Label Item
 ===============

--- a/source/docs/user_manual/print_composer/composer_items/composer_legend.rst
+++ b/source/docs/user_manual/print_composer/composer_items/composer_legend.rst
@@ -1,4 +1,3 @@
-|updatedisclaimer|
 
 .. index::
    single: legend_composer; Map_Legend

--- a/source/docs/user_manual/print_composer/composer_items/composer_map.rst
+++ b/source/docs/user_manual/print_composer/composer_items/composer_map.rst
@@ -1,4 +1,3 @@
-|updatedisclaimer|
 
 .. index:: composer_map
 

--- a/source/docs/user_manual/print_composer/composer_items/composer_scale_bar.rst
+++ b/source/docs/user_manual/print_composer/composer_items/composer_scale_bar.rst
@@ -1,4 +1,3 @@
-|updatedisclaimer|
 
 .. index::
    single: Scalebar; Map_Scalebar

--- a/source/docs/user_manual/print_composer/composer_items/index.rst
+++ b/source/docs/user_manual/print_composer/composer_items/index.rst
@@ -1,4 +1,3 @@
-|updatedisclaimer|
 
 .. _composer_items:
 

--- a/source/docs/user_manual/print_composer/create_output.rst
+++ b/source/docs/user_manual/print_composer/create_output.rst
@@ -1,4 +1,3 @@
-|updatedisclaimer|
 
 .. index::
    single:Printing; Export_Map

--- a/source/docs/user_manual/print_composer/index.rst
+++ b/source/docs/user_manual/print_composer/index.rst
@@ -1,4 +1,3 @@
-|updatedisclaimer|
 
 .. _label_printcomposer:
 

--- a/source/docs/user_manual/print_composer/overview_composer.rst
+++ b/source/docs/user_manual/print_composer/overview_composer.rst
@@ -1,4 +1,3 @@
-|updatedisclaimer|
 
 .. _overview_composer:
 

--- a/source/docs/user_manual/processing/3rdParty.rst
+++ b/source/docs/user_manual/processing/3rdParty.rst
@@ -1,4 +1,3 @@
-|updatedisclaimer|
 
 .. _`processing.results`:
 

--- a/source/docs/user_manual/processing/batch.rst
+++ b/source/docs/user_manual/processing/batch.rst
@@ -1,4 +1,3 @@
-|updatedisclaimer|
 
 The batch processing interface
 ===============================

--- a/source/docs/user_manual/processing/commander.rst
+++ b/source/docs/user_manual/processing/commander.rst
@@ -1,4 +1,3 @@
-|updatedisclaimer|
 
 .. _`processing.commander`:
 

--- a/source/docs/user_manual/processing/console.rst
+++ b/source/docs/user_manual/processing/console.rst
@@ -1,4 +1,3 @@
-|updatedisclaimer|
 
 Using processing algorithms from the console
 ==============================================

--- a/source/docs/user_manual/processing/history.rst
+++ b/source/docs/user_manual/processing/history.rst
@@ -1,4 +1,3 @@
-|updatedisclaimer|
 
 .. _`processing.history`:
 

--- a/source/docs/user_manual/processing/index.rst
+++ b/source/docs/user_manual/processing/index.rst
@@ -1,4 +1,3 @@
-|updatedisclaimer|
 
 .. _label_processing:
 

--- a/source/docs/user_manual/processing/intro.rst
+++ b/source/docs/user_manual/processing/intro.rst
@@ -1,4 +1,3 @@
-|updatedisclaimer|
 
 .. _sec_processing_intro:
 

--- a/source/docs/user_manual/processing/modeler.rst
+++ b/source/docs/user_manual/processing/modeler.rst
@@ -1,4 +1,3 @@
-|updatedisclaimer|
 
 .. _`processing.modeler`:
 

--- a/source/docs/user_manual/processing/toolbox.rst
+++ b/source/docs/user_manual/processing/toolbox.rst
@@ -1,4 +1,3 @@
-|updatedisclaimer|
 
 .. _`processing.toolbox`:
 

--- a/source/docs/user_manual/processing_algs/gdalogr/gdal_analysis.rst
+++ b/source/docs/user_manual/processing_algs/gdalogr/gdal_analysis.rst
@@ -1,4 +1,3 @@
-|updatedisclaimer|
 
 GDAL analysis
 =============

--- a/source/docs/user_manual/processing_algs/gdalogr/gdal_conversion.rst
+++ b/source/docs/user_manual/processing_algs/gdalogr/gdal_conversion.rst
@@ -1,4 +1,3 @@
-|updatedisclaimer|
 
 GDAL conversion
 ===============

--- a/source/docs/user_manual/processing_algs/gdalogr/gdal_extraction.rst
+++ b/source/docs/user_manual/processing_algs/gdalogr/gdal_extraction.rst
@@ -1,4 +1,3 @@
-|updatedisclaimer|
 
 GDAL extraction
 ===============

--- a/source/docs/user_manual/processing_algs/gdalogr/gdal_miscellaneous.rst
+++ b/source/docs/user_manual/processing_algs/gdalogr/gdal_miscellaneous.rst
@@ -1,4 +1,3 @@
-|updatedisclaimer|
 
 GDAL miscellaneous
 ==================

--- a/source/docs/user_manual/processing_algs/gdalogr/gdal_projections.rst
+++ b/source/docs/user_manual/processing_algs/gdalogr/gdal_projections.rst
@@ -1,4 +1,3 @@
-|updatedisclaimer|
 
 GDAL projections
 ================

--- a/source/docs/user_manual/processing_algs/gdalogr/index.rst
+++ b/source/docs/user_manual/processing_algs/gdalogr/index.rst
@@ -1,4 +1,3 @@
-|updatedisclaimer|
 
 ***********************
 GDAL algorithm provider

--- a/source/docs/user_manual/processing_algs/gdalogr/ogr_conversion.rst
+++ b/source/docs/user_manual/processing_algs/gdalogr/ogr_conversion.rst
@@ -1,4 +1,3 @@
-|updatedisclaimer|
 
 OGR conversion
 ==============

--- a/source/docs/user_manual/processing_algs/gdalogr/ogr_geoprocessing.rst
+++ b/source/docs/user_manual/processing_algs/gdalogr/ogr_geoprocessing.rst
@@ -1,4 +1,3 @@
-|updatedisclaimer|
 
 OGR geoprocessing
 =================

--- a/source/docs/user_manual/processing_algs/gdalogr/ogr_miscellaneous.rst
+++ b/source/docs/user_manual/processing_algs/gdalogr/ogr_miscellaneous.rst
@@ -1,4 +1,3 @@
-|updatedisclaimer|
 
 OGR miscellaneous
 =================

--- a/source/docs/user_manual/processing_algs/index.rst
+++ b/source/docs/user_manual/processing_algs/index.rst
@@ -1,4 +1,3 @@
-|updatedisclaimer|
 
 .. _processing_algs:
 

--- a/source/docs/user_manual/processing_algs/lidartools/index.rst
+++ b/source/docs/user_manual/processing_algs/lidartools/index.rst
@@ -1,4 +1,3 @@
-|updatedisclaimer|
 
 *******************************
 LAStools algorithm provider

--- a/source/docs/user_manual/processing_algs/lidartools/lastools.rst
+++ b/source/docs/user_manual/processing_algs/lidartools/lastools.rst
@@ -1,4 +1,3 @@
-|updatedisclaimer|
 
 ********
 LAStools

--- a/source/docs/user_manual/processing_algs/modelertools/modeleronly_tools.rst
+++ b/source/docs/user_manual/processing_algs/modelertools/modeleronly_tools.rst
@@ -1,4 +1,3 @@
-|updatedisclaimer|
 
 *************
 Modeler Tools

--- a/source/docs/user_manual/processing_algs/otb/calibration.rst
+++ b/source/docs/user_manual/processing_algs/otb/calibration.rst
@@ -1,4 +1,3 @@
-|updatedisclaimer|
 
 Calibration
 ===========

--- a/source/docs/user_manual/processing_algs/otb/feature_extraction.rst
+++ b/source/docs/user_manual/processing_algs/otb/feature_extraction.rst
@@ -1,4 +1,3 @@
-|updatedisclaimer|
 
 Feature extraction
 ==================

--- a/source/docs/user_manual/processing_algs/otb/geometry.rst
+++ b/source/docs/user_manual/processing_algs/otb/geometry.rst
@@ -1,4 +1,3 @@
-|updatedisclaimer|
 
 Geometry
 ========

--- a/source/docs/user_manual/processing_algs/otb/image_filtering.rst
+++ b/source/docs/user_manual/processing_algs/otb/image_filtering.rst
@@ -1,4 +1,3 @@
-|updatedisclaimer|
 
 Image filtering
 ===============

--- a/source/docs/user_manual/processing_algs/otb/image_manipulation.rst
+++ b/source/docs/user_manual/processing_algs/otb/image_manipulation.rst
@@ -1,4 +1,3 @@
-|updatedisclaimer|
 
 Image manipulation
 ==================

--- a/source/docs/user_manual/processing_algs/otb/index.rst
+++ b/source/docs/user_manual/processing_algs/otb/index.rst
@@ -1,4 +1,3 @@
-|updatedisclaimer|
 
 *******************************
 OrfeoToolbox algorithm provider

--- a/source/docs/user_manual/processing_algs/otb/learning.rst
+++ b/source/docs/user_manual/processing_algs/otb/learning.rst
@@ -1,4 +1,3 @@
-|updatedisclaimer|
 
 Learning
 ========

--- a/source/docs/user_manual/processing_algs/otb/miscellaneous.rst
+++ b/source/docs/user_manual/processing_algs/otb/miscellaneous.rst
@@ -1,4 +1,3 @@
-|updatedisclaimer|
 
 Miscellaneous
 =============

--- a/source/docs/user_manual/processing_algs/otb/segmentation.rst
+++ b/source/docs/user_manual/processing_algs/otb/segmentation.rst
@@ -1,4 +1,3 @@
-|updatedisclaimer|
 
 Segmentation
 ============

--- a/source/docs/user_manual/processing_algs/otb/stereo.rst
+++ b/source/docs/user_manual/processing_algs/otb/stereo.rst
@@ -1,4 +1,3 @@
-|updatedisclaimer|
 
 Stereo
 ======

--- a/source/docs/user_manual/processing_algs/otb/vector_data_manipulation.rst
+++ b/source/docs/user_manual/processing_algs/otb/vector_data_manipulation.rst
@@ -1,4 +1,3 @@
-|updatedisclaimer|
 
 Vector
 ======

--- a/source/docs/user_manual/processing_algs/qgis/database.rst
+++ b/source/docs/user_manual/processing_algs/qgis/database.rst
@@ -1,4 +1,3 @@
-|updatedisclaimer|
 
 Database
 ========

--- a/source/docs/user_manual/processing_algs/qgis/index.rst
+++ b/source/docs/user_manual/processing_algs/qgis/index.rst
@@ -1,4 +1,3 @@
-|updatedisclaimer|
 
 ***********************
 QGIS algorithm provider

--- a/source/docs/user_manual/processing_algs/qgis/raster_general_tools.rst
+++ b/source/docs/user_manual/processing_algs/qgis/raster_general_tools.rst
@@ -1,4 +1,3 @@
-|updatedisclaimer|
 
 Raster general
 ==============

--- a/source/docs/user_manual/processing_algs/qgis/raster_tools.rst
+++ b/source/docs/user_manual/processing_algs/qgis/raster_tools.rst
@@ -1,4 +1,3 @@
-|updatedisclaimer|
 
 Raster
 ======

--- a/source/docs/user_manual/processing_algs/qgis/table.rst
+++ b/source/docs/user_manual/processing_algs/qgis/table.rst
@@ -1,4 +1,3 @@
-|updatedisclaimer|
 
 Table
 =====

--- a/source/docs/user_manual/processing_algs/qgis/vector_analysis_tools.rst
+++ b/source/docs/user_manual/processing_algs/qgis/vector_analysis_tools.rst
@@ -1,4 +1,3 @@
-|updatedisclaimer|
 
 Vector analysis
 ===============

--- a/source/docs/user_manual/processing_algs/qgis/vector_creation_tools.rst
+++ b/source/docs/user_manual/processing_algs/qgis/vector_creation_tools.rst
@@ -1,4 +1,3 @@
-|updatedisclaimer|
 
 Vector creation
 ===============

--- a/source/docs/user_manual/processing_algs/qgis/vector_general_tools.rst
+++ b/source/docs/user_manual/processing_algs/qgis/vector_general_tools.rst
@@ -1,4 +1,3 @@
-|updatedisclaimer|
 
 Vector general
 ==============

--- a/source/docs/user_manual/processing_algs/qgis/vector_geometry_tools.rst
+++ b/source/docs/user_manual/processing_algs/qgis/vector_geometry_tools.rst
@@ -1,4 +1,3 @@
-|updatedisclaimer|
 
 Vector geometry
 ===============

--- a/source/docs/user_manual/processing_algs/qgis/vector_overlay_tools.rst
+++ b/source/docs/user_manual/processing_algs/qgis/vector_overlay_tools.rst
@@ -1,4 +1,3 @@
-|updatedisclaimer|
 
 Vector overlay
 ==============

--- a/source/docs/user_manual/processing_algs/qgis/vector_selection_tools.rst
+++ b/source/docs/user_manual/processing_algs/qgis/vector_selection_tools.rst
@@ -1,4 +1,3 @@
-|updatedisclaimer|
 
 Vector selection
 ================

--- a/source/docs/user_manual/processing_algs/qgis/vector_table_tools.rst
+++ b/source/docs/user_manual/processing_algs/qgis/vector_table_tools.rst
@@ -1,4 +1,3 @@
-|updatedisclaimer|
 
 Vector table
 ============

--- a/source/docs/user_manual/processing_algs/r/basic_statistics.rst
+++ b/source/docs/user_manual/processing_algs/r/basic_statistics.rst
@@ -1,4 +1,3 @@
-|updatedisclaimer|
 
 Basic statistics
 ================

--- a/source/docs/user_manual/processing_algs/r/home_range_analysis.rst
+++ b/source/docs/user_manual/processing_algs/r/home_range_analysis.rst
@@ -1,4 +1,3 @@
-|updatedisclaimer|
 
 Home range
 ==========

--- a/source/docs/user_manual/processing_algs/r/index.rst
+++ b/source/docs/user_manual/processing_algs/r/index.rst
@@ -1,4 +1,3 @@
-|updatedisclaimer|
 
 ********************
 R algorithm provider

--- a/source/docs/user_manual/processing_algs/r/point_pattern_analysis.rst
+++ b/source/docs/user_manual/processing_algs/r/point_pattern_analysis.rst
@@ -1,4 +1,3 @@
-|updatedisclaimer|
 
 Point pattern
 =============

--- a/source/docs/user_manual/processing_algs/r/raster_processing.rst
+++ b/source/docs/user_manual/processing_algs/r/raster_processing.rst
@@ -1,4 +1,3 @@
-|updatedisclaimer|
 
 Raster processing
 =================

--- a/source/docs/user_manual/processing_algs/r/vector_processing.rst
+++ b/source/docs/user_manual/processing_algs/r/vector_processing.rst
@@ -1,4 +1,3 @@
-|updatedisclaimer|
 
 Vector processing
 =================

--- a/source/docs/user_manual/processing_algs/saga/geostatistics.rst
+++ b/source/docs/user_manual/processing_algs/saga/geostatistics.rst
@@ -1,4 +1,3 @@
-|updatedisclaimer|
 
 Geostatistics
 =============

--- a/source/docs/user_manual/processing_algs/saga/grid_analysis.rst
+++ b/source/docs/user_manual/processing_algs/saga/grid_analysis.rst
@@ -1,4 +1,3 @@
-|updatedisclaimer|
 
 Grid analysis
 =============

--- a/source/docs/user_manual/processing_algs/saga/grid_calculus.rst
+++ b/source/docs/user_manual/processing_algs/saga/grid_calculus.rst
@@ -1,4 +1,3 @@
-|updatedisclaimer|
 
 Grid calculus
 =============

--- a/source/docs/user_manual/processing_algs/saga/grid_filter.rst
+++ b/source/docs/user_manual/processing_algs/saga/grid_filter.rst
@@ -1,4 +1,3 @@
-|updatedisclaimer|
 
 Grid filter
 ===========

--- a/source/docs/user_manual/processing_algs/saga/grid_gridding.rst
+++ b/source/docs/user_manual/processing_algs/saga/grid_gridding.rst
@@ -1,4 +1,3 @@
-|updatedisclaimer|
 
 Grid gridding
 =============

--- a/source/docs/user_manual/processing_algs/saga/grid_spline.rst
+++ b/source/docs/user_manual/processing_algs/saga/grid_spline.rst
@@ -1,4 +1,3 @@
-|updatedisclaimer|
 
 Grid spline
 ===========

--- a/source/docs/user_manual/processing_algs/saga/grid_tools.rst
+++ b/source/docs/user_manual/processing_algs/saga/grid_tools.rst
@@ -1,4 +1,3 @@
-|updatedisclaimer|
 
 Grid tools
 ==========

--- a/source/docs/user_manual/processing_algs/saga/grid_visualization.rst
+++ b/source/docs/user_manual/processing_algs/saga/grid_visualization.rst
@@ -1,4 +1,3 @@
-|updatedisclaimer|
 
 Grid visualization
 ==================

--- a/source/docs/user_manual/processing_algs/saga/imagery_classification.rst
+++ b/source/docs/user_manual/processing_algs/saga/imagery_classification.rst
@@ -1,4 +1,3 @@
-|updatedisclaimer|
 
 Imagery classification
 ======================

--- a/source/docs/user_manual/processing_algs/saga/imagery_rga.rst
+++ b/source/docs/user_manual/processing_algs/saga/imagery_rga.rst
@@ -1,4 +1,3 @@
-|updatedisclaimer|
 
 Imagery RGA
 ===========

--- a/source/docs/user_manual/processing_algs/saga/imagery_segmentation.rst
+++ b/source/docs/user_manual/processing_algs/saga/imagery_segmentation.rst
@@ -1,4 +1,3 @@
-|updatedisclaimer|
 
 Imagery segmentation
 ====================

--- a/source/docs/user_manual/processing_algs/saga/imagery_tools.rst
+++ b/source/docs/user_manual/processing_algs/saga/imagery_tools.rst
@@ -1,4 +1,3 @@
-|updatedisclaimer|
 
 Imagery tools
 =============

--- a/source/docs/user_manual/processing_algs/saga/index.rst
+++ b/source/docs/user_manual/processing_algs/saga/index.rst
@@ -1,4 +1,3 @@
-|updatedisclaimer|
 
 ***********************
 SAGA algorithm provider

--- a/source/docs/user_manual/processing_algs/saga/kriging.rst
+++ b/source/docs/user_manual/processing_algs/saga/kriging.rst
@@ -1,4 +1,3 @@
-|updatedisclaimer|
 
 Kriging
 =======

--- a/source/docs/user_manual/processing_algs/saga/shapes_grid.rst
+++ b/source/docs/user_manual/processing_algs/saga/shapes_grid.rst
@@ -1,4 +1,3 @@
-|updatedisclaimer|
 
 Shapes grid
 ===========

--- a/source/docs/user_manual/processing_algs/saga/shapes_lines.rst
+++ b/source/docs/user_manual/processing_algs/saga/shapes_lines.rst
@@ -1,4 +1,3 @@
-|updatedisclaimer|
 
 Shapes lines
 ============

--- a/source/docs/user_manual/processing_algs/saga/shapes_points.rst
+++ b/source/docs/user_manual/processing_algs/saga/shapes_points.rst
@@ -1,4 +1,3 @@
-|updatedisclaimer|
 
 Shapes points
 =============

--- a/source/docs/user_manual/processing_algs/saga/shapes_polygons.rst
+++ b/source/docs/user_manual/processing_algs/saga/shapes_polygons.rst
@@ -1,4 +1,3 @@
-|updatedisclaimer|
 
 Shapes polygons
 ===============

--- a/source/docs/user_manual/processing_algs/saga/shapes_tools.rst
+++ b/source/docs/user_manual/processing_algs/saga/shapes_tools.rst
@@ -1,4 +1,3 @@
-|updatedisclaimer|
 
 Shapes tools
 ============

--- a/source/docs/user_manual/processing_algs/saga/shapes_transect.rst
+++ b/source/docs/user_manual/processing_algs/saga/shapes_transect.rst
@@ -1,4 +1,3 @@
-|updatedisclaimer|
 
 Shapes transect
 ===============

--- a/source/docs/user_manual/processing_algs/saga/simulation_fire_spreading.rst
+++ b/source/docs/user_manual/processing_algs/saga/simulation_fire_spreading.rst
@@ -1,4 +1,3 @@
-|updatedisclaimer|
 
 Simulation fire
 ===============

--- a/source/docs/user_manual/processing_algs/saga/simulation_hydrology.rst
+++ b/source/docs/user_manual/processing_algs/saga/simulation_hydrology.rst
@@ -1,4 +1,3 @@
-|updatedisclaimer|
 
 Simulation hydrology
 ====================

--- a/source/docs/user_manual/processing_algs/saga/table_calculus.rst
+++ b/source/docs/user_manual/processing_algs/saga/table_calculus.rst
@@ -1,4 +1,3 @@
-|updatedisclaimer|
 
 Table calculus
 ==============

--- a/source/docs/user_manual/processing_algs/saga/table_tools.rst
+++ b/source/docs/user_manual/processing_algs/saga/table_tools.rst
@@ -1,4 +1,3 @@
-|updatedisclaimer|
 
 Table tools
 ===========

--- a/source/docs/user_manual/processing_algs/saga/terrain_analysis_channels.rst
+++ b/source/docs/user_manual/processing_algs/saga/terrain_analysis_channels.rst
@@ -1,4 +1,3 @@
-|updatedisclaimer|
 
 Terrain channels
 ================

--- a/source/docs/user_manual/processing_algs/saga/terrain_analysis_hydrology.rst
+++ b/source/docs/user_manual/processing_algs/saga/terrain_analysis_hydrology.rst
@@ -1,4 +1,3 @@
-|updatedisclaimer|
 
 Terrain hydrology
 =================

--- a/source/docs/user_manual/processing_algs/saga/terrain_analysis_lighting.rst
+++ b/source/docs/user_manual/processing_algs/saga/terrain_analysis_lighting.rst
@@ -1,4 +1,3 @@
-|updatedisclaimer|
 
 Terrain lighting
 ================

--- a/source/docs/user_manual/processing_algs/saga/terrain_analysis_morphometry.rst
+++ b/source/docs/user_manual/processing_algs/saga/terrain_analysis_morphometry.rst
@@ -1,4 +1,3 @@
-|updatedisclaimer|
 
 Terrain morphometry
 ===================

--- a/source/docs/user_manual/processing_algs/saga/terrain_analysis_profiles.rst
+++ b/source/docs/user_manual/processing_algs/saga/terrain_analysis_profiles.rst
@@ -1,4 +1,3 @@
-|updatedisclaimer|
 
 Terrain profiles
 ================

--- a/source/docs/user_manual/processing_algs/taudem/basic_grid_analysis_tools.rst
+++ b/source/docs/user_manual/processing_algs/taudem/basic_grid_analysis_tools.rst
@@ -1,4 +1,3 @@
-|updatedisclaimer|
 
 Basic Grid Analysis
 ===================

--- a/source/docs/user_manual/processing_algs/taudem/index.rst
+++ b/source/docs/user_manual/processing_algs/taudem/index.rst
@@ -1,4 +1,3 @@
-|updatedisclaimer|
 
 *************************
 TauDEM algorithm provider

--- a/source/docs/user_manual/processing_algs/taudem/specialized_grid_analysis_tools.rst
+++ b/source/docs/user_manual/processing_algs/taudem/specialized_grid_analysis_tools.rst
@@ -1,4 +1,3 @@
-|updatedisclaimer|
 
 Specialized Grid Analysis
 =========================

--- a/source/docs/user_manual/processing_algs/taudem/stream_network_analysis_tools.rst
+++ b/source/docs/user_manual/processing_algs/taudem/stream_network_analysis_tools.rst
@@ -1,4 +1,3 @@
-|updatedisclaimer|
 
 Stream Network Analysis
 =======================

--- a/source/docs/user_manual/qgis_browser/qgis_browser.rst
+++ b/source/docs/user_manual/qgis_browser/qgis_browser.rst
@@ -1,4 +1,3 @@
-|updatedisclaimer|
 
 .. _`label_qgis_browser`:
 

--- a/source/docs/user_manual/working_with_gps/index.rst
+++ b/source/docs/user_manual/working_with_gps/index.rst
@@ -1,4 +1,3 @@
-|updatedisclaimer|
 
 **********************
 Working with GPS Data

--- a/source/docs/user_manual/working_with_gps/live_GPS_tracking.rst
+++ b/source/docs/user_manual/working_with_gps/live_GPS_tracking.rst
@@ -1,4 +1,3 @@
-|updatedisclaimer|
 
 .. _`sec_gpstracking`:
 

--- a/source/docs/user_manual/working_with_gps/plugins_gps.rst
+++ b/source/docs/user_manual/working_with_gps/plugins_gps.rst
@@ -1,4 +1,3 @@
-|updatedisclaimer|
 
 .. _plugin_gps:
 

--- a/source/docs/user_manual/working_with_ogc/index.rst
+++ b/source/docs/user_manual/working_with_ogc/index.rst
@@ -1,4 +1,3 @@
-|updatedisclaimer|
 
 .. _sec_ogc:
 

--- a/source/docs/user_manual/working_with_ogc/ogc_client_support.rst
+++ b/source/docs/user_manual/working_with_ogc/ogc_client_support.rst
@@ -1,4 +1,3 @@
-|updatedisclaimer|
 
 .. _working_with_ogc:
 

--- a/source/docs/user_manual/working_with_ogc/ogc_server_support.rst
+++ b/source/docs/user_manual/working_with_ogc/ogc_server_support.rst
@@ -1,4 +1,3 @@
-|updatedisclaimer|
 
 .. index:: QGIS Server; WMS Server; WFS Server; WCS Server
 

--- a/source/docs/user_manual/working_with_projections/working_with_projections.rst
+++ b/source/docs/user_manual/working_with_projections/working_with_projections.rst
@@ -1,4 +1,3 @@
-|updatedisclaimer|
 
 .. _`label_projections`:
 

--- a/source/docs/user_manual/working_with_raster/index.rst
+++ b/source/docs/user_manual/working_with_raster/index.rst
@@ -1,4 +1,3 @@
-|updatedisclaimer|
 
 .. _working_with_raster:
 

--- a/source/docs/user_manual/working_with_raster/raster_analysis.rst
+++ b/source/docs/user_manual/working_with_raster/raster_analysis.rst
@@ -1,4 +1,3 @@
-|updatedisclaimer|
 
 .. _sec_raster_analysis:
 

--- a/source/docs/user_manual/working_with_raster/raster_properties.rst
+++ b/source/docs/user_manual/working_with_raster/raster_properties.rst
@@ -1,4 +1,3 @@
-|updatedisclaimer|
 
 Raster Properties Dialog
 ========================

--- a/source/docs/user_manual/working_with_raster/supported_data.rst
+++ b/source/docs/user_manual/working_with_raster/supported_data.rst
@@ -1,4 +1,3 @@
-|updatedisclaimer|
 
 .. index:: Raster
 .. index:: Arc/Info_Binary_Grid, Arc/Info_ASCII_Grid, GeoTIFF
@@ -12,11 +11,6 @@ Working with Raster Data
 
    .. contents::
       :local:
-
-.. % when the revision of a section has been finalized,
-.. % comment out the following line:
-.. %\updatedisclaimer
-
 
 This section describes how to visualize and set raster layer properties.
 QGIS uses the :index:`GDAL` library to read and write raster data formats,

--- a/source/docs/user_manual/working_with_vector/editing_geometry_attributes.rst
+++ b/source/docs/user_manual/working_with_vector/editing_geometry_attributes.rst
@@ -1,4 +1,3 @@
-|updatedisclaimer|
 
 *********
  Editing

--- a/source/docs/user_manual/working_with_vector/expression.rst
+++ b/source/docs/user_manual/working_with_vector/expression.rst
@@ -1,4 +1,3 @@
-|updatedisclaimer|
 
 .. index:: Expressions
 

--- a/source/docs/user_manual/working_with_vector/index.rst
+++ b/source/docs/user_manual/working_with_vector/index.rst
@@ -1,4 +1,3 @@
-|updatedisclaimer|
 
 .. _label_workingvector:
 

--- a/source/docs/user_manual/working_with_vector/style_library.rst
+++ b/source/docs/user_manual/working_with_vector/style_library.rst
@@ -1,4 +1,3 @@
-|updatedisclaimer|
 
 .. _vector_symbol_library:
 

--- a/source/docs/user_manual/working_with_vector/supported_data.rst
+++ b/source/docs/user_manual/working_with_vector/supported_data.rst
@@ -1,4 +1,3 @@
-|updatedisclaimer|
 
 .. _supported_format:
 

--- a/source/docs/user_manual/working_with_vector/vector_properties.rst
+++ b/source/docs/user_manual/working_with_vector/vector_properties.rst
@@ -1,4 +1,3 @@
-|updatedisclaimer|
 
 .. _vector_properties_dialog:
 

--- a/source/docs/user_manual/working_with_vector/virtual_layers.rst
+++ b/source/docs/user_manual/working_with_vector/virtual_layers.rst
@@ -1,4 +1,3 @@
-|updatedisclaimer|
 
 .. index:: Virtual_Layers
 


### PR DESCRIPTION
Failing to have the display of |updatedisclaimer|  ignored at the top of some pages in 2.14 doc (see #1322) this PR actually removes the reference itself from top of pages given that it's not really needed for a released doc. 
Fixes #1252