### PR TITLE
Display menu selection correctly in Training manual

### DIFF
--- a/source/docs/training_manual/basic_map/symbology.rst
+++ b/source/docs/training_manual/basic_map/symbology.rst
@@ -231,7 +231,7 @@ control the order in which the different symbol layers are rendered.
 
 To change the order of the symbol layers, select the :guilabel:`Line` layer in
 the :guilabel:`Symbol layers` panel, then click
-:guilabel:`Advanced --> Symbol levels...` in the
+:menuselection:`Advanced --> Symbol levels...` in the
 bottom right-hand corner of the window. This will open a dialog like this:
 
 .. image:: /static/training_manual/symbology/symbol_levels_dialog.png
@@ -372,8 +372,8 @@ To see the various options available for line data:
 
 
 * Ensure that the symbol levels are correct (via the
-  :guilabel:`Advanced --> Symbol levels` dialog we used earlier) before applying
-  the style.
+  :menuselection:`Advanced --> Symbol levels` dialog we used earlier) before
+  applying the style.
 
 
 Once you have applied the style, take a look at its results on the map. As you

--- a/source/docs/training_manual/complete_analysis/analysis_combination.rst
+++ b/source/docs/training_manual/complete_analysis/analysis_combination.rst
@@ -23,7 +23,7 @@ suitable plots.
   dataset.
 * If you are missing some layers, you should find them in
   :kbd:`exercise_data/residential_development/`
-* Use the :guilabel:`Intersect` tool (:guilabel:`Vector --> Geoprocessing Tools`)
+* Use the :guilabel:`Intersect` tool (:menuselection:`Vector --> Geoprocessing Tools`)
   to create a new vector layer called :kbd:`new_solution.shp` which contains
   only those buildings which intersect the :kbd:`suitable_terrain` layer.
 

--- a/source/docs/training_manual/complete_analysis/analysis_exercise.rst
+++ b/source/docs/training_manual/complete_analysis/analysis_exercise.rst
@@ -290,7 +290,7 @@ Activating the :guilabel:`Raster Terrain Analysis` plugin
 This plugin is included by default in QGIS 1.8. However, it may not be
 immediately visible. To check if it is accessible on your system:
 
-* Click on the menu item :guilabel:`Plugins --> Manage Plugins...`.
+* Click on the menu item :menuselection:`Plugins --> Manage Plugins...`.
 * Ensure that the box next to :guilabel:`Raster Terrain Analysis plugin` is
   selected.
 * Click :guilabel:`OK`.
@@ -500,7 +500,7 @@ rasters.
 Creating a bounding box vector
 -------------------------------------------------------------------------------
 
-* Click on the menu item :guilabel:`Layer --> New --> New Shapefile Layer...`.
+* Click on the menu item :menuselection:`Layer --> New --> New Shapefile Layer...`.
 * Under the :guilabel:`Type` heading, select the :guilabel:`Polygon` button.
 * Click :guilabel:`Specify CRS` and set the coordinate reference system
   :kbd:`WGS 84 / UTM zone 33S : EPSG:32733`.
@@ -735,7 +735,7 @@ Calculate polygon centroids
 Calculate which centroid is closest to your house
 -------------------------------------------------------------------------------
 
-* Click on the menu item :guilabel:`Vector --> Analysis Tools --> Distance
+* Click on the menu item :menuselection:`Vector --> Analysis Tools --> Distance
   matrix`.
 * The input layer should be your house, and the target layer
   :guilabel:`solution_centroids`. Both of these should use the :kbd:`id` field

--- a/source/docs/training_manual/databases/db_browser.rst
+++ b/source/docs/training_manual/databases/db_browser.rst
@@ -51,7 +51,7 @@ nice to learn how to add a filtered set of records from a table as a layer
 by using queries that we learned about in previous sections.
 
 * Start a new empty map with no layers
-* Click the :guilabel:`Add PostGIS Layers` button or select :guilabel:`Layer
+* Click the :guilabel:`Add PostGIS Layers` button or select :menuselection:`Layer
   --> Add PostGIS Layers` from the menu.
 * In the :guilabel:`Add PostGIS Table(s)` dialog that comes up, connect to the
   :kbd:`postgis_demo` connection.

