### PR TITLE
Move up the foreword chapter in the TOC

### DIFF
--- a/source/docs/user_manual/index.rst
+++ b/source/docs/user_manual/index.rst
@@ -12,8 +12,8 @@ QGIS User Guide
     :maxdepth: 2
 
     preamble/preamble
-    preamble/conventions
     preamble/foreword
+    preamble/conventions
     preamble/features
     preamble/whats_new
     introduction/getting_started


### PR DESCRIPTION
As a general comment this chapter should be shown before GUI conventions.