### PR TITLE
Use "stroke" instead of outline or pen in symbols dialog

### DIFF
--- a/source/docs/user_manual/working_with_vector/style_library.rst
+++ b/source/docs/user_manual/working_with_vector/style_library.rst
@@ -339,7 +339,7 @@ Appropriate for point geometry features, marker symbols have several
   height;
 * **Filled marker**: similar to the simple marker symbol layer, except that it
   uses a :ref:`fill sub symbol <vector_fill_symbols>` to render the marker.
-  This allows use of all the existing QGIS fill (and outline) styles for
+  This allows use of all the existing QGIS fill (and stroke) styles for
   rendering markers, e.g. gradient or shapeburst fills;
 * **Font marker**: use installed fonts as marker symbols;
 * **Geometry generator** (see :ref:`geometry_generator_symbol`);
@@ -348,14 +348,14 @@ Appropriate for point geometry features, marker symbols have several
 
 * **SVG marker**: provides you with images from your SVG paths (set in
   :menuselection:`Settings --> Options --> System` menu) to render as marker symbol.
-  Each SVG file colors and outline can be adapted;
+  Each SVG file colors and stroke can be adapted;
 * **Vector Field marker** (see :ref:`vector_field_marker`).
 
 .. note:: Requirements for a customizable SVG marker symbol
 
  To have the possibility to change the colors of a :guilabel:`SVG marker`, you have
  to add the placeholders ``param(fill)`` for fill color, ``param(outline)`` for
- outline color and ``param(outline-width)`` for stroke width.
+ stroke color and ``param(outline-width)`` for stroke width.
  These placeholders can optionally be followed by a default value, e.g.:
  
  .. code-block:: xml
@@ -370,8 +370,8 @@ For each marker symbol layer type, you can set some of the following properties:
 * :guilabel:`Color` for the fill and/or stroke, using all the capabilities of the
   :ref:`color-selector` widget;
 * :guilabel:`Size`
-* :guilabel:`Outline style`
-* :guilabel:`Outline width`
+* :guilabel:`Stroke style`
+* :guilabel:`Stroke width`
 * :guilabel:`Join Style`
 * :guilabel:`Rotation`
 * :guilabel:`Offset X,Y`: You can shift the symbol in the x- or y-direction;
@@ -391,12 +391,12 @@ layer types:
 * **Simple line** (default): available settings are:
 
   * :guilabel:`Color`
-  * :guilabel:`Pen width`
-  * :guilabel:`Pen style`
+  * :guilabel:`Stroke width`
+  * :guilabel:`Stroke style`
   * :guilabel:`Join style`
   * :guilabel:`Cap style`
   * :guilabel:`Offset`
-  * |checkbox| :guilabel:`Use custom dash pattern`: overrides the :guilabel:`Pen
+  * |checkbox| :guilabel:`Use custom dash pattern`: overrides the :guilabel:`Stroke
     style` setting with a custom dash.
 
 .. _arrow_symbol:
@@ -425,10 +425,10 @@ symbol layer types:
 * **Simple fill** (default): the following settings are available:
 
 * :guilabel:`Fill` color
-* :guilabel:`Outline` color
+* :guilabel:`Stroke` color
 * :guilabel:`Fill style`
-* :guilabel:`Outline style`
-* :guilabel:`Outline width`
+* :guilabel:`Stroke style`
+* :guilabel:`Stroke width`
 * :guilabel:`Join Style`
 * :guilabel:`Offset X,Y`
 

--- a/source/docs/user_manual/working_with_vector/style_library.rst
+++ b/source/docs/user_manual/working_with_vector/style_library.rst
@@ -343,6 +343,9 @@ Appropriate for point geometry features, marker symbols have several
   rendering markers, e.g. gradient or shapeburst fills;
 * **Font marker**: use installed fonts as marker symbols;
 * **Geometry generator** (see :ref:`geometry_generator_symbol`);
+
+.. _svg_marker:
+
 * **SVG marker**: provides you with images from your SVG paths (set in
   :menuselection:`Settings --> Options --> System` menu) to render as marker symbol.
   Each SVG file colors and outline can be adapted;
@@ -364,8 +367,8 @@ Appropriate for point geometry features, marker symbols have several
  
 For each marker symbol layer type, you can set some of the following properties:
 
-* :guilabel:`Color`, using all the capabilities of the :ref:`color-selector`
-  widget;
+* :guilabel:`Color` for the fill and/or stroke, using all the capabilities of the
+  :ref:`color-selector` widget;
 * :guilabel:`Size`
 * :guilabel:`Outline style`
 * :guilabel:`Outline width`
@@ -419,7 +422,16 @@ Fill Symbols
 Appropriate for polygon geometry features, fill symbols have also several
 symbol layer types:
 
-* **Simple fill** (default);
+* **Simple fill** (default): the following settings are available:
+
+* :guilabel:`Fill` color
+* :guilabel:`Outline` color
+* :guilabel:`Fill style`
+* :guilabel:`Outline style`
+* :guilabel:`Outline width`
+* :guilabel:`Join Style`
+* :guilabel:`Offset X,Y`
+
 * **Centroid fill**: places a marker symbol at the centroid of the visible
   feature. The marker can be placed on every part of a multi-part feature or
   only on its biggest part, and forced to be inside the polygon;
@@ -438,7 +450,7 @@ symbol layer types:
 * **Raster image fill**: you can fill polygons with a tiled raster image.
   Options include (data defined) file name, opacity, image size (in pixels, mm
   or map units), coordinate mode (feature or view) and rotation;
-* **SVG fill**: fills the polygon using SVG markers;
+* **SVG fill**: fills the polygon using :ref:`SVG markers <svg_marker>`;
 * **Shapeburst fill**: this option buffered a gradient fill, where a gradient
   is drawn from the boundary of a polygon towards the polygon's centre.
   Configurable parameters include distance from the boundary to shade, use of
@@ -452,15 +464,6 @@ symbol layer types:
   polygon boundary. The :guilabel:`Draw line only inside polygon` option helps
   polygon borders inside the polygon and can be useful to clearly represent
   adjacent polygon boundaries.
-
-The following settings are available:
-
-* :guilabel:`Color` for the symbol stroke and fill
-* :guilabel:`Fill style`
-* :guilabel:`Outline style`
-* :guilabel:`Outline width`
-* :guilabel:`Offset X,Y`
-* :guilabel:`Data defined properties ...`
 
 .. note::
 


### PR DESCRIPTION
Fixes #1712 (with some [backportable](https://github.com/DelazJ/QGIS-Documentation/commit/7fcd7f20b09f518cc22dbf548d38ca8d09c1558a) improvements)