### PR TITLE
Add precision on CRS selector and OTF reprojection

### DIFF
--- a/source/docs/documentation_guidelines/substitutions.rst
+++ b/source/docs/documentation_guidelines/substitutions.rst
@@ -284,7 +284,7 @@ Projections and Georeferencer
 Icon                            Substitution                        Icon                            Substitution
 ==============================  ==================================  ==============================  ==================================
 |geographic|                    ``|geographic|``                    |crs|                           ``|crs|``
-|customProjection|              ``|customProjection|``              \                               \
+|customProjection|              ``|customProjection|``              |setProjection|                 ``|setProjection|``
 |projectionDisabled|            ``|projectionDisabled|``            |projectionEnabled|             ``|projectionEnabled|``
 |georeferencer|                 ``|georeferencer|``                 |pencil|                        ``|pencil|``
 |linkQGisToGeoref|              ``|linkQGisToGeoref|``              |linkGeorefToQGis|              ``|linkGeorefToQGis|``

--- a/source/docs/user_manual/introduction/qgis_gui.rst
+++ b/source/docs/user_manual/introduction/qgis_gui.rst
@@ -447,8 +447,18 @@ Map View
 
 Also called **Map canvas**, this is the "business end" of QGIS ---
 maps are displayed in this area. The map displayed in this window
-will depend on the vector and raster layers you have chosen to load
-(see sections that follow for more information on how to load layers).
+will depend on the vector and raster layers you have chosen to load.
+
+When you add a layer (see e.g. :ref:`vector_loading_file`), 
+QGIS automatically looks for the Coordinate Reference System (CRS) and zooms to
+the layer extent if you work in a blank QGIS project. If there are already files
+in your project, the file will just be added, and in the case it has features
+falling in the map canvas extent, they will be visualized. If the file is in
+another CRS, you must :guilabel:`Enable on-the-fly CRS transformation` from the
+:menuselection:`Project --> Project Properties --> CRS` (see :ref:`otf_reprojection`).
+The newly added layer should now be visible if data are available in the current
+view extent.
+
 The map view can be panned, shifting the focus of the map display to
 another region, and it can be zoomed in and out. Various other operations can be
 performed on the map as described in the label_toolbars_ description above. The map

--- a/source/docs/user_manual/introduction/qgis_gui.rst
+++ b/source/docs/user_manual/introduction/qgis_gui.rst
@@ -449,15 +449,16 @@ Also called **Map canvas**, this is the "business end" of QGIS ---
 maps are displayed in this area. The map displayed in this window
 will depend on the vector and raster layers you have chosen to load.
 
-When you add a layer (see e.g. :ref:`vector_loading_file`), 
-QGIS automatically looks for the Coordinate Reference System (CRS) and zooms to
-the layer extent if you work in a blank QGIS project. If there are already files
-in your project, the file will just be added, and in the case it has features
-falling in the map canvas extent, they will be visualized. If the file is in
-another CRS, you must :guilabel:`Enable on-the-fly CRS transformation` from the
-:menuselection:`Project --> Project Properties --> CRS` (see :ref:`otf_reprojection`).
-The newly added layer should now be visible if data are available in the current
-view extent.
+When you add a layer (see e.g. :ref:`vector_loading_file`), QGIS automatically
+looks for its Coordinate Reference System (CRS) and zooms to its extent if you
+work in a blank QGIS project. The layer's CRS is then applied to the project.
+If there are already layers in the project, and in the case the new layer has
+the same CRS as the project, its features falling in the current map canvas
+extent will be visualized. If the new layer is in a different CRS from the
+project's, you must :guilabel:`Enable on-the-fly CRS transformation` from the
+:menuselection:`Project --> Project Properties --> CRS`
+(see :ref:`otf_transformation`). The added layer should now be visible if data
+are available in the current view extent.
 
 The map view can be panned, shifting the focus of the map display to
 another region, and it can be zoomed in and out. Various other operations can be

--- a/source/docs/user_manual/working_with_projections/working_with_projections.rst
+++ b/source/docs/user_manual/working_with_projections/working_with_projections.rst
@@ -101,31 +101,33 @@ defined, it will be displayed as shown in :ref:`figure_vector_general`.
    :guilabel:`Set project CRS from Layer` redefines the project CRS using
    the layer's CRS.
 
-.. index:: CRS; On-the-fly reprojection
-.. _otf_reprojection:
+.. index:: CRS; On-the-fly transformation
+.. _otf_transformation:
 
