### PR TITLE
crs.proj4String() not working in QGIS 2.14

### DIFF
--- a/source/docs/pyqgis_developer_cookbook/crs.rst
+++ b/source/docs/pyqgis_developer_cookbook/crs.rst
@@ -69,7 +69,7 @@ Accessing spatial reference system information
   print "Description:", crs.description()
   print "Projection Acronym:", crs.projectionAcronym()
   print "Ellipsoid Acronym:", crs.ellipsoidAcronym()
-  print "Proj4 String:", crs.proj4String()
+  print "Proj4 String:", crs.toProj4()
   # check whether it's geographic or projected coordinate system
   print "Is geographic:", crs.geographicFlag()
   # check type of map units in this CRS (values defined in QGis::units enum)


### PR DESCRIPTION
I was unsuccessful using crs.proj4String() and instead found crs.toProj4() that works in QGIS 2.14.

From: QgsCoordinateReferenceSystem Class Reference (https://qgis.org/api/classQgsCoordinateReferenceSystem.html)
Other function may be obsolete as well, I didn't test them all