### PR TITLE
Moving from 'Print Composer' to 'Print Layout' naming

### DIFF
--- a/source/docs/documentation_guidelines/substitutions.rst
+++ b/source/docs/documentation_guidelines/substitutions.rst
@@ -285,14 +285,14 @@ Icon                            Substitution                        Icon        
 ==============================  ==================================  ==============================  ==================================
 
 
-Print Composer
-==============
+Print Layout
+============
 
 =======================  ===========================  =======================  ===========================
 Icon                     Substitution                 Icon                     Substitution
 =======================  ===========================  =======================  ===========================
-|newComposer|            ``|newComposer|``            |composerManager|        ``|composerManager|``
-|duplicateComposer|      ``|duplicateComposer|``      \                        \
+|newLayout|              ``|newLayout|``              |layoutManager|          ``|layoutManager|``
+|duplicateLayout|        ``|duplicateLayout|``        \                        \
 |atlasSettings|          ``|atlasSettings|``          |atlas|                  ``|atlas|``
 |filePrint|              ``|filePrint|``              |saveMapAsImage|         ``|saveMapAsImage|``
 |saveAsSVG|              ``|saveAsSVG|``              |saveAsPDF|              ``|saveAsPDF|``
@@ -436,6 +436,7 @@ Icon                            Substitution                        Icon        
 |evisConnect|                   ``|evisConnect|``                   |evisFile|                      ``|evisFile|``
 ==============================  ==================================  ==============================  ==================================
 
+
 .. Substitutions definitions - AVOID EDITING PAST THIS LINE
    This will be automatically updated by the find_set_subst.py script.
    If you need to create a new substitution manually,
@@ -570,8 +571,6 @@ Icon                            Substitution                        Icon        
    :width: 1.5em
 .. |colorWheel| image:: /static/common/mIconColorWheel.png
    :width: 1.5em
-.. |composerManager| image:: /static/common/mActionComposerManager.png
-   :width: 1.5em
 .. |conditionalFormatting| image:: /static/common/mActionConditionalFormatting.png
    :width: 1.5em
 .. |contextHelp| image:: /static/common/mActionContextHelp.png
@@ -632,7 +631,7 @@ Icon                            Substitution                        Icon        
    :width: 1.5em
 .. |draw| image:: /static/common/mActionDraw.png
    :width: 1.5em
-.. |duplicateComposer| image:: /static/common/mActionDuplicateComposer.png
+.. |duplicateLayout| image:: /static/common/mActionDuplicateComposer.png
    :width: 1.5em
 .. |dxf2shpConverter| image:: /static/common/dxf2shp_converter.png
    :width: 1.5em
@@ -795,6 +794,8 @@ Icon                            Substitution                        Icon        
    :width: 1.5em
 .. |layerExtent| image:: /static/common/layer_extent.png
    :width: 1.5em
+.. |layoutManager| image:: /static/common/mActionComposerManager.png
+   :width: 1.5em
 .. |legend| image:: /static/common/legend.png
    :width: 1.5em
 .. |linkGeorefToQGis| image:: /static/common/mActionLinkGeorefToQGis.png
@@ -851,9 +852,9 @@ Icon                            Substitution                        Icon        
    :width: 1.5em
 .. |newBookmark| image:: /static/common/mActionNewBookmark.png
    :width: 1.5em
-.. |newComposer| image:: /static/common/mActionNewComposer.png
-   :width: 1.5em
 .. |newGeoPackageLayer| image:: /static/common/mActionNewGeoPackageLayer.png
+   :width: 1.5em
+.. |newLayout| image:: /static/common/mActionNewComposer.png
    :width: 1.5em
 .. |newMap| image:: /static/common/mActionNewMap.png
    :width: 1.5em

--- a/source/docs/documentation_guidelines/writing.rst
+++ b/source/docs/documentation_guidelines/writing.rst
@@ -437,7 +437,7 @@ rst file.
 
 * same environment for all the screen caps (same OS, same decoration, same font
   size). We have used Ubuntu with Unity and the default "ambience" theme.
-  For screenshots of QGIS main window and composer we have set it to show menus
+  For screenshots of QGIS main window and layouts we have set it to show menus
   on the window (not the default in unity).
 * reduce the window to the minimal space needed to show the feature (taking the
   all screen for a small modal window > overkill)

--- a/source/docs/gentle_gis_introduction/map_production.rst
+++ b/source/docs/gentle_gis_introduction/map_production.rst
@@ -266,10 +266,10 @@ Here are some ideas for you to try with your learners:
   or buildings. Create a list of legend elements and define what the icons should
   look like, so a reader can most easily figure out their meaning in the map.
 * Create a map layout with your learners on a sheet of paper. Decide on the title
-  of the map, what GIS layers you want to show and what colours and icons to have
+  of the map, what GIS layers you want to show and what colors and icons to have
   on the map. Use the techniques you learned in Topics :ref:`gentle_gis_vector_data`
   and :ref:`gentle_gis_attributes` to adjust the symbology accordingly. When you
-  have a template, open the QGIS Map Composer and try to arrange a map layout as
+  have a template, open the QGIS print layout and try to arrange a map layout as
   planned.
 
 Something to think about

--- a/source/docs/pyqgis_developer_cookbook/composer.rst
+++ b/source/docs/pyqgis_developer_cookbook/composer.rst
@@ -1,6 +1,6 @@
 .. index:: Map rendering, Map printing
 
-.. _composer:
+.. _layout:
 
 **************************
 Map Rendering and Printing
@@ -85,26 +85,26 @@ part is reported)
     ...
 
 
-.. index:: Output; Using Map Composer
+.. index:: Output; Using print layout
 
-Output using Map Composer
+Output using print layout
 =========================
 
-Map composer is a very handy tool if you would like to do a more sophisticated
-output than the simple rendering shown above. Using the composer it is possible
+Print layout is a very handy tool if you would like to do a more sophisticated
+output than the simple rendering shown above. It is possible
 to create complex map layouts consisting of map views, labels, legend, tables
 and other elements that are usually present on paper maps. The layouts can be
 then exported to PDF, raster images or directly printed on a printer.
 
-The composer consists of a bunch of classes. They all belong to the core
+The layout consists of a bunch of classes. They all belong to the core
 library. QGIS application has a convenient GUI for placement of the elements,
 though it is not available in the GUI library. If you are not familiar with
 `Qt Graphics View framework <http://doc.qt.io/qt-4.8/qgraphicsview.html>`_,
-then you are encouraged to check the documentation now, because the composer
+then you are encouraged to check the documentation now, because the layout
 is based on it. Also check the `Python documentation of the implementation of QGraphicView
 <http://pyqt.sourceforge.net/Docs/PyQt4/qgraphicsview.html>`_.
 
-The central class of the composer is :class:`QgsComposition` which is derived
+The central class of the layout is :class:`QgsComposition` which is derived
 from :class:`QGraphicsScene`. Let us create one
 
 ::
@@ -117,7 +117,7 @@ Note that the composition takes an instance of :class:`QgsMapRenderer`. In the
 code we expect we are running within QGIS application and thus use the map
 renderer from map canvas. The composition uses various parameters from the map
 renderer, most importantly the default set of map layers and the current extent.
-When using composer in a standalone application, you can create your own map
+When using a layout in a standalone application, you can create your own map
 renderer instance the same way as shown in the section above and pass it to
 the composition.
 
@@ -192,7 +192,7 @@ Currently supported items are:
 
 * table
 