-Define On The Fly (OTF) Reprojection
-====================================
+Define On The Fly (OTF) CRS Transformation
+==========================================
 
-QGIS supports OTF reprojection for both raster and vector data. However, OTF is
-not activated by default. When OTF is off, each layer is drawn using the
-coordinates as read from the data source. When on, the coordinates in each
-layer are projected to the coordinate reference system defined for the map canvas.
+QGIS supports on the fly CRS transformation for both raster and vector data.
+However, OTF is not activated by default. When OTF is off, each layer is drawn
+using the coordinates as read from the data source. When OTF is on, each layer's
+coordinates are transformed to the CRS of the project.
 
-There are three ways to enable On The Fly Reprojection:
+There are three ways to enable On The Fly CRS Transformation:
 
-* Select |projectProperties| :menuselection:`Project Properties --> CRS` from the
-  :menuselection:`Project` ( or |kde| :menuselection:`Settings`) menu. You can then
-  activate the |checkbox| :guilabel:`Enable on the fly CRS transformation` checkbox
-  in the |crs| :guilabel:`CRS` tab and select the CRS to use (see :ref:`crs_selector`)
+* Select |projectProperties| :menuselection:`Project Properties --> CRS` from
+  the :menuselection:`Project` ( or |kde| :menuselection:`Settings`) menu. You
+  can then  activate the |checkbox| :guilabel:`Enable on the fly CRS
+  transformation (OTF)` checkbox in the |crs| :guilabel:`CRS` tab and select
+  the CRS to use (see :ref:`crs_selector`)
 * Click on the |geographic| :sup:`CRS status` icon in the lower right-hand
   corner of the status bar, leading you to the previous dialog.
 * Turn OTF on by default in the |crs| :guilabel:`CRS` tab of the
   :menuselection:`Settings --> Options` dialog by selecting |checkbox|
-  :guilabel:`Enable 'on the fly' reprojection by default` or :guilabel:`Automatically
-  enable 'on the fly' reprojection if layers have different CRS`.
+  :guilabel:`Enable 'on the fly' reprojection by default` or
+  :guilabel:`Automatically enable 'on the fly' reprojection if layers have
+  different CRS`.
 
-If you have already loaded a layer and you want to enable OTF projection, the
+If you have already loaded a layer and you want to enable OTF reprojection, the
 best practice is to open the |crs| :guilabel:`CRS` tab of the :guilabel:`Project
 Properties` dialog, activate the |checkbox| :guilabel:`Enable 'on the fly'
 CRS transformation` checkbox, and select a CRS.

--- a/source/docs/user_manual/working_with_projections/working_with_projections.rst
+++ b/source/docs/user_manual/working_with_projections/working_with_projections.rst
@@ -172,6 +172,14 @@ layer, provided a set of projection databases. Items in the dialog are:
    Your layer position is then moved accordingly. You may have to do some trial
    and error in order to find the right position, hence its original CRS.
 
+.. note::
+
+   When operating across layers, for example, computing intersections between two
+   layers, it is important that both layers have the same CRS. To change the
+   projection of an existing layer, it is **insufficient** to simply change the
+   CRS in that layer's properties. Instead you must save the layer as a new layer,
+   and choose the desired CRS for the new layer. 
+
 .. index:: CRS
    single: CRS; Custom CRS
 

--- a/source/docs/user_manual/working_with_projections/working_with_projections.rst
+++ b/source/docs/user_manual/working_with_projections/working_with_projections.rst
@@ -52,8 +52,8 @@ shapefile and a :file:`.prj` extension. For example, a shapefile named
 
 Whenever you select a new CRS, the layer units will automatically be
 changed in the :guilabel:`General` tab of the |options|
-:guilabel:`Project Properties` dialog under the :guilabel:`Project` (Gnome,
-macOS) or :guilabel:`Settings` (KDE, Windows) menu.
+:guilabel:`Project Properties` dialog under the :guilabel:`Project`
+(or |kde| :guilabel:`Settings`) menu.
 
 .. index:: CRS
    single: CRS; Default CRS
@@ -63,8 +63,8 @@ Global Projection Specification
 
 QGIS starts each new project using the global default projection. The global
 default CRS is EPSG:4326 - WGS 84 (``proj=longlat +ellps=WGS84 +datum=WGS84 +no_defs``),
