### PR TITLE
New filename in sample set

### DIFF
--- a/source/docs/user_manual/working_with_raster/raster_properties.rst
+++ b/source/docs/user_manual/working_with_raster/raster_properties.rst
@@ -331,10 +331,10 @@ An even more flexible way to customize the transparency can be done in the
 :guilabel:`Custom transparency options` section. The transparency of every pixel
 can be set here.
 
-As an example, we want to set the water of our example raster file :file:`landcover.tif`
+As an example, we want to set the water of our example raster file :file:`landcover.img`
 to a transparency of 20%. The following steps are necessary:
 
-#. Load the raster file :file:`landcover.tif`.
+#. Load the raster file :file:`landcover.img`.
 #. Open the :guilabel:`Properties` dialog by double-clicking on the raster
    name in the legend, or by right-clicking and choosing :menuselection:`Properties`
    from the pop-up menu.


### PR DESCRIPTION
Line 334 and 337 : The file landcover.tif does not (longer) exist in the sample set for QGIS. (Alaska)
                               The file is now named landcover.img.
                                Changed the extension