### PR TITLE
Avoid indirect link that could break easily

### DIFF
--- a/source/docs/user_manual/working_with_ogc/ogc_server_support.rst
+++ b/source/docs/user_manual/working_with_ogc/ogc_server_support.rst
@@ -338,7 +338,7 @@ checkbox in the :guilabel:`WMS` or :guilabel:`WFS` column.
 
 You can overlay watermarks over the maps produced by your WMS by adding text
 annotations or SVG annotations to the project file.
-See the Annotation Tools section in :ref:`general_tools` for instructions on
+See the :ref:`_sec_annotations` section for instructions on
 creating annotations. For annotations to be displayed as watermarks on the WMS
 output, the :guilabel:`Fixed map position` check box in the
 :guilabel:`Annotation text` dialog must be unchecked.


### PR DESCRIPTION
better indicate the section itself