### PR TITLE
[processing] raster calculator update

### DIFF
--- a/source/docs/user_manual/processing/toolbox.rst
+++ b/source/docs/user_manual/processing/toolbox.rst
@@ -213,6 +213,15 @@ table can be of one of the following types.
   Depending on the algorithm, the number of rows can be modified or not by using
   the buttons on the right side of the window.
 
+.. _reference_layer_param:
+
+.. note:: Some algorithms require many parameter to run, e.g. in the
+  :ref:`qgisrastercalculator` you have to specify manually the cell size, the
+  extent and the CRS. You can avoid to choose all the parameters manually when
+  the algorithm has the ``Reference layers`` parameter. With this parameter you
+  can choose the reference layer and all its properties (cell size, extent, CRS)
+  will be used.
+
 Along with the :guilabel:`Parameters` tab, you will find another tab named
 :guilabel:`Log`. Information provided by the algorithm during its execution is
 written in this tab, and allow you to track the execution and be aware and have

--- a/source/docs/user_manual/processing_algs/qgis/rasteranalysis.rst
+++ b/source/docs/user_manual/processing_algs/qgis/rasteranalysis.rst
@@ -55,18 +55,29 @@ Parameters
 
   Default: *NDVI*
 
+``Reference layers(s)(used for automated extent, cellsize and CRS) [multipleinput]
+
+  Layer(s) that will be used to fetch extent, cell size and CRS. Choosing the
+  layer in this box avoids to fill all the other parameter by hand.
+
 ``Cell size (use 0 or empty to set it automatically)`` [number]
   Optional.
 
   Cell size of the output raster layer. If the cell size is not specified, the
-  minimum cell size of all input layers will be used. The cell size is assumed to
-  be the same in both X and Y axes.
+  minimum cell size of selected reference layer(s) will be used. The cell size is
+  assumed to be the same in both X and Y axes.
 
 ``Output extent (xmin, xmax, ymin, ymax)`` [extent]
   Optional.
 
   Extent of the output raster layer. If the extent is not specified, the minimum
-  extent that covers the input layers will be used.
+  extent that covers selected reference layer(s) will be used.
+
+``Output CRS `` [crs]
+  Optional
+
+  CRS of the output raster layer. If the output CRS is not specified, the CRS of
+  the first reference layer will be used.
 
 Outputs
 .......

--- a/source/docs/user_manual/processing_algs/qgis/rasteranalysis.rst
+++ b/source/docs/user_manual/processing_algs/qgis/rasteranalysis.rst
@@ -21,10 +21,6 @@ The resulting layer will have its values computed according to an expression.
 The expression can contain numerical values, operators and references to any of
 the layers in the current project.
 
-.. note:: you have to choose one (or more) layer(s) in the ``Reference layers``
-  option or you have to type the extent, cell size and CRS manually. If both
-  layer and options are chosen, the latter will overwrite the layer's properties.
-
 .. note:: When using the calculator in :ref:`processing_batch` or from the
   :ref:`console` the files to use have to be specified. The corresponding layers
   are referred using the base name of the file (without the full path). For instance,
@@ -44,7 +40,6 @@ Parameters
   box. Besides the visible buttons also the following functions are supported:
   ``sin()``, ``cos()``, ``tan()``, ``atan2()``, ``ln()``, ``log10()``.
 
-
 ``Expression`` [string]
   Expression that will be used to calculate the output raster layer. You can use
   the operator buttons provided to type directly the expression in this box.
@@ -63,7 +58,7 @@ Parameters
   Optional.
 
   Layer(s) that will be used to fetch extent, cell size and CRS. Choosing the
-  layer in this box avoids to fill all the other parameter by hand.
+  layer in this box avoids to fill all the other parameters by hand.
 
 ``Cell size (use 0 or empty to set it automatically)`` [number]
   Optional.

--- a/source/docs/user_manual/processing_algs/qgis/rasteranalysis.rst
+++ b/source/docs/user_manual/processing_algs/qgis/rasteranalysis.rst
@@ -73,7 +73,7 @@ Parameters
   Extent of the output raster layer. If the extent is not specified, the minimum
   extent that covers selected reference layer(s) will be used.
 
-``Output CRS `` [crs]
+``Output CRS`` [crs]
   Optional
 
   CRS of the output raster layer. If the output CRS is not specified, the CRS of

--- a/source/docs/user_manual/processing_algs/qgis/rasteranalysis.rst
+++ b/source/docs/user_manual/processing_algs/qgis/rasteranalysis.rst
@@ -55,7 +55,7 @@ Parameters
 
   Default: *NDVI*
 
-``Reference layers(s)(used for automated extent, cellsize and CRS) [multipleinput]
+``Reference layers(s)(used for automated extent, cellsize and CRS)`` [multipleinput]
 
   Layer(s) that will be used to fetch extent, cell size and CRS. Choosing the
   layer in this box avoids to fill all the other parameter by hand.

--- a/source/docs/user_manual/processing_algs/qgis/rasteranalysis.rst
+++ b/source/docs/user_manual/processing_algs/qgis/rasteranalysis.rst
@@ -21,6 +21,10 @@ The resulting layer will have its values computed according to an expression.
 The expression can contain numerical values, operators and references to any of
 the layers in the current project.
 
+.. note:: you have to choose one (or more) layer(s) in the ``Reference layers``
+  option or you have to type the extent, cell size and CRS manually. If both
+  layer and options are chosen, the latter will overwrite the layer's properties.
+
 .. note:: When using the calculator in :ref:`processing_batch` or from the
   :ref:`console` the files to use have to be specified. The corresponding layers
   are referred using the base name of the file (without the full path). For instance,
@@ -56,6 +60,7 @@ Parameters
   Default: *NDVI*
 
 ``Reference layers(s)(used for automated extent, cellsize and CRS)`` [multipleinput]
+  Optional.
 
   Layer(s) that will be used to fetch extent, cell size and CRS. Choosing the
   layer in this box avoids to fill all the other parameter by hand.


### PR DESCRIPTION
fix #2345 
**however** the parameter `Reference layers(s)(used for automated extent, cellsize and CRS)` is **not** optional as stated in the GUI. I made some tests and at least one layer has to be chosen, else the algorithm won't run.

@nirvn is this the expected behavior?