### PR TITLE
Set right caption in 2.18 Table Of Contents

### DIFF
--- a/source/docs/index.rst
+++ b/source/docs/index.rst
@@ -10,9 +10,9 @@ Please have a look into one of the documents below.
 .. toctree::
    :maxdepth: 2
 
-   User guide/Manual (QGIS Testing!) <user_manual/index>
-   User guide/Manual PDF's <http://docs.qgis.org/testing/pdf/>
-   PyQGIS cookbook (QGIS Testing!) <pyqgis_developer_cookbook/index>
+   User guide/Manual (QGIS 2.18) <user_manual/index>
+   User guide/Manual PDF's <http://docs.qgis.org/2.18/pdf/>
+   PyQGIS cookbook (QGIS 2.18) <pyqgis_developer_cookbook/index>
    QGIS Developers Guide <developers_guide/index>
    Documentation Guidelines <documentation_guidelines/index>
    A gentle introduction in GIS <gentle_gis_introduction/index>


### PR DESCRIPTION
The 2.18 doc showed QGIS Testing instead of 2.18.

What would be nice is to have it dynamically updated when a new branch is created (e.g. using its |version| replacement).
Anyone knows how to?