### PR TITLE
Rename GDAL algs filename to match groupId

### DIFF
--- a/source/docs/user_manual/processing_algs/gdal/index.rst
+++ b/source/docs/user_manual/processing_algs/gdal/index.rst
@@ -14,11 +14,11 @@ and `GDAL/OGR vector utilities <http://www.gdal.org/ogr_utilities.html>`_ .
 .. toctree::
      :maxdepth: 2
 
-     gdal_analysis
-     gdal_conversion
-     gdal_extraction
-     gdal_miscellaneous
-     gdal_projections
-     ogr_conversion
-     ogr_geoprocessing
-     ogr_miscellaneous
+     rasteranalysis
+     rasterconversion
+     rasterextraction
+     rastermiscellaneous
+     rasterprojections
+     vectorconversion
+     vectorgeoprocessing
+     vectormiscellaneous

--- a/source/docs/user_manual/processing_algs/gdal/rasteranalysis.rst
+++ b/source/docs/user_manual/processing_algs/gdal/rasteranalysis.rst
@@ -2,8 +2,8 @@
 
    |updatedisclaimer|
 
-GDAL analysis
-=============
+Raster analysis
+===============
 
 .. only:: html
 

--- a/source/docs/user_manual/processing_algs/gdal/rasterconversion.rst
+++ b/source/docs/user_manual/processing_algs/gdal/rasterconversion.rst
@@ -2,8 +2,8 @@
 
    |updatedisclaimer|
 
-GDAL conversion
-===============
+Raster conversion
+=================
 
 .. only:: html
 

--- a/source/docs/user_manual/processing_algs/gdal/rasterextraction.rst
+++ b/source/docs/user_manual/processing_algs/gdal/rasterextraction.rst
@@ -2,8 +2,8 @@
 
    |updatedisclaimer|
 
-GDAL extraction
-===============
+Raster extraction
+=================
 
 .. only:: html
 

--- a/source/docs/user_manual/processing_algs/gdal/rastermiscellaneous.rst
+++ b/source/docs/user_manual/processing_algs/gdal/rastermiscellaneous.rst
@@ -2,8 +2,8 @@
 
    |updatedisclaimer|
 
-GDAL miscellaneous
-==================
+Raster miscellaneous
+====================
 
 .. only:: html
 

--- a/source/docs/user_manual/processing_algs/gdal/rasterprojections.rst
+++ b/source/docs/user_manual/processing_algs/gdal/rasterprojections.rst
@@ -3,7 +3,7 @@
    |updatedisclaimer|
 
 Raster projections
-================
+==================
 
 .. only:: html
 

--- a/source/docs/user_manual/processing_algs/gdal/rasterprojections.rst
+++ b/source/docs/user_manual/processing_algs/gdal/rasterprojections.rst
@@ -2,7 +2,7 @@
 
    |updatedisclaimer|
 
-GDAL projections
+Raster projections
 ================
 
 .. only:: html

--- a/source/docs/user_manual/processing_algs/gdal/vectorconversion.rst
+++ b/source/docs/user_manual/processing_algs/gdal/vectorconversion.rst
@@ -2,8 +2,8 @@
 
    |updatedisclaimer|
 
-OGR conversion
-==============
+Vector conversion
+=================
 
 .. only:: html
 

--- a/source/docs/user_manual/processing_algs/gdal/vectorgeoprocessing.rst
+++ b/source/docs/user_manual/processing_algs/gdal/vectorgeoprocessing.rst
@@ -2,8 +2,8 @@
 
    |updatedisclaimer|
 
-OGR geoprocessing
-=================
+Vector geoprocessing
+====================
 
 .. only:: html
 

--- a/source/docs/user_manual/processing_algs/gdal/vectormiscellaneous.rst
+++ b/source/docs/user_manual/processing_algs/gdal/vectormiscellaneous.rst
@@ -2,8 +2,8 @@
 
    |updatedisclaimer|
 
-OGR miscellaneous
-=================
+Vector miscellaneous
+====================
 
 .. only:: html
 

--- a/source/docs/user_manual/processing_algs/index.rst
+++ b/source/docs/user_manual/processing_algs/index.rst
@@ -12,7 +12,7 @@ Processing providers and algorithms
      :maxdepth: 2
 
      qgis/index
-     gdalogr/index
+     gdal/index
      lidartools/lastools
      otb/index
      r/index


### PR DESCRIPTION
This was missing --> GDAL algs did not open right help pages.
Should SAGA algs also be renamed? (I don't have SAGA enabled on my computer to check how that behaves)