### PR TITLE
remove the $ in front of bash commands for consistency

### DIFF
--- a/source/docs/user_manual/working_with_ogc/server/config.rst
+++ b/source/docs/user_manual/working_with_ogc/server/config.rst
@@ -148,10 +148,10 @@ For example with spawn-fcgi:
 
 .. code-block:: bash
 
-  $ export QGIS_OPTIONS_PATH=/home/user/.local/share/QGIS/QGIS3/profiles/default/
-  $ export QGIS_SERVER_LOG_FILE=/home/user/qserv.log
-  $ export QGIS_SERVER_LOG_LEVEL=2
-  $ spawn-fcgi -f /usr/lib/cgi-bin/qgis_mapserv.fcgi -s /tmp/qgisserver.sock -U www-data -G www-data -n
+ export QGIS_OPTIONS_PATH=/home/user/.local/share/QGIS/QGIS3/profiles/default/
+ export QGIS_SERVER_LOG_FILE=/home/user/qserv.log
+ export QGIS_SERVER_LOG_LEVEL=2
+ spawn-fcgi -f /usr/lib/cgi-bin/qgis_mapserv.fcgi -s /tmp/qgisserver.sock -U www-data -G www-data -n
 
   QGIS Server Settings:
 
@@ -261,24 +261,24 @@ For linux, if you don't have a desktop environment installed (or you prefer the 
 
   .. code-block:: bash
 
-   $ sudo su
-   $ mkdir -p /usr/local/share/fonts/truetype/myfonts && cd /usr/local/share/fonts/truetype/myfonts
+   sudo su
+   mkdir -p /usr/local/share/fonts/truetype/myfonts && cd /usr/local/share/fonts/truetype/myfonts
 
    # copy the fonts from their location