-and it comes predefined in QGIS. This default can be changed via the
-**[Select...]** button in the first section, which is used to define the default
+and it comes predefined in QGIS. This default can be changed via the |setProjection|
+:sup:`Select CRS` button in the first section, which is used to define the default
 coordinate reference system for new projects, as shown in
 figure_projection_options_. This choice will be saved for use in subsequent QGIS
 sessions.
@@ -93,41 +93,42 @@ of the raster and vector properties dialog (see :ref:`label_generaltab` for
 rasters and :ref:`vectorgeneralmenu` for vectors). If your layer already has a CRS
 defined, it will be displayed as shown in :ref:`figure_vector_general`.
 
-.. tip:: **CRS in the Map Legend**
+.. tip:: **CRS in the Layers Panel**
 
-   Right-clicking on a layer in the Map Legend (section :ref:`label_legend`)
+   Right-clicking on a layer in the Layers Panel (section :ref:`label_legend`)
    provides two CRS shortcuts. :guilabel:`Set layer CRS` takes you directly
    to the Coordinate Reference System Selector dialog (see figure_projection_project_).
    :guilabel:`Set project CRS from Layer` redefines the project CRS using
    the layer's CRS.
 
-.. index:: On-the-fly reprojection
+.. index:: CRS; On-the-fly reprojection
+.. _otf_reprojection:
 
 Define On The Fly (OTF) Reprojection
 ====================================
 
 QGIS supports OTF reprojection for both raster and vector data. However, OTF is
-not activated by default. To use OTF projection, you must activate the
-|checkbox| :guilabel:`Enable on the fly CRS transformation` checkbox in the
-:guilabel:`CRS` tab of the |projectProperties| :menuselection:`Project
-Properties` dialog.
+not activated by default. When OTF is off, each layer is drawn using the
+coordinates as read from the data source. When on, the coordinates in each
+layer are projected to the coordinate reference system defined for the map canvas.
 
-**There are three ways to do this:**
+There are three ways to enable On The Fly Reprojection:
 
-#. Select |options| :menuselection:`Project Properties` from the
-   :menuselection:`Project` (Gnome, macOS) or :menuselection:`Settings` (KDE,
-   Windows) menu.
-#. Click on the |geographic| :sup:`CRS status` icon in the lower right-hand
-   corner of the status bar.
-#. Turn OTF on by default in the :guilabel:`CRS` tab of the
-   :guilabel:`Options` dialog by selecting |checkbox|
-   :guilabel:`Enable 'on the fly' reprojection by default` or :guilabel:`Automatically
-   enable 'on the fly' reprojection if layers have different CRS`.
+* Select |projectProperties| :menuselection:`Project Properties --> CRS` from the
+  :menuselection:`Project` ( or |kde| :menuselection:`Settings`) menu. You can then
+  activate the |checkbox| :guilabel:`Enable on the fly CRS transformation` checkbox
+  in the |crs| :guilabel:`CRS` tab and select the CRS to use (see :ref:`crs_selector`)
+* Click on the |geographic| :sup:`CRS status` icon in the lower right-hand
+  corner of the status bar, leading you to the previous dialog.
+* Turn OTF on by default in the |crs| :guilabel:`CRS` tab of the
+  :menuselection:`Settings --> Options` dialog by selecting |checkbox|
+  :guilabel:`Enable 'on the fly' reprojection by default` or :guilabel:`Automatically
+  enable 'on the fly' reprojection if layers have different CRS`.
 
 If you have already loaded a layer and you want to enable OTF projection, the
-best practice is to open the :guilabel:`CRS` tab of the :guilabel:`Project
-Properties` dialog, select a CRS, and activate the |checkbox|
-:guilabel:`Enable 'on the fly' CRS transformation` checkbox.
+best practice is to open the |crs| :guilabel:`CRS` tab of the :guilabel:`Project
+Properties` dialog, activate the |checkbox| :guilabel:`Enable 'on the fly'
+CRS transformation` checkbox, and select a CRS.
 The |geographic| :sup:`CRS status` icon will no longer be greyed out, and all
 layers will be OTF projected to the CRS shown next to the icon.
 
@@ -140,26 +141,27 @@ layers will be OTF projected to the CRS shown next to the icon.
 
    Project Properties Dialog
 
-The :guilabel:`CRS` tab of the :guilabel:`Project Properties` dialog contains
-five important components, as shown in Figure_projection_project_ and described below:
+.. index:: CRS Selection
+.. _crs_selector:
 