-By default the newly created composer items have zero position (top left corner
+By default the newly created layout items have zero position (top left corner
 of the page) and zero size. The position and size are always measured in
 millimeters
 
@@ -209,12 +209,12 @@ A frame is drawn around each item by default. How to remove the frame
 
   composerLabel.setFrame(False)
 
-Besides creating the composer items by hand, QGIS has support for composer
+Besides creating the layout items by hand, QGIS has support for layout
 templates which are essentially compositions with all their items saved to a
 .qpt file (with XML syntax). Unfortunately this functionality is not yet
 available in the API.
 
-Once the composition is ready (the composer items have been created and added
+Once the composition is ready (the layout items have been created and added
 to the composition), we can proceed to produce a raster and/or vector output.
 
 The default output settings for composition are page size A4 and resolution 300

--- a/source/docs/training_manual/assessment/index.rst
+++ b/source/docs/training_manual/assessment/index.rst
@@ -147,7 +147,7 @@ Analyze the data
 Final Map
 ===============================================================================
 
-* Use the :guilabel:`Map Composer` to create a final map, which incorporates
+* Use the :guilabel:`Print Layout` to create a final map, which incorporates
   your analysis results.
 * Include this map in a document along with your documented criteria. If the
   map has become too visually busy due to the added layer(s), deselect the

--- a/source/docs/training_manual/complete_analysis/assignment.rst
+++ b/source/docs/training_manual/complete_analysis/assignment.rst
@@ -1,7 +1,7 @@
 Assignment
 ===============================================================================
 
-Using the Map Composer, make a new map representing the results of your
+Using the print layout, make a new map representing the results of your
 analysis. Include these layers:
 
 - :guilabel:`places` (with labels),

--- a/source/docs/training_manual/forestry/forest_maps.rst
+++ b/source/docs/training_manual/forestry/forest_maps.rst
@@ -5,7 +5,7 @@ The systematic sampling design is ready and the field teams have loaded the GPS 
 
 **The goal for this lesson:** Learn to use the Atlas tool in QGIS to generate detailed printable maps to assist in the field inventory work.
 
-|basic| |FA| Preparing the Map Composer
+|basic| |FA| Preparing the Print Layout
 -------------------------------------------------------------------------------
 
 Before we can automate the detailed maps of the forest area and our sampling plots, we need to create a map template with all the elements we consider useful for the field work. Of course the most important will be a properly styled but, as you have seen before, you will also need to add lots of other elements that complete the printed map.
@@ -18,28 +18,29 @@ Open the QGIS project from the previous lesson :kbd:`forest_inventory.qgs`. You 
 
 Save the project with a new name, :kbd:`map_creation.qgs`.
 
-To create a printable map, remember that you use the :guilabel:`Composer Manager`:
+To create a printable map, remember that you use the :guilabel:`Layout Manager`:
 
-* Open :menuselection:`Project --> Composer Manager...`.
-* In the :guilabel:`Composer manager` dialog.
-* Click the :guilabel:`Add` button and name your composer :kbd:`forest_map`.
+* Open :menuselection:`Project --> Layout Manager...`.
+* In the :guilabel:`Layout manager` dialog.
+* Click the :guilabel:`Add` button and name your print layout :kbd:`forest_map`.
 * Click :guilabel:`OK`.
 * Click the :guilabel:`Show` button.
 
 Set up the printer options so that your maps will suit your paper and margins, for an A4 paper:
 
-* Open menuselection:`Composer --> Page Setup`.
+* Open menuselection:`Layout --> Page Setup...`.
 * :guilabel:`Size` is :guilabel:`A4 (217 x 297 mm)`.
 * :guilabel:`Orientation` is :guilabel:`Landscape`.
-* :guilabel:`Margins (milimeters)` are all set to :kbd:`5`.
+* :guilabel:`Margins (millimeters)` are all set to :kbd:`5`.
 
-In the :guilabel:`Print Composer` window, go to the :guilabel:`Composition` tab (on the right panel) and make sure that these settings for :guilabel:`Paper and quality` are the same you defined for the printer:
+In the :guilabel:`Print Layout` window, go to the :guilabel:`Composition` tab (on the right panel) and make sure that these settings for :guilabel:`Paper and quality` are the same you defined for the printer:
 
 * :guilabel:`Size`: :kbd:`A4 (210x297mm)`.
 * :guilabel:`Orientation`: :kbd:`Landscape`.
 * :guilabel:`Quality`: :kbd:`300dpi`.
 
-Composing a map is easier if you make use of the canvas grid to position the different elements. Review the settings for the composer grid:
+Composing a map is easier if you make use of the canvas grid to position the
+different elements. Review the settings for the layout grid:
 
 * In the :guilabel:`Composition` tab expand the :guilabel:`Grid` region.
 * Check that :guilabel:`Spacing` is set to :kbd:`10 mm`.
@@ -50,9 +51,11 @@ You need to activate the use of the grid:
 * Open the :menuselection:`View` menu.
 * Check :guilabel:`Show grid`.
 * Check :guilabel:`Snap to grid`.
-* Notice that options for using :guilabel:`guides` are checked by default, which allows you to see red guiding lines when you are moving elements in the composer.
+* Notice that options for using :guilabel:`guides` are checked by default, which
+  allows you to see red guiding lines when you are moving elements in the layout.
 
-Now you can start to add elements to your map canvas. Add first a map element so you can review how it looks as you will be making changes in the layers symbology:
+Now you can start to add elements to your map canvas. Add first a map element so
+you can review how it looks as you will be making changes in the layers symbology:
 
 * Click on the :guilabel:`Add New Map` button: |addMap|.
 * Click and drag a box on the canvas so that the map occupies most of it.
@@ -67,7 +70,7 @@ Notice how the mouse cursor snaps to the canvas grid. Use this function when you
 |basic| |FA| Adding Background Map
 -------------------------------------------------------------------------------
 
-Leave the composer open but go back to the map. Lets add some background data and create some styling so that the map content is as clear as possible.
+Leave the layout open but go back to the map. Lets add some background data and create some styling so that the map content is as clear as possible.
 
 * Add the background raster :kbd:`basic_map.tif` that you can find in the :kbd:`exercise_data\\forestry\\` folder.
 * When prompted select the :kbd:`ETRS89 / ETRS-TM35FIN` CRS for the raster.
@@ -76,15 +79,15 @@ As you can see the background map is already styled. This type of ready to use c
 
 * Now zoom to your sample plots, so that you can see only about four or five lines of plots.
 
-The current styling of the sample plots is not the best, but how does it look in the map composer?:
+The current styling of the sample plots is not the best, but how does it look in the print layout?:
 
 .. image:: img/plots_zoom1-2.png
    :align: center
 
-While during the last exercises, the white buffer was OK on top of the aerial image, now that the background image is mostly white you barely can see the labels. You can also check how it looks like on the composer:
+While during the last exercises, the white buffer was OK on top of the aerial image, now that the background image is mostly white you barely can see the labels. You can also check how it looks like on the layout:
 
-* Go to the :guilabel:`Print Composer` window.
-* Use the |select| button to select the map element in the composer.
+* Go to the :guilabel:`Print Layout` window.
+* Use the |select| button to select the map element in the layout.
 * Go to the :guilabel:`Item properties` tab.
 * Under :guilabel:`Extents` click on :guilabel:`Set to map canvas extent`.
 * If you need to refresh the element, under :guilabel:`Main properties` click on the :guilabel:`Update preview`.
@@ -100,14 +103,22 @@ You have been working in :doc:`../basic_map/index` with symbology and in :doc:`.
 .. image:: img/plots_zoom2_symbology.png
    :align: center
 
-You will use later the the green styling of the :kbd:`forest_stands_2012` layer. In order to keep it, and have a visualization of it that shows only the stand borders:
+You will use later the the green styling of the :kbd:`forest_stands_2012` layer.
+In order to keep it, and have a visualization of it that shows only the stand borders:
 
 * Right click on :kbd:`forest_stands_2012` and select :guilabel:`Duplicate`
-* you get a new layer named :kbd:`forest_stands_2012 copy` that you can use to define a different style, for example with no filling and red borders.
+* you get a new layer named :kbd:`forest_stands_2012 copy` that you can use to
+  define a different style, for example with no filling and red borders.
 
-Now you have two different visualizations of the forest stands and you can decide which one to display for your detail map.
+Now you have two different visualizations of the forest stands and you can decide
+which one to display for your detail map.
 
-Go back to the :guilabel:`Print composer` window often to see what the map would look like. For the purposes of creating detailed maps, you are looking for a symbology that looks good not at the scale of the whole forest area (left image below) but at a closer scale (right image below). Remember to use :guilabel:`Update preview` and :guilabel:`Set to map canvas extent` whenever you change the zoom in your map or the composer.
+Go back to the :guilabel:`Print Layout` window often to see what the map would
+look like. For the purposes of creating detailed maps, you are looking for a
+symbology that looks good not at the scale of the whole forest area (left image
+below) but at a closer scale (right image below). Remember to use
+:guilabel:`Update preview` and :guilabel:`Set to map canvas extent` whenever
+you change the zoom in your map or the layout.
 
 .. image:: img/composer_2-3.png
    :align: center
@@ -115,26 +126,28 @@ Go back to the :guilabel:`Print composer` window often to see what the map would
 |basic| |TY| Create a Basic Map Template
 -------------------------------------------------------------------------------
 
-Once you have a symbology your happy with, you are ready to add some more information to your printed map. Add at least the following elements:
+Once you have a symbology your happy with, you are ready to add some more information
+to your printed map. Add at least the following elements:
 
 * Title.
 * A scale bar.
 * Grid frame for your map.
 * Coordinates on the sides of the grid.
 
-You have created a similar composition already in :doc:`../map_composer/index`. Go back to that module as you need. You can look at this example image for reference:
+You have created a similar composition already in :doc:`../map_composer/index`.
+Go back to that module as you need. You can look at this example image for reference:
 
 .. image:: img/map_template1.png
    :align: center
 
 Export your map as an image and look at it.
 
-* :menuselection:`Composer --> Export as Image`.
+* :menuselection:`Layout --> Export as Image...`.
 * Use for example the :kbd:`JPG format`.
 
 That is what it will look like when printed.
 
-|basic| |FA| Adding More Elements to the Composer
+|basic| |FA| Adding More Elements to the Print Layout
 -------------------------------------------------------------------------------
 
 As you probably noticed in the suggested map template images, there are plenty of room on the right side of the canvas. Lets see what else could go in there. For the purposes of our map, a legend is not really necessary, but an overview map and some text boxes could add value to the map.
@@ -151,10 +164,10 @@ The overview map will help the field teams place the detail map inside the gener
 
 Notice that your overview map is not really giving an overview of the forest area which is what you want. You want this map to represent the whole forest area and you want it to show only the background map and the :kbd:`forest_stands_2012` layer, and not display the sample plots. And also you want to lock its view so it does not change anymore whenever you change the visibility or order of the layers.
 
-* Go back to the map, but don't close the :guilabel:`Print composer`.
+* Go back to the map, but don't close the :guilabel:`Print Layout`.
 * Right click the :kbd:`forest_stands_2012` layer and click on :guilabel:`Zoom to Layer Extent`.
 * Deactivate all layers except for :kbd:`basic_map` and :kbd:`forest_stands_2012`.
-* Go back to the :guilabel:`Print composer`.
+* Go back to the :guilabel:`Print Layout`.
 * With the small map selected, click the :guilabel:`Set to map canvas extent` to set its extents to what you can see in the map window.
 * Lock the view for the overview map by checking :guilabel:`Lock layers for map item` under :guilabel:`Main properties`.
 
@@ -162,8 +175,8 @@ Now your overview map is more what you expected and its view will not change any
 
 * Go to the map window again and select the layers you want to be visible (:kbd:`systematic_plots_clip`, :kbd:`forest_stands_2012 copy` and :kbd:`Basic_map`).
 * Zoom again to have only a few lines of sample plots visible.
-* Go back to the :guilabel:`Print composer` window.
-* Select the bigger map in your composer (|select|).
+* Go back to the :guilabel:`Print Layout` window.
+* Select the bigger map in your layout (|select|).
 * In :guilabel:`Item properties` click on :guilabel:`Update preview` and :guilabel:`Set to map canvas extent`.
 
 Notice that only the bigger map is displaying the current map view, and the small overview map is keeping the same view you had when you locked it.
@@ -184,7 +197,8 @@ You can also add a North arrow to the overview map:
 * Uncheck :guilabel:`Background`.
 * Resize the arrow image to a size that looks good on the small map.
 
-The basic map composer is ready, now you want to make use of the Atlas tool to generate as many detail maps in this format as you consider necessary.
+The basic map layout is ready, now you want to make use of the Atlas tool to
+generate as many detail maps in this format as you consider necessary.
 
 
 |basic| |FA| Creating an Atlas Coverage
@@ -216,7 +230,7 @@ The new polygons are covering the whole forest area and they give you an idea of
 
 The last step is to set up the Atlas tool:
 
-* Go back to the :guilabel:`Print Composer`.
+* Go back to the :guilabel:`Print Layout`.
 * In the panel on the right, go to the :guilabel:`Atlas generation` tab.
 * Set the options as follows:
 
@@ -256,7 +270,7 @@ Besides removing the polygons for those areas that are not interesting, you can 
 .. image:: img/remove_polygons.png
    :align: center
 
-You can go back to the :guilabel:`Print Composer` and check that the previews of the Atlas use only the polygons you left in the layer.
+You can go back to the :guilabel:`Print Layout` and check that the previews of the Atlas use only the polygons you left in the layer.
 
 The coverage layer you are using does not yet have useful information that you could use to customize the content of the labels in your map. The first step is to create them, you can add for example a zone code for the polygon areas and a field with some remarks for the field teams to have into account:
 
@@ -284,7 +298,7 @@ corresponding polygons (double click the cell to edit it):
 Almost ready, now you have to tell the Atlas tool that you want some of the text
 labels to use the information from the :kbd:`atlas_coverage` layer's attribute table.
 
-* Go back to the :guilabel:`Print Composer`.
+* Go back to the :guilabel:`Print Layout`.
 * Select the text label containing :kbd:`Detailed map...`.
 * Set the :guilabel:`Font` size to :kbd:`12`.
 * Set the cursor at the end of the text in the label.
@@ -324,7 +338,7 @@ Lets print the maps as a single PDF that you can send to the field office for pr
 * Under the :guilabel:`Output` check the :guilabel:`Single file export when
   possible`. This will put all the maps together into a PDF file, if this option
   is not checked you will get one file for every map.
-* Open :menuselection:`Composer --> Export as PDF...`. 
+* Open :menuselection:`Layout --> Export as PDF...`. 
 * Save the PDF file as :kbd:`inventory_2012_maps.pdf` in your
   :kbd:`exercise_data\\forestry\\samplig\\map_creation\\` folder.
 
@@ -337,12 +351,12 @@ images that would be created:
 .. image:: img/maps_as_images.png
    :align: center
 
-In the :guilabel:`Print Composer`, save your map as a composer template as
+In the :guilabel:`Print Layout`, save your map as a layout template as
 :kbd:`forestry_atlas.qpt` in your :kbd:`exercise_data\\forestry\\map_creation\\`
-folder. Use :menuselection:`Composer --> Save as Template`. You will be able to
+folder. Use :menuselection:`Layout --> Save as Template`. You will be able to
 use this template again and again.
 
-Close the :guilabel:`Print Composer` and save your QGIS project.
+Close the :guilabel:`Print Layout` and save your QGIS project.
 
 
 |IC|

--- a/source/docs/training_manual/forestry/results_map.rst
+++ b/source/docs/training_manual/forestry/results_map.rst
@@ -55,15 +55,15 @@ is using the :kbd:`Hard light` mode for the :guilabel:`Layer blending mode`. Not
 Try with different modes and see the differences in your map. Then choose the one you like better for your final map.
 
 
-|basic| |TY| Using a Composer Template to Create the Map result
+|basic| |TY| Using a Layout Template to Create the Map result
 -------------------------------------------------------------------------------
 
-Use a template prepared in advanced to present the results. The template :kbd:`forest_map.qpt` is located in the :kbd:`exercise_data\\forestry\\results\\` folder. Load it using the :menuselection:`Project --> Composer Manager...` dialog.
+Use a template prepared in advanced to present the results. The template :kbd:`forest_map.qpt` is located in the :kbd:`exercise_data\\forestry\\results\\` folder. Load it using the :menuselection:`Project --> Layout Manager...` dialog.
 
 .. image:: img/final_map_template.png
    :align: center
 
-Open the map composer and edit the final map to get a result you are happy with.
+Open the print layout and edit the final map to get a result you are happy with.
 
 The map template you are using will give a map similar to this one:
 

--- a/source/docs/training_manual/map_composer/index.rst
+++ b/source/docs/training_manual/map_composer/index.rst
@@ -2,7 +2,7 @@
 |MOD| Creating Maps
 *******************************************************************************
 
-In this module, you'll learn how to use the QGIS Map Composer to produce
+In this module, you'll learn how to use the QGIS print layout to produce
 quality maps with all the requisite map components.
 
 .. toctree::

--- a/source/docs/training_manual/map_composer/map_composer.rst
+++ b/source/docs/training_manual/map_composer/map_composer.rst
@@ -1,4 +1,4 @@
-|LS| Using Map Composer
+|LS| Using Print Layout
 ===============================================================================
 
 Now that you've got a map, you need to be able to print it or to export it to a
@@ -8,32 +8,32 @@ colors, etc. So for someone who doesn't have the data or the same GIS program
 (such as QGIS), the map file will be useless. Luckily, QGIS can export its map
 file to a format that anyone's computer can read, as well as printing out the
 map if you have a printer connected. Both exporting and printing is handled via
-the Map Composer.
+the print layout.
 
-**The goal for this lesson:** To use the QGIS Map Composer to create a basic
+**The goal for this lesson:** To use the QGIS print layout to create a basic
 map with all the required settings.
 
-|basic| |FA| The Composer Manager
+|basic| |FA| The Layout Manager
 -------------------------------------------------------------------------------
 
 QGIS allows you to create multiple maps using the same map file. For this
-reason, it has a tool called the :guilabel:`Composer Manager`.
+reason, it has a tool called the :guilabel:`Layout Manager`.
 
-* Click on the :menuselection:`Project --> Composer Manager` menu entry to open
-  this tool.  You'll see a blank :guilabel:`Composer manager` dialog appear.
-* Click the :guilabel:`Add` button and give the new composer the name of
+* Click on the :menuselection:`Project --> Layout Manager` menu entry to open
+  this tool.  You'll see a blank :guilabel:`Layout manager` dialog appear.
+* Click the :guilabel:`Add` button and give the new layout the name of
   |majorUrbanName|.
 * Click :guilabel:`OK`.
 * Click the :guilabel:`Show` button.
 
-(You could also close the dialog and navigate to a composer via the
-:menuselection:`File --> Print Composers` menus, as in the image below.)
+(You could also close the dialog and navigate to a layout via the
+:menuselection:`Project --> Layouts -->` menu, as in the image below.)
 
 .. image:: img/print_composer_menu.png
    :align: center
 
 Whichever route you take to get there, you will now see the :guilabel:`Print
-Composer` window:
+Layout` window:
 
 .. image:: img/print_composer_dialog.png
    :align: center
@@ -45,7 +45,7 @@ Composer` window:
 In this example, the composition was already the way we wanted it. Ensure that
 yours is as well.
 
-* In the :guilabel:`Print Composer` window, check that the values under
+* In the :guilabel:`Print Layout` window, check that the values under
   :menuselection:`Composition --> Paper and Quality` are set to the following:
 
 - :guilabel:`Size`: :kbd:`A4 (210x297mm)`
@@ -104,7 +104,7 @@ be at the wrong resolution and will look ugly or unreadable.
 Remember that the size and position you've given the map doesn't need to be
 final. You can always come back and change it later if you're not satisfied.
 For now, you need to ensure that you've saved your work on this map. Because a
-:guilabel:`Composer` in QGIS is part of the main map file, you'll need to save
+:guilabel:`Layout` in QGIS is part of the main map file, you'll need to save
 your main project. Go to the main QGIS window (the one with the
 :guilabel:`Layers list` and all the other familiar elements you were working
 with before), and save your project from there as usual.
@@ -156,7 +156,7 @@ contents of the label:
 
 * Select the label by clicking on it.
 * Click on the :guilabel:`Item Properties` tab in the side panel of the
-  :guilabel:`Composer` window.
+  :guilabel:`Layout` window.
 * Change the text of the label to "|majorUrbanName|":
 
 * Use this interface to set the font and alignment options:
@@ -235,7 +235,7 @@ move and resize the legend and or map. This is the result:
 .. note::  Did you remember to save your work often?
 
 Finally the map is ready for export! You'll see the export buttons near the top
-left corner of the :guilabel:`Composer` window:
+left corner of the :guilabel:`Layout` window:
 
   |filePrint| |saveMapAsImage| |saveAsSVG|
   |saveAsPDF|
@@ -278,7 +278,7 @@ For our purposes, we're going to use PDF.
 |IC|
 -------------------------------------------------------------------------------
 
-* Close the :guilabel:`Composer` window.
+* Close the :guilabel:`Layout` window.
 * Save your map.
 * Find your exported PDF using your operating system's file manager.
 * Open it.

--- a/source/docs/training_manual/qgis_server/wms.rst
+++ b/source/docs/training_manual/qgis_server/wms.rst
@@ -241,10 +241,10 @@ GetPrint requests
 -----------------
 
 One very nice feature of QGIS Server is that it makes use of the QGIS Desktop
-print composers. You can learn about it in the :ref:`server_getprint` section.
+print layouts. You can learn about it in the :ref:`server_getprint` section.
 
 If you open the :file:`world.qgs` project with QGIS Desktop you will find a
-print composer named ``Population distribution``. A simplified ``GetPrint``
+print layout named ``Population distribution``. A simplified ``GetPrint``
 request that exemplifies this amazing feature is:
 
 .. code-block:: guess

--- a/source/docs/user_manual/introduction/general_tools.rst
+++ b/source/docs/user_manual/introduction/general_tools.rst
@@ -84,8 +84,8 @@ At the top of the Layers panel, a toolbar allows you to:
    Layer Toolbar in Layers Panel
 
 .. note::
-   Tools to manage the layers panel are also available to layout the map
-   and legend items of the print composer
+   Tools to manage the layers panel are also available for map
+   and legend items of the print layout
 
 .. index:: Map themes
 .. _map_themes:
@@ -95,7 +95,7 @@ Configuring map themes
 
 The button |showMapTheme| allows you to configure **Map Themes** in the legend.
 These themes are helpful to quickly switch between different preconfigured layer 
-combinations and can also be used in Print Composer. 
+combinations and can also be used in print layout. 
 To create a map theme, activate the layers you want to include and configure 
 the desired layer styles. Then press the |showMapTheme| button and choose 
 :menuselection:`Add Theme...` from the drop-down menu and enter a name for the new theme.
@@ -106,8 +106,8 @@ The :menuselection:`Replace Theme -->` option allows you to overwrite an existin
 with the currently enabled layers and their styles while the 
 :menuselection:`Remove Current Theme` button deletes the active theme.
 
-All configured themes are also accessible in the Print Composer. This allows you
-to create a map layout based on specific themes (see :ref:`composer_main_properties`).
+All configured themes are also accessible in the print layout. This allows you
+to create a map layout based on specific themes (see :ref:`layout_main_properties`).
 
 Overview of the context menu of the Layers panel
 ................................................
@@ -807,7 +807,7 @@ Blending Modes
 
 QGIS offers different options for special rendering effects with these tools that
 you may previously only know from graphics programs. Blending modes can be applied
-on layers, on features but also on print composer items:
+on layers, on features but also on print layout items:
 
 * **Normal**: This is the standard blend mode, which uses the alpha channel of the top
   pixel to blend with the pixel beneath it. The colors aren't mixed.
@@ -1165,7 +1165,7 @@ Data defined override setup
 ===========================
 
 Beside many options in the vector layer properties dialog or settings in the print
-composer, you can find a |dataDefined| :sup:`Data defined override` icon.
+layout, you can find a |dataDefined| :sup:`Data defined override` icon.
 Thanks to :ref:`expressions <vector_expressions>` based on layer attributes or item
 settings, prebuild or custom functions and :ref:`variables <general_tools_variables>`,
 this tool allows you to set dynamic value for the concerned parameter. When enabled,
@@ -1190,7 +1190,7 @@ Parameters that can be used with data-defined tools are:
 
 * Style and symbols parameters
 * Labels parameters
-* Composer parameters
+* Layout parameters
 
 .. tip:: **Use right-click to (de)activate the data overriding**
 
@@ -1673,12 +1673,12 @@ Variables
 In QGIS, you can use variables to store useful recurrent values (e.g. the
 project's title, or the user's full name) that can be used in expressions.
 Variables can be defined at the application's global level, project level,
-layer level, composition level, and composer's item level. Just like CSS
+layer level, composition level, and layout item's level. Just like CSS
 cascading rules, variables can be overwritten - e.g., a project level
 variable will overwrite any application's global level variables set with
 the same name. You can use these variables to build text strings or other
 custom expressions using the @ character before the variable name. For
-example in composer creating a label with this content::
+example in print layout creating a label with this content::
 
   This map was made using QGIS [% @qgis_version %]. The project file for this
   map is: [% @project_path %]
@@ -1698,9 +1698,9 @@ manage:
 * **vector layer's variables** from the :guilabel:`Layer Properties` dialog
   (see :ref:`vector_properties_dialog`);
 * **composition's variables** from the :guilabel:`Composition` panel in the
-  Print composer (see :ref:`composer_composition_tab`);
-* and **composer item's variables** from the :guilabel:`Item properties`
-  panel in the Print composer (see :ref:`composer_item_options`).
+  Print layout (see :ref:`layout_composition_tab`);
+* and **layout item's variables** from the :guilabel:`Item properties`
+  panel in the Print layout (see :ref:`layout_item_options`).
 
 To differentiate from editable variables, read-only variable's names and
 values are emphasized in italic. On the other hand, higher level

--- a/source/docs/user_manual/introduction/getting_started.rst
+++ b/source/docs/user_manual/introduction/getting_started.rst
@@ -408,9 +408,9 @@ The kinds of information saved in a project file include:
 * Layer properties, including symbolization and styles
 * Projection for the map view
 * Last viewed extent
-* Print Composers
-* Print Composer elements with settings
-* Print Composer atlas settings
+* Print layouts
+* Print layout elements with settings
+* Print layout atlas settings
 * Digitizing settings
 * Table Relations
 * Project Macros
@@ -452,7 +452,7 @@ automatically zip your current project.
 Output
 ======
 
-.. index:: Print composer, Quick print, World file
+.. index:: Print layout, Quick print, World file
    single: Output; Save as image
 
 There are several ways to generate output from your QGIS session. We have
@@ -467,9 +467,11 @@ Here is a sampling of other ways to produce output files:
   a dialog where you can define the 'Symbology mode', the 'Symbology scale' and
   vector layers you want to export to DXF. Through the 'Symbology mode' symbols
   from the original QGIS Symbology can be exported with high fidelity.
-* Menu option :menuselection:`Project -->` |newComposer|
-  :menuselection:`New Print Composer...` opens a dialog where you can layout and
-  print the current map canvas (see section :ref:`label_printcomposer`).
+* Menu option :menuselection:`Project -->` |newLayout|
+  :menuselection:`New Print Layout` opens a dialog where you can layout and
+  print the current map canvas (see section :ref:`label_printlayout`).
+
+
 
 .. Substitutions definitions - AVOID EDITING PAST THIS LINE
    This will be automatically updated by the find_set_subst.py script.
@@ -491,7 +493,7 @@ Here is a sampling of other ways to produce output files:
    :width: 1.5em
 .. |fileSaveAs| image:: /static/common/mActionFileSaveAs.png
    :width: 1.5em
-.. |newComposer| image:: /static/common/mActionNewComposer.png
+.. |newLayout| image:: /static/common/mActionNewComposer.png
    :width: 1.5em
 .. |nix| image:: /static/common/nix.png
    :width: 1em

--- a/source/docs/user_manual/introduction/qgis_configuration.rst
+++ b/source/docs/user_manual/introduction/qgis_configuration.rst
@@ -478,8 +478,8 @@ Layout Settings
 
 **Composition defaults**
 
-You can define the :guilabel:`Default font` used within the :ref:`print composer
-<label_printcomposer>`.
+You can define the :guilabel:`Default font` used within the :ref:`print layout
+<label_printlayout>`.
 
 **Grid appearance**
 
@@ -493,10 +493,10 @@ You can define the :guilabel:`Default font` used within the :ref:`print composer
 * Define the :guilabel:`Snap tolerance` |selectNumber|
 
 
-**Composer Paths**
+**Layout Paths**
 
 * Define :guilabel:`Path(s) to search for extra print templates`: a list of folders
-  with custom composer templates to use while creating new one.
+  with custom layout templates to use while creating new one.
 
 .. _gdal_options:
 

--- a/source/docs/user_manual/introduction/qgis_gui.rst
+++ b/source/docs/user_manual/introduction/qgis_gui.rst
@@ -89,9 +89,9 @@ Menu Option                                              Shortcut              R
 :guilabel:`DWG/DXF Import...`                            \                     \                                           \
 :guilabel:`Snapping Options...`                          :kbd:`S`              see :ref:`snapping_tolerance`               \
 |projectProperties| :guilabel:`Project Properties...`    :kbd:`Ctrl+Shift+P`   see :ref:`sec_projects`                     \
-|newComposer| :guilabel:`New Print Composer`             :kbd:`Ctrl+P`         see :ref:`label_printcomposer`              :guilabel:`Project`
-|composerManager| :guilabel:`Composer manager...`        \                     see :ref:`label_printcomposer`              :guilabel:`Project`
-:menuselection:`Print Composers -->`                     \                     see :ref:`label_printcomposer`              \
+|newLayout| :guilabel:`New Print Layout`                 :kbd:`Ctrl+P`         see :ref:`label_printlayout`                :guilabel:`Project`
+|layoutManager| :guilabel:`Layout Manager...`            \                     see :ref:`label_printlayout`                :guilabel:`Project`
+:menuselection:`Layouts -->`                             \                     see :ref:`label_printlayout`                \
 |fileExit| :guilabel:`Exit QGIS`                         :kbd:`Ctrl+Q`         \                                           \
 =======================================================  ====================  ==========================================  ===============================
 
@@ -582,6 +582,7 @@ loading, processing tools...)
 
    Note that CRS choice on startup can be set in :menuselection:`Settings --> Options --> CRS`.
 
+
 .. Substitutions definitions - AVOID EDITING PAST THIS LINE
    This will be automatically updated by the find_set_subst.py script.
    If you need to create a new substitution manually,
@@ -609,8 +610,6 @@ loading, processing tools...)
 .. |circularStringCurvePoint| image:: /static/common/mActionCircularStringCurvePoint.png
    :width: 1.5em
 .. |circularStringRadius| image:: /static/common/mActionCircularStringRadius.png
