### PR TITLE
Move Keyboard Shortcuts from General tools to Configuration chapter

### DIFF
--- a/source/docs/user_manual/introduction/general_tools.rst
+++ b/source/docs/user_manual/introduction/general_tools.rst
@@ -16,38 +16,6 @@ General Tools
    .. contents::
       :local:
 
-.. _`shortcuts`:
-
-Keyboard shortcuts
-==================
-
-.. index::
-   single: Keyboard shortcuts
-
-QGIS provides default keyboard shortcuts for many features. You can find them in
-section :ref:`label_menubar`. Additionally, the menu option
-:menuselection:`Settings --> Configure Shortcuts...` allows you to change the default
-keyboard shortcuts and add new keyboard shortcuts to QGIS features.
-
-.. _figure_shortcuts:
-
-.. figure:: /static/user_manual/introduction/shortcuts.png
-   :align: center
-
-   Define shortcut options
-
-Configuration is very simple. Just select a feature from the list and click
-on :
-
-* **[Change]** and press the new combination you want to assign as new shortcut
-* **[Set none]** to clear any assigned shortcut
-* or **[Set default]** to backup the shortcut to its original and default value.
-
-Proceed as above for any other tools you wish to customize. Once you have
-finished your configuration, simply **[Close]** the dialog to have your changes
-applied. You can also **[Save]** the changes as an :file:`.XML` file
-and **[Load]** them into another QGIS installation.
-
 .. _`context_help`:
 
 Context help

--- a/source/docs/user_manual/introduction/qgis_configuration.rst
+++ b/source/docs/user_manual/introduction/qgis_configuration.rst
@@ -754,3 +754,34 @@ setups for different use cases as well.
 
    In most cases, you need to restart QGIS in order to have the change applied.
 
+.. _`shortcuts`:
+
+Keyboard shortcuts
+==================
+
+.. index::
+   single: Keyboard shortcuts
+
+QGIS provides default keyboard shortcuts for many features. You can find them in
+section :ref:`label_menubar`. Additionally, the menu option
+:menuselection:`Settings --> Configure Shortcuts...` allows you to change the default
+keyboard shortcuts and add new keyboard shortcuts to QGIS features.
+
+.. _figure_shortcuts:
+
+.. figure:: /static/user_manual/introduction/shortcuts.png
+   :align: center
+
+   Define shortcut options
+
+Configuration is very simple. Just select a feature from the list and click on :
+
+* **[Change]** and press the new combination you want to assign as new shortcut
+* **[Set none]** to clear any assigned shortcut
+* or **[Set default]** to backup the shortcut to its original and default value.
+
+Proceed as above for any other tools you wish to customize. Once you have
+finished your configuration, simply **[Close]** the dialog to have your changes
+applied. You can also **[Save]** the changes as an :file:`.XML` file
+and **[Load]** them into another QGIS installation.
+


### PR DESCRIPTION
I wonder if it is better placed there with other global configuration options (shortcuts are a kind of configuration you do for the application "once for all").
Opinions?