-#. **Enable 'on the fly' CRS transformation** --- This checkbox is used to
-   enable or disable OTF projection. When off, each layer is drawn using the
-   coordinates as read from the data source, and the components described below
-   are inactive. When on, the coordinates in each layer are projected to the
-   coordinate reference system defined for the map canvas.
-#. **Filter** --- If you know the EPSG code, the identifier, or the name for a
-   coordinate reference system, you can use the search feature to find it.
-   Enter the EPSG code, the identifier or the name.
-#. **Recently used coordinate reference systems** --- If you have certain CRSs
-   that you frequently use in your everyday GIS work, these will be displayed
-   in this list. Click on one of these items to select the associated CRS.
-#. **Coordinate reference systems of the world** --- This is a list of all CRSs
-   supported by QGIS, including Geographic, Projected and Custom coordinate
-   reference systems. To define a CRS, select it from the list by expanding
-   the appropriate node and selecting the CRS. The active CRS is preselected.
-#. **PROJ.4 text** --- This is the CRS string used by the PROJ.4 projection
-   engine. This text is read-only and provided for informational purposes.
+Coordinate Reference System Selector
+=====================================
+
+This dialog helps you assign a Coordinate Reference System to a project or a
+layer, provided a set of projection databases. Items in the dialog are:
+
+* **Filter**: If you know the EPSG code, the identifier, or the name for a
+  coordinate reference system, you can use the search feature to find it.
+  Enter the EPSG code, the identifier or the name.
+* **Recently used coordinate reference systems**: If you have certain CRSs
+  that you frequently use in your everyday GIS work, these will be displayed
+  in this list. Click on one of these items to select the associated CRS.
+* **Coordinate reference systems of the world**: This is a list of all CRSs
+  supported by QGIS, including Geographic, Projected and Custom coordinate
+  reference systems. To define a CRS, select it from the list by expanding
+  the appropriate node and selecting the CRS. The active CRS is preselected.
+* **PROJ.4 text**: This is the CRS string used by the PROJ.4 projection
+  engine. This text is read-only and provided for informational purposes.
 
 .. tip:: **Project Properties Dialog**
 
@@ -219,8 +221,8 @@ enter known WGS 84 latitude and longitude values in :guilabel:`North` and
 :guilabel:`East` fields, respectively. Click on **[Calculate]**, and compare the
 results with the known values in your coordinate reference system.
 
-
 .. index:: Datum transformation
+.. _datum_transformation:
 
 Default datum transformations
 =============================

--- a/source/docs/user_manual/working_with_projections/working_with_projections.rst
+++ b/source/docs/user_manual/working_with_projections/working_with_projections.rst
@@ -163,14 +163,14 @@ layer, provided a set of projection databases. Items in the dialog are:
 * **PROJ.4 text**: This is the CRS string used by the PROJ.4 projection
   engine. This text is read-only and provided for informational purposes.
 
-.. tip:: **Project Properties Dialog**
+.. tip:: **Looking for a layer CRS? Use the CRS selector.**
 
-   If you open the :guilabel:`Project Properties` dialog from the
-   :menuselection:`Project` menu, you must click on the :guilabel:`CRS`
-   tab to view the CRS settings.
-
-   Opening the dialog from the |geographic| :sup:`CRS status` icon will
-   automatically bring the :guilabel:`CRS` tab to the front.
+   Sometimes, you receive a layer and you don't know its projection. Assuming that you
+   have another layer with a valid crs that should overlaps with it, enable the
+   OTF reprojection and, in the :guilabel:`General` tab of the Layer properties
+   dialog, use the Coordinate Reference System selector to assign a projection.
+   Your layer position is then moved accordingly. You may have to do some trial
+   and error in order to find the right position, hence its original CRS.
 
 .. index:: CRS
    single: CRS; Custom CRS

--- a/source/docs/user_manual/working_with_raster/raster_properties.rst
+++ b/source/docs/user_manual/working_with_raster/raster_properties.rst
@@ -56,15 +56,16 @@ The :guilabel:`General` menu displays basic information about the selected raste
 including the layer source path, the display name in the legend (which can be
 modified), and the number of columns, rows and no-data values of the raster.
 
-Coordinate reference system
+Coordinate Reference System
 ...........................
 
