### PR TITLE
Clean selection and filter sections in attribute table chapter

### DIFF
--- a/source/docs/user_manual/introduction/general_tools.rst
+++ b/source/docs/user_manual/introduction/general_tools.rst
@@ -1075,6 +1075,8 @@ For the other tools, different behaviors can be performed holding:
   Combined to :kbd:`Shift` or :kbd:`Ctrl` keys, you can add or substract
   features to/from the current selection.
 
+.. _automatic_selection:
+
 Automatic selection
 --------------------
 

--- a/source/docs/user_manual/introduction/qgis_configuration.rst
+++ b/source/docs/user_manual/introduction/qgis_configuration.rst
@@ -134,9 +134,9 @@ Data Sources Settings
 * |checkbox| :guilabel:`Open attribute table in a dock window`
 * :guilabel:`Copy features as` 'Plain text, no geometry', 'Plain text, WKT geometry',
   or 'GeoJSON' when pasting features in other applications.
-* :guilabel:`Attribute table behavior` |selectString|. There are three
-  possibilities: 'Show all features', 'Show selected features' and 'Show
-  features visible on map'.
+* :guilabel:`Attribute table behavior` |selectString|: set filter on the attribute
+  table at the opening. There are three possibilities: 'Show all features',
+  'Show selected features' and 'Show features visible on map'.
 * :guilabel:`Default view`: define the view mode of the attribute table at every
   opening. It can be 'Remember last view', 'Table view' or 'Form view'.
 * :guilabel:`Attribute table row cache` |selectNumber|. This row cache makes
@@ -145,6 +145,23 @@ Data Sources Settings
   attribute table.
 * :guilabel:`Representation for NULL values`. Here, you can define a value for
   data fields containing a NULL value.
+
+.. _tip_table_filtering:
+
+.. tip:: **Improve opening of big data attribute table**
+
+ When working with layers with big amount of records, opening the attribute table
+ may be slow as the dialog request all the rows in the layer. Setting the
+ :guilabel:`Attribute table behavior` to **Show features visible on map** will
+ make QGIS request only the features in the current map canvas when opening the
+ table, allowing a quick data loading.
+
+ Note that data in this attribute table instance will be always tied to the canvas
+ extent it was opened with, meaning that selecting **Show All Features** within
+ such a table will not display new features. You can however update the set of
+ displayed features by changing the canvas extent and selecting **Show Features
+ Visible On Map** option in the attribute table. 
+
 
 **Data source handling**
 

--- a/source/docs/user_manual/working_with_vector/attribute_table.rst
+++ b/source/docs/user_manual/working_with_vector/attribute_table.rst
@@ -346,7 +346,7 @@ It is also possible to filter features using the :ref:`filter_select_form`.
 .. _filter_select_form:
 
 Filter/Select features using form
-=================================
+---------------------------------
 
 Clicking the |filterMap| :sup:`Filter/Select features using form` or
 pressing :kbd:`Ctrl+F` the attribute table dialog will switch to form view
@@ -378,7 +378,7 @@ mentioned in :ref:`filter_features`, or click the clear the expression and
 click **[Apply]**.
 
 Action on cells
-===============
+---------------
 
 Users have several possibilities to manipulate feature with the contextual menu
 like:
@@ -402,7 +402,7 @@ in the :menuselection:`Layer properties --> Actions` tab.
 See :ref:`actions_menu` for more information on actions.
 
 Save selected features as new layer
-===================================
+------------------------------------
 
 The selected features can be saved as any OGR-supported vector format and
 also transformed into another coordinate reference system (CRS). In the
@@ -415,7 +415,7 @@ It is also possible to specify OGR creation options within the dialog.
 .. _paste_into_layer:
 
 Paste into new layer
-=====================
+---------------------
 
 Features that are on the clipboard may be pasted into a new
 layer.  To do this, first make a layer editable.  Select some features, copy

--- a/source/docs/user_manual/working_with_vector/attribute_table.rst
+++ b/source/docs/user_manual/working_with_vector/attribute_table.rst
@@ -58,7 +58,7 @@ layer (figure_attributes_table_). According to the setting in
 :menuselection:`Settings --> Options --> Data sources` menu, the attribute table
 will open in a docked window or not. The total number of features in the layer
 and the number of currently selected/filtered features are shown in the
-attribute table title.
+attribute table title as well as if the layer is spatially limited.
 
 
 .. _figure_attributes_table:
@@ -302,52 +302,45 @@ more information and use case):
 It is also possible to select features using the :ref:`filter_select_form`.
 
 
-
-For a **simple search by attributes** on only one column, choose the
-:menuselection:`Column filter -->` from the menu in the bottom left corner.
-Select the field (column) on which the search should be
-performed from the drop-down menu, and hit the **[Apply]** button. Then, only
-the matching features are shown in the attribute table.
-
-
-The matching rows will be selected, and the total number of matching rows will
-appear in the title bar of the attribute table, as well as in the status bar of
-the main window. For searches that display only selected features on the map,
-use the Query Builder described in section :ref:`vector_query_builder`.
-
-To show selected records only, use :guilabel:`Show Selected Features` from the menu
-at the bottom left. See next section for more information on filter feature.
-
-The field calculator bar allows you to make calculations on the selected rows only.
-For example, as shown in figure_attributes_table_, you can alter the number
-of the ID field of the layer :file:`regions.shp` with the expression:
-
-::
-
- ID + 5
-
-It is also possible to select features using the :ref:`filter_select_form`.
-
 .. _filter_features:
 
-Filter features
-===============
+Filtering features
+------------------
 
