### PR TITLE
Referenced tutorials

### DIFF
--- a/source/docs/training_manual/create_vector_data/forms.rst
+++ b/source/docs/training_manual/create_vector_data/forms.rst
@@ -124,6 +124,8 @@ You can also design your own custom form completely from scratch.
 .. image:: /static/training_manual/create_vector_data/new_point_entry.png
    :align: center
 
+.. _creating-new-form:
+
 |hard| |FA| Creating a New Form
 -------------------------------------------------------------------------------
 

--- a/source/docs/user_manual/working_with_vector/vector_properties.rst
+++ b/source/docs/user_manual/working_with_vector/vector_properties.rst
@@ -1557,8 +1557,6 @@ layer as ``WMS`` or ``WFS``, you can also check here which fields could be retri
    :align: center
 
    Field properties tab
-   
-The QGIS trainings tutorial provides a tutorial: :ref:`ls-forms`.
 
 
 .. index:: Edit widget, Field configuration
@@ -1765,8 +1763,9 @@ combobox...) to the layer's fields, you need to give them the same name.
 
 Use the :guilabel:`Edit UI` to define the path to the file to use.
 
-For detailed information, see
-http://nathanw.net/2011/09/05/qgis-tips-custom-feature-forms-with-python-logic/. The QGIS trainings manual also provides a tutorial :ref:`hard-fa-creating-a-new-form` .
+You'll find some example in the :ref:`Creating a new form <creating-new-form>`
+lesson of the :ref:`QGIS-training-manual-index-reference`. For more advanced information,
+see http://nathanw.net/2011/09/05/qgis-tips-custom-feature-forms-with-python-logic/. 
 
 Enhance your form with custom functions
 .......................................

--- a/source/docs/user_manual/working_with_vector/vector_properties.rst
+++ b/source/docs/user_manual/working_with_vector/vector_properties.rst
@@ -1557,6 +1557,8 @@ layer as ``WMS`` or ``WFS``, you can also check here which fields could be retri
    :align: center
 
    Field properties tab
+   
+The QGIS trainings tutorial provides a tutorial: :ref:`ls-forms`.
 
 
 .. index:: Edit widget, Field configuration
@@ -1764,7 +1766,7 @@ combobox...) to the layer's fields, you need to give them the same name.
 Use the :guilabel:`Edit UI` to define the path to the file to use.
 
 For detailed information, see
-http://nathanw.net/2011/09/05/qgis-tips-custom-feature-forms-with-python-logic/.
+http://nathanw.net/2011/09/05/qgis-tips-custom-feature-forms-with-python-logic/. The QGIS trainings manual also provides a tutorial :ref:`hard-fa-creating-a-new-form` .
 
 Enhance your form with custom functions
 .......................................


### PR DESCRIPTION
The tutorials of the QGIS trainings manual (https://docs.qgis.org/2.18/en/docs/training_manual/create_vector_data/forms.html#ls-forms) were not referenced before.

Could you please check if I referenced the tutorials correctly (according to Sphinx) ?