### PR TITLE
Add list of contributors

### DIFF
--- a/source/docs/user_manual/index.rst
+++ b/source/docs/user_manual/index.rst
@@ -33,6 +33,7 @@ QGIS User Guide
     print_composer/index
     plugins/plugins_index
     preamble/help_and_support
+    preamble/contributors
     appendices/appendices
     literature_web/literature_and_web_references
 

--- a/source/docs/user_manual/preamble/contributors.rst
+++ b/source/docs/user_manual/preamble/contributors.rst
@@ -1,0 +1,92 @@
+.. only:: html
+
+   |updatedisclaimer|
+
+.. _doc_contributors:
+
+**************
+ Contributors
+**************
+
+.. only:: html
+
+   .. contents::
+      :local:
+
+QGIS is an open source project developed by a team of dedicated volunteers and
+organisations. We strive to be a welcoming community for people of all race, creed,
+gender and walks of life.
+At any moment, you can `get involved <http://qgis.org/en/site/getinvolved/index.html>`_.
+
+.. index::
+   :single: Contributors; Authors
+.. _doc_authors:
+
+Authors
+========
+
+Below are listed people who dedicate their time and energy to write, review,
+and update the whole QGIS documentation.
+
+
++--------------------+---------------------+----------------------+-----------------------+----------------------+ 
+| Tara Athan         | Radim Blazek        | K\. Koy              | Godofredo Contreras   | Martin Dobias        | 
++--------------------+---------------------+----------------------+-----------------------+----------------------+  
+| Peter Ersts        | Anne Ghisla         | Stephan Holl         | N\. Horning           | Magnus Homann        | 
++--------------------+---------------------+----------------------+-----------------------+----------------------+ 
+| Werner Macho       | Denis Rouzaud       | Tyler Mitchell       | Claudia A. Engel      | Lars Luthman         | 
++--------------------+---------------------+----------------------+-----------------------+----------------------+ 
+| Otto Dassau        | Brendan Morely      | David Willis         | Jürgen E. Fischer     | Yoichi Kayama        | 
++--------------------+---------------------+----------------------+-----------------------+----------------------+ 
+| Alex Bruy          | Anita Graser        | Victor Olaya         | Marco Hugentobler     | Gary E. Sherman      | 
++--------------------+---------------------+----------------------+-----------------------+----------------------+ 
+| Tim Sutton         | Larissa Junek       | Raymond Nijssen      | Richard Duivenvoorde  | Andreas Neumann      | 
++--------------------+---------------------+----------------------+-----------------------+----------------------+ 
+| Astrid Emde        | Yves Jacolin        | Alexandre Neto       | Alessandro Pasotti    | Hien Tran-Quang      | 
++--------------------+---------------------+----------------------+-----------------------+----------------------+ 
+| Andy Schmid        | Arnaud Morvan       | Akgar Gumbira        | Giovanni Allegri      | Diethard Jansen      | 
++--------------------+---------------------+----------------------+-----------------------+----------------------+ 
+| Andy Allan         | Matthias Kuhn       | Chris Berkhout       | Carson J.Q. Farmer    | Steven Cordwell      | 
++--------------------+---------------------+----------------------+-----------------------+----------------------+ 
+| Eric Goddard       | Frank Sokolic       | Luca Casagrande      | Harrissou Sant-anna   | Saber Razmjooei      | 
++--------------------+---------------------+----------------------+-----------------------+----------------------+ 
+| Ilkka Rinne        | Jacob Lanstorp      | Ujaval Gandhi        | Jean-Roc Morreale     | Salvatore Larosa     | 
++--------------------+---------------------+----------------------+-----------------------+----------------------+ 
+| João Gaspar        | Joshua Arnott       | Thomas Gratier       | Marco Bernasocchi     | Marie Silvestre      | 
++--------------------+---------------------+----------------------+-----------------------+----------------------+ 
+| Ko Nagase          | Larry Shaffer       | Luigi Pirelli        | Konstantinos Nikolaou | Maning Sambale       | 
++--------------------+---------------------+----------------------+-----------------------+----------------------+ 
+| Manel Clos         | Mattheo Ghetta      | Bernhard Ströbl      | Luca Manganelli       | Nathan Woodrow       | 
++--------------------+---------------------+----------------------+-----------------------+----------------------+ 
+| Nick Bearman       | Paul Blottière      | Vincent Picavet      | Maximilian Krambach   | René-Luc D'Hont      | 
++--------------------+---------------------+----------------------+-----------------------+----------------------+ 
+| Tom Chadwin        | Patrick Sunter      | Nyall Dawson         | Milo Van der Linden   | Paolo Cavallini      | 
++--------------------+---------------------+----------------------+-----------------------+----------------------+ 
+| Paolo Corti        | Hugo Mercier        | Gavin Macaulay       | Stefan Blumentrath    | Nicholas Duggan      | 
++--------------------+---------------------+----------------------+-----------------------+----------------------+ 
+| David Adler        | Vincent Mora        | Tudor Barascu        | QGIS Koran Translator | Stéphane Brunner     | 
++--------------------+---------------------+----------------------+-----------------------+----------------------+ 
+| Jaka Kranjc        | Tom Kralidis        | Zoltan Siki          | Sebastian Dietrich    | Uros Preloznik       | 
++--------------------+---------------------+----------------------+-----------------------+----------------------+ 
+| Dick Groskamp      | Mezene Worku        | GiordanoPezzola      | badewannencaptain     | zstadler             |
++--------------------+---------------------+----------------------+-----------------------+----------------------+ 
+| ajazepk            | icephale            | Andrei               | Alexandre (Busquets?) | andremano            | 
++--------------------+---------------------+----------------------+-----------------------+----------------------+
+| Ramon              | embelding           |                      |                       |                      | 
++--------------------+---------------------+----------------------+-----------------------+----------------------+
+
+Despite our efforts to release a full featured and up-to-date documentation,
+if you find any error or miss some feature, feel free to report that or propose
+a fix at `QGIS Documentation repository <http://www.github.com/qgis/QGIS-Documentation/>`_.
+
+
+.. index:: 
+   :single: Contributors; Translators
+.. _doc_translators:
+
+Translators
+===========
+
+QGIS is a multi-language application and as is, also provides a documentation
+translated into several languages. This is possible thanks to:
+