-At the bottom of the attribute table, there is a drop-down list of different
-filters:
+Once you have selected features in the attribute table, you may want to display
+only these records in the table. This can be easily done using the
+:guilabel:`Show Selected Features` item from the drop-down list at the bottom
+left of the attribute table dialog. This list offers the following filters:
 
 * :guilabel:`Show All Features`
 * :guilabel:`Show Selected Features`
 * :guilabel:`Show Features visible on map`
 * :guilabel:`Show Edited and New Features`
-* :guilabel:`Field Filter` - allows the user to choose a column from a
-  list. Then, type a value and press :kbd:`Enter` to filter.
+* :guilabel:`Field Filter` - allows the user to filter based on value of a field:
+  choose a column from a list, type a value and press :kbd:`Enter` to filter.
+  Then, only the matching features are shown in the attribute table.
 * :guilabel:`Advanced filter (Expression)` - Opens the expression builder
   dialog. Within it, you can create complex expressions to match table rows.
   For example, you can filter the table using more that one field.
   See :ref:`vector_expressions` for more information.
 
 It is also possible to filter features using the :ref:`filter_select_form`.
+
+.. note::
+  
+  Filtering records out of the attribute table does not filter features out
+  of the layer; they are simply momentaneously hidden from the table and can be
+  accessed from the map canvas or by removing the filter. For filters that do
+  hide features from the layer, use the
+  :ref:`Query Builder <vector_query_builder>`.
+
+.. tip:: **Update datasource filtering with** ``Show Features Visible on Map`` 
+
+  When for performance reasons, features shown in attribute table are spatially
+  limited to the canvas extent at its opening (see :ref:`Data Source Options
+  <tip_table_filtering>` for a how-to), selecting :guilabel:`Show Features
+  Visible on Map` on a new canvas extent updates the spatial restriction.
+
 
 
 .. _filter_select_form:

--- a/source/docs/user_manual/working_with_vector/attribute_table.rst
+++ b/source/docs/user_manual/working_with_vector/attribute_table.rst
@@ -140,10 +140,16 @@ Table view vs Form view
 -----------------------
 
 QGIS provides two view modes to easily manipulate data in the attribute table:
-the |openTable| Table view and the |formView| Form view which uses the layer
-fields configuration (see :ref:`vector_attributes_menu`). You can switch from
-one to the other by clicking the convenient icon at the bottom right of the
-dialog.
+
+* the |openTable| Table view, displaying values of multiple features in a
+  tabular mode, each row representing a feature and each column a field;
+* and the |formView| Form view which shows identifiers of features in a first
+  panel and displays only the attributes of the clicked identifier in the second
+  one. Form view uses the layer fields configuration
+  (see :ref:`vector_attributes_menu`).
+  
+You can switch from one mode to the other by clicking the convenient icon at the
+bottom right of the dialog.
 
 You can also specify the :guilabel:`Default view` mode at the opening of the
 attribute table in :menuselection:`Settings --> Options --> Data Sources` menu.
@@ -245,14 +251,18 @@ to define:
 .. index::
    pair: Attributes; Selection
 
-Selecting features in an attribute table
-========================================
+Interacting with features in an attribute table
+===============================================
 
-**Each selected row** in the attribute table displays the attributes of a
-selected feature in the layer. If the set of features selected in the main
-window is changed, the selection is also updated in the attribute table.
-Likewise, if the set of rows selected in the attribute table is changed, the
-set of features selected in the main window will be updated.
+Selecting features
+------------------
+
+In table view, each row in the attribute table displays the attributes of a
+unique feature in the layer. Selecting a row selects the feature and likewise,
+selecting a feature in the map canvas (in case of geometry enabled layer)
+selects the row in the attribute table. If the set of features selected in the
+map canvas (or attribute table) is changed, then the selection is also updated
+in the attribute table (or map canvas) accordingly.
 
 Rows can be selected by clicking on the row number on the left side of the
 row. **Multiple rows** can be marked by holding the :kbd:`Ctrl` key.
@@ -262,6 +272,35 @@ between the current cursor position and the clicked row are selected.
 Moving the cursor position in the attribute table, by clicking a cell in the
 table, does not change the row selection. Changing the selection in the main
 canvas does not move the cursor position in the attribute table.
+
+In form view of the attribute table, features are by default identified in the
+left panel by the value of their displayed field (see :ref:`maptips`). This
+identifier can be replaced using the drop-down list at the top of the panel,
+either by selecting an existing field or using a custom expression. You can
+also choose to sort the list of features from the drop-down menu.
+
+Click a value in the left panel to display the feature's attributes in the
+right one. To select a feature, you need to click inside the square symbol at
+the left of the identifier. By default, the symbol turns into yellow. Like in
+the table view, you can perform multiple feature selection using the keyboard
+combinations previously exposed.
+
+.. actually, it looks like there's a difference in keyboard usage but i feel
+   it's a bug. Report at https://issues.qgis.org/issues/16553.
+
+Beyond selecting features with the mouse, you can perform automatic selection
+based on feature's attribute using tools available in the attribute table
+toolbar, such as (see section :ref:`automatic_selection` and following one for
+more information and use case):
+
+* |expressionSelect| :guilabel:`Select By Expression...`
+* |formSelect| :guilabel:`Select Features By Value...`
+* |deselectAll| :guilabel:`Deselect Features from All Layers`
+* |selectAll| :guilabel:`Select All Features`
+* |invertSelection| :guilabel:`Invert Feature Selection`.
+
+It is also possible to select features using the :ref:`filter_select_form`.
+
 
 
 For a **simple search by attributes** on only one column, choose the


### PR DESCRIPTION
The current description mix sections about selection tools and filtering tools. It also ignores working on a form view of attribute table. 
This PR tries to fix things, clearly separating these different needs in a clear structure (Related to #1754 cleanup). Note that it doesn't touch sections relative action on cells or layer creation.
Also fixes #560 about attribute table spatial filtering