-   :width: 1.5em
-.. |composerManager| image:: /static/common/mActionComposerManager.png
    :width: 1.5em
 .. |customProjection| image:: /static/common/mActionCustomProjection.png
    :width: 1.5em
@@ -669,6 +668,8 @@ loading, processing tools...)
    :width: 1.5em
 .. |labeling| image:: /static/common/labelingSingle.png
    :width: 1.5em
+.. |layoutManager| image:: /static/common/mActionComposerManager.png
+   :width: 1.5em
 .. |management| image:: /static/common/management.png
    :width: 1.5em
 .. |mapTips| image:: /static/common/mActionMapTips.png
@@ -685,7 +686,7 @@ loading, processing tools...)
    :width: 1.5em
 .. |newBookmark| image:: /static/common/mActionNewBookmark.png
    :width: 1.5em
-.. |newComposer| image:: /static/common/mActionNewComposer.png
+.. |newLayout| image:: /static/common/mActionNewComposer.png
    :width: 1.5em
 .. |newMap| image:: /static/common/mActionNewMap.png
    :width: 1.5em

--- a/source/docs/user_manual/preamble/features.rst
+++ b/source/docs/user_manual/preamble/features.rst
@@ -47,7 +47,7 @@ friendly GUI. The many helpful tools available in the GUI include:
 *  QGIS browser
 *  On-the-fly reprojection
 *  DB Manager
-*  Map composer
+*  Print layout
 *  Overview panel
 *  Spatial bookmarks
 *  Annotation tools

--- a/source/docs/user_manual/print_composer/composer_items/composer_attribute_table.rst
+++ b/source/docs/user_manual/print_composer/composer_items/composer_attribute_table.rst
@@ -13,16 +13,16 @@ The Attribute Table Item
    .. contents::
       :local:
 
-It is possible to add parts of a vector attribute table to the Print Composer
+It is possible to add parts of a vector attribute table to the Print Layout
 canvas: Click the |openTable| :sup:`Add attribute table` icon, click and drag
-with the left mouse button on the Print Composer canvas to place and size the
+with the left mouse button on the Print Layout canvas to place and size the
 item. You can better position and customize its appearance in the
 :guilabel:`Item Properties` panel.
 
 The :guilabel:`Item properties` panel of an attribute table provides the
-following functionalities (see figure_composer_table_):
+following functionalities (see figure_layout_table_):
 
-.. _Figure_composer_table:
+.. _figure_layout_table:
 
 .. figure:: img/attribute_properties.png
    :align: center
@@ -34,9 +34,9 @@ Main properties
 ---------------
 
 The :guilabel:`Main properties` dialog of the attribute table provides the
-following functionalities (see figure_composer_table_ppt_):
+following functionalities (see figure_layout_table_ppt_):
 
-.. _Figure_composer_table_ppt:
+.. _figure_layout_table_ppt:
 
 .. figure:: img/attribute_mainproperties.png
    :align: center
@@ -50,10 +50,10 @@ following functionalities (see figure_composer_table_ppt_):
   the :guilabel:`Atlas generation` panel, there are two additional
   :guilabel:`Source` possible:
 
-  * **Current atlas feature** (see figure_composer_table_atlas_): you won't see
+  * **Current atlas feature** (see figure_layout_table_atlas_): you won't see
     any option to choose the layer, and the table item will only show a row with
     the attributes from the current feature of the atlas coverage layer.
-  * and **Relation children** (see figure_composer_table_relation_): an option
+  * and **Relation children** (see figure_layout_table_relation_): an option
     with the relation names will show up. This feature can only be used if you
     have defined a relation using your atlas coverage layer as parent, and the
     table will show the children rows of the atlas coverage layer's current
@@ -64,7 +64,7 @@ following functionalities (see figure_composer_table_ppt_):
   actual contents of the table has changed.
 
 
-.. _Figure_composer_table_atlas:
+.. _figure_layout_table_atlas:
 
 .. figure:: img/attribute_mainatlas.png
    :align: center
@@ -72,7 +72,7 @@ following functionalities (see figure_composer_table_ppt_):
    Attribute table Main properties for 'Current atlas feature'
 
 
-.. _Figure_composer_table_relation:
+.. _figure_layout_table_relation:
 
 .. figure:: img/attribute_mainrelation.png
    :align: center
@@ -81,12 +81,12 @@ following functionalities (see figure_composer_table_ppt_):
 
 
 * The button **[Attributes...]** starts the :guilabel:`Select attributes` menu,
-  see figure_composer_table_select_, that can be used to change the visible
+  see figure_layout_table_select_, that can be used to change the visible
   contents of the table. After making changes use the **[OK]** button to apply
   changes to the table. The upper part of the window shows the list of the
   attributes to display and the lower part helps to set the way the data is sorted.
 
-  .. _Figure_composer_table_select:
+  .. _figure_layout_table_select:
 
   .. figure:: img/attribute_select.png
      :align: center
@@ -129,9 +129,9 @@ Feature filtering
 -----------------
 
 The :guilabel:`Feature filtering` dialog of the attribute table provides
-the following functionalities (see figure_composer_table_filter_):
+the following functionalities (see figure_layout_table_filter_):
 
-.. _Figure_composer_table_filter:
+.. _figure_layout_table_filter:
 
 .. figure:: img/attribute_filter.png
    :align: center
@@ -143,8 +143,7 @@ You can:
 * Define the :guilabel:`Maximum rows` to be displayed.
 * Activate |checkbox| :guilabel:`Remove duplicate rows from table` to show unique records only.
 * Activate |checkbox| :guilabel:`Show only visible features within a map` and select the
-  corresponding :guilabel:`Composer map` to display the attributes of features only visible
-  on selected map.
+  corresponding :guilabel:`Linked map` whose visible features attributes will be displayed.
 * Activate |checkbox| :guilabel:`Show only features intersecting Atlas feature` is only
   available when |checkbox| :guilabel:`Generate an atlas` is activated. When activated it will
   show a table with only the features which intersect the current atlas feature.
@@ -165,9 +164,9 @@ Appearance
 ----------
 
 The :guilabel:`Appearance` dialog of the attribute table provides
-the following functionalities  (see figure_composer_table_appearance_):
+the following functionalities  (see figure_layout_table_appearance_):
 
-.. _Figure_composer_table_appearance:
+.. _figure_layout_table_appearance:
 
 .. figure:: img/attribute_appearance.png
    :align: center
@@ -194,9 +193,9 @@ the following functionalities  (see figure_composer_table_appearance_):
   the table in the first row, when the result is an empty table.
 * With :guilabel:`Background color` you can set the background color of the table.
   The :guilabel:`Advanced customization` option helps you define different background colors
-  for each cell (see figure_composer_table_background_)
+  for each cell (see figure_layout_table_background_)
 
-.. _Figure_composer_table_background:
+.. _figure_layout_table_background:
 
 .. figure:: img/attribute_background.png
    :align: center
@@ -213,9 +212,9 @@ Show grid
 ---------
 
 The :guilabel:`Show grid` dialog of the attribute table provides
-the following functionalities (see figure_composer_table_grid_):
+the following functionalities (see figure_layout_table_grid_):
 
