### PR TITLE
Print composer panels are no longer called "tabs"

### DIFF
--- a/source/docs/user_manual/print_composer/composer_items/composer_attribute_table.rst
+++ b/source/docs/user_manual/print_composer/composer_items/composer_attribute_table.rst
@@ -15,24 +15,25 @@ The Attribute Table Item
 
 It is possible to add parts of a vector attribute table to the Print Composer
 canvas: Click the |openTable| :sup:`Add attribute table` icon, click and drag
-with the left mouse button on the Print Composer canvas to place and size the item.
-You can better position and customize its appearance in the :guilabel:`Item Properties` tab.
+with the left mouse button on the Print Composer canvas to place and size the
+item. You can better position and customize its appearance in the
+:guilabel:`Item Properties` panel.
 
-The :guilabel:`Item properties` tab of an attribute table provides the following
-functionalities (see figure_composer_table_):
+The :guilabel:`Item properties` panel of an attribute table provides the
+following functionalities (see figure_composer_table_):
 
 .. _Figure_composer_table:
 
 .. figure:: /static/user_manual/print_composer/attribute_properties.png
    :align: center
 
-   Attribute table Item properties Tab
+   Attribute table Item Properties Panel
 
 
 Main properties
 ---------------
 
-The :guilabel:`Main properties` dialog of the attribute table` provides the
+The :guilabel:`Main properties` dialog of the attribute table provides the
 following functionalities (see figure_composer_table_ppt_):
 
 .. _Figure_composer_table_ppt:
@@ -42,21 +43,25 @@ following functionalities (see figure_composer_table_ppt_):
 
    Attribute table Main properties Dialog
 
-* For :guilabel:`Source` you can normally select only 'Layer features'.
-* With :guilabel:`Layer` you can choose from the vector layers loaded in the project.
-* In case you activated the |checkbox|:guilabel:`Generate an atlas` option in the
-  :guilabel:`Atlas generation` tab, there are two additional :guilabel:`Source` possible:
-  'Current atlas feature' (see figure_composer_table_atlas_) and 'Relation children'
-  (see figure_composer_table_relation_). Choosing the 'Current atlas feature'
-  you won't see any option to choose the layer, and the table item will only
-  show a row with the attributes from the current feature of the atlas coverage layer.
-  Choosing 'Relation children', an option with the relation names will show up.
-  The 'Relation children' option can only be used if you have defined a relation using
-  your atlas coverage layer as parent, and the table will show the children rows of
-  the atlas coverage layer's current feature (for further information about the
-  atlas generation, see :ref:`atlas_generation`).
-* The button **[Refresh table data]** can be used to refresh the table when the actual
-  contents of the table has changed.
+* For :guilabel:`Source` you can normally select only **Layer features**.
+* With :guilabel:`Layer` you can choose from the vector layers loaded in the
+  project.
+* In case you activated the |checkbox|:guilabel:`Generate an atlas` option in
+  the :guilabel:`Atlas generation` panel, there are two additional
+  :guilabel:`Source` possible:
+
+  * **Current atlas feature** (see figure_composer_table_atlas_): you won't see
+    any option to choose the layer, and the table item will only show a row with
+    the attributes from the current feature of the atlas coverage layer.
+  * and **Relation children** (see figure_composer_table_relation_): an option
+    with the relation names will show up. This feature can only be used if you
+    have defined a relation using your atlas coverage layer as parent, and the
+    table will show the children rows of the atlas coverage layer's current
+    feature (for further information about the atlas generation, see
+    :ref:`atlas_generation`).
+
+* The button **[Refresh table data]** can be used to refresh the table when the
+  actual contents of the table has changed.
 
 
 .. _Figure_composer_table_atlas:

--- a/source/docs/user_manual/print_composer/composer_items/composer_html_frame.rst
+++ b/source/docs/user_manual/print_composer/composer_items/composer_html_frame.rst
@@ -16,8 +16,8 @@ It is possible to add a frame that displays the contents of a website or even
 create and style your own HTML page and display it!
 
 Click the |addHtml| :sup:`Add HTML frame` icon, place the element by dragging a
-rectangle holding down the left mouse button on the Print Composer canvas and position
-and customize the appearance in the :guilabel:`Item Properties` tab
+rectangle holding down the left mouse button on the Print Composer canvas and
+position and customize the appearance in the :guilabel:`Item Properties` panel
 (see figure_composer_html_).
 
 .. _Figure_composer_html:
@@ -25,17 +25,18 @@ and customize the appearance in the :guilabel:`Item Properties` tab
 .. figure:: /static/user_manual/print_composer/html_properties.png
    :align: center
 
-   HTML frame, the item properties Tab
+   HTML Frame, the Item Properties Panel
 
 
 HTML Source
 ------------
 
 As an HTML source, you can either set a URL and activate the URL radiobutton or
-enter the HTML source directly in the textbox provided and activate the Source radiobutton.
+enter the HTML source directly in the textbox provided and activate the Source
+radiobutton.
 
-The :guilabel:`HTML Source` dialog of the HTML frame :guilabel:`Item Properties` tab
-provides the following functionalities (see figure_composer_html_ppt_):
+The :guilabel:`HTML Source` dialog of the HTML frame :guilabel:`Item Properties`
+panel provides the following functionalities (see figure_composer_html_ppt_):
 
 .. _Figure_composer_html_ppt:
 
@@ -44,28 +45,30 @@ provides the following functionalities (see figure_composer_html_ppt_):
 
    HTML frame, the HTML Source properties
 
-* In :guilabel:`URL` you can enter the URL of a webpage you copied from your internet
-  browser or select an HTML file using the browse button |browseButton|. There is also the
-  option to use the Data defined override button, to provide an URL from the contents of an
-  attribute field of a table or using a regular expression.
-* In :guilabel:`Source` you can enter text in the textbox with some HTML tags or provide a full
-  HTML page.
+* In :guilabel:`URL` you can enter the URL of a webpage you copied from your
+  Internet browser or select an HTML file using the browse button |browseButton|.
+  There is also the option to use the Data defined override button, to provide
+  an URL from the contents of an attribute field of a table or using a regular
+  expression.
+* In :guilabel:`Source` you can enter text in the textbox with some HTML tags or
+  provide a full HTML page.
 * The **[insert an expression]** button can be used to insert an expression like
-  ``[%Year($now)%]`` in the Source textbox to display the current year. This button is only
-  activated when radiobutton :guilabel:`Source` is selected. After inserting the expression
-  click somewhere in the textbox before refreshing the HTML frame, otherwise you will
-  lose the expression.
-* Activate |checkbox| :guilabel:`Evaluate QGIS expressions in HTML code` to see the result of
-  the expression you have included, otherwise you will see the expression instead.
-* Use the **[Refresh HTML]** button to refresh the HTML frame(s) to see the result of
-  changes.
+  ``[%Year($now)%]`` in the Source textbox to display the current year. This
+  button is only activated when radiobutton :guilabel:`Source` is selected.
+  After inserting the expression click somewhere in the textbox before
+  refreshing the HTML frame, otherwise you will lose the expression.
+* Activate |checkbox| :guilabel:`Evaluate QGIS expressions in HTML code` to see
+  the result of the expression you have included, otherwise you will see the
+  expression instead.
+* Use the **[Refresh HTML]** button to refresh the HTML frame(s) to see the
+  result of changes.
 
 
 Frames
 -------
 
-The :guilabel:`Frames` dialog of the HTML frame :guilabel:`Item Properties` tab
-provides the following functionalities (see figure_composer_html_frames_):
+The :guilabel:`Frames` dialog of the HTML frame :guilabel:`Item Properties`
+panel provides the following functionalities (see figure_composer_html_frames_):
 
 .. _Figure_composer_html_frames:
 
@@ -76,20 +79,21 @@ provides the following functionalities (see figure_composer_html_frames_):
 
 * With :guilabel:`Resize mode` you can select how to render the HTML contents:
 
-  * `Use existing frames` displays the result in the first frame and added frames only.
-  * `Extend to next page` will create as many frames (and corresponding pages) as
-    necessary to render the height of the web page. Each frame can be moved around on
-    the layout. If you resize a frame, the webpage will be divided up between the
-    other frames. The last frame will be trimmed to fit the web page.
-  * `Repeat on every page` will repeat the upper left of the web page on every page
-    in frames of the same size.
+  * `Use existing frames` displays the result in the first frame and added
+    frames only.
+  * `Extend to next page` will create as many frames (and corresponding pages)
+    as necessary to render the height of the web page. Each frame can be moved
+    around on the layout. If you resize a frame, the webpage will be divided up
+    between the other frames. The last frame will be trimmed to fit the web page.
+  * `Repeat on every page` will repeat the upper left of the web page on every
+    page in frames of the same size.
   * `Repeat until finished` will also create as many frames as the
     `Extend to next page` option, except all frames will have the same size.
 
-* Use the **[Add Frame]** button to add another frame with the same size as selected
-  frame. If the HTML page that will not fit in the first frame it will continue
-  in the next frame when you use :guilabel:`Resize mode` or :guilabel:`Use
-  existing frames`.
+* Use the **[Add Frame]** button to add another frame with the same size as
+  selected frame. If the HTML page that will not fit in the first frame it will
+  continue in the next frame when you use :guilabel:`Resize mode` or
+  :guilabel:`Use existing frames`.
 * Activate |checkbox| :guilabel:`Don't export page if frame is empty` prevents
   the map layout from being exported when the frame has no HTML contents. This
   means all other composer items,