--- a/source/docs/user_manual/preamble/contributors.rst
+++ b/source/docs/user_manual/preamble/contributors.rst
@@ -29,50 +29,50 @@ Below are listed people who dedicate their time and energy to write, review,
 and update the whole QGIS documentation.
 
 
-+--------------------+---------------------+----------------------+-----------------------+----------------------+ 
-| Tara Athan         | Radim Blazek        | K\. Koy              | Godofredo Contreras   | Martin Dobias        | 
-+--------------------+---------------------+----------------------+-----------------------+----------------------+  
-| Peter Ersts        | Anne Ghisla         | Stephan Holl         | N\. Horning           | Magnus Homann        | 
-+--------------------+---------------------+----------------------+-----------------------+----------------------+ 
-| Werner Macho       | Denis Rouzaud       | Tyler Mitchell       | Claudia A. Engel      | Lars Luthman         | 
-+--------------------+---------------------+----------------------+-----------------------+----------------------+ 
-| Otto Dassau        | Brendan Morely      | David Willis         | Jürgen E. Fischer     | Yoichi Kayama        | 
-+--------------------+---------------------+----------------------+-----------------------+----------------------+ 
-| Alex Bruy          | Anita Graser        | Victor Olaya         | Marco Hugentobler     | Gary E. Sherman      | 
-+--------------------+---------------------+----------------------+-----------------------+----------------------+ 
-| Tim Sutton         | Larissa Junek       | Raymond Nijssen      | Richard Duivenvoorde  | Andreas Neumann      | 
-+--------------------+---------------------+----------------------+-----------------------+----------------------+ 
-| Astrid Emde        | Yves Jacolin        | Alexandre Neto       | Alessandro Pasotti    | Hien Tran-Quang      | 
-+--------------------+---------------------+----------------------+-----------------------+----------------------+ 
-| Andy Schmid        | Arnaud Morvan       | Akgar Gumbira        | Giovanni Allegri      | Diethard Jansen      | 
-+--------------------+---------------------+----------------------+-----------------------+----------------------+ 
-| Andy Allan         | Matthias Kuhn       | Chris Berkhout       | Carson J.Q. Farmer    | Steven Cordwell      | 
-+--------------------+---------------------+----------------------+-----------------------+----------------------+ 
-| Eric Goddard       | Frank Sokolic       | Luca Casagrande      | Harrissou Sant-anna   | Saber Razmjooei      | 
-+--------------------+---------------------+----------------------+-----------------------+----------------------+ 
-| Ilkka Rinne        | Jacob Lanstorp      | Ujaval Gandhi        | Jean-Roc Morreale     | Salvatore Larosa     | 
-+--------------------+---------------------+----------------------+-----------------------+----------------------+ 
-| João Gaspar        | Joshua Arnott       | Thomas Gratier       | Marco Bernasocchi     | Marie Silvestre      | 
-+--------------------+---------------------+----------------------+-----------------------+----------------------+ 
-| Ko Nagase          | Larry Shaffer       | Luigi Pirelli        | Konstantinos Nikolaou | Maning Sambale       | 
-+--------------------+---------------------+----------------------+-----------------------+----------------------+ 
-| Manel Clos         | Mattheo Ghetta      | Bernhard Ströbl      | Luca Manganelli       | Nathan Woodrow       | 
-+--------------------+---------------------+----------------------+-----------------------+----------------------+ 
-| Nick Bearman       | Paul Blottière      | Vincent Picavet      | Maximilian Krambach   | René-Luc D'Hont      | 
-+--------------------+---------------------+----------------------+-----------------------+----------------------+ 
-| Tom Chadwin        | Patrick Sunter      | Nyall Dawson         | Milo Van der Linden   | Paolo Cavallini      | 
-+--------------------+---------------------+----------------------+-----------------------+----------------------+ 
-| Paolo Corti        | Hugo Mercier        | Gavin Macaulay       | Stefan Blumentrath    | Nicholas Duggan      | 
-+--------------------+---------------------+----------------------+-----------------------+----------------------+ 
-| David Adler        | Vincent Mora        | Tudor Barascu        | QGIS Koran Translator | Stéphane Brunner     | 
-+--------------------+---------------------+----------------------+-----------------------+----------------------+ 
-| Jaka Kranjc        | Tom Kralidis        | Zoltan Siki          | Sebastian Dietrich    | Uros Preloznik       | 
-+--------------------+---------------------+----------------------+-----------------------+----------------------+ 
-| Dick Groskamp      | Mezene Worku        | GiordanoPezzola      | badewannencaptain     | zstadler             |
-+--------------------+---------------------+----------------------+-----------------------+----------------------+ 
-| ajazepk            | icephale            | Andrei               | Alexandre (Busquets?) | andremano            | 
 +--------------------+---------------------+----------------------+-----------------------+----------------------+