-.. _Figure_composer_table_grid:
+.. _figure_layout_table_grid:
 
 .. figure:: img/attribute_grid.png
    :align: center
@@ -232,9 +231,9 @@ Fonts and text styling
 ----------------------
 
 The :guilabel:`Fonts and text styling` dialog of the attribute table
-provides the following functionalities (see figure_composer_table_fonts_):
+provides the following functionalities (see figure_layout_table_fonts_):
 
-.. _Figure_composer_table_fonts:
+.. _figure_layout_table_fonts:
 
 .. figure:: img/attribute_fonts.png
    :align: center
@@ -246,16 +245,16 @@ provides the following functionalities (see figure_composer_table_fonts_):
 * For :guilabel:`Table heading` you can additionally set the :guilabel:`Alignment`
   to `Follow column alignment` or override this setting by choosing `Left`,
   `Center` or `Right`. The column alignment is set using the :guilabel:`Select
-  Attributes` dialog (see Figure_composer_table_select_ ).
+  Attributes` dialog (see figure_layout_table_select_ ).
 
 
 Frames
 -------
 
 The :guilabel:`Frames` dialog of the attribute table provides
-the following functionalities (see figure_composer_table_frames_):
+the following functionalities (see figure_layout_table_frames_):
 
-.. _Figure_composer_table_frames:
+.. _figure_layout_table_frames:
 
 .. figure:: img/attribute_frame.png
    :align: center
@@ -279,7 +278,7 @@ the following functionalities (see figure_composer_table_frames_):
   will continue in the next frame when you use the Resize mode `Use existing frames`.
 * Activate |checkbox| :guilabel:`Don't export page if frame is empty` prevents
   the page to be exported when the table frame has no contents. This means all
-  other composer items, maps, scalebars, legends etc. will not be visible in the result.
+  other layout items, maps, scalebars, legends etc. will not be visible in the result.
 * Activate |checkbox| :guilabel:`Don't draw background if frame is empty`
   prevents the background to be drawn when the table frame has no contents.
 

--- a/source/docs/user_manual/print_composer/composer_items/composer_html_frame.rst
+++ b/source/docs/user_manual/print_composer/composer_items/composer_html_frame.rst
@@ -16,11 +16,11 @@ It is possible to add a frame that displays the contents of a website or even
 create and style your own HTML page and display it!
 
 Click the |addHtml| :sup:`Add HTML frame` icon, place the element by dragging a
-rectangle holding down the left mouse button on the Print Composer canvas and
+rectangle holding down the left mouse button on the Print Layout canvas and
 position and customize the appearance in the :guilabel:`Item Properties` panel
-(see figure_composer_html_).
+(see figure_layout_html_).
 
-.. _Figure_composer_html:
+.. _figure_layout_html:
 
 .. figure:: img/html_properties.png
    :align: center
@@ -36,9 +36,9 @@ enter the HTML source directly in the textbox provided and activate the Source
 radiobutton.
 
 The :guilabel:`HTML Source` dialog of the HTML frame :guilabel:`Item Properties`
-panel provides the following functionalities (see figure_composer_html_ppt_):
+panel provides the following functionalities (see figure_layout_html_ppt_):
 
-.. _Figure_composer_html_ppt:
+.. _figure_layout_html_ppt:
 
 .. figure:: img/html_source.png
    :align: center
@@ -68,9 +68,9 @@ Frames
 -------
 
 The :guilabel:`Frames` dialog of the HTML frame :guilabel:`Item Properties`
-panel provides the following functionalities (see figure_composer_html_frames_):
+panel provides the following functionalities (see figure_layout_html_frames_):
 
-.. _Figure_composer_html_frames:
+.. _figure_layout_html_frames:
 
 .. figure:: img/html_frame.png
    :align: center
@@ -96,7 +96,7 @@ panel provides the following functionalities (see figure_composer_html_frames_):
   :guilabel:`Use existing frames`.
 * Activate |checkbox| :guilabel:`Don't export page if frame is empty` prevents
   the map layout from being exported when the frame has no HTML contents. This
-  means all other composer items,
+  means all other layout items,
   maps, scalebars, legends etc. will not be visible in the result.
 * Activate |checkbox| :guilabel:`Don't draw background if frame is empty`
   prevents the HTML frame being drawn if the frame is empty.
@@ -107,9 +107,9 @@ Use smart page breaks and User style sheet
 
 The :guilabel:`Use smart page breaks` dialog and :guilabel:`Use style sheet`
 dialog of the HTML frame :guilabel:`Item Properties` panel provides the
-following functionalities (see figure_composer_html_breaks_):
+following functionalities (see figure_layout_html_breaks_):
 
-.. _Figure_composer_html_breaks:
+.. _figure_layout_html_breaks:
 
 .. figure:: img/html_breaks.png
    :align: center

--- a/source/docs/user_manual/print_composer/composer_items/composer_image.rst
+++ b/source/docs/user_manual/print_composer/composer_items/composer_image.rst
@@ -7,16 +7,16 @@
 The Image Item
 ===============
 
-To add an image, click the |addImage| :sup:`Add image` icon and drag a rectangle onto the Composer
-canvas with the left mouse button. You can then position and customize
-its appearance in the image :guilabel:`Item Properties` panel.
+To add an image, click the |addImage| :sup:`Add image` icon and drag a rectangle
+onto the layout canvas with the left mouse button. You can then position and
+customize its appearance in the image :guilabel:`Item Properties` panel.
 
 .. index:: Picture database, Rotated north arrow
 
 The image :guilabel:`Item Properties` tab provides the following functionalities
-(see figure_composer_image_):
+(see figure_layout_image_):
 
-.. _Figure_composer_image:
+.. _figure_layout_image:
 
 .. figure:: img/image_mainproperties.png
    :align: center
@@ -84,7 +84,7 @@ the selected map item.
 It is also possible to select a north arrow directly. If you first select a
 north arrow image from **Search directories** and then use the browse button
 |browseButton| of the field :guilabel:`Image source`, you can now select one of
-the north arrow from the list as displayed in figure_composer_image_north_.
+the north arrow from the list as displayed in figure_layout_image_north_.
 
 .. note::
 
@@ -92,7 +92,7 @@ the north arrow from the list as displayed in figure_composer_image_north_.
    done on purpose for languages that do not use an 'N' for North, so they can
    use another letter.
 
-.. _Figure_composer_image_north:
+.. _figure_layout_image_north:
 
 .. figure:: img/north_arrows.png
    :align: center

--- a/source/docs/user_manual/print_composer/composer_items/composer_items_options.rst
+++ b/source/docs/user_manual/print_composer/composer_items/composer_items_options.rst
@@ -2,21 +2,21 @@
 
    |updatedisclaimer|
 
-.. _composer_item_options:
+.. _layout_item_options:
 
-Composer Items Common Options
-=============================
+Layout Items Common Options
+===========================
 
 .. only:: html
 
    .. contents::
       :local:
 
-Composer items have a set of common properties you will find at the bottom of
+Layout items have a set of common properties you will find at the bottom of
 the :guilabel:`Item Properties` panel: Position and size, Rotation, Frame,
-Background, Item ID, Variables and Rendering (See figure_composer_common_).
+Background, Item ID, Variables and Rendering (See figure_layout_common_).
 
-.. _Figure_composer_common:
+.. _figure_layout_common:
 
 .. figure:: img/common_properties.png
    :align: center
@@ -36,7 +36,7 @@ Background, Item ID, Variables and Rendering (See figure_composer_common_).
   Click on the [Color...] button to display a dialog where you can pick a color
   or choose from a custom setting.
   Transparency can be adjusted through atlering the alpha field settings.
-* Use the :guilabel:`Item ID` to create a relationship to other Print Composer
+* Use the :guilabel:`Item ID` to create a relationship to other print layout
   items. This is used with QGIS server and other potential web clients. You can
   set an ID on an item (for example, a map or a label), and then the web client
   can send data to set a property (e.g., label text) for that specific item.
@@ -58,15 +58,15 @@ Background, Item ID, Variables and Rendering (See figure_composer_common_).
 
 
 .. index:: Rendering mode
-.. _Composer_Rendering_Mode:
+.. _layout_Rendering_Mode:
 
 Rendering mode
 --------------
 
-QGIS now allows advanced rendering for Composer items just like vector and
+QGIS allows advanced rendering for layout items just like vector and
 raster layers.
 
-.. _figure_composer_common_rendering:
+.. _figure_layout_common_rendering:
 
 .. figure:: img/rendering_mode.png
    :align: center
@@ -78,7 +78,7 @@ raster layers.
   your overlaying and underlaying items can be mixed according to the mode set
   (see :ref:`blend-modes` for description of each effect).
 * :guilabel:`Transparency` |slider|: You can make the underlying item in the
-  Composer visible with this tool.
+  layout visible with this tool.
   Use the slider to adapt the visibility of your item to your needs.
   You can also make a precise definition of the percentage of visibility in the
   menu beside the slider.
@@ -91,7 +91,7 @@ raster layers.
 Size and position
 -----------------
 
-Each item inside the Composer can be moved and resized to create a perfect
+Each item inside the print layout can be moved and resized to create a perfect
 layout.For both operations the first step is to activate the |select|
 :sup:`Select/Move item` tool and to click on the item; you can then move it
 using the mouse while holding the left button. If you need to constrain the
@@ -134,32 +134,32 @@ Alignment
 ---------
 
 Raising or lowering the visual hierarchy for elements are inside the |raiseItems|
-:sup:`Raise selected items` pull-down menu. Choose an element on the Print Composer
+:sup:`Raise selected items` pull-down menu. Choose an element on the print layout
 canvas and select the matching functionality to raise or lower the selected
 element compared to the other elements. This order is
 shown in the :menuselection:`Items` panel. You can also raise or lower objects
 in the :menuselection:`Items` panel by clicking and dragging an object's label
 in this list.
 
-.. _figure_composer_common_align:
+.. _figure_layout_common_align:
 
 .. figure:: img/alignment_lines.png
    :align: center
 
-   Alignment helper lines in the Print Composer
+   Alignment helper lines in the print layout
 
 There are several alignment options available within the |alignLeft|
-:sup:`Align selected items` pull-down menu (see figure_composer_common_align_).
+:sup:`Align selected items` pull-down menu (see figure_layout_common_align_).
 To use an alignment function, you first select the elements then click on the
 matching alignment icon. All selected elements will then be aligned to their
-common bounding box. When moving items on the Composer canvas, alignment helper
+common bounding box. When moving items on the layout canvas, alignment helper
 lines appear when borders, centers or corners are aligned.
 
 Variables
 ---------
 
 The :guilabel:`Variables` lists all the variables available at
-the composer item's level (which includes all global, project and
+the layout item's level (which includes all global, project and
 composition's variables). Map items also include Map settings variables that
 provide easy access to values like the map's scale, extent, and so on.
 

--- a/source/docs/user_manual/print_composer/composer_items/composer_items_shape.rst
+++ b/source/docs/user_manual/print_composer/composer_items/composer_items_shape.rst
@@ -11,7 +11,7 @@ Shape Items
       :local:
 
 .. index:: 
-   single: Composer Item; Arrow
+   single: Layout item; Arrow
 .. _arrow_item:
 
 The Arrow Item
@@ -19,19 +19,19 @@ The Arrow Item
 
 To add an arrow, click the |addArrow| :sup:`Add Arrow` icon, place the element
 holding down the left mouse button and drag a line to draw the arrow on the
-Print Composer canvas and position and customize the appearance in the scale bar
+print layout canvas and position and customize the appearance in the scale bar
 :guilabel:`Item Properties` panel.
 
 When you also hold down the :kbd:`Shift` key while placing the arrow, it is
 placed in an angle of exactly 45\ |degrees| .
 
 The arrow item can be used to add a line or a simple arrow that can be used,
-for example, to show the relation between other print composer items. To create
+for example, to show the relation between other print layout items. To create
 a north arrow, the image item should be considered first. QGIS has a set of
 North arrows in SVG format. Furthermore you can connect an image item with a map
 so it can rotate automatically with the map (see :ref:`image_item`).
 
-.. _figure_composer_arrow:
+.. _figure_layout_arrow:
 
 .. figure:: img/arrow_properties.png
    :align: center
@@ -74,7 +74,7 @@ QGIS predefined SVG images can be changed using the corresponding options. Custo
 SVG may require some tags following this :ref:`instruction <parameterized_svg>`.
 
 .. index:: 
-   single: Composer Item; Basic shape
+   single: Layout item; Basic shape
 .. _basic_shape_item:
 
 The Basic Shape Items
@@ -87,7 +87,7 @@ Customize the appearance in the :guilabel:`Item Properties` panel.
 When you also hold down the :kbd:`Shift` key while placing the basic shape
 you can create a perfect square, circle or triangle.
 
-.. _figure_composer_basic_shape:
+.. _figure_layout_basic_shape:
 
 .. figure:: img/shape_properties.png
    :align: center
@@ -108,7 +108,7 @@ the corners.
    the frame.
 
 .. index:: 
-   single: Composer Item; Node-based shape
+   single: Layout item; Node-based shape
 .. _node_based_shape_item:
 
 The Node-Based Shape Items
@@ -125,7 +125,7 @@ add nodes to your current shape. When you're done, a simple right click
 terminates the shape. Customize the appearance in the :guilabel:`Item Properties`
 panel.
 
-.. _figure_composer_nodes_shape:
+.. _figure_layout_nodes_shape:
 
 .. figure:: img/shape_nodes_properties.png
    :align: center

--- a/source/docs/user_manual/print_composer/composer_items/composer_label.rst
+++ b/source/docs/user_manual/print_composer/composer_items/composer_label.rst
@@ -11,13 +11,13 @@ The Label Item
       :local:
 
 To add a label, click the |label| :sup:`Add label` icon, place the element
-with the left mouse button on the Print Composer canvas and position and
+with the left mouse button on the print layout canvas and position and
 customize its appearance in the label :guilabel:`Item Properties` panel.
 
 The :guilabel:`Item Properties` panel of a label item provides the following
-functionality for the label item (see Figure_composer_label_):
+functionality for the label item (see figure_layout_label_):
 
-.. _Figure_composer_label:
+.. _figure_layout_label:
 
 .. figure:: img/label_mainproperties.png
    :align: center
@@ -28,7 +28,7 @@ Main properties
 ----------------
 
 * The main properties dialog is where the text (HTML or not) or the expression
-  needed to fill the label is added to the Composer canvas.
+  needed to fill the label is added to the layout canvas.
 * Labels can be interpreted as HTML code: check |checkbox|
   :guilabel:`Render as HTML`. You can now insert a URL, a clickable image that
   links to a web page or something more complex.
@@ -44,7 +44,7 @@ Appearance
 * Define :guilabel:`Font` by clicking on the **[Font...]** button or a
   :guilabel:`Font color` selecting a color using the color selection tool.
 * You can specify different horizontal and vertical margins in ``mm``. This is
-  the margin from the edge of the composer item. The label can be positioned
+  the margin from the edge of the layout item. The label can be positioned
   outside the bounds of the label e.g. to align label items with other items.
   In this case you have to use negative values for the margin.
 * Using the :guilabel:`Alignment` is another way to position your label. Note