@@ -101,9 +105,9 @@ provides the following functionalities (see figure_composer_html_frames_):
 Use smart page breaks and User style sheet
 -------------------------------------------
 
-The :guilabel:`Use smart page breaks` dialog and :guilabel:`Use style sheet` dialog of
-the HTML frame :guilabel:`Item Properties` tab provides the following functionalities
-(see figure_composer_html_breaks_):
+The :guilabel:`Use smart page breaks` dialog and :guilabel:`Use style sheet`
+dialog of the HTML frame :guilabel:`Item Properties` panel provides the
+following functionalities (see figure_composer_html_breaks_):
 
 .. _Figure_composer_html_breaks:
 
@@ -112,17 +116,19 @@ the HTML frame :guilabel:`Item Properties` tab provides the following functional
 
    HTML frame, Use smart page breaks and User stylesheet properties
 
-* Activate |checkbox| :guilabel:`Use smart page breaks` to prevent the html frame contents
-  from breaking mid-way a line of text so it continues nice and smooth in the next frame.
-* Set the :guilabel:`Maximum distance` allowed when calculating where to place page
-  breaks in the html. This distance is the maximum amount of empty space allowed at the
-  bottom of a frame after calculating the optimum break location. Setting a larger value
-  will result in better choice of page break location, but more wasted space at the bottom
-  of frames. This is only used when :guilabel:`Use smart page breaks` is activated.
-* Activate |checkbox| :guilabel:`User stylesheet` to apply HTML styles that often is provided
-  in cascading style sheets. An example of style code is provide below to set the color of
-  ``<h1>`` header tag to green and set the font and fontsize of text included in paragraph
-  tags ``<p>``.
+* Activate |checkbox| :guilabel:`Use smart page breaks` to prevent the html
+  frame contents from breaking mid-way a line of text so it continues nice and
+  smooth in the next frame.
+* Set the :guilabel:`Maximum distance` allowed when calculating where to place
+  page breaks in the html. This distance is the maximum amount of empty space
+  allowed at the bottom of a frame after calculating the optimum break location.
+  Setting a larger value will result in better choice of page break location,
+  but more wasted space at the bottom of frames. This is only used when
+  :guilabel:`Use smart page breaks` is activated.
+* Activate |checkbox| :guilabel:`User stylesheet` to apply HTML styles that
+  often is provided in cascading style sheets. An example of style code is
+  provide below to set the color of ``<h1>`` header tag to green and set the
+  font and fontsize of text included in paragraph tags ``<p>``.
 
   .. code-block:: css
 

--- a/source/docs/user_manual/print_composer/composer_items/composer_image.rst
+++ b/source/docs/user_manual/print_composer/composer_items/composer_image.rst
@@ -9,7 +9,7 @@ The Image Item
 
 To add an image, click the |addImage| :sup:`Add image` icon and drag a rectangle onto the Composer
 canvas with the left mouse button. You can then position and customize
-its appearance in the image :guilabel:`Item Properties` tab.
+its appearance in the image :guilabel:`Item Properties` panel.
 
 .. index:: Picture database, Rotated north arrow
 
@@ -21,43 +21,47 @@ The image :guilabel:`Item Properties` tab provides the following functionalities
 .. figure:: /static/user_manual/print_composer/image_mainproperties.png
    :align: center
 
-   Image Item properties Tab
+   Image Item Properties panel
 
 
-You first have to select the image you want to display.
-There are several ways to set the :guilabel:`image source` in the **Main properties** area.
+You first have to select the image you want to display. There are several ways
+to set the :guilabel:`image source` in the **Main properties** area.
 
-#. Use the browse button |browseButton| of :guilabel:`image source` to select a file on your
-   computer using the browse dialog. The browser will start in the SVG-libraries provided with QGIS.
-   Besides :file:`SVG`, you can also select other image formats like :file:`.png` or :file:`.jpg`.
-#. You can enter the source directly in the :guilabel:`image source` text field. You can even provide
-   a remote URL-address to an image.
-#. From the **Search directories** area you can also select an image from :guilabel:`loading previews ...`
-   to set the image source.
-#. Use the data defined button |dataDefined| to set the image source from a record or using a
-   regular expression.
+#. Use the browse button |browseButton| of :guilabel:`image source` to select a
+   file on your computer using the browse dialog. The browser will start in the
+   SVG-libraries provided with QGIS. Besides :file:`SVG`, you can also select
+   other image formats like :file:`.png` or :file:`.jpg`.
+#. You can enter the source directly in the :guilabel:`image source` text field.
+   You can even provide a remote URL-address to an image.
+#. From the **Search directories** area you can also select an image from
+   :guilabel:`loading previews ...` to set the image source.
+#. Use the data defined button |dataDefined| to set the image source from a
+   record or using a regular expression.
 
-With the :guilabel:`Resize mode` option, you can set how the image is displayed when the frame
-is changed, or choose to resize the frame of the image item so it matches the original size of
-the image.
+With the :guilabel:`Resize mode` option, you can set how the image is displayed
+when the frame is changed, or choose to resize the frame of the image item so
+it matches the original size of the image.
 
 You can select one of the following modes:
 
 * Zoom: Enlarges the image to the frame while maintaining aspect ratio of picture.
 * Stretch: Stretches image to fit inside the frame, ignores aspect ratio.
-* Clip: Use this mode for raster images only, it sets the size of the image to original image size
-  without scaling and the frame is used to clip the image, so only the part of the image inside the
-  frame is visible.
-* Zoom and resize frame: Enlarges image to fit frame, then resizes frame to fit resultant image.
-* Resize frame to image size: Sets size of frame to match original size of image without scaling.
+* Clip: Use this mode for raster images only, it sets the size of the image to
+  original image size without scaling and the frame is used to clip the image,
+  so only the part of the image inside the frame is visible.
+* Zoom and resize frame: Enlarges image to fit frame, then resizes frame to fit
+  resultant image.
+* Resize frame to image size: Sets size of frame to match original size of image
+  without scaling.
 
 Selected resize mode can disable the item options 'Placement' and 'Image rotation'.
 The :guilabel:`Image rotation` is active for the resize mode 'Zoom' and 'Clip'.
 
-With :guilabel:`Placement` you can select the position of the image inside it's frame.
-The **Search directories** area allows you to add and remove directories with images in SVG format
-to the picture database. A preview of the pictures found in the selected directories is shown in a
-pane and can be used to select and set the image source.
+With :guilabel:`Placement` you can select the position of the image inside its
+frame. The **Search directories** area allows you to add and remove directories
+with images in SVG format to the picture database. A preview of the pictures
+found in the selected directories is shown in a pane and can be used to select
+and set the image source.
 
 .. _parameterized_svg:
 
@@ -77,14 +81,16 @@ Activating the |checkbox| :guilabel:`Sync with map` checkbox synchronizes the
 rotation of the image (i.e., a rotated north arrow) with the rotation applied to
 the selected map item.
 
-It is also possible to select a north arrow directly. If you first select a north arrow image from
-**Search directories** and then use the browse button |browseButton| of the field :guilabel:`Image source`,
-you can now select one of the north arrow from the list as displayed in figure_composer_image_north_.
+It is also possible to select a north arrow directly. If you first select a
+north arrow image from **Search directories** and then use the browse button
+|browseButton| of the field :guilabel:`Image source`, you can now select one of
+the north arrow from the list as displayed in figure_composer_image_north_.
 
 .. note::
 
-   Many of the north arrows do not have an 'N' added in the north arrow, this is done on
-   purpose for languages that do not use an 'N' for North, so they can use another letter.
+   Many of the north arrows do not have an 'N' added in the north arrow, this is
+   done on purpose for languages that do not use an 'N' for North, so they can
+   use another letter.
 
 .. _Figure_composer_image_north:
 

--- a/source/docs/user_manual/print_composer/composer_items/composer_items_options.rst
+++ b/source/docs/user_manual/print_composer/composer_items/composer_items_options.rst
@@ -12,23 +12,23 @@ Composer Items Common Options
    .. contents::
       :local:
 
-Composer items have a set of common properties you will find on the bottom of
-the :guilabel:`Item Properties` tab: Position and size, Rotation, Frame,
-Background, Item ID and Rendering (See figure_composer_common_).
+Composer items have a set of common properties you will find at the bottom of
+the :guilabel:`Item Properties` panel: Position and size, Rotation, Frame,
+Background, Item ID, Variables and Rendering (See figure_composer_common_).
 
 .. _Figure_composer_common:
 
 .. figure:: /static/user_manual/print_composer/common_properties.png
    :align: center
 
-   Common Item properties Dialogs
+   Common Item Properties Dialogs
 
 .. _Frame_Dialog:
 
-* The :guilabel:`Position and size` dialog lets you define the size and position of the frame
-  which contains the item.
-  You can also choose which :guilabel:`Reference point` will be set at the **X** and **Y**
-  coordinates previously defined.
+* The :guilabel:`Position and size` dialog lets you define the size and position
+  of the frame which contains the item.
+  You can also choose which :guilabel:`Reference point` will be set at the **X**
+  and **Y** coordinates previously defined.
 * The :guilabel:`Rotation` sets the rotation of the element (in degrees).
 * The |checkbox| :guilabel:`Frame` shows or hides the frame around the item.
   Click on the [Color] and [Thickness] buttons to adjust those properties.
@@ -36,13 +36,14 @@ Background, Item ID and Rendering (See figure_composer_common_).
   Click on the [Color...] button to display a dialog where you can pick a color
   or choose from a custom setting.
   Transparency can be adjusted through atlering the alpha field settings.
