### PR TITLE
Because it's more about QGIS than QGIS Testing

### DIFF
--- a/readme.rst
+++ b/readme.rst
@@ -1,32 +1,36 @@
+QGIS Documentation
+******************
+
 .. image:: https://travis-ci.org/qgis/QGIS-Documentation.svg?branch=master
     :target: https://travis-ci.org/qgis/QGIS-Documentation
-    
-QGIS Testing Documentation
-***************************
 
 .. contents::
    :local:
 
-QGIS Testing Documentation is built from corresponding branch and NOT translated.
+Introduction
+------------
 
-Only the current stable branch is available for translation.
+This repository is meant to write and manage the Official Documentation of 
+`QGIS <https://qgis.org>`_, an Open Source GIS Software.
 
-Latest stable documentation is on http://docs.qgis.org/2.14
+Latest stable documentation is on http://docs.qgis.org/2.14 and its PDF versions
+are available at http://docs.qgis.org/2.14/pdf.
 
-Testing is http://docs.qgis.org/testing
+The ongoing work for future releases is published as QGIS Testing Documentation.
+It's built from the ``master`` branch and NOT translated. QGIS Testing Documentation
+is on http://docs.qgis.org/testing and http://docs.qgis.org/testing/pdf/
 
-- QGIS 2.8 docs http://docs.qgis.org/2.8
-- QGIS 2.6 docs http://docs.qgis.org/2.6
-- QGIS 2.2 docs http://docs.qgis.org/2.2
-- QGIS 2.0 docs http://docs.qgis.org/2.0
-- QGIS 1.8 docs http://docs.qgis.org/1.8
+Previous releases are also available:
 
-Translations are also available via the docs.qgis.org language path:
-for example for the German language: http://docs.qgis.org/2.14/de
+- QGIS 2.8 docs http://docs.qgis.org/2.8 and http://docs.qgis.org/2.8/pdf/
+- QGIS 2.6 docs http://docs.qgis.org/2.6 and http://docs.qgis.org/2.6/pdf/
+- QGIS 2.2 docs http://docs.qgis.org/2.2 and http://docs.qgis.org/2.2/pdf/
+- QGIS 2.0 docs http://docs.qgis.org/2.0 and http://docs.qgis.org/2.0/pdf/
+- QGIS 1.8 docs http://docs.qgis.org/1.8 and http://docs.qgis.org/1.8/pdf/
 
-PDF versions of the manual are available here: http://docs.qgis.org/2.14/pdf, http://docs.qgis.org/2.8/pdf, http://docs.qgis.org/2.6/pdf/ http://docs.qgis.org/2.2/pdf/ 
-http://docs.qgis.org/2.0/pdf/, http://docs.qgis.org/1.8/pdf/ and http://docs.qgis.org/testing/pdf
-
+Translations of released docs are also available via the docs.qgis.org language path:
+for example for the 2.14 German language: http://docs.qgis.org/2.14/de.
+Note that only the current stable branch is available for translation.
 
 Documentation is static generated website using Sphinx (http://sphinx-doc.org/), 
 based on restructured text sources (rst: http://docutils.sourceforge.net/rst.html)


### PR DESCRIPTION
 The introduction made too much focus on QGIS Testing Doc than QGIS Doc itself