### PR TITLE
Update list of panels

### DIFF
--- a/source/docs/user_manual/introduction/general_tools.rst
+++ b/source/docs/user_manual/introduction/general_tools.rst
@@ -66,6 +66,10 @@ plugins can point to dedicated web pages.
 
 Panels
 =======
+QGIS provides by default many panels to work with.
+Some of these panels are described below while others may be found in different
+parts of the document. A complete list of default panels provided by QGIS is
+available at :ref:`panels_tools`.
 
 .. index:: Panels; Layers
 .. _`label_legend`:
@@ -85,13 +89,13 @@ panel allows you to:
   preset layers combination
 * |filterMap| :sup:`Filter Legend by Map Content`: only the layers that are set
   visible and whose features intersect the current map canvas have their style
-  rendered in the layers panel. Otherwise, a generic NULL symbol is applied to the
-  layer. Based on the layer symbology, this is a convenient way to identify which
-  kind of features from which layers cover your area of interest.
+  rendered in the layers panel. Otherwise, a generic NULL symbol is applied to
+  the layer. Based on the layer symbology, this is a convenient way to identify
+  which kind of features from which layers cover your area of interest.
 * |expressionFilter| :sup:`Filter Legend by Expression`: helps you apply an
   expression to remove from the selected layer tree styles that have no feature
-  satisfying the condition. This can be used for example to highlight features that are
-  within a given area/feature of another layer.
+  satisfying the condition. This can be used for example to highlight features
+  that are within a given area/feature of another layer.
   From the drop-down list, you can edit and clear the expression set.
 * |expandTree| :sup:`Expand All` or |collapseTree| :sup:`Collapse All`
   layers and groups in the layers panel.

--- a/source/docs/user_manual/introduction/qgis_gui.rst
+++ b/source/docs/user_manual/introduction/qgis_gui.rst
@@ -366,7 +366,7 @@ switch on and off QGIS widgets (:menuselection:`Panels -->`) or toolbars
 (:menuselection:`Toolbars -->`). You can (de)activate any of them by
 right-clicking the menu bar or a toolbar and choose the item you want.
 Each panel or toolbar can be moved and placed wherever you feel comfortable
-with in QGIS interface.
+within QGIS interface.
 The list can also be extended with the activation of :ref:`Core or external
 plugins <plugins>`.
 
@@ -411,11 +411,14 @@ holding the mouse over the toolbars.
    initial GUI <tip_restoring_configuration>`.
 
 .. index:: Panels
+.. _panels_tools:
 
 Panels
 ------
 
-QGIS provides by default many panels to work with.
+Besides toolbars, QGIS provides by default many panels to work with. Panels are
+special widgets that you can interact with (selecting options, checking boxes,
+filling values...) in order to perform a more complex task.
 
 
 .. _figure_panels:
@@ -429,9 +432,9 @@ QGIS provides by default many panels to work with.
 
    The Panels menu
 
-Some of these panels are described
-below while others may be found in different parts of the document, namely:
+Below are listed default panels provided by QGIS:
 
+* the :ref:`label_legend`
 * the :ref:`Browser Panel <label_qgis_browser>`
 * the :ref:`Advanced Digitizing Panel <advanced_digitizing_panel>`
 * the :ref:`Spatial Bookmarks Panel <sec_bookmarks>`
@@ -439,13 +442,13 @@ below while others may be found in different parts of the document, namely:
 * the :ref:`Tile Scale Panel <tilesets>`
 * the :ref:`Identify Panel <identify>`
 * the :ref:`User Input Panel <rotate_feature>`
-* the :ref:`layer_order`
+* the :ref:`Layer Order Panel <layer_order>`
+* the :ref:`layer_styling_panel` 
 * the :ref:`statistical_summary`
 * the :ref:`overview_panels`
 * the :ref:`log_message_panel`
 * the :ref:`undo_redo_panel`
-* the :ref:`label_processing`
-
+* the :ref:`Processing Toolbox <label_processing>`
 
 .. _`label_mapview`:
 


### PR DESCRIPTION
unlike what is stated, no description of panel is available in [qgis_gui](http://docs.qgis.org/testing/en/docs/user_manual/introduction/qgis_gui.html#panels). So this PR moves that comment to [general tools](http://docs.qgis.org/testing/en/docs/user_manual/introduction/general_tools.html#panels) (where some of them are described) and updates the list (and display) of panels.

NB: Travis will fail due to #1423 (waiting for review)