-* Use the :guilabel:`Item ID` to create a relationship to other Print Composer items.
-  This is used with QGIS server and other potential web
-  clients. You can set an ID on an item (for example, a map or a label), and then the web client
-  can send data to set a property
-  (e.g., label text) for that specific item. The GetProjectSettings command will list the items
-  and IDs which are available in a layout.
-* :guilabel:`Rendering` mode helps you set whether and how the item can be displayed.
+* Use the :guilabel:`Item ID` to create a relationship to other Print Composer
+  items. This is used with QGIS server and other potential web clients. You can
+  set an ID on an item (for example, a map or a label), and then the web client
+  can send data to set a property (e.g., label text) for that specific item.
+  The GetProjectSettings command will list the items and IDs which are available
+  in a layout.
+* :guilabel:`Rendering` mode helps you set whether and how the item can be
+  displayed.
 
 .. note::
 
@@ -62,7 +63,8 @@ Background, Item ID and Rendering (See figure_composer_common_).
 Rendering mode
 --------------
 
-QGIS now allows advanced rendering for Composer items just like vector and raster layers.
+QGIS now allows advanced rendering for Composer items just like vector and
+raster layers.
 
 .. _figure_composer_common_rendering:
 
@@ -71,39 +73,41 @@ QGIS now allows advanced rendering for Composer items just like vector and raste
 
    Rendering mode
 
-* :guilabel:`Blending mode`: With this tool you can achieve effects which would otherwise
-  only be achieved using graphic rendering software. The pixels of your overlaying and
-  underlaying items can be mixed according to the mode set (see :ref:`blend-modes`
-  for description of each effect).
-* :guilabel:`Transparency` |slider|: You can make the underlying item in the Composer visible
-  with this tool.
+* :guilabel:`Blending mode`: With this tool you can achieve effects which would
+  otherwise only be achieved using graphic rendering software. The pixels of
+  your overlaying and underlaying items can be mixed according to the mode set
+  (see :ref:`blend-modes` for description of each effect).
+* :guilabel:`Transparency` |slider|: You can make the underlying item in the
+  Composer visible with this tool.
   Use the slider to adapt the visibility of your item to your needs.
-  You can also make a precise definition of the percentage of visibility in the menu beside the
-  slider.
-* |checkbox| :guilabel:`Exclude item from exports`: You can decide to make an item invisible in
-  all exports.
-  After activating this checkbox, the item will not be included in export to PDF, print etc..
+  You can also make a precise definition of the percentage of visibility in the
+  menu beside the slider.
+* |checkbox| :guilabel:`Exclude item from exports`: You can decide to make an
+  item invisible in all exports.
+  After activating this checkbox, the item will not be included in export to
+  PDF, print etc..
 
 
 Size and position
 -----------------
 
-Each item inside the Composer can be moved and resized to create a perfect layout.
-For both operations the first step is to activate the |select| :sup:`Select/Move item` tool
-and to click on the item; you can then move it using the mouse while holding the left button.
-If you need to constrain the movements to the horizontal or the vertical axis, just hold
-the :kbd:`Shift` button on the keyboard while moving the mouse.
-If you need better precision, you can move a selected item using the :kbd:`Arrow keys` on the keyboard;
+Each item inside the Composer can be moved and resized to create a perfect
+layout.For both operations the first step is to activate the |select|
+:sup:`Select/Move item` tool and to click on the item; you can then move it
+using the mouse while holding the left button. If you need to constrain the
+movements to the horizontal or the vertical axis, just hold the :kbd:`Shift`
+button on the keyboard while moving the mouse. If you need better precision,
+you can move a selected item using the :kbd:`Arrow keys` on the keyboard;
 if the movement is too slow, you can speed up it by holding :kbd:`Shift`.
 
-A selected item will show squares on its boundaries; moving one of them with the mouse, will resize
-the item in the corresponding direction. While resizing,
+A selected item will show squares on its boundaries; moving one of them with
+the mouse, will resize the item in the corresponding direction. While resizing,
 holding :kbd:`Shift` will maintain the aspect ratio. Holding :kbd:`Alt` will
 resize from the item center.
 
 The correct position for an item can be obtained using the grid snapping or
-smart guides. Guides are set by clicking and dragging within the ruler area. To move a guide,
-click on the ruler, level with the guide and drag it to a new
+smart guides. Guides are set by clicking and dragging within the ruler area.
+To move a guide, click on the ruler, level with the guide and drag it to a new
 position. To delete a guide move it off the canvas. If you need to disable the
 snap on the fly, hold :kbd:`Ctrl` while moving the mouse.
 
@@ -113,16 +117,15 @@ You can then resize/move this group like a single item.
 
 Once you have found the correct position for an item, you can lock it by using
 the items on the toolbar or ticking the box next to the item in the
-:menuselection:`Items` tab. Locked items are **not** selectable on the canvas.
+:menuselection:`Items` panel. Locked items are **not** selectable on the canvas.
 
-Locked items can be unlocked by selecting the item in the
-:menuselection:`Items` tab and unchecking the tickbox or you can use the icons
-on the toolbar.
+Locked items can be unlocked by selecting the item in the :menuselection:`Items`
+panel and unchecking the tickbox or you can use the icons on the toolbar.
 
 To unselect an item, just click on it holding the :kbd:`Shift` button.
 
-Inside the :menuselection:`Edit` menu, you can find actions to select all the items,
-to clear all selections or to invert the current selection.
+Inside the :menuselection:`Edit` menu, you can find actions to select all the
+items, to clear all selections or to invert the current selection.
 
 
 .. index:: Items alignment
@@ -134,8 +137,8 @@ Raising or lowering the visual hierarchy for elements are inside the |raiseItems
 :sup:`Raise selected items` pull-down menu. Choose an element on the Print Composer
 canvas and select the matching functionality to raise or lower the selected
 element compared to the other elements. This order is
-shown in the :menuselection:`Items` tab. You can also raise or lower objects
-in the :menuselection:`Items` tab by clicking and dragging an object's label
+shown in the :menuselection:`Items` panel. You can also raise or lower objects
+in the :menuselection:`Items` panel by clicking and dragging an object's label
 in this list.
 
 .. _figure_composer_common_align:
@@ -146,11 +149,11 @@ in this list.
    Alignment helper lines in the Print Composer
 
 There are several alignment options available within the |alignLeft|
-:sup:`Align selected items` pull-down menu (see figure_composer_common_align_). To use an
-alignment function, you first select the elements then click on the
-matching alignment icon. All selected elements will then be aligned to their common bounding box.
-When moving items on the Composer canvas, alignment helper lines appear when borders, centers or
-corners are aligned.
+:sup:`Align selected items` pull-down menu (see figure_composer_common_align_).
+To use an alignment function, you first select the elements then click on the
+matching alignment icon. All selected elements will then be aligned to their
+common bounding box. When moving items on the Composer canvas, alignment helper
+lines appear when borders, centers or corners are aligned.
 
 Variables
 ---------
@@ -160,7 +163,7 @@ the composer item's level (which includes all global, project and
 composition's variables). Map items also include Map settings variables that
 provide easy access to values like the map's scale, extent, and so on.
 