--- a/source/docs/user_manual/print_composer/composer_items/composer_legend.rst
+++ b/source/docs/user_manual/print_composer/composer_items/composer_legend.rst
@@ -2,7 +2,7 @@
 
    |updatedisclaimer|
 
-.. index:: Legend composer, Map legend
+.. index:: Legend item, Map legend
 
 The Legend Item
 ================
@@ -13,14 +13,14 @@ The Legend Item
       :local:
 
 To add a map legend, click the |addLegend| :sup:`Add new legend` icon,
-place the element with the left mouse button on the Print Composer canvas and
+place the element with the left mouse button on the print layout canvas and
 position and customize the appearance in the legend :guilabel:`Item Properties`
 panel.
 
 The :guilabel:`Item properties` panel of a legend item provides the following
-functionalities (see figure_composer_legend_):
+functionalities (see figure_layout_legend_):
 
-.. _Figure_composer_legend:
+.. _figure_layout_legend:
 
 .. figure:: img/legend_properties.png
    :align: center
@@ -31,9 +31,9 @@ Main properties
 ---------------
 
 The :guilabel:`Main properties` dialog of the legend :guilabel:`Item Properties`
-panel provides the following functionalities (see figure_composer_legend_ppt_):
+panel provides the following functionalities (see figure_layout_legend_ppt_):
 
-.. _Figure_composer_legend_ppt:
+.. _figure_layout_legend_ppt:
 
 .. figure:: img/legend_mainproperties.png
    :align: center
@@ -57,9 +57,9 @@ Legend items
 ------------
 
 The :guilabel:`Legend items` dialog of the legend :guilabel:`Item Properties`
-panel provides the following functionalities (see figure_composer_legend_items_):
+panel provides the following functionalities (see figure_layout_legend_items_):
 
-.. _Figure_composer_legend_items:
+.. _figure_layout_legend_items:
 
 .. figure:: img/legend_items.png
    :align: center
@@ -92,7 +92,7 @@ panel provides the following functionalities (see figure_composer_legend_items_)
     that has different legend items (e.g., from a rule-based or categorized
     symbology), you can specify a boolean expression to remove from the legend
     tree, styles that have no feature satisfying a condition. Note that the
-    features are nevertheless kept and shown in the composer map item.
+    features are nevertheless kept and shown in the layout map item.
 
   While the default behavior of the legend item is to mimic the
   :guilabel:`Layers panel` tree, displaying the same groups, layers and classes
@@ -102,8 +102,8 @@ panel provides the following functionalities (see figure_composer_legend_items_)
   contextual menu.
 
   After changing the symbology in the QGIS main window, you can click on
-  **[Update All]** to adapt the changes in the legend element of the Print
-  Composer.
+  **[Update All]** to adapt the changes in the legend element of the print
+  layout.
 
 * While generating an atlas with polygon features, you can filter out legend
   items that lie outside the current atlas feature. To do that, check the
@@ -116,9 +116,9 @@ Fonts, Columns, Symbol
 
 The :guilabel:`Fonts`, :guilabel:`Columns` and :guilabel:`Symbol` dialogs of the
 legend :guilabel:`Item Properties` panel provide the following functionalities
-(see figure_composer_legend_fonts_):
+(see figure_layout_legend_fonts_):
 
-.. _Figure_composer_legend_fonts:
+.. _figure_layout_legend_fonts:
 
 .. figure:: img/legend_fonts.png
    :align: center
@@ -147,16 +147,16 @@ WMS LegendGraphic and Spacing
 
 The :guilabel:`WMS LegendGraphic` and :guilabel:`Spacing` dialogs of the legend
 :guilabel:`Item Properties` panel provide the following functionalities (see
-figure_composer_legend_wms_):
+figure_layout_legend_wms_):
 
-.. _Figure_composer_legend_wms:
+.. _figure_layout_legend_wms:
 
 .. figure:: img/legend_wms.png
    :align: center
 
    WMS LegendGraphic and Spacing Dialogs
 
-When you have added a WMS layer and you insert a legend composer item, a request
+When you have added a WMS layer and you insert a legend item, a request
 will be sent to the WMS server to provide a WMS legend. This Legend will only be
 shown if the WMS server provides the GetLegendGraphic capability.
 The WMS legend content will be provided as a raster image.

--- a/source/docs/user_manual/print_composer/composer_items/composer_map.rst
+++ b/source/docs/user_manual/print_composer/composer_items/composer_map.rst
@@ -2,7 +2,7 @@
 
    |updatedisclaimer|
 
-.. index:: composer map
+.. index:: Map item
 
 The Map Item
 =============
@@ -12,8 +12,8 @@ The Map Item
    .. contents::
       :local:
 
-Click on the |addMap| :sup:`Add new map` toolbar button in the Print Composer
-toolbar to add the QGIS map canvas. Now, drag a rectangle onto the Composer
+Click on the |addMap| :sup:`Add new map` toolbar button in the print layout
+toolbar to add the QGIS map canvas. Now, drag a rectangle onto the layout
 canvas with the left mouse button to add the map. To display the current map, you
 can choose between three different modes in the map :guilabel:`Item Properties`
 panel:
@@ -21,24 +21,24 @@ panel:
 * **Rectangle** is the default setting. It only displays an empty box with a
   message 'Map will be printed here'.
 * **Cache** renders the map in the current screen resolution. If you zoom the
-  Composer window in or out, the map is not rendered again but the image will
+  layout window in or out, the map is not rendered again but the image will
   be scaled.
-* **Render** means that if you zoom the Composer window in or out, the map will
+* **Render** means that if you zoom the layout window in or out, the map will
   be rendered again, but for space reasons, only up to a maximum resolution.
 
-**Cache** is the default preview mode for newly added Print Composer maps.
+**Cache** is the default preview mode for newly added print layout maps.
 
 You can resize the map item by clicking on the |select| :sup:`Select/Move item`
 button, selecting the element, and dragging one of the blue handles in the
 corner of the map.  This button also helps to move the map to another place.
 Select the item and while holding the left mouse button, move to the new place
 and release the mouse button. After you have found the right place for an item,
-you can lock the item position within the Print Composer canvas. Select the
+you can lock the item position within the print layout canvas. Select the
 map item and use the toolbar |locked| :sup:`Lock Selected Items` or the
 :menuselection:`Items` panel to Lock the item. A locked item can only be selected
 using the :menuselection:`Items` panel. Once selected you can use the
 :menuselection:`Items` panel to unlock individual items. The |unlocked|
-:sup:`Unlock All Items` icon will unlock all locked composer items. With the
+:sup:`Unlock All Items` icon will unlock all locked layout items. With the
 map selected, you can now adapt more properties in the map
 :guilabel:`Item Properties` panel.
 
@@ -46,15 +46,15 @@ To move layers within the map element, select the map element, click the
 |moveItemContent| :sup:`Move item content` icon and move the layers within
 the map item frame with the left mouse button.
 
-.. _`composer_main_properties`:
+.. _`layout_main_properties`:
 
 Main properties
 ---------------
 
 The :guilabel:`Main properties` dialog of the map :guilabel:`Item Properties`
-panel provides the following functionalities (see figure_composer_map_):
+panel provides the following functionalities (see figure_layout_map_):
 
-.. _Figure_composer_map:
+.. _figure_layout_map:
 
 .. figure:: img/map_mainproperties.png
    :align: center
@@ -64,7 +64,7 @@ panel provides the following functionalities (see figure_composer_map_):
 * The **Preview** drop-down menu allows you to select one of the preview modes
   'Rectangle', 'Cache' and 'Render', as described above. If you change the
   view on the QGIS map canvas by changing vector or raster properties, you can
-  update the Print Composer view by selecting the map element and clicking
+  update the print layout view by selecting the map element and clicking
   the **[Update preview]** button.
 * The field :guilabel:`Scale` |selectNumber| manually sets the map item scale.
 * The field :guilabel:`Map rotation` |selectNumber| allows you to rotate the
@@ -77,9 +77,9 @@ Layers
 ------
 
 The :guilabel:`Layers` dialog of the map item panel provides the following
-functionality (see figure_composer_map_layers_):
+functionality (see figure_layout_map_layers_):
 
-.. _Figure_composer_map_layers:
+.. _figure_layout_map_layers:
 
 .. figure:: img/map_layers.png
    :align: center
@@ -98,7 +98,7 @@ style (symbology, labels, diagrams) of the layers.
 To lock the layers shown in a map item to the current map canvas check
 |checkbox| :guilabel:`Lock layers`. After this option is enabled, any
 changes on the layers' visibility in QGIS' main window won't affect
-the Composer's map item. Nevertheless, style and labels of locked
+the layout's map item. Nevertheless, style and labels of locked
 layers are still refreshed according to QGIS' main window.
 You can prevent this by using :guilabel:`Lock styles for layers`.
 
@@ -109,7 +109,7 @@ Select the theme you want to display. The map canvas will lock the
 theme layers automatically by enabling the |checkbox| :guilabel:`Lock
 layers`. You can release the theme by unchecking the |checkbox|
 :guilabel:`Lock layers` and press the |draw| button in the
-map composer's :guilabel:`Navigation` toolbar.
+print layout's :guilabel:`Navigation` toolbar.
 
 Note that, unlike the :guilabel:`Follow map theme`, using the
 :guilabel:`Lock layers` option enabled and set to a theme, the map item
@@ -130,9 +130,9 @@ Extents
 -------
 
 The :guilabel:`Extents` dialog of the map item panel provides the following
-functionalities (see figure_composer_map_extents_):
+functionalities (see figure_layout_map_extents_):
 
-.. _Figure_composer_map_extents:
+.. _figure_layout_map_extents:
 
 .. figure:: img/map_extents.png
    :align: center
@@ -141,16 +141,16 @@ functionalities (see figure_composer_map_extents_):
 
 The **Map extents** area allows you to specify the map extent using ``X`` and
 ``Y`` min/max values and by clicking the **[Set to map canvas extent]** button.
-This button sets the map extent of the composer map item to the extent of the
+This button sets the map extent of the layout map item to the extent of the
 current map view in the main QGIS application.
 The button **[View extent in map canvas]** does exactly the opposite; it
 updates the extent of the map view in the QGIS application to the extent
-of the composer map item.
+of the layout map item.
 
 If you change the view on the QGIS map canvas by changing
-vector or raster properties, you can update the Print Composer view by selecting
-the map element in the Print Composer and clicking the **[Update preview]**
-button in the map :guilabel:`Item Properties` panel (see figure_composer_map_).
+vector or raster properties, you can update the print layout view by selecting
+the map element in the print layout and clicking the **[Update preview]**
+button in the map :guilabel:`Item Properties` panel (see figure_layout_map_).
 
 .. index:: Grids, Map grid
 
@@ -167,7 +167,7 @@ provides the possibility to add several grids to a map item.
 
 When you double-click the added grid you can give it another name.
 
-.. _Figure_composer_map_grid:
+.. _Figure_layout_map_grid:
 
 .. figure:: img/map_grids.png
    :align: center
@@ -176,9 +176,9 @@ When you double-click the added grid you can give it another name.
 
 After you have added a grid, you can activate the checkbox |checkbox|
 :guilabel:`Draw grid` to overlay a grid onto the map element. Expand this option
-to provide a lot of configuration options, see Figure_composer_map_grid_draw_.
+to provide a lot of configuration options, see Figure_layout_map_grid_draw_.
 
-.. _Figure_composer_map_grid_draw:
+.. _Figure_layout_map_grid_draw:
 
 .. figure:: img/map_draw_grid.png
    :align: center
@@ -190,11 +190,11 @@ annotations only'.
 'Frame and annotations only' is especially useful when working with rotated maps
 or reprojected grids. In the divisions section of the Grid Frame Dialog mentioned
 below you then have a corresponding setting. Symbology of the grid and its
-rendering mode can be chosen. See :ref:`Composer_Rendering_Mode`. Furthermore,
+rendering mode can be chosen. See :ref:`layout_Rendering_Mode`. Furthermore,
 you can define an interval in the X and Y directions, an X and Y offset,
 and the width used for the cross or line grid type.
 
-.. _Figure_composer_map_frame:
+.. _Figure_layout_map_frame:
 
 .. figure:: img/map_grid_frame.png
    :align: center
@@ -224,7 +224,7 @@ and the width used for the cross or line grid type.
   color, the annotation distance from the map frame and the precision of the
   drawn coordinates.
 
-.. _Figure_composer_map_coord:
+.. _figure_layout_map_coord:
 
 .. figure:: img/map_grid_draw_coordinates.png
    :align: center
@@ -238,7 +238,7 @@ Overviews
 The :guilabel:`Overviews` dialog of the map :guilabel:`Item Properties` panel
 provides the following functionalities:
 
-.. _Figure_composer_map_overview:
+.. _figure_layout_map_overview:
 
 .. figure:: img/map_overview.png
    :align: center
@@ -246,13 +246,13 @@ provides the following functionalities:
    Map Overviews Dialog
 
 You can choose to create an overview map, which shows the extents of the other
-map(s) that are available in the composer. First you need to create the map(s)
+map(s) that are available in the layout. First you need to create the map(s)
 you want to include in the overview map and the map you want to use as the
 overview map, just like a normal map.
 
 Then expand :guilabel:`Overviews` option and press the green plus icon-button to
 add an overview.
-Initially this overview is named 'Overview 1' (see Figure_composer_map_overview_).
+Initially this overview is named 'Overview 1' (see Figure_layout_map_overview_).
 You can change the name when you double-click on the overview item in the list
 named 'Overview 1' and change it to another name.
 

--- a/source/docs/user_manual/print_composer/composer_items/composer_scale_bar.rst
+++ b/source/docs/user_manual/print_composer/composer_items/composer_scale_bar.rst
@@ -14,13 +14,13 @@ The Scale Bar Item
       :local:
 
 To add a scale bar, click the |scaleBar| :sup:`Add new scalebar` icon, place
-the element with the left mouse button on the Print Composer canvas and position
+the element with the left mouse button on the print layout canvas and position
 and customize the appearance in the scale bar :guilabel:`Item Properties` panel.
 
 The :guilabel:`Item properties` of a scale bar item tab provides the following
-functionalities (see figure_composer_scalebar_):
+functionalities (see figure_layout_scalebar_):
 
-.. _Figure_composer_scalebar:
+.. _figure_layout_scalebar:
 
 .. figure:: img/scalebar_properties.png
    :align: center
@@ -32,9 +32,9 @@ Main properties
 
 The :guilabel:`Main properties` dialog of the scale bar
 :guilabel:`Item Properties` panel provides the following functionalities
-(see figure_composer_scalebar_ppt_):
+(see figure_layout_scalebar_ppt_):
 
-.. _Figure_composer_scalebar_ppt:
+.. _figure_layout_scalebar_ppt:
 
 .. figure:: img/scalebar_mainproperties.png
    :align: center
@@ -54,9 +54,9 @@ Units and Segments
 
 The :guilabel:`Units` and :guilabel:`Segments` dialogs of the scale bar
 :guilabel:`Item Properties` panel provide the following functionalities
-(see figure_composer_scalebar_units_):
+(see figure_layout_scalebar_units_):
 