-| Ramon              | embelding           |                      |                       |                      | 
+| Tara Athan         | Radim Blazek        | K\. Koy              | Godofredo Contreras   | Martin Dobias        |
++--------------------+---------------------+----------------------+-----------------------+----------------------+
+| Peter Ersts        | Anne Ghisla         | Stephan Holl         | N\. Horning           | Magnus Homann        |
++--------------------+---------------------+----------------------+-----------------------+----------------------+
+| Werner Macho       | Denis Rouzaud       | Tyler Mitchell       | Claudia A. Engel      | Lars Luthman         |
++--------------------+---------------------+----------------------+-----------------------+----------------------+
+| Otto Dassau        | Brendan Morely      | David Willis         | Jürgen E. Fischer     | Yoichi Kayama        |
++--------------------+---------------------+----------------------+-----------------------+----------------------+
+| Alex Bruy          | Anita Graser        | Victor Olaya         | Marco Hugentobler     | Gary E. Sherman      |
++--------------------+---------------------+----------------------+-----------------------+----------------------+
+| Tim Sutton         | Larissa Junek       | Raymond Nijssen      | Richard Duivenvoorde  | Andreas Neumann      |
++--------------------+---------------------+----------------------+-----------------------+----------------------+
+| Astrid Emde        | Yves Jacolin        | Alexandre Neto       | Alessandro Pasotti    | Hien Tran-Quang      |
++--------------------+---------------------+----------------------+-----------------------+----------------------+
+| Andy Schmid        | Arnaud Morvan       | Akgar Gumbira        | Giovanni Allegri      | Diethard Jansen      |
++--------------------+---------------------+----------------------+-----------------------+----------------------+
+| Andy Allan         | Matthias Kuhn       | Chris Berkhout       | Carson J.Q. Farmer    | Steven Cordwell      |
++--------------------+---------------------+----------------------+-----------------------+----------------------+
+| Eric Goddard       | Frank Sokolic       | Luca Casagrande      | Harrissou Sant-anna   | Saber Razmjooei      |
++--------------------+---------------------+----------------------+-----------------------+----------------------+
+| Ilkka Rinne        | Jacob Lanstorp      | Ujaval Gandhi        | Jean-Roc Morreale     | Salvatore Larosa     |
++--------------------+---------------------+----------------------+-----------------------+----------------------+
+| João Gaspar        | Joshua Arnott       | Thomas Gratier       | Marco Bernasocchi     | Marie Silvestre      |
++--------------------+---------------------+----------------------+-----------------------+----------------------+
+| Ko Nagase          | Larry Shaffer       | Luigi Pirelli        | Konstantinos Nikolaou | Maning Sambale       |
++--------------------+---------------------+----------------------+-----------------------+----------------------+
+| Manel Clos         | Mattheo Ghetta      | Bernhard Ströbl      | Luca Manganelli       | Nathan Woodrow       |
++--------------------+---------------------+----------------------+-----------------------+----------------------+
+| Nick Bearman       | Paul Blottière      | Vincent Picavet      | Maximilian Krambach   | René-Luc D'Hont      |
++--------------------+---------------------+----------------------+-----------------------+----------------------+
+| Tom Chadwin        | Patrick Sunter      | Nyall Dawson         | Milo Van der Linden   | Paolo Cavallini      |
++--------------------+---------------------+----------------------+-----------------------+----------------------+
+| Paolo Corti        | Hugo Mercier        | Gavin Macaulay       | Stefan Blumentrath    | Nicholas Duggan      |
++--------------------+---------------------+----------------------+-----------------------+----------------------+
+| David Adler        | Vincent Mora        | Tudor Barascu        | QGIS Koran Translator | Stéphane Brunner     |
++--------------------+---------------------+----------------------+-----------------------+----------------------+
+| Jaka Kranjc        | Tom Kralidis        | Zoltan Siki          | Sebastian Dietrich    | Uros Preloznik       |
++--------------------+---------------------+----------------------+-----------------------+----------------------+
+| Dick Groskamp      | Mezene Worku        | Alexandre Busquets   | Dominic Keller        | Andre Mano           |
++--------------------+---------------------+----------------------+-----------------------+----------------------+
+| ajazepk            | icephale            | Andrei               | GiordanoPezzola       | zstadler             |
++--------------------+---------------------+----------------------+-----------------------+----------------------+
+| Ramon              | embelding           |                      |                       |                      |
 +--------------------+---------------------+----------------------+-----------------------+----------------------+
 
 Despite our efforts to release a full featured and up-to-date documentation,