-In :guilabel:`Variables`, it`s also possible to manage item-level variables.
+In :guilabel:`Variables`, it's also possible to manage item-level variables.
 Click the |signPlus| button to add a new custom variable. Likewise, select any
 custom item-level variable from the list and click the |signMinus| button to
 remove it.

--- a/source/docs/user_manual/print_composer/composer_items/composer_items_shape.rst
+++ b/source/docs/user_manual/print_composer/composer_items/composer_items_shape.rst
@@ -17,40 +17,45 @@ Shape Items
 The Arrow Item
 --------------
 
-To add an arrow, click the |addArrow| :sup:`Add Arrow` icon, place the element holding
-down the left mouse button and drag a line to draw the arrow on the Print Composer canvas and
-position and customize the appearance in the scale bar :guilabel:`Item Properties` tab.
+To add an arrow, click the |addArrow| :sup:`Add Arrow` icon, place the element
+holding down the left mouse button and drag a line to draw the arrow on the
+Print Composer canvas and position and customize the appearance in the scale bar
+:guilabel:`Item Properties` panel.
 
-When you also hold down the :kbd:`Shift` key while placing the arrow, it is placed in an angle
-of exactly 45\ |degrees| .
+When you also hold down the :kbd:`Shift` key while placing the arrow, it is
+placed in an angle of exactly 45\ |degrees| .
 
-The arrow item can be used to add a line or a simple arrow that can be used, for example, to
-show the relation between other print composer items. To create a north arrow, the image item should
-be considered first. QGIS has a set of North arrows in SVG format. Furthermore you can connect
-an image item with a map so it can rotate automatically with the map (see :ref:`image_item`).
+The arrow item can be used to add a line or a simple arrow that can be used,
+for example, to show the relation between other print composer items. To create
+a north arrow, the image item should be considered first. QGIS has a set of
+North arrows in SVG format. Furthermore you can connect an image item with a map
+so it can rotate automatically with the map (see :ref:`image_item`).
 
 .. _figure_composer_arrow:
 
 .. figure:: /static/user_manual/print_composer/arrow_properties.png
    :align: center
 
-   Arrow Item properties Tab
+   Arrow Item Properties Panel
 
 Item Properties
 ...............
 
-The :guilabel:`Arrow` item properties tab allows you to configure an arrow item.
+The :guilabel:`Arrow` item properties panel allows you to configure an arrow item.
 
-The  **[Line style ...]** button can be used to set the line style using the line style symbol editor.
+The  **[Line style...]** button can be used to set the line style using the line
+style symbol editor.
 
 In :guilabel:`Arrows markers` you can select one of three radio buttons.
 
-* :guilabel:`Default`: To draw a regular arrow, gives you options to style the arrow head
+* :guilabel:`Default`: To draw a regular arrow, gives you options to style the
+  arrow head
 * :guilabel:`None`: To draw a line without arrow head
 * :guilabel:`SVG Marker`: To draw a line with an SVG :guilabel:`Start marker`
   and/or :guilabel:`End marker`
 
-For :guilabel:`Default` Arrow marker you can use following options to style the arrow head.
+For :guilabel:`Default` Arrow marker you can use following options to style the
+arrow head.
 
 * :guilabel:`Arrow outline color`: Set the outline color of the arrow head
 * :guilabel:`Arrow fill color`: Set the fill color of the arrow head
@@ -59,13 +64,14 @@ For :guilabel:`Default` Arrow marker you can use following options to style the 
 
 For :guilabel:`SVG Marker` you can use following options.
 
-* :guilabel:`Start marker`: Choose an SVG image to draw at the beginning of the line
+* :guilabel:`Start marker`: Choose an SVG image to draw at the beginning of the
+  line
 * :guilabel:`End marker`: Choose an SVG image to draw at the end of the line
 * :guilabel:`Arrow head width`: Set the size of Start and/or End marker
 
-SVG images are automatically rotated with the line. Outline and fill colors of QGIS
-predefined SVG images can be changed using the corresponding options. Custom SVG
-may require some tags following this :ref:`instruction <parameterized_svg>`.
+SVG images are automatically rotated with the line. Outline and fill colors of
+QGIS predefined SVG images can be changed using the corresponding options. Custom
+SVG may require some tags following this :ref:`instruction <parameterized_svg>`.
 
 .. index:: 
    single: Composer Item; Basic shape
@@ -76,7 +82,7 @@ The Basic Shape Items
 
 To add a basic shape (ellipse, rectangle, triangle), click the |addBasicShape|
 :sup:`Add basic shape` icon,  place the element holding down the left mouse.
-Customize the appearance in the :guilabel:`Item Properties` tab.
+Customize the appearance in the :guilabel:`Item Properties` panel.
 
 When you also hold down the :kbd:`Shift` key while placing the basic shape
 you can create a perfect square, circle or triangle.
@@ -86,18 +92,20 @@ you can create a perfect square, circle or triangle.
 .. figure:: /static/user_manual/print_composer/shape_properties.png
    :align: center
 
-   Shape Item properties Tab
+   Shape Item Properties Panel
 
-The :guilabel:`Shape` item properties tab allows you to select if you want to draw an ellipse,
-rectangle or triangle inside the given frame.
+The :guilabel:`Shape` item properties panel allows you to select if you want to
+draw an ellipse, rectangle or triangle inside the given frame.
 
-You can set the style of the shape using the advanced symbol style dialog with which you can
-define its outline and fill color, fill pattern, use markers etcetera.
+You can set the style of the shape using the advanced symbol style dialog with
+which you can define its outline and fill color, fill pattern, use markers...
 
-For the rectangle shape, you can set the value of the corner radius to round of the corners.
+For the rectangle shape, you can set the value of the corner radius to round of
+the corners.
 
 .. note::
-   Unlike other items, you can not style the frame or the background color of the frame.
+   Unlike other items, you can not style the frame or the background color of
+   the frame.
 
 .. index:: 
    single: Composer Item; Node-based shape
@@ -106,26 +114,26 @@ For the rectangle shape, you can set the value of the corner radius to round of 
 The Node-Based Shape Items
 --------------------------
 
-While arrow and basic shape items offer you simple and predefined geometric item to use,
-a node-based shape (polygon or polyline) helps you create a custom and more advanced
-geometric item. You can add as many lines or sides as you want to the item and
-independently and directly interact with each of its vertices.
+While arrow and basic shape items offer you simple and predefined geometric item
+to use, a node-based shape (polygon or polyline) helps you create a custom and
+more advanced geometric item. You can add as many lines or sides as you want to
+the item and independently and directly interact with each of its vertices.
 
 To add a node-based shape, click the
 |addNodesShape| :sup:`Add nodes item` icon. Then perform left clicks to
 add nodes to your current shape. When you're done, a simple right click
 terminates the shape. Customize the appearance in the :guilabel:`Item Properties`
-tab.
+panel.
 
 .. _figure_composer_nodes_shape:
 
 .. figure:: /static/user_manual/print_composer/shape_nodes_properties.png
    :align: center
 
-   Nodes Shape Item properties Tab
+   Nodes Shape Item Properties Panel
 
 You can set the style of the shape using the advanced symbol style dialog
-available thanks to the **[Change ...]** button in :guilabel:`Main properties`.
+available thanks to the **[Change...]** button in :guilabel:`Main properties`.
 
 A specific tool is provided to edit node-based shapes through
 |editNodesShape| :sup:`Edit Nodes Item`. Within this mode, you can select

--- a/source/docs/user_manual/print_composer/composer_items/composer_label.rst
+++ b/source/docs/user_manual/print_composer/composer_items/composer_label.rst
@@ -11,10 +11,10 @@ The Label Item
       :local:
 
 To add a label, click the |label| :sup:`Add label` icon, place the element
-with the left mouse button on the Print Composer canvas and position and customize
-its appearance in the label :guilabel:`Item Properties` tab.
+with the left mouse button on the Print Composer canvas and position and
+customize its appearance in the label :guilabel:`Item Properties` panel.
 
-The :guilabel:`Item Properties` tab of a label item provides the following
+The :guilabel:`Item Properties` panel of a label item provides the following
 functionality for the label item (see Figure_composer_label_):
 
 .. _Figure_composer_label:
@@ -22,31 +22,32 @@ functionality for the label item (see Figure_composer_label_):
 .. figure:: /static/user_manual/print_composer/label_mainproperties.png
    :align: center
 
-   Label Item properties Tab
+   Label Item Properties Panel
 
 Main properties
 ----------------
 
 * The main properties dialog is where the text (HTML or not) or the expression
   needed to fill the label is added to the Composer canvas.
-* Labels can be interpreted as HTML code: check |checkbox| :guilabel:`Render as HTML`.
-  You can now insert a URL, a clickable image that links to a web page or something more complex.
-* You can also insert an expression. Click on **[Insert an expression]** to open a new dialog.
-  Build an expression by clicking the functions available in the left side of the panel.
-  Two special categories can be useful, particularly associated with the atlas functionality:
-  geometry functions and records functions. At the bottom, a preview of the expression is shown.
+* Labels can be interpreted as HTML code: check |checkbox|
+  :guilabel:`Render as HTML`. You can now insert a URL, a clickable image that
+  links to a web page or something more complex.
+* You can also insert an expression. Click on **[Insert an expression]** to open
+  a new dialog. Build an expression by clicking the functions available in the
+  left side of the panel. Two special categories can be useful, particularly
+  associated with the atlas functionality: **geometry** and **records**
+  functions. At the bottom, a preview of the expression is shown.
 
 Appearance
 ----------
 
-* Define :guilabel:`Font` by clicking on the **[Font...]** button or a :guilabel:`Font color`
-  selecting a color using the color selection tool.
-* You can specify different horizontal and vertical margins in mm.
-  This is the margin from the edge of the composer item. The label can be positioned outside
-  the bounds of the label e.g. to align label items with other items. In this case you have to
-  use negative values for the margin.
-* Using the :guilabel:`Alignment` is another way to position your label. Note that when e.g. using
-  the :guilabel:`Horizontal alignment` in |radioButtonOn|:guilabel:`Center` Position the
-  :guilabel:`Horizontal margin` feature is disabled.
-
-
+* Define :guilabel:`Font` by clicking on the **[Font...]** button or a
+  :guilabel:`Font color` selecting a color using the color selection tool.
+* You can specify different horizontal and vertical margins in ``mm``. This is
+  the margin from the edge of the composer item. The label can be positioned
+  outside the bounds of the label e.g. to align label items with other items.
+  In this case you have to use negative values for the margin.
+* Using the :guilabel:`Alignment` is another way to position your label. Note
+  that when e.g. using the :guilabel:`Horizontal alignment` in |radioButtonOn|
+  :guilabel:`Center` Position the :guilabel:`Horizontal margin` feature is
+  disabled.

--- a/source/docs/user_manual/print_composer/composer_items/composer_legend.rst
+++ b/source/docs/user_manual/print_composer/composer_items/composer_legend.rst
@@ -15,9 +15,9 @@ The Legend Item
 To add a map legend, click the |addLegend| :sup:`Add new legend` icon,
 place the element with the left mouse button on the Print Composer canvas and
 position and customize the appearance in the legend :guilabel:`Item Properties`
-tab.
+panel.
 
-The :guilabel:`Item properties` of a legend item tab provides the following
+The :guilabel:`Item properties` panel of a legend item provides the following
 functionalities (see figure_composer_legend_):
 
 .. _Figure_composer_legend:
@@ -25,13 +25,13 @@ functionalities (see figure_composer_legend_):
 .. figure:: /static/user_manual/print_composer/legend_properties.png
    :align: center
 
-   Legend Item properties Tab
+   Legend Item Properties Panel
 
 Main properties
 ---------------
 
 The :guilabel:`Main properties` dialog of the legend :guilabel:`Item Properties`
-tab provides the following functionalities (see figure_composer_legend_ppt_):
+panel provides the following functionalities (see figure_composer_legend_ppt_):
 
 .. _Figure_composer_legend_ppt:
 
@@ -56,8 +56,8 @@ In Main properties you can:
 Legend items
 ------------
 
-The :guilabel:`Legend items` dialog of the legend :guilabel:`Item Properties` tab
-provides the following functionalities (see figure_composer_legend_items_):
+The :guilabel:`Legend items` dialog of the legend :guilabel:`Item Properties`
+panel provides the following functionalities (see figure_composer_legend_items_):
 
 .. _Figure_composer_legend_items:
 
@@ -102,11 +102,12 @@ provides the following functionalities (see figure_composer_legend_items_):
   contextual menu.
 
   After changing the symbology in the QGIS main window, you can click on
-  **[Update All]** to adapt the changes in the legend element of the Print Composer.
+  **[Update All]** to adapt the changes in the legend element of the Print
+  Composer.
 
-* While generating an atlas with polygon features, you can filter out legend items
-  that lie outside the current atlas feature. To do that, check the |checkbox|
-  :guilabel:`Only show items inside current atlas feature` option. 
+* While generating an atlas with polygon features, you can filter out legend
+  items that lie outside the current atlas feature. To do that, check the
+  |checkbox| :guilabel:`Only show items inside current atlas feature` option.
 
 
 
@@ -114,7 +115,7 @@ Fonts, Columns, Symbol
 ----------------------
 
 The :guilabel:`Fonts`, :guilabel:`Columns` and :guilabel:`Symbol` dialogs of the
-legend :guilabel:`Item Properties` tab provide the following functionalities
+legend :guilabel:`Item Properties` panel provide the following functionalities
 (see figure_composer_legend_fonts_):
 
 .. _Figure_composer_legend_fonts:
@@ -129,12 +130,13 @@ legend :guilabel:`Item Properties` tab provide the following functionalities
   Click on a category button to open a **Select font** dialog.
 * You provide the labels with a **Color** using the advanced color picker,
   however the selected color will be given to all font items in the legend..
-* Legend items can be arranged over several columns. Set the number of columns in
-  the :guilabel:`Count` |selectNumber| field.
+* Legend items can be arranged over several columns. Set the number of columns
+  in the :guilabel:`Count` |selectNumber| field.
 
-  * |checkbox| :guilabel:`Equal column widths` sets how legend columns should be adjusted.
-  * The |checkbox| :guilabel:`Split layers` option allows a categorized or a graduated layer
-    legend to be divided between columns.
+  * |checkbox| :guilabel:`Equal column widths` sets how legend columns should be
+    adjusted.
+  * The |checkbox| :guilabel:`Split layers` option allows a categorized or a
+    graduated layer legend to be divided between columns.
 
 * You can also change the width and height of the legend symbol, set a color and
   a thickness in case of raster layer symbol.
@@ -144,7 +146,7 @@ WMS LegendGraphic and Spacing
 ------------------------------
 
 The :guilabel:`WMS LegendGraphic` and :guilabel:`Spacing` dialogs of the legend
-:guilabel:`Item Properties` tab provide the following functionalities (see
+:guilabel:`Item Properties` panel provide the following functionalities (see
 figure_composer_legend_wms_):
 
 .. _Figure_composer_legend_wms:

--- a/source/docs/user_manual/print_composer/composer_items/composer_map.rst
+++ b/source/docs/user_manual/print_composer/composer_items/composer_map.rst
@@ -12,16 +12,16 @@ The Map Item
    .. contents::
       :local:
 
-Click on the |addMap| :sup:`Add new map` toolbar button in the Print
-Composer toolbar to add the QGIS map canvas. Now, drag a rectangle onto the Composer
+Click on the |addMap| :sup:`Add new map` toolbar button in the Print Composer
+toolbar to add the QGIS map canvas. Now, drag a rectangle onto the Composer
 canvas with the left mouse button to add the map. To display the current map, you
 can choose between three different modes in the map :guilabel:`Item Properties`
-tab:
+panel:
 
 * **Rectangle** is the default setting. It only displays an empty box with a
   message 'Map will be printed here'.
-* **Cache** renders the map in the current screen resolution. If you zoom
-  the Composer window in or out, the map is not rendered again but the image will
+* **Cache** renders the map in the current screen resolution. If you zoom the
+  Composer window in or out, the map is not rendered again but the image will
   be scaled.
 * **Render** means that if you zoom the Composer window in or out, the map will
   be rendered again, but for space reasons, only up to a maximum resolution.
@@ -35,12 +35,12 @@ Select the item and while holding the left mouse button, move to the new place
 and release the mouse button. After you have found the right place for an item,
 you can lock the item position within the Print Composer canvas. Select the
 map item and use the toolbar |locked| :sup:`Lock Selected Items` or the
-:menuselection:`Items` tab to Lock the item. A locked item can only be selected
-using the :menuselection:`Items` tab. Once selected you can use the
-:menuselection:`Items` tab to unlock individual items. The |unlocked|
+:menuselection:`Items` panel to Lock the item. A locked item can only be selected
+using the :menuselection:`Items` panel. Once selected you can use the
+:menuselection:`Items` panel to unlock individual items. The |unlocked|
 :sup:`Unlock All Items` icon will unlock all locked composer items. With the
 map selected, you can now adapt more properties in the map
-:guilabel:`Item Properties` tab.
+:guilabel:`Item Properties` panel.
 
 To move layers within the map element, select the map element, click the
 |moveItemContent| :sup:`Move item content` icon and move the layers within
@@ -52,14 +52,14 @@ Main properties
 ---------------
 
 The :guilabel:`Main properties` dialog of the map :guilabel:`Item Properties`
-tab provides the following functionalities (see figure_composer_map_):
+panel provides the following functionalities (see figure_composer_map_):
 
 .. _Figure_composer_map:
 
 .. figure:: /static/user_manual/print_composer/map_mainproperties.png
    :align: center
 
-   Map Item properties Tab
+   Map Item Properties Panel
 
 * The **Preview** drop-down menu allows you to select one of the preview modes
   'Rectangle', 'Cache' and 'Render', as described above. If you change the
@@ -76,7 +76,7 @@ tab provides the following functionalities (see figure_composer_map_):
 Layers
 ------
 
-The :guilabel:`Layers` dialog of the map item tab provides the following
+The :guilabel:`Layers` dialog of the map item panel provides the following
 functionality (see figure_composer_map_layers_):
 
 .. _Figure_composer_map_layers:
@@ -129,7 +129,7 @@ functionality (see figure_composer_map_layers_):
 Extents
 -------
 
-The :guilabel:`Extents` dialog of the map item tab provides the following
+The :guilabel:`Extents` dialog of the map item panel provides the following
 functionalities (see figure_composer_map_extents_):
 
 .. _Figure_composer_map_extents:
@@ -139,30 +139,33 @@ functionalities (see figure_composer_map_extents_):
 
    Map Extents Dialog
 
-The **Map extents** area allows you to specify the map extent using X and Y min/max
-values and by clicking the **[Set to map canvas extent]** button. This button sets
-the map extent of the composer map item to the extent of the current map view in the
-main QGIS application. The button **[View extent in map canvas]** does exactly the
-opposite, it updates the extent of the map view in the QGIS application to the extent
+The **Map extents** area allows you to specify the map extent using ``X`` and
+``Y`` min/max values and by clicking the **[Set to map canvas extent]** button.
+This button sets the map extent of the composer map item to the extent of the
+current map view in the main QGIS application.
+The button **[View extent in map canvas]** does exactly the opposite; it
+updates the extent of the map view in the QGIS application to the extent
 of the composer map item.
 
 If you change the view on the QGIS map canvas by changing
 vector or raster properties, you can update the Print Composer view by selecting
-the map element in the Print Composer and clicking the **[Update preview]** button
-in the map :guilabel:`Item Properties` tab (see figure_composer_map_).
+the map element in the Print Composer and clicking the **[Update preview]**
+button in the map :guilabel:`Item Properties` panel (see figure_composer_map_).
 
 .. index:: Grids, Map grid
 
 Grids
 -----
 
-The :guilabel:`Grids` dialog of the map :guilabel:`Item Properties` tab provides the
-possibility to add several grids to a map item.
+The :guilabel:`Grids` dialog of the map :guilabel:`Item Properties` panel
+provides the possibility to add several grids to a map item.
 
-* With the plus and minus button you can add or remove a selected grid.
-* With the up and down button you can move a grid in the list and set the drawing priority.
+* With the |signPlus| and |signMinus| buttons you can add or remove a selected
+  grid.
+* With the |arrowUp| and |arrowDown| buttons you can move a grid in the list
+  and set the drawing priority.
 
-When you double click on the added grid you can give it another name.
+When you double-click the added grid you can give it another name.
 
 .. _Figure_composer_map_grid:
 
@@ -172,8 +175,8 @@ When you double click on the added grid you can give it another name.
    Map Grids Dialog
 
 After you have added a grid, you can activate the checkbox |checkbox|
-:guilabel:`Draw grid` to overlay a grid onto the map element. Expand this option to provide
-a lot of configuration options, see Figure_composer_map_grid_draw_.
+:guilabel:`Draw grid` to overlay a grid onto the map element. Expand this option
+to provide a lot of configuration options, see Figure_composer_map_grid_draw_.
 
 .. _Figure_composer_map_grid_draw:
 
@@ -204,20 +207,22 @@ and the width used for the cross or line grid type.
 
 * With 'Latitude/Y only' and 'Longitude/X only' setting in the divisions section
   you have the possibility to prevent a mix of latitude/y and longitude/x
-  coordinates showing on a side when working with rotated maps or reprojected grids.
+  coordinates showing on a side when working with rotated maps or reprojected
+  grids.
 
 * Advanced rendering mode is also available for grids.
 
-* The |checkbox| :guilabel:`Draw coordinates` checkbox allows you to add coordinates
-  to the map frame. You can choose the annotation numeric format, the options
-  range from decimal to degrees, minute and seconds, with or without suffix,
-  aligned or not and a custom format using the expression dialog.
+* The |checkbox| :guilabel:`Draw coordinates` checkbox allows you to add
+  coordinates to the map frame. You can choose the annotation numeric format,
+  the options range from decimal to degrees, minute and seconds, with or without
+  suffix, aligned or not and a custom format using the expression dialog.
   You can choose which annotation to show. The options are: show all, latitude
   only, longitude only, or disable(none). This is useful when the map is rotated.
   The annotation can be drawn inside or outside the map frame. The annotation
-  direction can be defined as horizontal, vertical ascending or vertical descending.
-  Finally, you can define the annotation font, the annotation font color, the annotation
-  distance from the map frame and the precision of the drawn coordinates.
+  direction can be defined as horizontal, vertical ascending or vertical
+  descending. Finally, you can define the annotation font, the annotation font
+  color, the annotation distance from the map frame and the precision of the
+  drawn coordinates.
 
 .. _Figure_composer_map_coord:
 
@@ -230,7 +235,7 @@ and the width used for the cross or line grid type.
 Overviews
 ---------
 
-The :guilabel:`Overviews` dialog of the map :guilabel:`Item Properties` tab
+The :guilabel:`Overviews` dialog of the map :guilabel:`Item Properties` panel
 provides the following functionalities:
 
 .. _Figure_composer_map_overview:
@@ -258,8 +263,8 @@ named 'Overview 1' and change it to another name.
 
 When you select the overview item in the list you can customize it.
 
-* The |checkbox| :guilabel:`Draw "<name_overview>" overview` needs to be activated
-  to draw the extent of selected map frame.
+* The |checkbox| :guilabel:`Draw "<name_overview>" overview` needs to be
+  activated to draw the extent of selected map frame.
 * The :guilabel:`Map frame` combo list can be used to select the map item whose
   extents will be drawn on the present map item.
 * The :guilabel:`Frame Style` allows you to change the style of the overview frame.

--- a/source/docs/user_manual/print_composer/composer_items/composer_scale_bar.rst
+++ b/source/docs/user_manual/print_composer/composer_items/composer_scale_bar.rst
@@ -15,7 +15,7 @@ The Scale Bar Item
 
 To add a scale bar, click the |scaleBar| :sup:`Add new scalebar` icon, place
 the element with the left mouse button on the Print Composer canvas and position
-and customize the appearance in the scale bar :guilabel:`Item Properties` tab.
+and customize the appearance in the scale bar :guilabel:`Item Properties` panel.
 
 The :guilabel:`Item properties` of a scale bar item tab provides the following
 functionalities (see figure_composer_scalebar_):
@@ -25,13 +25,14 @@ functionalities (see figure_composer_scalebar_):
 .. figure:: /static/user_manual/print_composer/scalebar_properties.png
    :align: center
 
-   Scale Bar Item properties Tab
+   Scale Bar Item Properties Panel
 
 Main properties
 ---------------
 
-The :guilabel:`Main properties` dialog of the scale bar :guilabel:`Item Properties` tab
-provides the following functionalities (see figure_composer_scalebar_ppt_):
+The :guilabel:`Main properties` dialog of the scale bar
+:guilabel:`Item Properties` panel provides the following functionalities
+(see figure_composer_scalebar_ppt_):
 
 .. _Figure_composer_scalebar_ppt:
 
@@ -43,7 +44,8 @@ provides the following functionalities (see figure_composer_scalebar_ppt_):
 * First, choose the map the scale bar will be attached to.
 * Then, choose the style of the scale bar. Six styles are available:
 
-  * **Single box** and **Double box** styles, which contain one or two lines of boxes alternating colors.
+  * **Single box** and **Double box** styles, which contain one or two lines of
+    boxes alternating colors.
   * **Middle**, **Up** or **Down** line ticks.
   * **Numeric**, where the scale ratio is printed (i.e., 1:50000).
 
@@ -51,7 +53,7 @@ Units and Segments
 ------------------
 
 The :guilabel:`Units` and :guilabel:`Segments` dialogs of the scale bar
-:guilabel:`Item Properties` tab provide the following functionalities
+:guilabel:`Item Properties` panel provide the following functionalities
 (see figure_composer_scalebar_units_):
 
 .. _Figure_composer_scalebar_units:
@@ -66,22 +68,26 @@ In these two dialogs, you can set how the scale bar will be represented.
 * Select the units you want to use with :guilabel:`Scalebar units`.
   There are four possible choices: **Map Units**, the default one and **Meters**,
   **Feet** or **Nautical Miles** which may force unit conversions.
-* The :guilabel:`Label unit multiplier` specifies how many scalebar units per labeled unit.
-  Eg, if your scalebar units are set to "meters", a multiplier of 1000 will result
-  in the scale bar labels in "kilometers".
-* The :guilabel:`Label for units` field defines the text used to describe the units
-  of the scale bar, eg "m" or "km". This should be matched to reflect the multiplier above.
-* You can define how many :guilabel:`Segments` will be drawn on the left and on the right side of the scale bar.
-* You can set how long each segment will be (:guilabel:`fixed width`), or limit the scale bar size in mm
-  with :guilabel:`Fit segment width` option. In the latter case, each time the map scale changes,
-  the scale bar is resized (and its label updated) to fit the range set.
+* The :guilabel:`Label unit multiplier` specifies how many scalebar units per
+  labeled unit. Eg, if your scalebar units are set to "meters", a multiplier of
+  1000 will result in the scale bar labels in "kilometers".
+* The :guilabel:`Label for units` field defines the text used to describe the
+  units of the scale bar, eg "m" or "km". This should be matched to reflect the
+  multiplier above.
+* You can define how many :guilabel:`Segments` will be drawn on the left and on
+  the right side of the scale bar.
+* You can set how long each segment will be (:guilabel:`fixed width`), or limit
+  the scale bar size in mm with :guilabel:`Fit segment width` option. In the
+  latter case, each time the map scale changes, the scale bar is resized (and
+  its label updated) to fit the range set.
 * :guilabel:`Height` is used to define the height of the bar.
 
 Display
 --------
 
-The :guilabel:`Display` dialog of the scale bar :guilabel:`Item Properties` tab provide
-the following functionalities (see figure_composer_scalebar_display_):
+The :guilabel:`Display` dialog of the scale bar :guilabel:`Item Properties`
+panel provides the following functionalities (see
+figure_composer_scalebar_display_):
 
 .. _Figure_composer_scalebar_display:
 
@@ -95,18 +101,19 @@ You can define how the scale bar will be displayed in its frame.
 * :guilabel:`Box margin` : space between text and frame borders
 * :guilabel:`Labels margin` :  space between text and scale bar drawing
 * :guilabel:`Line width` : line width of the scale bar drawing
-* :guilabel:`Join style` : Corners at the end of scalebar in style Bevel, Rounded or Square
-  (only available for Scale bar style Single Box & Double Box)
+* :guilabel:`Join style` : Corners at the end of scalebar in style Bevel,
+  Rounded or Square (only available for Scale bar style Single Box & Double Box)
 * :guilabel:`Cap style` : End of all lines in style Square, Round or Flat
   (only available for Scale bar style Line Ticks Up, Down and Middle)
-* :guilabel:`Alignment` : Puts text on the left, middle or right side of the frame
-  (works only for Scale bar style Numeric)
+* :guilabel:`Alignment` : Puts text on the left, middle or right side of the
+  frame (works only for Scale bar style Numeric)
 
 Fonts and colors
 -----------------
 
-The :guilabel:`Fonts and colors` dialog of the scale bar :guilabel:`Item Properties` tab
-provide the following functionalities (see figure_composer_scalebar_fonts_):
+The :guilabel:`Fonts and colors` dialog of the scale bar
+:guilabel:`Item Properties` panel provides the following functionalities
+(see figure_composer_scalebar_fonts_):
 
 .. _Figure_composer_scalebar_fonts:
 
@@ -125,6 +132,6 @@ You can define the fonts and colors used for the scale bar.
 
 Fill colors are only used for scale box styles Single Box and Double Box.
 To select a color you can use the list option using the dropdown arrow to open
-a simple color selection option or the more advanced color selection option, that is
-started when you click in the colored box in the dialog.
+a simple color selection option or the more advanced color selection option,
+that is started when you click in the colored box in the dialog.
 

--- a/source/docs/user_manual/print_composer/create_output.rst
+++ b/source/docs/user_manual/print_composer/create_output.rst
@@ -34,8 +34,8 @@ without bounding boxes. This can be enabled by deactivating :guilabel:`View -->`
 |checkbox| :guilabel:`Show bounding boxes` or pressing the shortcut
 :kbd:`Ctrl+Shift+B`.
 
-The Print Composer allows you to create several output formats, and it is possible
-to define the resolution (print quality) and paper size:
+The Print Composer allows you to create several output formats, and it is
+possible to define the resolution (print quality) and paper size:
 
 * The |filePrint| :sup:`Print` icon allows you to print the layout to a
   connected printer or a PostScript file, depending on installed printer drivers.
@@ -54,7 +54,7 @@ enter the filename to use to export composition: in the case of multi-page
 composition, each page will be exported to a file with the given name
 appended with the page number.
 
-You can then override the print resolution (set in Composition tab) and resize
+You can then override the print resolution (set in Composition panel) and resize
 exported image dimensions.
 
 .. _crop_to_content:
@@ -129,8 +129,8 @@ blend modes, transparency or symbol effects, these cannot be printed
 as vectors, and the effects may be lost. Checking :guilabel:`Print as a
 raster` in the :ref:`composer_composition_tab` helps to keep the effects but
 rasterize the composition. Note that the :guilabel:`Force layer to render as
