### PR TITLE
Move the QGIS native algorithms at the top of the list

### DIFF
--- a/source/docs/user_manual/processing_algs/index.rst
+++ b/source/docs/user_manual/processing_algs/index.rst
@@ -11,11 +11,11 @@ Processing providers and algorithms
 .. toctree::
      :maxdepth: 2
 
+     qgis/index
      gdalogr/index
      lidartools/lastools
      modelertools/modeleronly_tools
      otb/index
-     qgis/index
      r/index
      saga/index
      taudem/index


### PR DESCRIPTION
Because we are our own best advocates, let's first show QGIS native algs before other providers at http://docs.qgis.org/testing/en/docs/user_manual/processing_algs/index.html