-Display the current coordinate reference system of the layer as a PROJ.4 string. You
-can change the projection, selecting a recently used one in the drop-down list or
-clicking on |setProjection| :sup:`Select CRS` button (see :ref:`crs_selector`).
-Use this process only if the CRS applied to the layer is a wrong one or if none was applied.
-If you wish to reproject your data into another CRS, rather use layer reprojection
-algorithms from Processing or :ref:`Save it into another layer <general_saveas>`.
+Displays the layer's Coordinate Reference System (CRS) as a PROJ.4 string. You
+can change the layer's CRS, selecting a recently used one in the drop-down list
+or clicking on |setProjection| :sup:`Select CRS` button (see :ref:`crs_selector`).
+Use this process only if the CRS applied to the layer is a wrong one or if none
+was applied. If you wish to reproject your data into another CRS, rather use
+layer reprojection algorithms from Processing or :ref:`Save it into another
+layer <general_saveas>`.
 
 Scale dependent visibility
 --------------------------

--- a/source/docs/user_manual/working_with_raster/raster_properties.rst
+++ b/source/docs/user_manual/working_with_raster/raster_properties.rst
@@ -59,9 +59,12 @@ modified), and the number of columns, rows and no-data values of the raster.
 Coordinate reference system
 ...........................
 
-Here, you find the coordinate reference system (CRS) information printed as a
-PROJ.4 string. If this setting is not correct, it can be modified by clicking
-the **[Specify]** button.
+Display the current coordinate reference system of the layer as a PROJ.4 string. You
+can change the projection, selecting a recently used one in the drop-down list or
+clicking on |setProjection| :sup:`Select CRS` button (see :ref:`crs_selector`).
+Use this process only if the CRS applied to the layer is a wrong one or if none was applied.
+If you wish to reproject your data into another CRS, rather use layer reprojection
+algorithms from Processing or :ref:`Save it into another layer <general_saveas>`.
 
 Scale dependent visibility
 --------------------------

--- a/source/docs/user_manual/working_with_vector/vector_properties.rst
+++ b/source/docs/user_manual/working_with_vector/vector_properties.rst
@@ -52,10 +52,11 @@ Layer Info
 Coordinate Reference System
 ---------------------------
 
-* Display the current coordinate reference system of the layer as a PROJ.4 string. You
-  can change the projection, selecting a recently used one in the drop-down list or
-  clicking on |setProjection| :sup:`Select CRS` button (see :ref:`crs_selector`).
-  Use this process only if the CRS applied to the layer is a wrong one or if none was applied.
+* Displays the layer's Coordinate Reference System (CRS) as a PROJ.4 string.
+  You can change the layer's CRS, selecting a recently used one
+  in the drop-down list or clicking on |setProjection| :sup:`Select CRS` button
+  (see :ref:`crs_selector`). Use this process only if the CRS applied to the
+  layer is a wrong one or if none was applied.
   If you wish to reproject your data into another CRS, rather use layer reprojection
   algorithms from Processing or :ref:`Save it into another layer <general_saveas>`.
 * Create a :guilabel:`Spatial Index` (only for OGR-supported formats)

--- a/source/docs/user_manual/working_with_vector/vector_properties.rst
+++ b/source/docs/user_manual/working_with_vector/vector_properties.rst
@@ -44,20 +44,23 @@ There are several options available:
 Layer Info
 ----------
 
-* Change the display name of the layer in :guilabel:`displayed as`
-* Define the :guilabel:`Layer source` of the vector layer
+* Set the :guilabel:`Layer name` to display in the :guilabel:`Layers Panel`
+* Display the :guilabel:`Layer source` of the vector layer
 * Define the :guilabel:`Data source encoding` to define
   provider-specific options and to be able to read the file
 
 Coordinate Reference System
 ---------------------------
 
-* :guilabel:`Specify` the coordinate reference system. Here, you
-  can view or change the projection of the specific vector layer.
+* Display the current coordinate reference system of the layer as a PROJ.4 string. You
+  can change the projection, selecting a recently used one in the drop-down list or
+  clicking on |setProjection| :sup:`Select CRS` button (see :ref:`crs_selector`).
+  Use this process only if the CRS applied to the layer is a wrong one or if none was applied.
+  If you wish to reproject your data into another CRS, rather use layer reprojection
+  algorithms from Processing or :ref:`Save it into another layer <general_saveas>`.
 * Create a :guilabel:`Spatial Index` (only for OGR-supported formats)
 * :guilabel:`Update Extents` information for a layer
-* View or change the projection of the specific vector layer, clicking on
-  :guilabel:`Specify ...`
+
 
 Scale dependent visibility
 --------------------------


### PR DESCRIPTION
Insert a section to be reached from QGIS application Help button
Fix description
Add tip and note on the behavior of the CRS selection tool (inspired a bit by recent discussion on dev ML - actually a frequent confusion for new users)