-raster` in the Rendering tab of Layer Properties is a layer-level alternative that
-avoids global composition rasterization.
+raster` in the Rendering tab of Layer Properties dialog is a layer-level
+alternative that avoids global composition rasterization.
 
 If you need to export your layout as a **georeferenced PDF**, in the
 :ref:`composer_composition_tab`, make sure to select the correct map item to
@@ -152,22 +152,22 @@ current geometry. Fields associated with this geometry can be used within text
 labels.
 
 Every page will be generated with each feature. To enable the generation
-of an atlas and access generation parameters, refer to the `Atlas generation` tab.
-This tab contains the following widgets (see figure_composer_atlas_):
+of an atlas and access generation parameters, refer to the `Atlas generation`
+panel.This panel contains the following widgets (see figure_composer_atlas_):
 
 .. _figure_composer_atlas:
 
 .. figure:: /static/user_manual/print_composer/atlas_properties.png
    :align: center
 
-   Atlas generation tab
+   Atlas Generation Panel
 
 * |checkbox| :guilabel:`Generate an atlas`, which enables or disables the atlas
   generation.
-* A :guilabel:`Coverage layer` |selectString| combo box that allows you to choose
-  the   (vector) layer containing the features on which to iterate over.
+* A :guilabel:`Coverage layer` |selectString| combo box that allows you to
+  choose the (vector) layer containing the features on which to iterate over.
 * An optional |checkbox| :guilabel:`Hidden coverage layer` that, if checked,
