### PR TITLE
Import QVariant in examples that require it

### DIFF
--- a/source/docs/pyqgis_developer_cookbook/vector.rst
+++ b/source/docs/pyqgis_developer_cookbook/vector.rst
@@ -320,6 +320,8 @@ For deletion of fields just provide a list of field indexes.
 
 ::
 
+  from PyQt4.QtCore import QVariant
+
   if caps & QgsVectorDataProvider.AddAttributes:
       res = layer.dataProvider().addAttributes([QgsField("mytext", QVariant.String), QgsField("myint", QVariant.Int)])
 
@@ -354,6 +356,8 @@ editing functions work only when the editing mode is turned on. Usage of
 editing functions
 
 ::
+
+  from PyQt4.QtCore import QVariant
 
   # add two features (QgsFeature instances)
   layer.addFeatures([feat1,feat2])
@@ -505,6 +509,8 @@ There are two possibilities how to export a vector layer:
 
 ::
 
+    from PyQt4.QtCore import QVariant
+
     # define fields for feature attributes. A QgsFields object is needed
     fields = QgsFields()
     fields.append(QgsField("first", QVariant.Int))
@@ -581,6 +587,8 @@ The following example of a URI incorporates all these options
 The following example code illustrates creating and populating a memory provider
 
 ::
+
+  from PyQt4.QtCore import QVariant
 
   # create layer
   vl = QgsVectorLayer("Point", "temporary_points", "memory")


### PR DESCRIPTION
Those examples that make use of `QVariant` current fail when used in the Python Console with:

    NameError: name 'QVariant' is not defined