-.. _Figure_composer_scalebar_units:
+.. _figure_layout_scalebar_units:
 
 .. figure:: img/scalebar_units.png
    :align: center
@@ -87,9 +87,9 @@ Display
 
 The :guilabel:`Display` dialog of the scale bar :guilabel:`Item Properties`
 panel provides the following functionalities (see
-figure_composer_scalebar_display_):
+figure_layout_scalebar_display_):
 
-.. _Figure_composer_scalebar_display:
+.. _figure_layout_scalebar_display:
 
 .. figure:: img/scalebar_display.png
    :align: center
@@ -113,9 +113,9 @@ Fonts and colors
 
 The :guilabel:`Fonts and colors` dialog of the scale bar
 :guilabel:`Item Properties` panel provides the following functionalities
-(see figure_composer_scalebar_fonts_):
+(see figure_layout_scalebar_fonts_):
 
-.. _Figure_composer_scalebar_fonts:
+.. _figure_layout_scalebar_fonts:
 
 .. figure:: img/scalebar_fonts.png
    :align: center

--- a/source/docs/user_manual/print_composer/composer_items/index.rst
+++ b/source/docs/user_manual/print_composer/composer_items/index.rst
@@ -3,12 +3,12 @@
    |updatedisclaimer|
 
 
-.. index:: Composer items, Create maps, Layout maps, Compose maps
-.. _composer_items:
+.. index:: Layout items, Create maps, Layout maps, Compose maps
+.. _layout_items:
 
 
-Composer Items
-==============
+Layout Items
+============
 
 .. toctree::
    :maxdepth: 1

--- a/source/docs/user_manual/print_composer/create_output.rst
+++ b/source/docs/user_manual/print_composer/create_output.rst
@@ -16,15 +16,15 @@
    .. contents::
       :local:
 
-Figure_composer_output_ shows the Print Composer with an example print layout,
+figure_layout_output_ shows the print layout with an example print layout,
 including each type of map item described in the previous section.
 
-.. _figure_composer_output:
+.. _figure_layout_output:
 
 .. figure:: img/print_composer_complete.png
    :align: center
 
-   Print Composer with map view, legend, image, scale bar, coordinates, text and
+   Print Layout with map view, legend, image, scale bar, coordinates, text and
    HTML frame added
 
 .. index:: Export as image, Export as PDF, Export as SVG
@@ -34,16 +34,16 @@ without bounding boxes. This can be enabled by deactivating :menuselection:`View
 |checkbox| :guilabel:`Show bounding boxes` or pressing the shortcut
 :kbd:`Ctrl+Shift+B`.
 
-The Print Composer allows you to create several output formats, and it is
+The print layout allows you to create several output formats, and it is
 possible to define the resolution (print quality) and paper size:
 
 * The |filePrint| :sup:`Print` icon allows you to print the layout to a
   connected printer or a PostScript file, depending on installed printer drivers.
-* The |saveMapAsImage| :sup:`Export as image` icon exports the Composer
+* The |saveMapAsImage| :sup:`Export as image` icon exports the layout
   canvas in several image formats, such as PNG, BPM, TIF, JPG,...
-* The |saveAsSVG| :sup:`Export as SVG` icon saves the Print Composer canvas
+* The |saveAsSVG| :sup:`Export as SVG` icon saves the print layout canvas
   as an SVG (Scalable Vector Graphic).
-* The |saveAsPDF| :sup:`Export as PDF` icon saves the defined Print Composer
+* The |saveAsPDF| :sup:`Export as PDF` icon saves the defined print layout
   canvas directly as a PDF.
 
 .. _export_layout_image:
@@ -63,7 +63,7 @@ You can then override the print resolution and the exported image dimensions
 .. _crop_to_content:
 
 By checking |checkbox| :guilabel:`Crop to content` option, the image output
-by the composer includes the minimal area enclosing all the items (map,
+by the layout includes the minimal area enclosing all the items (map,
 legend, scale bar, shapes, label, image...) of each page of the composition:
 
 * If the composition includes a single page, then the output is resized to
@@ -77,7 +77,7 @@ legend, scale bar, shapes, label, image...) of each page of the composition:
 The :guilabel:`Crop to content` dialog also allows to add some margins around
 the cropped bounds.
 
-.. _figure_composer_output_image:
+.. _figure_layout_output_image:
 
 .. figure:: img/image_export_options.png
    :align: center
@@ -86,7 +86,7 @@ the cropped bounds.
 
 If you need to export your layout as a **georeferenced image** (e.g., to share
 with other projects), you need to enable this feature under the
-:ref:`composer_composition_tab`.
+:ref:`layout_composition_tab`.
 
 If the output format is a TIFF format, all you need to do is making sure to
 select the correct map item to use in |selectString|
@@ -115,7 +115,7 @@ The SVG export options dialog also allows to:
 * :guilabel:`export map layers as svg groups`:
 * render map labels as outlines
 
-.. _figure_composer_output_svg:
+.. _figure_layout_output_svg:
 
 .. figure:: img/svg_export_options.png
    :align: center
@@ -139,13 +139,13 @@ single PDF file.
 If you applied to your composition or any shown layer an advanced effect such as
 blend modes, transparency or symbol effects, these cannot be printed
 as vectors, and the effects may be lost. Checking :guilabel:`Print as a
-raster` in the :ref:`composer_composition_tab` helps to keep the effects but
+raster` in the :ref:`layout_composition_tab` helps to keep the effects but
 rasterize the composition. Note that the :guilabel:`Force layer to render as
 raster` in the Rendering tab of Layer Properties dialog is a layer-level
 alternative that avoids global composition rasterization.
 
 If you need to export your layout as a **georeferenced PDF**, in the
-:ref:`composer_composition_tab`, make sure to select the correct map item to
+:ref:`layout_composition_tab`, make sure to select the correct map item to
 use in |selectString| :guilabel:`Reference map`.
 
 
@@ -156,7 +156,7 @@ use in |selectString| :guilabel:`Reference map`.
 Generate an Atlas
 =================
 
-The Print Composer includes generation functions that allow you to create map
+The print layout includes generation functions that allow you to create map
 books in an automated way. The concept is to use a coverage layer, which contains
 geometries and fields. For each geometry in the coverage layer, a new output will
 be generated where the content of some canvas maps will be moved to highlight the
@@ -165,9 +165,9 @@ labels.
 
 Every page will be generated with each feature. To enable the generation
 of an atlas and access generation parameters, refer to the `Atlas generation`
-panel.This panel contains the following widgets (see figure_composer_atlas_):
+panel.This panel contains the following widgets (see figure_layout_atlas_):
 
-.. _figure_composer_atlas:
+.. _figure_layout_atlas:
 
 .. figure:: img/atlas_properties.png
    :align: center
@@ -285,7 +285,7 @@ opens. Enter the following expression:
    THEN 'Landscape' ELSE 'Portrait' END
 
 Now the paper orients itself automatically. For each Region you need to
-reposition the location of the composer item as well. For the map item you can
+reposition the location of the layout item as well. For the map item you can
 use the |dataDefined| button of field :guilabel:`Width` to set it
 dynamically using following expression:
 
@@ -313,7 +313,7 @@ You can provide the following expression for field :guilabel:`X` :
    (CASE WHEN bounds_width($atlasgeometry) > bounds_height($atlasgeometry)
    THEN 297 ELSE 210 END) / 2
 
-For all other composer items you can set the position in a similar way so they
+For all other layout items you can set the position in a similar way so they
 are correctly positioned when the page is automatically rotated in portrait or
 landscape.
 
@@ -327,14 +327,14 @@ This is just one example of how you can use the Data Defined Override option.
 Preview and generate
 --------------------
 
-.. _figure_composer_atlas_preview:
+.. _figure_layout_atlas_preview:
 
 .. figure:: img/atlas_preview.png
    :align: center
 
    Atlas Preview toolbar
 
-Once the atlas settings have been configured and composer items (map, table,
+Once the atlas settings have been configured and layout items (map, table,
 image...) linked to it, you can create a preview of all the pages by clicking
 :menuselection:`Atlas --> Preview Atlas` or |atlas| :sup:`Preview Atlas` icon.
 You can then use the arrows in the same toolbar to navigate through all the
@@ -351,7 +351,7 @@ atlas :guilabel:`Page name` option.
 
 
 As for simple compositions, an atlas can be generated in different ways (see
-:ref:`create-output` for more information). Instead of :menuselection:`Composer`
+:ref:`create-output` for more information). Instead of :menuselection:`Layout`
 menu, rather use tools from :menuselection:`Atlas` menu or Atlas toolbar.
 
 This means that you can directly print your compositions with :menuselection:`Atlas --> Print Atlas`.
@@ -370,7 +370,7 @@ an image or SVG file.
 
   If you want to print or export the composition of only one feature of the atlas,
   simply start the preview, select the desired feature in the drop-down list