-  will hide   the coverage layer (but not the other ones) during the generation.
+  will hide the coverage layer (but not the other ones) during the generation.
 * An optional :guilabel:`Page name` combo box to give a more explicit name to
   each feature page(s) when previewing atlas. You can select an attribute of
   the coverage layer or set an expression. If this option is empty, QGIS will
@@ -235,7 +235,8 @@ or, another combination:
    [%format_number($area/1000000,2) %] km2
 
 The information ``[% upper(CITY_NAME) || ',' || ZIPCODE || ' is ' format_number($area/1000000,2) %]``
-is an expression used inside the label. Both expressions would result in the generated atlas as::
+is an expression used inside the label. Both expressions would result in the
+generated atlas as::
 
   The area of PARIS,75001 is 1.94 km2
 
@@ -246,33 +247,33 @@ Data Defined Override Buttons
 -----------------------------
 
 There are several places where you can use a |dataDefined| :sup:`Data Defined
-Override` button to override the selected setting. These options are particularly
-useful with Atlas Generation.
+Override` button to override the selected setting. These options are
+particularly useful with Atlas Generation.
 
-For the following examples the `Regions` layer of the QGIS sample dataset is used
-and selected for Atlas Generation.
+For the following examples the `Regions` layer of the QGIS sample dataset is
+used and selected for Atlas Generation.
 We also assume the paper format `A4 (210X297)` is selected in the
-:guilabel:`Composition` tab for field :guilabel:`Presets`.
+:guilabel:`Composition` panel for field :guilabel:`Presets`.
 
-With a `Data Defined Override` button you can dynamically set the paper orientation.
-When the height (north-south) of the extents of a region is greater than its width
-(east-west), you rather want to use `portrait` instead of `landscape` orientation
-to optimize the use of paper.
+With a `Data Defined Override` button you can dynamically set the paper
+orientation. When the height (north-south) of the extents of a region is greater
+than its width (east-west), you rather want to use `portrait` instead of
+`landscape` orientation to optimize the use of paper.
 
 In the :guilabel:`Composition` you can set the field :guilabel:`Orientation`
 and select `Landscape` or `Portrait`. We want to set the orientation dynamically
 using an expression depending on the region geometry.
 Press the |dataDefined| button of field :guilabel:`Orientation`, select
-:menuselection:`Edit...` so the :guilabel:`Expression string builder` dialog opens.
-Enter the following expression:
+:menuselection:`Edit...` so the :guilabel:`Expression string builder` dialog
+opens. Enter the following expression:
 
 .. code::
 
    CASE WHEN bounds_width($atlasgeometry) > bounds_height($atlasgeometry)
    THEN 'Landscape' ELSE 'Portrait' END
 
-Now the paper orients itself automatically. For each Region you need to reposition
-the location of the composer item as well. For the map item you can
+Now the paper orients itself automatically. For each Region you need to
+reposition the location of the composer item as well. For the map item you can
 use the |dataDefined| button of field :guilabel:`Width` to set it
 dynamically using following expression:
 

--- a/source/docs/user_manual/print_composer/overview_composer.rst
+++ b/source/docs/user_manual/print_composer/overview_composer.rst
@@ -20,8 +20,9 @@ group, align, position and rotate each element and adjust their properties to
 create your layout. The layout can be printed or exported to image formats,
 PostScript, PDF or to SVG (export to SVG is not working properly with some
 recent Qt4 versions; you should try and check individually on your system).
-You can save the layout as a template and load it again in another session. Finally,
-generating several maps based on a template can be done through the atlas generator.
+You can save the layout as a template and load it again in another session.
+Finally, generating several maps based on a template can be done through the
+atlas generator.
 
 
 .. index:: Composer template, Map template
@@ -50,14 +51,16 @@ To demonstrate how to create a map please follow the next instructions.
    Inside the drawn rectangle the legend will be drawn.
 #. Select the |select| :sup:`Select/Move item` icon to select the map on
    the canvas and move it a bit.
-#. While the map item is still selected you can also change the size of the map item.
-   Click while holding down the left mouse button, in a white little rectangle in one
-   of the corners of the map item and drag it to a new location to change it's size.
-#. Click the :guilabel:`Item Properties` tab on the left lower panel and find the setting
-   for the orientation. Change the value of the setting :guilabel:`Map orientation` to
-   '15.00\ |degrees| '. You should see the orientation of the map item change.
-#. Now, you can print or export your print composition to image formats, PDF or to SVG
-   with the export tools in Composer menu.
+#. While the map item is still selected you can also change the size of the map
+   item. Click while holding down the left mouse button, in a white little
+   rectangle in one of the corners of the map item and drag it to a new location
+   to change its size.
+#. Click the :guilabel:`Item Properties` panel on the left down side and find
+   the setting for the orientation. Change the value of the setting
+   :guilabel:`Map orientation` to '15.00\ |degrees| '. You should see the
+   orientation of the map item change.
+#. Now, you can print or export your print composition to image formats, PDF or
+   to SVG with the export tools in Composer menu.
 #. Finally, you can save your print composition within the project file with the
    |fileSave| :sup:`Save Project` button.
 
@@ -76,8 +79,8 @@ The Composer Manager
 ====================
 
 The Composer Manager is the main window to manage print composers in the project.
-It helps you add new print composer, duplicate an existing one, rename or delete it.
-To open the composer manager dialog, click on the |composerManager|
+It helps you add new print composer, duplicate an existing one, rename or delete
+it. To open the composer manager dialog, click on the |composerManager|
 :sup:`Composer Manager` button in the toolbar or choose :menuselection:`Composer
 --> Composer Manager`. It can also be reached from the main window of QGIS with
 :menuselection:`Project --> Composer Manager`.
@@ -91,22 +94,24 @@ To open the composer manager dialog, click on the |composerManager|
    The Print Composer Manager
 
 
-The composer manager lists in its upper part all the available print composers in the project.
-The bottom part shows tools that help to:
+The composer manager lists in its upper part all the available print composers
+in the project. The bottom part shows tools that help to:
 
-* show the selected composer(s): you can open multiple print composers in one-click
-* duplicate the selected composer (available only if one print composer is selected):
-  it creates a new composer using the selected composer as template.
+* show the selected composer(s): you can open multiple print composers in
+  one-click
+* duplicate the selected composer (available only if one print composer is
+  selected): it creates a new composer using the selected composer as template.
   You'll be prompted to choose a new title for the new composer
 * rename the composer (also available only if one print composer is selected):
   You'll be prompted to choose a new title for the composer. Note that you can
   also rename the composer by double-clicking on its title in the upper part
-* remove the composer: the selected print composer(s) will be deleted from the project.
+* remove the composer: the selected print composer(s) will be deleted from the
+  project.
 
-With the Composer Manager, it's also possible to create new print composers as an
-empty composer or from a saved template. By default, QGIS will look for templates
-in user directory (:file:`~/.qgis2/composer_templates`) or application's one
-(:file:`ApplicationFolder/composer_templates`).
+With the Composer Manager, it's also possible to create new print composers as
+an empty composer or from a saved template. By default, QGIS will look for
+templates in user directory (:file:`~/.qgis2/composer_templates`) or
+application's one (:file:`ApplicationFolder/composer_templates`).
 QGIS will retrieve all the available templates and propose them in the combobox.
 The selected template will be used to create a new composer when clicking
 :guilabel:`Add` button.
@@ -119,9 +124,9 @@ template and use it to create a new print composer.
 Menus, tools and panels of the print composer
 =============================================
 
-Opening the Print Composer provides you with a blank canvas that represents
-the paper surface when using the print option. Initially you find buttons on
-the left beside the canvas to add map composer items: the current QGIS map canvas,
+Opening the Print Composer provides you with a blank canvas that represents the
+paper surface when using the print option. Initially you find buttons on the
+left beside the canvas to add map composer items: the current QGIS map canvas,
 text labels, images, legends, scale bars, basic shapes, arrows, attribute tables
 and HTML frames. In this toolbar you also find toolbar buttons to navigate,
 zoom in on an area and pan the view on the composer and toolbar buttons to
@@ -139,27 +144,29 @@ any elements are added.
    Print Composer
 
 
-On the right beside the canvas you find two panels.
-The upper panel holds the tabs :guilabel:`Items` and :guilabel:`Command History`
-and the lower panel holds the tabs :guilabel:`Composition`, :guilabel:`Item properties`
+On the right beside the canvas you find two set of panels. The upper one holds
+the panels :guilabel:`Items` and :guilabel:`Command History` and the lower holds
+the panels :guilabel:`Composition`, :guilabel:`Item properties`
 and :guilabel:`Atlas generation`.
 
-* The :guilabel:`Items` tab provides a list of all map composer items added to the canvas.
-* The :guilabel:`Command history` tab displays a history of all changes applied
+* The :guilabel:`Items` panel provides a list of all map composer items added to
+  the canvas.
+* The :guilabel:`Command history` panel displays a history of all changes applied
   to the Print Composer layout. With a mouse click, it is possible to undo and
   redo layout steps back and forth to a certain status.
-* The :guilabel:`Composition` tab allows you to set paper size, orientation, the page
-  background, number of pages and print quality for the output file in dpi. Furthermore,
-  you can also activate the |checkbox| :guilabel:`Print as raster` checkbox. This means
-  all items will be converted to raster before printing or saving as PostScript or PDF.
-  In this tab, you can also customize settings for grid and smart guides.
-* The :guilabel:`Item Properties` tab displays the properties for the selected
+* The :guilabel:`Composition` panel allows you to set paper size, orientation, the
+  page background, number of pages and print quality for the output file in dpi.
+  Furthermore, you can also activate the |checkbox| :guilabel:`Print as raster`
+  checkbox. This means all items will be converted to raster before printing or
+  saving as PostScript or PDF.
+  In this panel, you can also customize settings for grid and smart guides.
+* The :guilabel:`Item Properties` panel displays the properties for the selected
   item. Click the |select| :sup:`Select/Move item` icon to select
   an item (e.g., legend, scale bar or label) on the canvas. Then click the
-  :guilabel:`Item Properties` tab and customize the settings for the selected
+  :guilabel:`Item Properties` panel and customize the settings for the selected
   item (see :ref:`composer_items` for detailed information on each item
   settings).
-* The :guilabel:`Atlas generation` tab allows you to enable the generation of an
+* The :guilabel:`Atlas generation` panel allows you to enable the generation of an
   atlas for the current Composer and gives access to its parameters
   (see :ref:`atlas_generation` for detailed information on atlas
   generation usage).
@@ -170,12 +177,12 @@ mouse position, current page number, a combo box to set the zoom level,
 the number of selected items if applicable and, in the case of atlas generation,
 the number of features.
 
-In the upper part of the Print composer window, you can find menus and other toolbars.
-All Print Composer tools are available in menus and as icons in a toolbar.
-See a list of tools in table_composer_tools_.
+In the upper part of the Print composer window, you can find menus and other
+toolbars. All Print Composer tools are available in menus and as icons in a
+toolbar. See a list of tools in table_composer_tools_.
 
-The toolbars and the tabs can be switched off and on using the right mouse button
-over any toolbar or through :menuselection:`View --> Toolbars` or
+The toolbars and the panels can be switched off and on using the right mouse
+button over any toolbar or through :menuselection:`View --> Toolbars` or
 :menuselection:`View --> Panels`.
 
 
@@ -284,7 +291,8 @@ that will be used as default on any composer during your work.
 * :guilabel:`Compositions defaults` let you specify the default font to use.
 * With :guilabel:`Grid appearance`, you can set the grid style and its color.
   There are three types of grid: **Dots**, **Solid** lines and **Crosses**.
-* :guilabel:`Grid and guide defaults` defines spacing, offset and tolerance of the grid.
+* :guilabel:`Grid and guide defaults` defines spacing, offset and tolerance of
+  the grid.
 
 
 Edit Menu
@@ -304,8 +312,8 @@ same position they were in their initial page. It ensures to copy/paste items at
 the same place, from page to page.
 
 .. note::
-   HTML items can not be copied in this way. As a workaround, use the **[Add Frame]**
-   button in the :menuselection:`Item Properties` tab.
+   HTML items can not be copied in this way. As a workaround, use the
+   **[Add Frame]** button in the :menuselection:`Item Properties` panel.
 
 
 View Menu
@@ -327,8 +335,8 @@ To navigate in the canvas layout, the Print Composer provides some general tools
   click in the rule (above or at the left side of the layout) and drag and drop
   to the desired location.
 * `Snap Guides`: allows user to snap items to the guides,
-* `Smart Guides`: uses other composer items as guides to dynamically snap to as user
-  moves or reshapes an item.
+* `Smart Guides`: uses other composer items as guides to dynamically snap to as
+  user moves or reshapes an item.
 * `Clear Guides` to remove all current guides.
 * `Show Bounding box` around the items.
 * `Show Rules` around the layout.
@@ -342,9 +350,9 @@ To navigate in the canvas layout, the Print Composer provides some general tools
 * `Panels` lists all panels available to hide/show them.
 * `Toolbars` same as above for toolbars.
 
-You can change the zoom level also using the mouse wheel or the combo box in the status bar.
-If you need to switch to pan mode while working in the Composer area, you can hold
-the :kbd:`Spacebar` or the mouse wheel.
+You can change the zoom level also using the mouse wheel or the combo box in
+the status bar. If you need to switch to pan mode while working in the Composer
+area, you can hold the :kbd:`Spacebar` or the mouse wheel.
 With :kbd:`Ctrl+Spacebar`, you can temporarily switch to Zoom In mode,
 and with :kbd:`Ctrl+Shift+Spacebar`, to Zoom Out mode.
 
@@ -364,13 +372,13 @@ To maximise the space available to interact with a composition you can use
 
 .. _composer_composition_tab:
 
-Composition Tab
----------------
+Composition Panel
+-----------------
 
 Page size and settings
 ......................
 
-In the :guilabel:`Composition` tab, you can define the global settings of the
+In the :guilabel:`Composition` panel, you can define the global settings of the
 current composition.
 
 
@@ -391,8 +399,9 @@ layer, while a third one shows an HTML frame linking to your organization websit
 Set the :guilabel:`Number of pages` to the desired value. you can also custom the
 :guilabel:`Page Background` with the color or the symbol you want.
 
-The Page size options apply to all the pages in the composition. However, you can
-modify the values using the data defined override options (see :ref:`atlas_data_defined_override`).
+The Page size options apply to all the pages in the composition. However, you
+can modify the values using the data defined override options
+(see :ref:`atlas_data_defined_override`).
 
 A custom page size can also be set, using the :guilabel:`Resize page` tool.
 This creates an unique page composition, resizes the page to fit the current
@@ -476,8 +485,8 @@ More information on variables usage in the General Tools
 
 .. index:: Revert layout actions
 
-Command History Tab: Revert and Restore actions
------------------------------------------------
+Command History Panel: Revert and Restore actions
+-------------------------------------------------
 
 During the layout process, it is possible to revert and restore changes.
 This can be done with the revert and restore tools:
@@ -485,8 +494,9 @@ This can be done with the revert and restore tools:
 * |undo| :sup:`Revert last change`
 * |redo| :sup:`Restore last change`
 
-This can also be done by mouse click within the :guilabel:`Command history` tab
-(see figure_composer_). The History tab lists the last actions done within the composer.
+This can also be done by mouse click within the :guilabel:`Command history`
+panel (see figure_composer_). The History panel lists the last actions done
+within the composer.
 Just select the point you want to revert to and once you do new action all
 the actions done after the selected one will be removed.
 
@@ -499,10 +509,10 @@ the actions done after the selected one will be removed.
 
 .. _composer_items_tab:
 
-Items Tab
----------
+Items Panel
+-----------
 
-The :guilabel:`Items` tab offers some options to manage selection and
+The :guilabel:`Items` panel offers some options to manage selection and
 visibility of items.
 All the items added to the print composer canvas are shown in a list and
 selecting an item makes the corresponding row selected in the list as well as
@@ -523,4 +533,4 @@ For any selected item, you can :
 Once you have found the correct position for an item, you can lock it by ticking
 the box in |locked| column. Locked items are **not** selectable on the canvas.
 Locked items can be unlocked by selecting the item in the :menuselection:`Items`
-tab and unchecking the tickbox or you can use the icons on the toolbar.
+panel and unchecking the tickbox or you can use the icons on the toolbar.


### PR DESCRIPTION
- replace tab by panel (fix #1716)
- break lines to 80 characters

(ps: backport may not be straightforward)