--- a/source/docs/training_manual/databases/db_manager.rst
+++ b/source/docs/training_manual/databases/db_manager.rst
@@ -76,7 +76,7 @@ metadata, but what if we wanted to alter the table to add an additional column
 perhaps? DB Manager allows you to do this directly. 
 
 * Select the table you want to edit in the tree
-* Select :guilabel:`Table --> Edit Table` from the menu to open the 
+* Select :menuselection:`Table --> Edit Table` from the menu to open the 
   :guilabel:`Table Properties` dialog.
 
 .. image:: /static/training_manual/databases/edit_table.png
@@ -145,7 +145,7 @@ Lets take a look at how we can perform a *VACUUM ANALYZE* command from within
 DB Manager. 
 
 * Select one of your tables in the DB Manager Tree.
-* Select :guilabel:`Table --> Run Vacuum Analyze` from the menu.
+* Select :menuselection:`Table --> Run Vacuum Analyze` from the menu.
 
 Thats it! PostgreSQL will perform the operation. Depending on how big your
 table is, this may take some time to complete.

--- a/source/docs/training_manual/databases/spatialite.rst
+++ b/source/docs/training_manual/databases/spatialite.rst
@@ -32,7 +32,7 @@ any tables to this database. Let's go ahead and do that.
 
 * Find the button to create a new layer and use the dropdown to create a new 
   new Spatialite layer, or select
-  :guilabel:`Layer --> New --> New Spatialite Layer`.
+  :menuselection:`Layer --> New --> New Spatialite Layer`.
 
   |newSpatiaLiteLayer|
 

--- a/source/docs/training_manual/forestry/forest_maps.rst
+++ b/source/docs/training_manual/forestry/forest_maps.rst
@@ -265,56 +265,82 @@ The coverage layer you are using does not yet have useful information that you c
 * Use the |calculateField| calculator to create and populate the following two fields.
 * Create a field named :kbd:`Zone` and type :kbd:`Whole number (integer)`.
 * In the :guilabel:`Expression` box write/copy/construct :kbd:`$rownum`.
-* Create another field named :kbd:`Remarks`, of type :kbd:`Text (string)` and a width of :kbd:`255`.
-* In the :guilabel:`Expression` box write :kbd:`'No remarks.'`. This will set all the default value for all the polygons.
+* Create another field named :kbd:`Remarks`, of type :kbd:`Text (string)` and
+  a width of :kbd:`255`.
+* In the :guilabel:`Expression` box write :kbd:`'No remarks.'`. This will set
+  all the default value for all the polygons.
 
-The forest manager will have some information about the area that might be useful when visiting the area. For example, the existence of a bridge, a swamp or the location of a protected species. The :kbd:`atlas_coverage` layer is probably in edit mode still, add the following text in the :kbd:`Remarks` field to the corresponding polygons (double click the cell to edit it):
+The forest manager will have some information about the area that might be useful
+when visiting the area. For example, the existence of a bridge, a swamp or the
+location of a protected species. The :kbd:`atlas_coverage` layer is probably in
+edit mode still, add the following text in the :kbd:`Remarks` field to the
+corresponding polygons (double click the cell to edit it):
 
 * For the :kbd:`Zone` 2: :kbd:`Bridge to the North of plot 19. Siberian squirrel between p_13 and p_14.`.
 * For the :kbd:`Zone` 6: :kbd:`Difficult to transit in swamp to the North of the lake.`.
 * For the :kbd:`Zone` 7: :kbd:`Siberian squirrel to the South East of p_94.`.
 * Disable editing and save your edits.
 
-Almost ready, now you have to tell the Atlas tool that you want some of the text labels to use the information from the :kbd:`atlas_coverage` layer's attribute table.
+Almost ready, now you have to tell the Atlas tool that you want some of the text
+labels to use the information from the :kbd:`atlas_coverage` layer's attribute table.
 
 * Go back to the :guilabel:`Print Composer`.
 * Select the text label containing :kbd:`Detailed map...`.
 * Set the :guilabel:`Font` size to :kbd:`12`.
 * Set the cursor at the end of the text in the label.
-* In  the :guilabel:`Item properties` tab, inside the :guilabel:`Main properties` click on :guilabel:`Insert an expression`.
-* In the :guilabel:`Function list` double click on the field :kbd:`Zone` under :guilabel:`Field and Values`.
+* In  the :guilabel:`Item properties` tab, inside the :guilabel:`Main properties`
+  click on :guilabel:`Insert an expression`.
+* In the :guilabel:`Function list` double click on the field :kbd:`Zone` under
+  :guilabel:`Field and Values`.
 * Click :guilabel:`OK`.
