### PR TITLE
Add description for dependencies tab

### DIFF
--- a/source/docs/user_manual/working_with_vector/vector_properties.rst
+++ b/source/docs/user_manual/working_with_vector/vector_properties.rst
@@ -2867,6 +2867,25 @@ Metadata are currently saved in the project file. It can also be saved as an
 :file:`.XML` file alongside file based layers or in a local :file:`.sqlite`
 database for remote layers (e.g. PostGIS).
 
+.. index:: Dependencies
+.. _vectordependenciesmenu:
+
+Dependencies Properties
+=======================
+
+|dependencies| The :guilabel:`Dependencies` tab allows to declare data
+dependencies between layers. A data dependency occurs when a data modification
+in a layer, not by direct user manipulation, may modify data of other layers.
+This is the case for instance when geometry of a layer is updated by a
+database trigger or custom PyQGIS scripting after modification of another
+layer's geometry.
+
+In the :guilabel:`Dependencies` tab, you can select any layers which may externally
+alter the data in the current layer. Correctly specifying dependent layers
+allows QGIS to invalidate caches for this layer when the dependent layers are
+altered.
+
+
 .. index:: Legend, Embedded widget
 .. _vectorlegendmenu:
 
@@ -2963,6 +2982,8 @@ format of the image. Currently png, jpg and jpeg image formats are supported.
 .. |degrees| unicode:: 0x00B0
    :ltrim:
 .. |deleteAttribute| image:: /static/common/mActionDeleteAttribute.png
+   :width: 1.5em
+.. |dependencies| image:: /static/common/dependencies.png
    :width: 1.5em
 .. |diagram| image:: /static/common/diagram.png
    :width: 2em


### PR DESCRIPTION
Fix #1370
Honestly I do not really understand the use case. @mhugo can you please elaborate more on QGIS layer caching. I thought that triggers were acting automatically and will update the layer in QGIS. From what I've experienced (i just use some simple triggers and views), the "resulting" layer was updated as soon as canvas was refreshed.
What's the difference here? Some use case that could help readers to understand when to use this feature?
Thanks