### PR TITLE
Fix menuselection typo in 10.2.2

### DIFF
--- a/source/docs/training_manual/qgis_plugins/plugin_examples.rst
+++ b/source/docs/training_manual/qgis_plugins/plugin_examples.rst
@@ -95,7 +95,7 @@ properly:
      :align: center
 
 * Now use the plugin to give you a Google map of the area. You can click on
-  :menuselection:`Plugins --> OpenLayers Plugin --> Add Google Hybrid Layer` to
+  :menuselection:`Web --> OpenLayers Plugin --> Add Google Hybrid Layer` to
   add it: 
 
   .. image:: /static/training_manual/qgis_plugins/add_google_hybrid.png


### PR DESCRIPTION
Should use 'Web -->...' not 'Plugins -->...' to access
'OpenLayers Plugin' functionality.