-* The text inside the box in the :guilabel:`Item properties` should show :kbd:`Detail map inventory zone: [% "Zone" %]`. Note that the :kbd:`[% "Zone" %]` will be substituted by the value of the field :kbd:`Zone` for the corresponding feature from the layer :kbd:`atlas_coverage`.
+* The text inside the box in the :guilabel:`Item properties` should show
+  :kbd:`Detail map inventory zone: [% "Zone" %]`. Note that the :kbd:`[% "Zone" %]`
+  will be substituted by the value of the field :kbd:`Zone` for the corresponding
+  feature from the layer :kbd:`atlas_coverage`.
 
 Test the contents of the label by looking at the different Atlas preview maps.
 
-Do the same for the labels with the text :kbd:`Remarks:` using the field whit the zone information. You can leave a break line before you enter the expression. You can see the result for the preview of zone 2 in the image below:
+Do the same for the labels with the text :kbd:`Remarks:` using the field with
+the zone information. You can leave a break line before you enter the expression.
+You can see the result for the preview of zone 2 in the image below:
 
 .. image:: /static/training_manual/forestry/preview_zone2.png
    :align: center
 
-Use the Atlas preview to browse through all the maps you will be creating soon and enjoy!
+Use the Atlas preview to browse through all the maps you will be creating soon
+and enjoy!
 
 |basic| |FA| Printing the Maps
 -------------------------------------------------------------------------------
 
-Last but not least, printing or exporting your maps to image files or PDF files. You can use the :menuselection:`Atlas --> Export Atlas as Images...` or :menuselection:`Atlas --> Export Atlas as PDF...`. Currently the SVG export format is not working properly and will give a poor result.
+Last but not least, printing or exporting your maps to image files or PDF files.
+You can use the :menuselection:`Atlas --> Export Atlas as Images...` or
+:menuselection:`Atlas --> Export Atlas as PDF...`. Currently the SVG export
+format is not working properly and will give a poor result.
 
 Lets print the maps as a single PDF that you can send to the field office for printing:
 
 * Go to the :guilabel:`Atlas generation` tab on the right panel.
-* Under the :guilabel:`Output` check the :guilabel:`Single file export when possible`. This will put all the maps together into a PDF file, if this option is not checked you will get one file for every map.
+* Under the :guilabel:`Output` check the :guilabel:`Single file export when
+  possible`. This will put all the maps together into a PDF file, if this option
+  is not checked you will get one file for every map.
 * Open :menuselection:`Composer --> Export as PDF...`. 
-* Save the PDF file as :kbd:`inventory_2012_maps.pdf` in your :kbd:`exercise_data\\forestry\\samplig\\map_creation\\` folder.
+* Save the PDF file as :kbd:`inventory_2012_maps.pdf` in your
+  :kbd:`exercise_data\\forestry\\samplig\\map_creation\\` folder.
 
 Open the PDF file to check that everything went as expected.
 
-You could just as easily create separate images for every map (remember to uncheck the single file creation), here you can see the thumbnails of the images that would be created:
+You could just as easily create separate images for every map (remember to
+uncheck the single file creation), here you can see the thumbnails of the
+images that would be created:
 
 .. image:: /static/training_manual/forestry/maps_as_images.png
    :align: center
 
-In the :guilabel:`Print Composer`, save your map as a composer template as :kbd:`forestry_atlas.qpt` in your :kbd:`exercise_data\\forestry\\map_creation\\` folder. Use :menuselection:`Composer --> Save as Template`. You will be able to use this template again and again.
+In the :guilabel:`Print Composer`, save your map as a composer template as
+:kbd:`forestry_atlas.qpt` in your :kbd:`exercise_data\\forestry\\map_creation\\`
+folder. Use :menuselection:`Composer --> Save as Template`. You will be able to
+use this template again and again.
 
 Close the :guilabel:`Print Composer` and save your QGIS project.
 
@@ -322,10 +348,15 @@ Close the :guilabel:`Print Composer` and save your QGIS project.
 |IC|
 -------------------------------------------------------------------------------
 