@@ -89,4 +89,5 @@ Translators
 
 QGIS is a multi-language application and as is, also provides a documentation
 translated into several languages. This is possible thanks to:
+
 

--- a/source/docs/user_manual/preamble/contributors.rst
+++ b/source/docs/user_manual/preamble/contributors.rst
@@ -75,10 +75,6 @@ and update the whole QGIS documentation.
 | Ramon              | embelding           |                      |                       |                      |
 +--------------------+---------------------+----------------------+-----------------------+----------------------+
 
-Despite our efforts to release a full featured and up-to-date documentation,
-if you find any error or miss some feature, feel free to report that or propose
-a fix at `QGIS Documentation repository <http://www.github.com/qgis/QGIS-Documentation/>`_.
-
 
 .. index:: 
    :single: Contributors; Translators
@@ -87,7 +83,60 @@ a fix at `QGIS Documentation repository <http://www.github.com/qgis/QGIS-Documen
 Translators
 ===========
 
-QGIS is a multi-language application and as is, also provides a documentation
-translated into several languages. This is possible thanks to:
+QGIS is a multi-language application and as is, also publishes a documentation
+translated into several languages. Many other languages are being translated
+and would be released as soon as they reach a reasonable percentage of
+translation. If you wish to help improving a language or request a new one,
+please see http://qgis.org/en/site/getinvolved/index.html.
 
+The current translations are made possible thanks to:
+
+===================== ========================================================
+ Language              Contributors
+===================== ========================================================
+Bahasian Indonesian   Emir Hartato, I Made Anombawa, Januar V. Simarmata, Muhammad
+                      Iqnaul Haq Siregar, Trias Aditya
+Chinese (Traditional) Calvin Ngei, Zhang Jun, Richard Xie
+Dutch                 Carlo van Rijswijk, Dick Groskamp, Diethard Jansen,
+                      Raymond Nijssen, Richard Duivenvoorde, Willem Hoffman
+Finnish               Matti Mäntynen, Kari Mikkonen
+French                Arnaud Morvan, Augustin Roche, Didier Vanden Berghe,
+                      Dofabien, Etienne Trimaille, Harrissou Sant-anna,
+                      Jean-Roc Morreale, Jérémy Garniaux, Loïc Buscoz, Lsam,
+                      Marc-André Saia, Marie Silvestre, Mathieu Bossaert,
+                      Mathieu Lattes, Mayeul Kauffmann, Médéric Ribreux,
+                      Mehdi Semchaoui, Michael Douchin, Nicolas Boisteault,
+                      Nicolas Rochard, Pascal Obstetar, Robin Prest, Rod Bera,
+                      Stéphane Henriod, Stéphane Possamai, sylther, Sylvain Badey,
+                      Sylvain Maillard, Vincent Picavet, Xavier Tardieu,
+                      Yann Leveille-Menez, yoda89
+Galician              Xan Vieiro
+German                Jürgen E. Fischer, Otto Dassau, Stephan Holl,
+                      Werner Macho
+Hindi                 Harish Kumar Solanki
+Italian               Alessandro Fanna, Anne Ghisla, Flavio Rigolon, Giuliano
+                      Curti, Luca Casagrande, Luca Delucchi, Marco Braida,
+                      Matteo Ghetta, Maurizio Napolitano, Michele Beneventi,
+                      Michele Ferretti, Roberto Angeletti, Paolo Cavallini,
+                      Stefano Campus
+Japanese              Baba Yoshihiko, Minoru Akagi, Norihiro Yamate,
+                      Takayuki Mizutani, Takayuki Nuimura, Yoichi Kayama
+Korean                OSGeo Korean Chapter
+Polish                Andrzej Świąder, Borys Jurgiel, Ewelina Krawczak, Jakub
+                      Bobrowski, Mateusz Łoskot, Michał Kułach, Michał Smoczyk,
+                      Milena Nowotarska, Radosław Pasiok, Robert Szczepanek,
+                      Tomasz Paul
+Portuguese            Alexandre Neto, Duarte Carreira, Giovanni Manghi, João Gaspar,
+                      Joana Simões, Leandro Infantini, Nelson Silva, Pedro Palheiro,
+                      Pedro Pereira, Ricardo Sena
+Portuguese (Brasil)   Arthur Nanni, Felipe Sodré Barros, Leônidas Descovi Filho,
+                      Marcelo Soares Souza, Narcélio de Sá Pereira Filho,
+                      Sidney Schaberle Goveia
+Romanian              Alex Bădescu, Bogdan Pacurar, Georgiana Ioanovici, Lonut
+                      Losifescu-Enescu, Sorin Călinică, Tudor Bărăscu
+Russian               Alexander Bruy, Artem Popov
+Spanish               Carlos Dávila, Diana Galindo, Edwin Amado, Gabriela Awad,
+                      Javier César Aldariz, Mayeul Kauffmann
+Ukrainian             Alexander Bruy
+===================== ========================================================
 

--- a/source/docs/user_manual/preamble/preamble.rst
+++ b/source/docs/user_manual/preamble/preamble.rst
@@ -43,24 +43,10 @@ form, the browser displays and handles both identically.
 
 **User, Installation and Coding Guide Authors and Editors:**
 
-+--------------------+---------------------+----------------------+----------------------+----------------------+ 
-| Tara Athan         | Radim Blazek        | Godofredo Contreras  | Otto Dassau          | Martin Dobias        | 
-+--------------------+---------------------+----------------------+----------------------+----------------------+ 
-| Peter Ersts        | Anne Ghisla         | Stephan Holl         | N\. Horning          | Magnus Homann        | 
-+--------------------+---------------------+----------------------+----------------------+----------------------+ 
-| Werner Macho       | Carson J.Q. Farmer  | Tyler Mitchell       | K\. Koy              | Lars Luthman         | 
-+--------------------+---------------------+----------------------+----------------------+----------------------+ 
-| Claudia A. Engel   | Brendan Morely      | David Willis         | Jürgen E. Fischer    | Marco Hugentobler    | 
-+--------------------+---------------------+----------------------+----------------------+----------------------+ 
-| Larissa Junek      | Diethard Jansen     | Paolo Corti          | Gavin Macaulay       | Gary E. Sherman      | 
-+--------------------+---------------------+----------------------+----------------------+----------------------+ 
-| Tim Sutton         | Alex Bruy           | Raymond Nijssen      | Richard Duivenvoorde | Andreas Neumann      | 
-+--------------------+---------------------+----------------------+----------------------+----------------------+ 
-| Astrid Emde        | Yves Jacolin        | Alexandre Neto       | Andy Schmid          | Hien Tran-Quang      | 
-+--------------------+---------------------+----------------------+----------------------+----------------------+
+The list of the persons who contribute on writing, reviewing and translating
+the following documentation is available at :ref:`doc_contributors`.
 
-
-Copyright (c) 2004 - 2014 QGIS Development Team
+Copyright (c) 2004 - 2016 QGIS Development Team
 
 **Internet:** http://www.qgis.org
 


### PR DESCRIPTION
This PR aims to provide a list of docs contributors (writers and translators) as there's a list for the application contributors in the About panel.
## Writers

The list of writers is a mix of:
- the authors listed in the [preamble chapter](http://docs.qgis.org/testing/en/docs/user_manual/preamble/preamble.html) of the doc (thus removed from this part of the doc)
- [github contributors](https://github.com/qgis/QGIS-Documentation/graphs/contributors) with at least one commit in the current repository.
  There are some people I couldn't find their real name. Could you please provide your real name so that we update the list: @andremano @nydydn @mewoch @embelding @badewannencaptain @ajazepk @abusquets @GiordanoPezzola @Icephale ~~@mezwor @DiGro~~ @zstadler ? Thanks
## Translators

Nobody is currently listed because I think the best way to do it is to have a tool that picks the list of translators either from Transifex or from https://github.com/qgis/QGIS/blob/master/doc/TRANSLATORS, filtering the languages that are really used for docs and generate a table from it; Then, if that list could be live updated....

This is clearly beyond my skills!!! **So it'd be greatly nice if any of you is willing to do it**... (see #669)
## Doc structure

The new `contributors.rst` file is placed in the preamble folder and is shown almost at the end of the user manual. Does this make sense to you? Do you find a better place?
![contributors](https://cloud.githubusercontent.com/assets/7983394/19626212/a38c9960-992c-11e6-9f54-95363f37baab.PNG)