-   $ cp /fonts_location/* .
+   cp /fonts_location/* .
 
-   $ chown root *
-   $ cd .. && fc-cache -f -v
+   chown root *
+   cd .. && fc-cache -f -v
 
 * On Fedora based systems:
 
   .. code-block:: bash
 
-   $ sudo su
-   $ mkdir /usr/share/fonts/myfonts && cd /usr/share/fonts/myfonts
+   sudo su
+   mkdir /usr/share/fonts/myfonts && cd /usr/share/fonts/myfonts
 
    # copy the fonts from their location
-   $ cp /fonts_location/* .
+   cp /fonts_location/* .
 
-   $ chown root *
-   $ cd .. && fc-cache -f -v
+   chown root *
+   cd .. && fc-cache -f -v

--- a/source/docs/user_manual/working_with_ogc/server/getting_started.rst
+++ b/source/docs/user_manual/working_with_ogc/server/getting_started.rst
@@ -46,10 +46,10 @@ Enable the rewrite module to pass HTTP BASIC auth headers:
 
 .. code-block:: bash
 
-  $ sudo a2enmod rewrite
-  $ cat /etc/apache2/conf-available/qgis-server-port.conf
-  Listen 80
-  $ sudo a2enconf qgis-server-port
+ sudo a2enmod rewrite
+ cat /etc/apache2/conf-available/qgis-server-port.conf
+ Listen 80
+ sudo a2enconf qgis-server-port
 
 This is the virtual host configuration, stored in
 :file:`/etc/apache2/sites-available/001-qgis-server.conf`:
@@ -98,8 +98,8 @@ Now enable the virtual host and restart Apache:
 
 .. code-block:: bash
 
-  $ sudo a2ensite 001-qgis-server
-  $ sudo service apache2 restart
+ sudo a2ensite 001-qgis-server
+ sudo service apache2 restart
 
 QGIS Server is now available at http://localhost/cgi-bin/qgis-server.cgi.
 
@@ -119,7 +119,7 @@ NGINX:
 
 .. code-block:: bash
 
-  $ sudo apt-get install nginx
+ sudo apt-get install nginx
 
 
 fcgiwrap
@@ -130,8 +130,7 @@ the corresponding package:
 
 .. code-block:: bash
 
-  $ sudo apt-get install fcgiwrap
-
+ sudo apt-get install fcgiwrap
 
 Then, introduce the following block in your NGINX server configuration:
 
@@ -149,8 +148,8 @@ Finally, restart NGINX and fcgiwrap to take into account the new configuration:
 
 .. code-block:: bash
 
-  $ sudo service nginx restart
-  $ sudo service fcgiwrap restart
+ sudo service nginx restart
+ sudo service fcgiwrap restart
 
 QGIS Server is now available at http://localhost/qgisserver.
 
@@ -179,16 +178,16 @@ And restart NGINX to take into account the new configuration:
 
 .. code-block:: bash
 
-  $ sudo service nginx restart
+ sudo service nginx restart
 
 Finally, considering that there is no default service file for spawn-fcgi, you
 have to manually start QGIS Server in your terminal:
 
 .. code-block:: bash
 
-  $ sudo spawn-fcgi -f /usr/lib/bin/cgi-bin/qgis_mapserv.fcgi \
-                    -s /var/run/qgisserver.socket \
-                    -U www-data -G www-data -n
+ sudo spawn-fcgi -f /usr/lib/bin/cgi-bin/qgis_mapserv.fcgi \
+                 -s /var/run/qgisserver.socket \
+                 -U www-data -G www-data -n
 
 Of course, you may write an init script (like a ``qgisserver.service`` file
 with Systemd) to start QGIS Server at boot time or whenever you want.
@@ -265,7 +264,7 @@ To install the package:
 
 .. code-block:: bash
 
-  $ sudo apt-get install xvfb
+ sudo apt-get install xvfb
 
 Then, according to your HTTP server, you should configure the **DISPLAY**
 parameter or directly use **xvfb-run**.
@@ -274,29 +273,29 @@ For example with NGINX and spawn-fcgi using xvfb-run:
 
 .. code-block:: bash
 
-  $ xvfb-run /usr/bin/spawn-fcgi -f /usr/lib/bin/cgi-bin/qgis_mapserv.fcgi \
-                                 -s /tmp/qgisserver.socket \
-                                 -G www-data -U www-data -n
+ xvfb-run /usr/bin/spawn-fcgi -f /usr/lib/bin/cgi-bin/qgis_mapserv.fcgi \
+                              -s /tmp/qgisserver.socket \
+                              -G www-data -U www-data -n
 
 The other option is to start a virtual X server environment with a specific
 display number thanks to **Xvfb**:
 
 .. code-block:: bash
 
-  $ /usr/bin/Xvfb :99 -screen 0 1024x768x24 -ac +extension GLX +render -noreset
+ /usr/bin/Xvfb :99 -screen 0 1024x768x24 -ac +extension GLX +render -noreset
 
 Then we just have to set the **DISPLAY** environment variable in the HTTP server
 configuration. For example with NGINX:
 
 .. code-block:: nginx
 
-  fastcgi_param  DISPLAY       ":99";
+ fastcgi_param  DISPLAY       ":99";
 
 Or with Apache:
 
 .. code-block:: apache
 
-  FcgidInitialEnv DISPLAY       ":99"
+ FcgidInitialEnv DISPLAY       ":99"
 
 
 
@@ -315,10 +314,10 @@ retrieve the project:
 
 .. code-block:: bash
 
-  $ cd /home/user/
-  $ wget https://github.com/qgis/QGIS-Training-Data/archive/master.zip -O qgis-server-tutorial.zip
-  $ unzip qgis-server-tutorial.zip
-  $ mv QGIS-Training-Data-master/training_manual_data/qgis-server-tutorial-data ~
+ cd /home/user/
+ wget https://github.com/qgis/QGIS-Training-Data/archive/master.zip -O qgis-server-tutorial.zip
+ unzip qgis-server-tutorial.zip
+ mv QGIS-Training-Data-master/training_manual_data/qgis-server-tutorial-data ~
 
 The project file is ``qgis-server-tutorial-data-master/world.qgs``. Of course,
 you can use your favorite GIS software to open this file and take a look on the
@@ -361,10 +360,10 @@ For example with spawn-fcgi:
 
 .. code-block:: bash
 
-  $ export PROJECT_FILE=/home/user/qgis-server-tutorial-data-master/world.qgs
-  $ spawn-fcgi -f /usr/lib/bin/cgi-bin/qgis_mapserv.fcgi \
-               -s /var/run/qgisserver.socket \
-               -U www-data -G www-data -n
+ export PROJECT_FILE=/home/user/qgis-server-tutorial-data-master/world.qgs
+ spawn-fcgi -f /usr/lib/bin/cgi-bin/qgis_mapserv.fcgi \
+            -s /var/run/qgisserver.socket \
+            -U www-data -G www-data -n
 
 
 

--- a/source/docs/user_manual/working_with_ogc/server/plugins.rst
+++ b/source/docs/user_manual/working_with_ogc/server/plugins.rst
@@ -22,13 +22,13 @@ environment variable:
 
 .. code-block:: bash
 
-  $ sudo mkdir -p /opt/qgis-server/plugins
-  $ cd /opt/qgis-server/plugins
-  $ sudo wget https://github.com/elpaso/qgis-helloserver/archive/master.zip
-  # In case unzip was not installed before:
-  $ sudo apt-get install unzip
-  $ sudo unzip master.zip
-  $ sudo mv qgis-helloserver-master HelloServer
+ sudo mkdir -p /opt/qgis-server/plugins
+ cd /opt/qgis-server/plugins
+ sudo wget https://github.com/elpaso/qgis-helloserver/archive/master.zip
+ In case unzip was not installed before:
+ sudo apt-get install unzip
+ sudo unzip master.zip
+ sudo mv qgis-helloserver-master HelloServer
 
 
 HTTP Server configuration
@@ -64,8 +64,8 @@ Then, restart Apache:
 
 .. code-block:: bash
 
-  $ sudo a2ensite 001-qgis-server
-  $ sudo service apache2 restart
+ sudo a2ensite 001-qgis-server
+ sudo service apache2 restart
 
 .. tip::
 
@@ -87,9 +87,8 @@ Test the server with the HelloWorld plugin:
 
 .. code-block:: bash
 
-  $ wget -q -O - "http://localhost/cgi-bin/qgis_mapserv.fcgi?SERVICE=HELLO"
+ wget -q -O - "http://localhost/cgi-bin/qgis_mapserv.fcgi?SERVICE=HELLO"
   HelloServer!
-
 
 You can have a look at the default GetCapabilities of the QGIS server at:
 :file:`http://localhost/cgi-bin/qgis_mapserv.fcgi?SERVICE=WMS&VERSION=1.3.0&REQUEST=GetCapabilities`


### PR DESCRIPTION
I noticed that we're inconsistent when presenting the bash commands.

@pblottiere You prefer the $ in front so that it's recognizable, and we could go that way everywhere.
However, I found it a little bit annoying to copy the commands as double clicking the line with the commands adds the $ and I have to delete it everytime  + this means two characters in plus on the line.
So I would go without the ``$`` in front.

@DelazJ @SrNetoChan @yjacolin @pblottiere Opinions?