-  and click on :menuselection:`Composer --> Print` (or :menuselection:`export...`
+  and click on :menuselection:`Layout --> Print` (or :menuselection:`Export...`
   to any supported file format).
 
 

--- a/source/docs/user_manual/print_composer/index.rst
+++ b/source/docs/user_manual/print_composer/index.rst
@@ -3,14 +3,14 @@
    |updatedisclaimer|
 
 .. index:: Create maps, Map layout, Output map
-.. _label_printcomposer:
+.. _label_printlayout:
 
-**************
-Print Composer
-**************
+*******************
+Laying out the maps
+*******************
 
-With the Print Composer you can create nice maps and atlasses that can be printed
-or saved as PDF-file, an image or an SVG-file. This is a powerful way to share
+With the Map Layout you can create nice maps and atlasses that can be printed
+or saved as image, PDF or SVG file. This is a powerful way to share
 geographical information produced with QGIS that can be included in reports or published.
 
 

--- a/source/docs/user_manual/print_composer/overview_composer.rst
+++ b/source/docs/user_manual/print_composer/overview_composer.rst
@@ -2,18 +2,18 @@
 
    |updatedisclaimer|
 
-.. _overview_composer:
+.. _overview_layout:
 
-********************************
- Overview of the Print Composer
-********************************
+******************************
+ Overview of the Print Layout
+******************************
 
 .. only:: html
 
    .. contents::
       :local:
 
-The Print Composer provides growing layout and printing capabilities. It allows
+The print layout provides growing layout and printing capabilities. It allows
 you to add elements such as the QGIS map canvas, text labels, images, legends,
 scale bars, basic shapes, arrows, attribute tables and HTML frames. You can size,
 group, align, position and rotate each element and adjust their properties to
@@ -25,17 +25,17 @@ Finally, generating several maps based on a template can be done through the
 atlas generator.
 
 
-.. index:: Composer template, Map template
+.. index:: Layout template, Map template
 
 Sample Session
 ==============
 
-Before you start to work with the Print Composer, you need to load some raster
+Before you start to work with the print layout, you need to load some raster
 or vector layers in the QGIS map canvas and adapt their properties to suit your
 own convenience. After everything is rendered and symbolized to your liking,
-click the |newComposer| :sup:`New Print Composer` icon in the toolbar or
-choose :menuselection:`File --> New Print Composer`. You will be prompted to
-choose a title for the new Composer.
+click the |newLayout| :sup:`New Print Layout` icon in the toolbar or
+choose :menuselection:`File --> New Print Layout`. You will be prompted to
+choose a title for the new layout.
 
 
 To demonstrate how to create a map please follow the next instructions.
@@ -44,7 +44,7 @@ To demonstrate how to create a map please follow the next instructions.
    and draw a rectangle on the canvas holding down the left mouse button.
    Inside the drawn rectangle the QGIS map view to the canvas.
 #. Select the |scaleBar| :sup:`Add new scalebar` toolbar button and click
-   with the left mouse button on the Print Composer canvas. A scalebar will be
+   with the left mouse button on the print layout canvas. A scalebar will be
    added to the canvas.
 #. Select the |addLegend| :sup:`Add new legend` toolbar button and draw a
    rectangle on the canvas holding down the left mouse button.
@@ -59,89 +59,89 @@ To demonstrate how to create a map please follow the next instructions.
    the setting for the orientation. Change the value of the setting
    :guilabel:`Map orientation` to '15.00\ |degrees| '. You should see the
    orientation of the map item change.
-#. Now, you can print or export your print composition to image formats, PDF or
-   to SVG with the export tools in Composer menu.
-#. Finally, you can save your print composition within the project file with the
+#. Now, you can print or export your print layout to image formats, PDF or
+   to SVG with the export tools in :menuselection:`Layout` menu.
+#. Finally, you can save your print layout within the project file with the
    |fileSave| :sup:`Save Project` button.
 
 
-You can add multiple elements to the Composer. It is also possible to have more
-than one map view or legend or scale bar in the Print Composer canvas, on one or
+You can add multiple elements to the print layout. It is also possible to have more
+than one map view or legend or scale bar in the print layout canvas, on one or
 several pages. Each element has its own properties and, in the case of the map,
-its own extent. If you want to remove any elements from the Composer canvas you
+its own extent. If you want to remove any elements from the layout canvas you
 can do that with the :kbd:`Delete` or the :kbd:`Backspace` key.
 
 
-.. index:: Composer manager
-.. _composer_manager:
+.. index:: Layout manager
+.. _layout_manager:
 
-The Composer Manager
+The Layout Manager
 ====================
 
-The Composer Manager is the main window to manage print composers in the project.
-It helps you add new print composer, duplicate an existing one, rename or delete
-it. To open the composer manager dialog, click on the |composerManager|
-:sup:`Composer Manager` button in the toolbar or choose :menuselection:`Composer
---> Composer Manager`. It can also be reached from the main window of QGIS with
-:menuselection:`Project --> Composer Manager`.
+The :guilabel:`Layout Manager` is the main window to manage print layouts in the project.
+It helps you add new print layout, duplicate an existing one, rename or delete
+it. To open the layout manager dialog, click on the |layoutManager|
+:sup:`Layout Manager` button in the toolbar or choose :menuselection:`Layout
+--> Layout Manager`. It can also be reached from the main window of QGIS with
+:menuselection:`Project --> Layout Manager...`.
 
 
-.. _figure_composer_manager:
+.. _figure_layout_manager:
 
 .. figure:: img/print_composer_manager.png
    :align: center
 
-   The Print Composer Manager
+   The Print Layout Manager
 
 
-The composer manager lists in its upper part all the available print composers
+The layout manager lists in its upper part all the available print layouts
 in the project. The bottom part shows tools that help to:
 
-* show the selected composer(s): you can open multiple print composers in
+* show the selected print layout(s): you can open multiple print layouts in
   one-click
-* duplicate the selected composer (available only if one print composer is
-  selected): it creates a new composer using the selected composer as template.
-  You'll be prompted to choose a new title for the new composer
-* rename the composer (also available only if one print composer is selected):
-  You'll be prompted to choose a new title for the composer. Note that you can
-  also rename the composer by double-clicking on its title in the upper part
-* remove the composer: the selected print composer(s) will be deleted from the
+* duplicate the selected print layout (available only if one print layout is
+  selected): it creates a new layout using the selected one as template.
+  You'll be prompted to choose a new title for the new layout
+* rename the layout (available only if one print layout is selected):
+  You'll be prompted to choose a new title for the layout. Note that you can
+  also rename the print layout by double-clicking on its title in the upper part
+* remove the layout: the selected print layout(s) will be deleted from the
   project.
 
-With the Composer Manager, it's also possible to create new print composers as
-an empty composer or from a saved template. By default, QGIS will look for
-templates in user directory (:file:`~/.qgis2/composer_templates`) or
+With the layout manager, it's also possible to create new print layouts as
+an empty layout or from a saved template. By default, QGIS will look for
+templates in user profile folder (:file:`~/.qgis2/composer_templates`) or
 application's one (:file:`ApplicationFolder/composer_templates`).
 QGIS will retrieve all the available templates and propose them in the combobox.
-The selected template will be used to create a new composer when clicking
+The selected template will be used to create a new print layout when clicking
 :guilabel:`Add` button.
-You can also save composer templates in another folder.
+You can also save layout templates in another folder.
 Choosing *specific* in the template list offers the ability to select such
-template and use it to create a new print composer.
+template and use it to create a new print layout.
 
 .. _print_composer_menus:
 
-Menus, tools and panels of the print composer
+Menus, tools and panels of the print layout
 =============================================
 
-Opening the Print Composer provides you with a blank canvas that represents the
+Opening the print layout provides you with a blank canvas that represents the
 paper surface when using the print option. Initially you find buttons on the
-left beside the canvas to add map composer items: the current QGIS map canvas,
+left beside the canvas to add print layout items: the current QGIS map canvas,
 text labels, images, legends, scale bars, basic shapes, arrows, attribute tables
-and HTML frames. In this toolbar you also find toolbar buttons to navigate,
-zoom in on an area and pan the view on the composer and toolbar buttons to
-select a map composer item and to move the contents of the map item.
+and HTML frames. In this toolbar you also find buttons to navigate,
+zoom in on an area and pan the view on the layout a well as buttons to
+select any layout item and to move the contents of the map item.
 
 
-Figure_composer_overview_ shows the initial view of the Print Composer before
+figure_layout_overview_ shows the initial view of the print layout before
 any elements are added.
 
-.. _Figure_composer_overview:
+.. _figure_layout_overview:
 
 .. figure:: img/print_composer_blank.png
    :align: center
 
-   Print Composer
+   Print Layout
 
 
 On the right beside the canvas you find two set of panels. The upper one holds
@@ -149,10 +149,10 @@ the panels :guilabel:`Items` and :guilabel:`Command History` and the lower holds
 the panels :guilabel:`Composition`, :guilabel:`Item properties`
 and :guilabel:`Atlas generation`.
 
-* The :guilabel:`Items` panel provides a list of all map composer items added to
+* The :guilabel:`Items` panel provides a list of all the print layout items added to
   the canvas.
 * The :guilabel:`Command history` panel displays a history of all changes applied
-  to the Print Composer layout. With a mouse click, it is possible to undo and
+  to the layout. With a mouse click, it is possible to undo and
   redo layout steps back and forth to a certain status.
 * The :guilabel:`Composition` panel allows you to set paper size, orientation, the
   page background, number of pages and print quality for the output file in dpi.
@@ -164,22 +164,22 @@ and :guilabel:`Atlas generation`.
   item. Click the |select| :sup:`Select/Move item` icon to select
   an item (e.g., legend, scale bar or label) on the canvas. Then click the
   :guilabel:`Item Properties` panel and customize the settings for the selected
-  item (see :ref:`composer_items` for detailed information on each item
+  item (see :ref:`layout_items` for detailed information on each item
   settings).
 * The :guilabel:`Atlas generation` panel allows you to enable the generation of an
-  atlas for the current Composer and gives access to its parameters
+  atlas for the current layout and gives access to its parameters
   (see :ref:`atlas_generation` for detailed information on atlas
   generation usage).
 
 
-In the bottom part of the Print Composer window, you can find a status bar with
+In the bottom part of the print layout window, you can find a status bar with
 mouse position, current page number, a combo box to set the zoom level,
 the number of selected items if applicable and, in the case of atlas generation,
 the number of features.
 
-In the upper part of the Print composer window, you can find menus and other
-toolbars. All Print Composer tools are available in menus and as icons in a
-toolbar. See a list of tools in table_composer_tools_.
+In the upper part of the print layout window, you can find menus and other
+toolbars. All print layout tools are available in menus and as icons in a
+toolbar. See a list of tools in table_layout_tools_.
 
 The toolbars and the panels can be switched off and on using the right mouse
 button over any toolbar or through :menuselection:`View --> Toolbars` or
@@ -187,21 +187,21 @@ button over any toolbar or through :menuselection:`View --> Toolbars` or
 
 
 .. index::
-   single: Print composer; Tools
+   single: Print layout; Tools
 
-.. _composer_tools:
+.. _layout_tools:
 
 Tools
 -----
 
-.. _table_composer_tools:
+.. _table_layout_tools:
 
 +-----------------------+---------------------------------------+---------------------+------------------------------------------+
 | Icon                  | Purpose                               | Icon                | Purpose                                  |
 +=======================+=======================================+=====================+==========================================+
-| |fileSave|            | Save Project                          | |newComposer|       | New Composer                             |
+| |fileSave|            | Save Project                          | |newLayout|         | New Layout                               |
 +-----------------------+---------------------------------------+---------------------+------------------------------------------+
-| |duplicateComposer|   | Duplicate Composer                    | |composerManager|   | Composer Manager                         |
+| |duplicateLayout|     | Duplicate Layout                      | |layoutManager|     | Layout Manager                           |
 +-----------------------+---------------------------------------+---------------------+------------------------------------------+
 | |fileOpen|            | Load from template                    | |fileSaveAs|        | Save as template                         |
 +-----------------------+---------------------------------------+---------------------+------------------------------------------+
@@ -256,39 +256,39 @@ Tools
 | |saveMapAsImage|      | Export Atlas as Image                 |  |atlasSettings|    | Atlas Settings                           |
 +-----------------------+---------------------------------------+---------------------+------------------------------------------+
 
-Table Composer 1: Print Composer Tools
+Table Layout 1: Print Layout Tools
 
-Composer Menu
--------------
+Layout Menu
+-----------
 
-With the :menuselection:`Composer --> Save Project` action, you can save
-the project file directly from the print composer window.
-The :menuselection:`Composer` menu also provides actions to:
+With the :menuselection:`Layout --> Save Project` action, you can save
+the project file directly from the print layout window.
+The :menuselection:`Layout` menu also provides actions to:
 
-* Create a new and blank print composer with |newComposer| :sup:`New Composer...`
-* |duplicateComposer| :sup:`Duplicate Composer...` : Create a new print composer
+* Create a new and blank print layout with |newLayout| :guilabel:`New Layout...`
+* |duplicateLayout| :guilabel:`Duplicate Layout...` : Create a new print layout
   by duplicating the current one
-* Open the |composerManager| :sup:`Composer Manager...`
-* :guilabel:`Print Composers...` : Open an existing print composer
+* Open the |layoutManager| :guilabel:`Layout Manager...`
+* :menuselection:`Layouts -->` : Open an existing print layout
 
-Once the layout is designed, with |fileSaveAs| :sup:`Save as template`
-and |fileOpen| :sup:`Add items from template` icons, you can save
-the current state of a Print Composer session as a :file:`.qpt` template
+Once the layout is designed, with |fileSaveAs| :guilabel:`Save as template`
+and |fileOpen| :guilabel:`Add items from template` icons, you can save
+the current state of a print layout session as a :file:`.qpt` template
 and load its item again in another session.
 
-In the :menuselection:`Composer` menu, there are also powerful ways to share
+In the :menuselection:`Layout` menu, there are also powerful ways to share
 geographical information produced with QGIS that can be included in reports or
-published. These tools are |saveMapAsImage| :sup:`Export as Image...`,
-|saveAsPDF| :sup:`Export as PDF...`, |saveAsSVG| :sup:`Export as
-SVG...` and |filePrint| :sup:`Print...`.
+published. These tools are |saveMapAsImage| :guilabel:`Export as Image...`,
+|saveAsPDF| :guilabel:`Export as PDF...`, |saveAsSVG| :guilabel:`Export as
+SVG...` and |filePrint| :guilabel:`Print...`.
 
 Settings Menu
 -------------
 
-From :menuselection:`Settings --> Composer Options` you can set some options
-that will be used as default on any composer during your work.
+From :menuselection:`Settings --> Layout Options...` you can set some options
+that will be used as default on any layout during your work.
 
-* :guilabel:`Compositions defaults` let you specify the default font to use.
+* :guilabel:`Layout defaults` let you specify the default font to use.
 * With :guilabel:`Grid appearance`, you can set the grid style and its color.
   There are three types of grid: **Dots**, **Solid** lines and **Crosses**.
 * :guilabel:`Grid and guide defaults` defines spacing, offset and tolerance of
@@ -301,7 +301,7 @@ Edit Menu
 Copy/Cut and Paste Items
 ........................
 
-The print composer includes actions to use the common Copy/Cut/Paste functionality
+The print layout includes actions to use the common Copy/Cut/Paste functionality
 for the items in the layout. As usual first you need to select the items using
 one of the options seen above; at this point the actions can be found in the
 :menuselection:`Edit` menu.
@@ -322,7 +322,7 @@ View Menu
 Navigation Tools
 ................
 
-To navigate in the canvas layout, the Print Composer provides some general tools:
+To navigate in the canvas layout, the print layout provides some general tools:
 
 * |zoomIn| :sup:`Zoom In`
 * |zoomOut| :sup:`Zoom Out`
@@ -335,23 +335,23 @@ To navigate in the canvas layout, the Print Composer provides some general tools
   click in the rule (above or at the left side of the layout) and drag and drop
   to the desired location.
 * `Snap Guides`: allows user to snap items to the guides,
-* `Smart Guides`: uses other composer items as guides to dynamically snap to as
+* `Smart Guides`: uses other layout items as guides to dynamically snap to as
   user moves or reshapes an item.
 * `Clear Guides` to remove all current guides.
 * `Show Bounding box` around the items.
 * `Show Rules` around the layout.
-* `Show Pages` or set up pages to transparent. Often composer is used
+* `Show Pages` or set up pages to transparent. Often layout is used
   to create non-print layouts, e.g. for inclusion in presentations or other
   documents, and it's desirable to export the composition using a totally
   transparent background. It's sometimes referred to as "infinite canvas" in
   other editing packages.
-* `Toggle Full Screen` makes the composer window to full screen.
+* `Toggle Full Screen` makes the layout window to full screen.
 * `Hide Panels` hides/shows the right panel
 * `Panels` lists all panels available to hide/show them.
 * `Toolbars` same as above for toolbars.
 
 You can change the zoom level also using the mouse wheel or the combo box in
-the status bar. If you need to switch to pan mode while working in the Composer
+the status bar. If you need to switch to pan mode while working in the layout
 area, you can hold the :kbd:`Spacebar` or the mouse wheel.
 With :kbd:`Ctrl+Spacebar`, you can temporarily switch to Zoom In mode,
 and with :kbd:`Ctrl+Shift+Spacebar`, to Zoom Out mode.
@@ -370,7 +370,7 @@ To maximise the space available to interact with a composition you can use
    interact by pressing :kbd:`F11` or using :menuselection:`View -->` |checkbox|
    :guilabel:`Toggle full screen`.
 
-.. _composer_composition_tab:
+.. _layout_composition_tab:
 
 Composition Panel
 -----------------
@@ -383,7 +383,7 @@ current composition.
 .. figure:: img/composition_settings.png
    :align: center
 
-   Composition settings in the Print Composer
+   Composition Settings in the Print Layout
 
 General settings
 ................
@@ -395,7 +395,7 @@ Set the :guilabel:`Number of pages` to the desired value. You can also
 custom the :guilabel:`Page Background` with the color or the symbol you want.
 
 The :guilabel:`reference map` select the map item to be used as the
-composition's master map. The map composer will use this map in any
+composition's master map. The layout will use this map in any
 properties and variable calculating units or scale. This includes exporting
 the composition to georeferenced formats.
 
@@ -437,7 +437,7 @@ and contains information to georeference it easily.
 .. figure:: img/composition_export.png
    :align: center
 
-   Export Settings in the Print Composer
+   Export Settings in the Print Layout
 
 Grid and guides
 ...............
@@ -449,11 +449,11 @@ place some items. These marks can be:
   ensure that :guilabel:`Show Rulers` and :guilabel:`Show Guides` in :menuselection:`View`
   menu are checked. Then, click and drag from within the ruler to the paper sheet.
   A vertical or horizontal line is added to the paper and you can set its position
-  following the coordinates displayed at the left bottom of the composer dialog.
+  following the coordinates displayed at the left bottom of the print layout dialog.
 * or regular **Grid**.
 
 Whether grids or guides should be shown is set in :menuselection:`View` menu.
-There, you can also decide if they might be used to snap composer items. The
+There, you can also decide if they might be used to snap layout items. The
 :guilabel:`Grid and guides` section lets you customize grid settings like
 :guilabel:`Grid spacing`, :guilabel:`Grid offset` and :guilabel:`Snap tolerance`
 to your need. The tolerance is the maximum distance below which an item is snapped
@@ -464,11 +464,11 @@ to a grid or a guide.
 .. figure:: img/composition_guides.png
    :align: center
 
-   Snapping to grids in the Print Composer
+   Snapping to Grids in the Print Layout
 
-In the :menuselection:`Options --> Composer` menu in QGIS main canvas, you can
+In the :menuselection:`Options --> Layout` menu in QGIS main canvas, you can
 also set the spacing, offset and snap tolerance of the grid as much as its style
-and color. These options are applied by default to any new print composer.
+and color. These options are applied by default to any new print layout.
 
 
 Variables
@@ -490,7 +490,7 @@ More information on variables usage in the General Tools
 .. figure:: img/composition_variables.png
    :align: center
 
-   Variables editor in the Print Composer
+   Variables Editor in the Print Layout
 
 .. index:: Revert layout actions
 
@@ -504,28 +504,28 @@ This can be done with the revert and restore tools:
 * |redo| :sup:`Restore last change`
 
 This can also be done by mouse click within the :guilabel:`Command history`
-panel (see figure_composer_). The History panel lists the last actions done
-within the composer.
+panel (see figure_layout_). The History panel lists the last actions done
+within the print layout.
 Just select the point you want to revert to and once you do new action all
 the actions done after the selected one will be removed.
 
-.. _figure_composer:
+.. _figure_layout:
 
 .. figure:: img/command_hist.png
    :align: center
 
-   Command history in the Print Composer
+   Command History in the Print Layout
 
-.. _composer_items_tab:
+.. _layout_items_tab:
 
 Items Panel
 -----------
 
 The :guilabel:`Items` panel offers some options to manage selection and
 visibility of items.
-All the items added to the print composer canvas are shown in a list and
+All the items added to the print layout canvas are shown in a list and
 selecting an item makes the corresponding row selected in the list as well as
-selecting a row does select the corresponding item in the print composer canvas.
+selecting a row does select the corresponding item in the print layout canvas.
 This is thus a handy way to select an item placed behind another one.
 Note that a selected row is shown as bold.
 
@@ -535,7 +535,7 @@ For any selected item, you can :
 * |locked| lock or unlock its position,
 * order its Z position. You can move up and down each item in the list with a
   click and drag. The upper item in the list will be brought to the foreground
-  in the print composer canvas.
+  in the print layout canvas.
   By default, a newly created item is placed in the foreground.
 * change the name by double-clicking the text.
 
@@ -543,6 +543,7 @@ Once you have found the correct position for an item, you can lock it by ticking
 the box in |locked| column. Locked items are **not** selectable on the canvas.
 Locked items can be unlocked by selecting the item in the :menuselection:`Items`
 panel and unchecking the tickbox or you can use the icons on the toolbar.
+
 
 .. Substitutions definitions - AVOID EDITING PAST THIS LINE
    This will be automatically updated by the find_set_subst.py script.
@@ -590,13 +591,11 @@ panel and unchecking the tickbox or you can use the icons on the toolbar.
    :width: 1.5em
 .. |checkbox| image:: /static/common/checkbox.png
    :width: 1.3em
-.. |composerManager| image:: /static/common/mActionComposerManager.png
-   :width: 1.5em
 .. |degrees| unicode:: 0x00B0
    :ltrim:
 .. |draw| image:: /static/common/mActionDraw.png
    :width: 1.5em
-.. |duplicateComposer| image:: /static/common/mActionDuplicateComposer.png
+.. |duplicateLayout| image:: /static/common/mActionDuplicateComposer.png
    :width: 1.5em
 .. |editNodesShape| image:: /static/common/mActionEditNodesShape.png
    :width: 1.5em
@@ -612,6 +611,8 @@ panel and unchecking the tickbox or you can use the icons on the toolbar.
    :width: 1.5em
 .. |label| image:: /static/common/mActionLabel.png
    :width: 1.5em
+.. |layoutManager| image:: /static/common/mActionComposerManager.png
+   :width: 1.5em
 .. |locked| image:: /static/common/locked.png
    :width: 1.5em
 .. |lowerItems| image:: /static/common/mActionLowerItems.png
@@ -622,7 +623,7 @@ panel and unchecking the tickbox or you can use the icons on the toolbar.
    :width: 1.5em
 .. |moveItemsToTop| image:: /static/common/mActionMoveItemsToTop.png
    :width: 1.5em
-.. |newComposer| image:: /static/common/mActionNewComposer.png
+.. |newLayout| image:: /static/common/mActionNewComposer.png
    :width: 1.5em
 .. |openTable| image:: /static/common/mActionOpenTable.png
    :width: 1.5em

--- a/source/docs/user_manual/working_with_ogc/ogc_client_support.rst
+++ b/source/docs/user_manual/working_with_ogc/ogc_client_support.rst
@@ -510,11 +510,11 @@ definitions:
 
 .. _`ogc-wms-legend`:
 
-Show WMS legend graphic in table of contents and composer
+Show WMS legend graphic in table of contents and layout
 ---------------------------------------------------------
 
 The QGIS WMS data provider is able to display a legend graphic in the table of
-contents' layer list and in the map composer. The WMS legend will be shown only
+contents' layer list and in the print layout. The WMS legend will be shown only
 if the WMS server has GetLegendGraphic capability and the layer has
 getCapability url specified, so you additionally have to select a styling for the
 layer.
@@ -524,7 +524,7 @@ you have to click on it to open it in real dimension (due to QgsLegendInterface
 architectural limitation). Clicking on the layer's legend will open a frame with
 the legend at full resolution.
 
-In the print composer, the legend will be integrated at it's original (downloaded)
+In the print layout, the legend will be integrated at it's original (downloaded)
 dimension. Resolution of the legend graphic can be set in the item properties
 under :guilabel:`Legend --> WMS LegendGraphic` to match your printing requirements
 

--- a/source/docs/user_manual/working_with_ogc/server/getting_started.rst
+++ b/source/docs/user_manual/working_with_ogc/server/getting_started.rst
@@ -420,15 +420,15 @@ Use the |signPlus| button below to select those CRSs
 from the Coordinate Reference System Selector, or click :guilabel:`Used`
 to add the CRSs used in the QGIS project to the list.
 
-If you have print composers defined in your project, they will be listed in the
+If you have print layouts defined in your project, they will be listed in the
 `GetProjectSettings` response, and they can be used by the GetPrint request to
-create prints, using one of the print composer layouts as a template.
+create prints, using one of the print layout layouts as a template.
 This is a QGIS-specific extension to the WMS 1.3.0 specification.
-If you want to exclude any print composer from being published by the WMS,
-check |checkbox| :guilabel:`Exclude composers` and click the
+If you want to exclude any print layout from being published by the WMS,
+check |checkbox| :guilabel:`Exclude layouts` and click the
 |signPlus| button below.
-Then, select a print composer from the :guilabel:`Select print composer` dialog
-in order to add it to the excluded composers list.
+Then, select a print layout from the :guilabel:`Select print layout` dialog
+in order to add it to the excluded layouts list.
 
 If you want to exclude any layer or layer group from being published by the
 WMS, check |checkbox| :guilabel:`Exclude Layers` and click the

--- a/source/docs/user_manual/working_with_ogc/server/services.rst
+++ b/source/docs/user_manual/working_with_ogc/server/services.rst
@@ -677,14 +677,14 @@ passing the **WITH_MAPTIP** vendor parameter.
 GetPrint
 --------
 
-QGIS Server has the capability to create print composer output in pdf or pixel
-format. Print composer windows in the published project are used as templates.
+QGIS Server has the capability to create print layout output in pdf or pixel
+format. Print layout windows in the published project are used as templates.
 In the GetPrint request, the client has the possibility to specify parameters
-of the contained composer maps and labels.
+of the contained layout maps and labels.
 
 Example:
 
-The published project has two composer maps. In the `GetProjectSettings` response,
+The published project has two print layouts. In the `GetProjectSettings` response,
 they are listed as possible print templates:
 
 .. code-block:: xml
@@ -705,15 +705,15 @@ The client has now the information to request a print output::
 
 Parameters in the GetPrint request are:
 
-* **<map_id>:EXTENT** gives the extent for a composer map as xmin,ymin,xmax,ymax.
+* **<map_id>:EXTENT** gives the extent for a layout map item as xmin,ymin,xmax,ymax.
 * **<map_id>:ROTATION** map rotation in degrees
 * **<map_id>:GRID_INTERVAL_X**, **<map_id>:GRID_INTERVAL_Y** Grid line density for a
-  composer map in x- and y-direction
-* **<map_id>:SCALE** Sets a mapscale to a composer map. This is useful to ensure
+  map in x- and y-direction
+* **<map_id>:SCALE** Sets a map scale to a layout map item. This is useful to ensure
   scale based visibility of layers and labels even if client and server may
   have different algorithms to calculate the scale denominator
 * **<map_id>:LAYERS**, **<map_id>:STYLES** possibility to give layer and styles
-  list for composer map (useful in case of overview maps which should have only
+  list for layout map item (useful in case of overview maps which should have only
   a subset of layers)
 
 

--- a/source/docs/user_manual/working_with_vector/expression.rst
+++ b/source/docs/user_manual/working_with_vector/expression.rst
@@ -18,7 +18,7 @@ Expressions
 Based on layer data and prebuilt or user defined functions, **Expressions**
 offer a powerful way to manipulate attribute value, geometry and variables
 in order to dynamically change the geometry style, the content or position
-of the label, the value for diagram, the height of a composer item,
+of the label, the value for diagram, the height of a layout item,
 select some features, create virtual field ...
 
 .. _expression_builder:
@@ -34,7 +34,7 @@ is available from many parts in QGIS and, can particularly be accessed when:
   :sup:`Select By Expression...` tool;
 * :ref:`editing attributes <calculate_fields_values>` with e.g. the
   |calculateField| :sup:`Field calculator` tool;
-* manipulating symbology, label or composer item parameters with the |dataDefined|
+* manipulating symbology, label or layout item parameters with the |dataDefined|
   :sup:`Data defined override` tool (see :ref:`data_defined`);
 * building a :ref:`geometry generator <geometry_generator_symbol>` symbol layer;
 * doing some :ref:`geoprocessing <label_processing>`.
@@ -431,18 +431,18 @@ This group contains functions for manipulating colors.
 Composition Functions
 ---------------------
 
-This group contains functions to manipulate print composer items properties.
+This group contains functions to manipulate print layout items properties.
 
 ==================  ========================================================
  Function            Description
 ==================  ========================================================
- item_variables      Returns a map of variables from a composer item inside
+ item_variables      Returns a map of variables from a layout item inside
                      this composition
 ==================  ========================================================
 
 **Some example:**
 
-* Get the scale of the 'Map 0' in the current print composer::
+* Get the scale of the 'Map 0' in the current print layout::
 
     map_get( item_variables('Map 0'), 'map_scale')
 
@@ -1088,7 +1088,7 @@ It means that some functions may not be available according to the context:
 - from the |expressionSelect| :sup:`Select by expression` dialog
 - from the |calculateField| :sup:`Field calculator` dialog
 - from the layer properties dialog
-- from the print composer
+- from the print layout
 
 To use these functions in an expression, they should be preceded by @ character
 (e.g, @row_number). Are concerned:
@@ -1113,15 +1113,15 @@ To use these functions in an expression, they should be preceded by @ character
  grid_axis               Returns the current grid annotation axis
                          (eg, 'x' for longitude, 'y' for latitude)
  grid_number             Returns the current grid annotation value
- item_id                 Returns the composer item user ID
+ item_id                 Returns the layout item user ID
                          (not necessarily unique)
- item_uuid               Returns the composer item unique ID
+ item_uuid               Returns the layout item unique ID
  layer                   Returns the current layer
  layer_id                Returns the ID of current layer
  layer_name              Returns the name of current layer
  layout_dpi              Returns the composition resolution (DPI)
  layout_numpages         Returns the number of pages in the composition
- layout_page             Returns the current page of the composer item
+ layout_page             Returns the current page of the layout item
  layout_pageheight       Returns the composition height in mm
  layout_pagewidth        Returns the composition width in mm
  map_crs                 Returns the Coordinate reference system of the current map
@@ -1133,7 +1133,7 @@ To use these functions in an expression, they should be preceded by @ character
  map_extent_width        Returns the current width of the map
  map_id                  Returns the ID of current map destination.
                          This will be 'canvas' for canvas renders, and
-                         the item ID for composer map renders
+                         the item ID for layout map renders
  map_rotation            Returns the current rotation of the map
  map_scale               Returns the current scale of the map
  map_units               Returns the units of map measurements

--- a/source/docs/user_manual/working_with_vector/vector_properties.rst
+++ b/source/docs/user_manual/working_with_vector/vector_properties.rst
@@ -479,7 +479,7 @@ The assistant lets you define:
 To the right side of the dialog, you can preview the features representation
 within a live-update widget. This representation is added to the layer tree in
 the layer legend and is also used to shape the layer representation in the
-print composer legend item.
+print layout legend item.
 
 The values presented in the varying size assistant above will set the size
 'Data-defined override' with:
@@ -503,7 +503,7 @@ option either on size (for point layer) or width (for line layer).
 
 Like the proportional symbol, the size-related symbol is added to the layer tree,
 at the top of the categorized or graduated classes symbols. And both representation
-are also available in the print composer legend item.
+are also available in the print layout legend item.
 
 .. _figure_symbology_multivariate:
 
@@ -1691,7 +1691,7 @@ You can move up and down any row with click and drag, sorting how attributes
 are displayed. You can also change the label in the 'Legend' column
 or the attribute color by double-clicking the item.
 
-This label is the default text displayed in the legend of the print composer
+This label is the default text displayed in the legend of the print layout
 or of the layer tree.
 
 .. _figure_diagrams_attributes:
@@ -1806,7 +1806,7 @@ in the :ref:`label_legend`, besides the layer symbology. It can be:
 * the represented attributes: color and legend text set in :guilabel:`Attributes` tab
 * and if applicable, the diagram size, whose symbol you can customize.
 
-When set, the diagram legend items are also available in the print composer legend,
+When set, the diagram legend items are also available in the print layout legend,
 besides the layer symbology.
 
 
@@ -2781,7 +2781,7 @@ setting that enables generalisation by default for newly added layers (see
 
 
 While rendering extremely detailed layers (e.g. polygon layers with a huge number
-of nodes), this can cause composer exports in PDF/SVG format to be huge as all
+of nodes), this can cause layout exports in PDF/SVG format to be huge as all
 nodes are included in the exported file. This can also make the resultant file
 very slow to work with/open in other programs.
 
@@ -2789,7 +2789,7 @@ Checking |checkbox| :guilabel:`Force layer to render as raster` forces these
 layers to be rasterised so that the exported files won't have to include all
 the nodes contained in these layers and the rendering is therefore sped up.
 
-You can also do this by forcing the composer to export as a raster,
+You can also do this by forcing the layout to export as a raster,
 but that is an all-or-nothing solution, given that the rasterisation
 is applied to all layers.
 
@@ -2900,6 +2900,7 @@ format of the image. Currently png, jpg and jpeg image formats are supported.
    QGIS Server tab in vector layers properties dialog
 
 
+
 .. Substitutions definitions - AVOID EDITING PAST THIS LINE
    This will be automatically updated by the find_set_subst.py script.
    If you need to create a new substitution manually,
@@ -2922,8 +2923,6 @@ format of the image. Currently png, jpg and jpeg image formats are supported.
    :width: 1.5em
 .. |autoPlacement| image:: /static/common/mIconAutoPlacementSettings.png
    :width: 1.5em
-.. |browseButton| image:: /static/common/browsebutton.png
-   :width: 2.3em
 .. |categorizedSymbol| image:: /static/common/rendererCategorizedSymbol.png
    :width: 1.5em
 .. |changeLabelProperties| image:: /static/common/mActionChangeLabelProperties.png

--- a/source/substitutions.txt
+++ b/source/substitutions.txt
@@ -180,7 +180,7 @@
    :width: 1.5em
 .. |comboBox|  image:: /static/common/combobox.png
    :width: 1.5em
-.. |composerManager| image:: /static/common/mActionComposerManager.png
+.. |layoutManager| image:: /static/common/mActionComposerManager.png
    :width: 1.5em
 .. |conditionalFormatting| image:: /static/common/mActionConditionalFormatting.png
    :width: 1.5em
@@ -264,7 +264,7 @@
    :width: 1.5em
 .. |draw| image:: /static/common/mActionDraw.png
    :width: 1.5em
-.. |duplicateComposer| image:: /static/common/mActionDuplicateComposer.png
+.. |duplicateLayout| image:: /static/common/mActionDuplicateComposer.png
    :width: 1.5em
 .. |duplicateLayer| image:: /static/common/mActionDuplicateLayer.png
    :width: 1.5em
@@ -654,7 +654,7 @@
    :width: 1.5em
 .. |newBookmark| image:: /static/common/mActionNewBookmark.png
    :width: 1.5em
-.. |newComposer| image:: /static/common/mActionNewComposer.png
+.. |newLayout| image:: /static/common/mActionNewComposer.png
    :width: 1.5em
 .. |newGeoPackageLayer| image:: /static/common/mActionNewGeoPackageLayer.png
    :width: 1.5em


### PR DESCRIPTION
This is a first round of replacement, from "print composer" to "print layout".
It does not rename file or screenshots nor update the description to match layout behavior (ie, a lot remains to do)