-You have managed to create a template map that can be used to automatically generate detail maps to be used in the field to help navigate to the different plots. As you noticed, this was not an easy task but the benefit will come when you need to create similar maps for other regions and you can use the template you just saved.
+You have managed to create a template map that can be used to automatically
+generate detail maps to be used in the field to help navigate to the different
+plots. As you noticed, this was not an easy task but the benefit will come when
+you need to create similar maps for other regions and you can use the template
+you just saved.
 
 |WN|
 -------------------------------------------------------------------------------
 
-In the next lesson, you will see how you can use LiDAR data to create a DEM and then use it to your enhance your data and maps visibility.
+In the next lesson, you will see how you can use LiDAR data to create a DEM and
+then use it to your enhance your data and maps visibility.
 

--- a/source/docs/training_manual/foreword/preparing_data.rst
+++ b/source/docs/training_manual/foreword/preparing_data.rst
@@ -35,7 +35,7 @@ water, such as streams and rivers.
 
 * Open a new QGIS project
 * In the :guilabel:`Vector` menu dropdown, select
-  :guilabel:`OpenStreetMap --> Download Data`. You can then manually enter the
+  :menuselection:`OpenStreetMap --> Download Data`. You can then manually enter the
   co-ordinates of the region you wish to use, or you can use an existing layer
   to set the co-ordinates.
 * Choose a location to save the resulting .osm file and click :guilabel:`Ok`:

--- a/source/docs/training_manual/qgis_plugins/plugin_examples.rst
+++ b/source/docs/training_manual/qgis_plugins/plugin_examples.rst
@@ -15,7 +15,7 @@ and get acquainted with some useful plugins.
 
 From the lesson on raster analysis, you're already familiar with raster
 analysis functions. You used GDAL tools (accessible via
-:guilabel:`Raster --> Analysis`) for this. However, you should also know about
+:menuselection:`Raster --> Analysis`) for this. However, you should also know about
 the Raster Terrain Analysis plugin. This ships standard with newer versions of
 QGIS, and so you don't need to install it separately.
 
@@ -125,8 +125,8 @@ layer, with our own vector road layer as overlay:
 
 * Close the :guilabel:`Plugin Manager`.
 * You can now use the GeoSearch plugin to search for placenames. Click on 
-  :guilabel:`Plugins --> GeoSearch Plugin --> GeoSearch` to open the GeoSearch
-  dialog.
+  :menuselection:`Plugins --> GeoSearch Plugin --> GeoSearch` to open the
+  GeoSearch dialog.
 
   .. image:: /static/training_manual/qgis_plugins/geosearch_menu.png
      :align: center

--- a/source/docs/training_manual/rasters/data_manipulation.rst
+++ b/source/docs/training_manual/rasters/data_manipulation.rst
@@ -36,12 +36,12 @@ map. Are the rasters not loading? Well, there they are in the :guilabel:`Layers
 list`, so obviously they did load. The problem is that they're not in the same
 projection. Luckily, we've already seen what to do in this situation.
 
-* Select :guilabel:`Project --> Project Properties` in the menu:
+* Select :menuselection:`Project --> Project Properties` in the menu:
 * Select :guilabel:`CRS` tab in the menu:
 * Enable "on the fly" reprojection.
 * Set it to the same projection as the rest of your data (:kbd:`WGS 84 / UTM
   zone 33S`).
-* Click :guilabel:`OK`.
+* Click **[OK]**.
 
 The rasters should fit nicely:
 

--- a/source/docs/training_manual/vector_analysis/spatial_statistics.rst
+++ b/source/docs/training_manual/vector_analysis/spatial_statistics.rst
@@ -64,8 +64,8 @@ Sampling the data
 * To create a sample dataset from the raster, you'll need to use the
   :guilabel:`Point sampling tool` plugin.
 * Refer ahead to the module on plugins if necessary.
-* Search for the phrase :kbd:`point sampling` in the :guilabel:`Plugin --> Manage
-  and Install Plugins...` and you will find the plugin.
+* Search for the phrase :kbd:`point sampling` in the :menuselection:`Plugin -->
+  Manage and Install Plugins...` and you will find the plugin.
 * As soon as it has been activated with the :guilabel:`Plugin Manager`, you
   will find the tool under :menuselection:`Plugins --> Analyses --> Point
   sampling tool`:


### PR DESCRIPTION
Because `:guilabel:` doesn't render `-->`

I also found that the training manual is full of sphinx role misuse, particularly `:kbd:` which is used for files and text instead of keyboards commands.