### PR TITLE
fix #1982 - Add get_feature_by_id

### DIFF
--- a/source/docs/user_manual/working_with_vector/expression.rst
+++ b/source/docs/user_manual/working_with_vector/expression.rst
@@ -987,6 +987,8 @@ This group contains functions that operate on record identifiers.
                       feature
  get_feature          Returns the first feature of a layer matching a
                       given attribute value
+ get_feature_by_id    Returns the feature of a layer matching the given 
+                      feature ID
  is_selected          Returns if a feature is selected
  num_selected         Returns the number of selected features on a given layer
  uuid                 Generates a Universally Unique Identifier (UUID)


### PR DESCRIPTION
Fix #1982 Add get_feature_by_id function to the Record and Attributes functions on the expressions page