### PR TITLE
 Reorganizing sections in general tools chapter

### DIFF
--- a/source/docs/user_manual/introduction/general_tools.rst
+++ b/source/docs/user_manual/introduction/general_tools.rst
@@ -1498,6 +1498,78 @@ with name and description.
    case of vector, have the same geometry type (point, line or polygon).
 
 
+.. index:: Variables, Expressions
+.. _`general_tools_variables`:
+
+Storing values in Variables
+===========================
+
+In QGIS, you can use variables to store useful recurrent values (e.g. the
+project's title, or the user's full name) that can be used in expressions.
+Variables can be defined at the application's global level, project level,
+layer level, layout level, and layout item's level. Just like CSS
+cascading rules, variables can be overwritten - e.g., a project level
+variable will overwrite any application's global level variables set with
+the same name. You can use these variables to build text strings or other
+custom expressions using the ``@`` character before the variable name. For
+example in print layout creating a label with this content::
+
+  This map was made using QGIS [% @qgis_version %]. The project file for this
+  map is: [% @project_path %]
+
+Will render the label like this::
+
+  This map was made using QGIS 2.14. The project file for this map is:
+  /gis/qgis-user-conference-2015.qgs
+
+Besides the :ref:`preset read-only variables <variables_functions>`, you can
+define your own custom variables for any of the levels mentioned above. You can
+manage:
+
+* **global variables** from the :menuselection:`Settings --> Options` menu;
+* **project's variables** from :guilabel:`Project Properties` (see
+  :ref:`project_properties`);
+* **vector layer's variables** from the :guilabel:`Layer Properties` dialog
+  (see :ref:`vector_properties_dialog`);
+* **layout's variables** from the :guilabel:`Layout` panel in the
+  Print layout (see :ref:`layout_panel`);
+* and **layout item's variables** from the :guilabel:`Item Properties`
+  panel in the Print layout (see :ref:`layout_item_options`).
+
+To differentiate from editable variables, read-only variable's names and
+values are emphasized in italic. On the other hand, higher level
+variables overwritten by lower level ones are strike through.
+
+.. _figure_variables_dialog:
+
+.. figure:: img/options_variables.png
+   :align: center
+
+   Variables editor at the project's level
+
+.. note:: You can read more about variables and find some examples
+   in Nyall Dawson's `Exploring variables in QGIS 2.12, part 1
+   <http://nyalldawson.net/2015/12/exploring-variables-in-qgis-2-12-part-1/>`_,
+   `part 2 <http://nyalldawson.net/2015/12/exploring-variables-in-qgis-pt-2-project-management/>`_
+   and `part 3 <http://nyalldawson
+   .net/2015/12/exploring-variables-in-qgis-pt-3-layer-level-variables/>`_
+   blog posts.
+
+.. _authentication:
+
+Authentication
+==============
+
+QGIS has facility to store/retrieve authentication credentials in a secure
+manner. Users can securely save credentials into authentication configurations,
+which are stored in a portable database, can be applied to server or database
+connections, and safely referenced by their ID tokens in project or settings
+files. For more information see :ref:`authentication_index`.
+
+A master password needs to be set up when initializing the authentication
+system and its portable database.
+
+
 .. _common_widgets:
 
 Common widgets
@@ -1680,78 +1752,6 @@ Parameters that can be used with data-defined tools are:
 .. note:: When the data-defined override option is setup correctly the
    icon is yellow |dataDefineOn| or |dataDefineExpressionOn|; if it is broken,
    the icon is red |dataDefineError| or |dataDefineExpressionError|.
-
-
-.. index:: Variables, Expressions
-.. _`general_tools_variables`:
-
-Variables
----------
-
-In QGIS, you can use variables to store useful recurrent values (e.g. the
-project's title, or the user's full name) that can be used in expressions.
-Variables can be defined at the application's global level, project level,
-layer level, layout level, and layout item's level. Just like CSS
-cascading rules, variables can be overwritten - e.g., a project level
-variable will overwrite any application's global level variables set with
-the same name. You can use these variables to build text strings or other
-custom expressions using the ``@`` character before the variable name. For
-example in print layout creating a label with this content::
-
-  This map was made using QGIS [% @qgis_version %]. The project file for this
-  map is: [% @project_path %]
-
-Will render the label like this::
-
-  This map was made using QGIS 2.14. The project file for this map is:
-  /gis/qgis-user-conference-2015.qgs
-
-Besides the :ref:`preset read-only variables <variables_functions>`, you can
-define your own custom variables for any of the levels mentioned above. You can
-manage:
-
-* **global variables** from the :menuselection:`Settings --> Options` menu;
-* **project's variables** from :guilabel:`Project Properties` (see
-  :ref:`project_properties`);
-* **vector layer's variables** from the :guilabel:`Layer Properties` dialog
-  (see :ref:`vector_properties_dialog`);
-* **layout's variables** from the :guilabel:`Layout` panel in the
-  Print layout (see :ref:`layout_panel`);
-* and **layout item's variables** from the :guilabel:`Item Properties`
-  panel in the Print layout (see :ref:`layout_item_options`).
-
-To differentiate from editable variables, read-only variable's names and
-values are emphasized in italic. On the other hand, higher level
-variables overwritten by lower level ones are strike through.
-
-.. _figure_variables_dialog:
-
-.. figure:: img/options_variables.png
-   :align: center
-
-   Variables editor at the project's level
-
-.. note:: You can read more about variables and find some examples
-   in Nyall Dawson's `Exploring variables in QGIS 2.12, part 1
-   <http://nyalldawson.net/2015/12/exploring-variables-in-qgis-2-12-part-1/>`_,
-   `part 2 <http://nyalldawson.net/2015/12/exploring-variables-in-qgis-pt-2-project-management/>`_
-   and `part 3 <http://nyalldawson
-   .net/2015/12/exploring-variables-in-qgis-pt-3-layer-level-variables/>`_
-   blog posts.
-
-.. _authentication:
-
-Authentication
---------------
-
-QGIS has facility to store/retrieve authentication credentials in a secure
-manner. Users can securely save credentials into authentication configurations,
-which are stored in a portable database, can be applied to server or database
-connections, and safely referenced by their ID tokens in project or settings
-files. For more information see :ref:`authentication_index`.
-
-A master password needs to be set up when initializing the authentication
-system and its portable database.
 
 
 .. Substitutions definitions - AVOID EDITING PAST THIS LINE

--- a/source/docs/user_manual/introduction/general_tools.rst
+++ b/source/docs/user_manual/introduction/general_tools.rst
@@ -236,34 +236,9 @@ as sub-item), the following options are available at layer level or class level:
     in case of vector, have the same geometry type (point, line or polygon).
 
 
-.. index:: Layers; Order
-
-.. _layer_order:
-
-Layer Order Panel
------------------
-
-There is a panel that allows you to define an independent drawing order for
-the layers panel. You can activate it in the menu :menuselection:`Settings
---> Panels --> Layer Order Panel`. This feature allows you to, for instance,
-order your layers in order of importance, but still display them in the
-correct order (see figure_layer_order_; you can notice that the ``airports``
-features are displayed over the ``alaska`` polygon despite their layers
-placement in the Layers panel).
-Unchecking the |checkbox| :guilabel:`Control rendering order` box underneath
-the list of layers will cause a revert to default behavior.
-
-.. _figure_layer_order:
-
-.. figure:: img/layer_order.png
-    :align: center
-
-    Define a legend independent layer order
-
 .. index::
    single: Layer properties
    single: Panels; Style
-   
 .. _layer_styling_panel:
 
 Layer Styling Panel
@@ -312,10 +287,32 @@ You no longer need to hit the **[Apply]** button.
 .. Todo: Actually, what could be nice is to provide example in the Cookbook to have an
  internal and always guaranteed link (see #2071)
 
+.. index:: Layers; Order
+.. _layer_order:
+
+Layer Order Panel
+-----------------
+
+There is a panel that allows you to define an independent drawing order for
+the layers panel. You can activate it in the menu :menuselection:`Settings
+--> Panels --> Layer Order Panel`. This feature allows you to, for instance,
+order your layers in order of importance, but still display them in the
+correct order (see figure_layer_order_; you can notice that the ``airports``
+features are displayed over the ``alaska`` polygon despite their layers
+placement in the Layers panel).
+Unchecking the |checkbox| :guilabel:`Control rendering order` box underneath
+the list of layers will cause a revert to default behavior.
+
+.. _figure_layer_order:
+
+.. figure:: img/layer_order.png
+    :align: center
+
+    Define a legend independent layer order
+
 .. index::
    single: Map; Overview
    single: Panels; Overview
-
 .. _`overview_panels`:
 
 Overview Panel

--- a/source/docs/user_manual/introduction/general_tools.rst
+++ b/source/docs/user_manual/introduction/general_tools.rst
@@ -240,8 +240,8 @@ as sub-item), the following options are available at layer level or class level:
 
 .. _layer_order:
 
-Working with the Legend independent layer order
-------------------------------------------------
+Layer Order Panel
+-----------------
 
 There is a panel that allows you to define an independent drawing order for
 the layers panel. You can activate it in the menu :menuselection:`Settings
@@ -309,8 +309,53 @@ You no longer need to hit the **[Apply]** button.
   layer properties in the Layer Styling Panel. See
   https://nathanw.net/2016/06/29/qgis-style-dock-part-2-plugin-panels/ for an example.
 
-.. Actually, what could be nice is to provide example in the Cookbook to have an
+.. Todo: Actually, what could be nice is to provide example in the Cookbook to have an
  internal and always guaranteed link (see #2071)
+
+.. index::
+   single: Map; Overview
+   single: Panels; Overview
+
+.. _`overview_panels`:
+
+Overview Panel
+--------------
+
+In QGIS, you can use an overview panel that provides a full extent view of
+layers added to it. Within the view is a rectangle showing the current map
+extent. This allows you to quickly determine which area of the map you are
+currently viewing. Note that labels are not rendered to the map overview even
+if the layers in the map overview have been set up for labelling. If you click
+and drag the red rectangle in the overview that shows your current extent, the
+main map view will update accordingly.
+
+
+.. index::
+   single: Log messages
+   single: Panels; Log messages
+
+.. _`log_message_panel`:
+
+Log Messages Panel
+------------------
+
+When loading or processing some operations, you can track and follow messages
+that appear in different tabs using the |messageLog| :guilabel:`Log Messages Panel`.
+It can be activated using the most right icon in the bottom status bar.
+
+
+.. index:: Undo, Redo
+   single: Panels; Undo
+   single: Panels; Redo
+
+.. _`undo_redo_panel`:
+
+Undo/Redo Panel
+---------------
+
+For each layer being edited, this panel shows the list of actions done, allowing
+to quickly undo a set of actions by simply selecting the action listed above.
+More details at :ref:`Undo and Redo edits <undoredo_edits>`.
 
 .. index::
    single: Panels; Statistic
@@ -364,57 +409,67 @@ Table: Statistics available for each field type
 
     Show statistics on a field
 
-.. index::
-   single: Map; Overview
-   single: Panels; Overview
 
-.. _`overview_panels`:
+.. index:: Nesting projects, Embed layers and groups
+.. _nesting_projects:
 
-QGIS Overview Panel
---------------------
+Nesting Projects
+================
 
-In QGIS, you can use an overview panel that provides a full extent view of
-layers added to it. Within the view is a rectangle showing the current map
-extent. This allows you to quickly determine which area of the map you are
-currently viewing. Note that labels are not rendered to the map overview even
-if the layers in the map overview have been set up for labelling. If you click
-and drag the red rectangle in the overview that shows your current extent, the
-main map view will update accordingly.
+Sometimes, you'd like to keep in different projects a bunch of layers with the
+same style. You can either create a :ref:`default style <store_style>` for
+these layers or embed them from another project to save you tons of work.
+
+Embed layers and groups from an existing project has some advantages over
+styling:
+
+* all types of layers (vector or raster, local or online...) can be added
+* fetching groups and layers, you can keep the same tree structure of the
+  "background" layers in your different projects
+* While the embedded layers are editable, you can't change their properties
+  such as symbology, labels, forms, default values, actions... This ensures
+  homogeneity throughout the projects
+* modify the items in the original project and changes are propagated to all
+  the other projects.
+
+If you want to embed content from other project files into your project, select
+:menuselection:`Layer --> Embed Layers and Groups` and:
+
+#. Press |browseButton| to look for a project; you can see the content of the
+   project (see figure_embed_dialog_).
+#. Press :kbd:`Ctrl` ( or |osx| :kbd:`Cmd`) and click on the layers and
+   groups you wish to retrieve.
+#. Press **[OK]**. The selected layers and groups are embedded in the Layer
+   panel and can be visualized in the map canvas now. Names of embedded items
+   appear in italic to distinguish them from regular layers and groups.
+
+.. _figure_embed_dialog:
+
+.. figure:: img/embed_dialog.png
+   :align: center
+
+   Select layers and groups to embed
+
+Like any other layer, an embedded layer can be removed from the project by
+right-click on the layer and choose |removeLayer| :sup:`Remove`.
+
+.. tip:: **Change rendering of an embedded layer**
+
+ It's not possible to change rendering of an embedded layer, unless you make
+ the changes in the original project file. However, right-click on a layer and
+ select :guilabel:`Duplicate` creates a layer which is fully-featured and not
+ dependent to the original project. You can then safely remove the linked
+ layer.
 
 
-.. index::
-   single: Log messages
-   single: Panels; Log messages
-
-.. _`log_message_panel`:
-
-Log Messages Panel
-------------------
-
-When loading or processing some operations, you can track and follow messages
-that appear in different tabs using the |messageLog| Log Messages Panel.
-It can be activated using the most right icon in the bottom status bar.
-
-
-.. index:: Undo, Redo
-   single: Panels; Undo
-   single: Panels; Redo
-
-.. _`undo_redo_panel`:
-
-Undo/Redo Panel
----------------
-
-For each layer being edited, this panel shows the list of actions done, allowing
-to quickly undo a set of actions by simply selecting the action listed above.
-More details at :ref:`Undo and Redo edits <undoredo_edits>`.
-
+Working with map canvas
+=======================
 
 .. index:: Rendering
 .. _`redraw_events`:
 
 Rendering
-=========
+---------
 
 By default, QGIS renders all visible layers whenever the map canvas is
 refreshed. The events that trigger a refresh of the map canvas include:
@@ -430,7 +485,7 @@ QGIS allows you to control the rendering process in a number of ways.
 .. _`label_scaledepend`:
 
 Scale Dependent Rendering
--------------------------
+.........................
 
 Scale-dependent rendering allows you to specify the minimum and maximum scales
 at which a layer (raster or vector) will be visible. To set scale-dependent rendering,
@@ -456,7 +511,7 @@ the current map canvas scale as boundary of the range visibility.
 .. _`label_controlmap`:
 
 Controlling Map Rendering
--------------------------
+.........................
 
 Map rendering can be controlled in various ways, as described below.
 
@@ -465,7 +520,7 @@ Map rendering can be controlled in various ways, as described below.
 .. _`label_suspendrender`:
 
 Suspending Rendering
-....................
+^^^^^^^^^^^^^^^^^^^^
 
 To suspend rendering, click the |checkbox| :guilabel:`Render` checkbox in the
 lower right corner of the status bar. When the |checkbox| :guilabel:`Render`
@@ -488,7 +543,7 @@ causes an immediate refresh of the map canvas.
 .. _`label_settinglayer`:
 
 Setting Layer Add Option
-........................
+^^^^^^^^^^^^^^^^^^^^^^^^
 
 You can set an option to always load new layers without drawing them. This
 means the layer will be added to the map, but its visibility checkbox in the
@@ -504,7 +559,7 @@ should be displayed` checkbox. Any layer subsequently added to the map will be o
 .. _label_stoprender:
 
 Stopping Rendering
-..................
+^^^^^^^^^^^^^^^^^^
 
 To stop the map drawing, press the :kbd:`ESC` key. This will halt the refresh of
 the map canvas and leave the map partially drawn. It may take a bit of time
@@ -520,7 +575,7 @@ between pressing :kbd:`ESC` and the time the map drawing is halted.
 .. _`label_renderquality`:
 
 Influence Rendering Quality
-...........................
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 QGIS has an option to influence the rendering quality of the map. Choose menu
 option :menuselection:`Settings --> Options`, click on the :guilabel:`Rendering`
@@ -531,7 +586,7 @@ at the expense of some drawing performance`.
    single: Rendering; Speed-up
 
 Speed-up rendering
-..................
+^^^^^^^^^^^^^^^^^^
 
 There are some settings that allow you to improve rendering speed. Open the QGIS options
 dialog using :menuselection:`Settings --> Options`, go to the :guilabel:`Rendering`
@@ -551,11 +606,748 @@ tab and select or deselect the following checkboxes:
   Be aware that you can also face rendering inconsistencies.
 
 
+.. index:: Zoom, Pan, Map navigation
+.. _zoom_pan:
+
+Zooming and Panning
+-------------------
+
+QGIS provides tools to zoom and pan to your area of interest.
+
+Apart from using the |pan| :sup:`pan` and |zoomIn|
+:sup:`zoom-in` / |zoomOut| :sup:`zoom-out` icons on the toolbar
+with the mouse, navigating can also be done with the mouse wheel, spacebar
+and the arrow keys. A :guilabel:`Zoom factor` can be set under the
+:menuselection:`Settings -->` |options| :menuselection:`Options --> Map tools`
+menu to define the scale behavior while zooming.
+
+With the mouse wheel
+....................
+
+You can press the mouse wheel to pan inside of the main window (on macOS,
+you may need to hold :kbd:`cmd` key).
+You can roll the mouse wheel to zoom in and out on the map; the mouse
+cursor position will be the center of the zoomed area of interest.
+Holding down :kbd:`Ctrl` while rolling the mouse wheel results in a finer zoom.
+
+With the arrow keys
+...................
+
+Panning the map is possible with the arrow keys.
+Place the mouse cursor inside the map area, and click on the right arrow key
+to pan east, left arrow key to pan west, up arrow key to pan north, and down
+arrow key to pan south.
+
+You can also use the space bar to temporarily cause mouse movements to pan
+the map. The :kbd:`PgUp` and :kbd:`PgDown` keys on your keyboard will cause
+the map display to zoom in or out following the zoom factor set. Pressing
+:kbd:`Ctrl +` or :kbd:`Ctrl -` also performs an immediate zoom in/out
+on the map canvas.
+
+When certain map tools are active (Identify, Measure...), you can perform a zoom by
+holding down :kbd:`Shift` and dragging a rectangle on the map to zoom to that area.
+This is enabled for the map tools which are not selection tools (since they
+use :kbd:`Shift` for adding to selection) nor edit tools.
+
+
+.. index::
+   single: Bookmarks
+   see: Spatial bookmarks; Bookmarks
+.. _`sec_bookmarks`:
+
+Spatial Bookmarks
+-----------------
+
+Spatial Bookmarks allow you to "bookmark" a geographic location and return to
+it later. By default, bookmarks are saved on the computer, meaning that they are available
+from any project in the same computer. If you wish to store the bookmark in the project
+file (:file:`.qgs`) then you can do this by selecting the :guilabel:`In Project` checkbox.
+
+Creating a Bookmark
+...................
+
+To create a bookmark:
+
+#. Zoom or pan to the area of interest.
+#. Select the menu option :menuselection:`View --> New Bookmark` or press
+   :kbd:`Ctrl-B`. The Spatial Bookmark panel opens with the newly created bookmark.
+#. Enter a descriptive name for the bookmark (up to 255 characters).
+#. Check the :guilabel:`In Project` box if you wish to save the bookmark in the project file.
+#. Press :kbd:`Enter` to add the bookmark or click elsewhere.
+
+Note that you can have multiple bookmarks with the same name.
+
+Working with Bookmarks
+......................
+
+To use or manage bookmarks, select the menu option
+:menuselection:`View --> Show Bookmarks`. The :guilabel:`Spatial Bookmarks`
+panel allows you to:
+
+* Zoom to a Bookmark: select the desired bookmark and then click
+  :guilabel:`Zoom To Bookmark`. You can also zoom to a bookmark by
+  double-clicking on it.
+* Delete a Bookmark: select the bookmark and click :guilabel:`Delete Bookmark`.
+  Confirm your choice.
+* Import or Export a bookmark: To share or transfer your bookmarks between
+  computers you can use the :guilabel:`Import/Export Bookmarks` pull down menu
+  in the :guilabel:`Spatial Bookmarks` dialog. All the bookmarks are transferred.
+
+
+.. index:: Decorations
+.. _decorations:
+
+Decorations
+-----------
+
+The Decorations of QGIS include the Grid, the Copyright Label, the North Arrow
+and the Scale Bar. They are used to 'decorate' the map by adding cartographic
+elements.
+
+.. index:: Grid
+.. _grid_decoration:
+
+Grid
+....
+
+|transformed| :sup:`Grid` allows you to add a coordinate grid and coordinate
+annotations to the map canvas.
+
+.. _figure_decorations_grid:
+
+.. figure:: img/grid_dialog.png
+   :align: center
+
+   The Grid Dialog
+
+#. Select from menu :menuselection:`View --> Decorations --> Grid`.
+   The dialog starts (see figure_decorations_grid_).
+#. Activate the |checkbox| :guilabel:`Enable grid` checkbox and set grid
+   definitions according to the layers loaded in the map canvas.
+#. Activate the |checkbox| :guilabel:`Draw annotations` checkbox and set
+   annotation definitions according to the layers loaded in the map canvas.
+#. Click **[Apply]** to verify that it looks as expected or **[OK]** if you're satisfied.
+
+.. index:: Copyright
+.. _copyright_decoration:
+
+Copyright Label
+...............
+
+|copyrightLabel| :sup:`Copyright label` adds a copyright label using the text
+you prefer to the map.
+
+.. _figure_decorations_copyright:
+
+.. figure:: img/copyright.png
+   :align: center
+
+   The Copyright Dialog
+
+#. Select from menu :menuselection:`View --> Decorations --> Copyright Label`.
+   The dialog starts (see figure_decorations_copyright_).
+#. Make sure the |checkbox| :guilabel:`Enable Copyright Label` checkbox is
+   checked.
+#. Enter the text you want to place on the map. You can use HTML as
+   shown in the example.
+#. Choose the placement of the label from the :guilabel:`Placement`
+   |selectString| combo box.
+#. You can refine the placement of the item by setting a Horizontal and/or Vertical
+   `Marging from (Canvas) Edge`. These values can be a distance in **Millimeter** or
+   **Pixels** or set as **Percentage** of the width or height of the map canvas.
+#. You can change the color to apply.
+#. Click **[Apply]** to verify that it looks as expected or **[OK]** if you're satisfied.
+
+In the example above, which is the default, QGIS places a copyright symbol
+followed by the date in the lower right-hand corner of the map canvas.
+
+.. index:: North arrow
+.. _northarrow_decoration:
+
+North Arrow
+...........
+
+|northArrow| :sup:`North Arrow` places a simple north arrow on the map canvas.
+Currently, there is only one style available. You can adjust the angle of the
+arrow or let QGIS set the direction automatically.
+If you choose to let QGIS determine the direction, it makes its best guess
+as to how the arrow should be oriented.
+For placement of the arrow, you have four options, corresponding to
+the four corners of the map canvas.
+You can refine the placement of the arrow by setting a Horizontal and/or Vertical
+`Marging from (Canvas) Edge`. These values can be a distance in **Millimeter** or
+**Pixels** or set as **Percentage** of the width or height of the map canvas.
+
+.. _figure_decorations_north:
+
+.. figure:: img/north_arrow_dialog.png
+   :align: center
+
+   The North Arrow Dialog
+
+.. index:: Scale bar
+.. _scalebar_decoration:
+
+Scale Bar
+.........
+
+|scaleBar| :sup:`Scale Bar` adds a simple scale bar to the map canvas. You
+can control the style and placement, as well as the labelling of the bar.
+
+.. _figure_decorations_scale:
+
+.. figure:: img/scale_bar_dialog.png
+   :align: center
+
+   The Scale Bar Dialog
+
+QGIS only supports displaying the scale in the same units as your map frame.
+So if the units of your layers are in meters, you can't create a scale bar in
+feet. Likewise, if you are using decimal degrees, you can't create a scale
+bar to display distance in meters.
+
+To add a scale bar:
+
+#. Select from menu :menuselection:`View --> Decorations --> Scale Bar`.
+   The dialog starts (see figure_decorations_scale_).
+#. Make sure the |checkbox| :guilabel:`Enable scale bar` checkbox is checked.
+#. Choose the style from the :guilabel:`Scale bar style` |selectString|
+   combo box.
+#. Select the color for the bar :guilabel:`Color of bar` |selectColor| or use
+   the default black color.
+#. Set the :guilabel:`Size of bar` |selectNumber|.
+#. Optionally, check |checkbox| :guilabel:`Automatically snap to round number
+   on resize` to display values easy-to-read.
+#. Choose the placement from the :guilabel:`Placement` |selectString| combo box.
+#. You can refine the placement of the item by setting a Horizontal and/or Vertical
+   `Marging from (Canvas) Edge`. These values can be a distance in **Millimeter** or
+   **Pixels** or set as **Percentage** of the width or height of the map canvas.
+#. Click **[Apply]** to verify that it looks as expected or **[OK]** if you're satisfied.
+
+.. tip::
+
+   **Settings of Decorations**
+
+   When you save a :file:`.qgs` project, any changes you have made to Grid,
+   North Arrow, Scale Bar and Copyright will be saved in the project and restored
+   the next time you load the project.
+
+
+.. index::
+   single: Annotation
+   see: Annotation; Form annotation
+.. _sec_annotations:
+
+Annotation Tools
+----------------
+
+Annotations are information added to the map canvas and shown within a
+balloon. These information can be of different types and annotations are 
+added using the corresponding tools in the :guilabel:`Attributes Toolbar`:
+
+* |textAnnotation| :sup:`Text Annotation` for custom formatted text;
+* |formAnnotation| :sup:`Html Annotation` to place the content of an :file:`html`
+  file ;
+* |saveAsSVG| :sup:`SVG Annotation` to add an :file:`SVG` symbol;
+* |formAnnotation| :sup:`Form Annotation`: useful to display attributes
+  of a vector layer in a customized :file:`ui` file (see figure_custom_annotation_).
+  This is similar to the :ref:`custom attribute forms <provide_ui_file>`,
+  but displayed in an annotation item. Also see this video
+  https://youtu.be/0pDBuSbQ02o?t=2m25s from Tim Sutton for more information.
+
+.. _figure_custom_annotation:
+
+.. figure:: img/custom_annotation.png
+   :align: center
+
+   Customized qt designer annotation form
+
+.. Todo: Ideally, to sync with the text, this screen shot should not show the
+ dialog of form annotation but instead different forms in action, this will be all
+ about showing what an annotation looks like.
+ Annotation dialog will need to be shown only when it's described (which is done below)
+ 
+To add an annotation, select the corresponding tool and click on the map canvas.
+An empty balloon is added. Double-click on it and a dialog opens with various
+options. This dialog is almost the same for all the annotation types:
+
+* at the top, a file selector to fill with the path to a :file:`html`, :file:`svg`
+  or :file:`ui` file depending on the type of annotation. For text annotation,
+  you have instead to enter your message in a text box and set its rendering with
+  provided font tools;
+* |checkbox| :guilabel:`Fixed map position`: when unchecked, the balloon placement
+  is based on a screen position (instead of the map), meaning that it's always shown
+  regardless the map canvas extent;
+* :guilabel:`Linked layer`: allows the annotation to be associated with a map layer
+  and visible only when that layer is visible; 
+* :guilabel:`Map marker`: using :ref:`QGIS symbols <symbol-selector>`, allows to
+  set the symbol to display at the balloon anchor position (shown only when
+  :guilabel:`Fixed map position` is checked);
+* :guilabel:`Frame style`: Allows to set the frame background color, transparency,
+  stroke color or width... of the balloon using QGIS symbols;
+* :guilabel:`Contents margins`: set interior margins of the annotation frame.
+
+.. _figure_annotation:
+
+.. figure:: img/annotation.png
+   :align: center
+
+   Annotation text dialog
+
+Annotation can be selected when an annotation tool is enabled. Then it can be
+moved by map position (by dragging the map marker) or by moving only the balloon.
+Also the |annotation| :sup:`Move Annotation` tool allows you to move the
+balloon on the map canvas.
+
+To delete an annotation, select it and either press the :kbd:`DEL` or :kbd:`Backspace`
+button or either double-click and press the **[Delete]** button in its properties dialog.
+
+.. note::
+   If you press :kbd:`Ctrl+T` while an :guilabel:`Annotation` tool (move annotation,
+   text annotation, form annotation) is active, the visibility states of the items
+   are inverted.
+
+.. tip:: **Layout the map with annotations**
+
+  You can print or export annotations with your map to various formats using:
+
+  * map canvas export tools available in :menuselection:`Project` menu;
+  * or :ref:`print layout <create-output>`: in that case you need to check the
+    :guilabel:`Draw map canvas items` in the corresponding map item properties.
+
+
+.. index::
+   pair: Tools; Measure
+.. _`sec_measure`:
+
+Measuring
+---------
+
+General information
+...................
+
+QGIS provides four means of measuring geometries:
+
+* the interactive measurement tools |measure|,
+* measuring in the |calculateField| :sup:`Field Calculator`,
+* derived measures in the :ref:`identify` tool,
+* and a vector analysis tool: :menuselection:`Vector --> Geometry Tools -->
+  Export/Add Geometry Columns`
+
+Measuring works within projected coordinate systems (e.g., UTM) and unprojected
+data. The first three measuring tools behave equally to global project settings:
+
+* If :guilabel:`"on the fly" CRS transformation` (see :ref:`otf_transformation`)
+  is enabled, the default measurement metric is
+  - different from most other GIS - ellipsoidal, using the ellipsoid defined in
+  :menuselection:`File --> Project properties --> General`. This is true both
+  when geographic and projected coordinate systems are defined for the project.
+* If you want to calculate the projected / planimetric area or distance using cartesian
+  maths, the measurement ellipsoid has to be set to "None / Planimetric"
+  (:menuselection:`File --> Project properties --> CRS`). However,
+  with a geographic (= unprojected) CRS defined for the data and project, area and
+  distance measurement will be ellipsoidal.
+* If :guilabel:`"on the fly" CRS transformation` is disabled, the measurement
+  metric is planimetric when the project coordinate system is projected and
+  ellipsoidal when the project coordinate system is unprojected / geographic.
+
+However, neither the identify tool nor the field calculator will transform your
+data to the project CRS before measuring. If you want to achieve this, you have
+to use the vector analysis tool: :menuselection:`Vector --> Geometry Tools -->
+Export/Add Geometry Columns`. Here, measurement is by default planimetric except
+if you choose the ellipsoidal measure.
+
+Measure length, areas and angles interactive
+............................................
+   
+Click the |measure| icon in the Attribute toolbar to begin measurements.
+The downward arrow near the icon helps you switch to the convenient tool to measure
+|measure| length, |measureArea| area or |measureAngle| angle.
+The default unit used in the dialog is the one set in :menuselection:`Project -->
+Project Properties --> General` menu.
+
+.. note:: **Configuring the measure tool**
+
+   While measuring length or area, clicking the :guilabel:`Configuration` button
+   at the bottom of the widget helps you define in menu :menuselection:`Settings -->
+   Options --> Map Tools` the rubberband color, the precision of the measurements
+   and the unit behavior. You can also choose your preferred measurement or angle
+   units but keep in mind that those values are superseded in the current project
+   by options made in :menuselection:`Project --> Project Properties --> General` menu.
+
+All measuring modules use the snapping settings from the digitizing module (see
+section :ref:`snapping_tolerance`). So, if you want
+to measure exactly along a line feature, or around a polygon feature, first set
+its layer snapping tolerance. Now, when using the measuring
+tools, each mouse click (within the tolerance setting) will snap to that layer.
+
+.. index::
+   single: Measure; Distances
+   single: Measure; Areas
+   single: Measure; Angles
+
+By default, |measure| :sup:`Measure Line`: QGIS measures real distances
+between given points according to a defined ellipsoid.
+The tool then allows you to click points on the map. Each segment length,
+as well as the total, shows up in the measure window.
+To stop measuring, click your right mouse button.
+
+Note that you can use the drop-down list near the total to interactively change
+the measurement units while measuring. This unit is kept for the widget until
+a new or another project is opened.
+
+The :guilabel:`Info` section in the dialog explains how calculations are made
+according to CRS settings available.
+
+.. %FixMe: currently, validating the Settings --> Options dialog revert any change
+   made on units in the measurement dialog (see http://hub.qgis.org/issues/15436
+   bug or not? should it be documented?)
+
+.. _figure_measure_length:
+
+.. figure:: img/measure_line.png
+   :align: center
+
+   Measure Distance
+
+|measureArea| :sup:`Measure Area`: Areas can also be measured. In the
+measure window, the accumulated area size appears. Right-click to stop drawing.
+The Info section is also available as well as the ability to switch between
+different area units.
+
+.. _figure_measure_area:
+
+.. figure:: img/measure_area.png
+   :align: center
+
+   Measure Area
+
+|measureAngle| :sup:`Measure Angle`: You can also measure angles. The
+cursor becomes cross-shaped. Click to draw the first segment of the angle you
+wish to measure, then move the cursor to draw the desired angle. The measure
+is displayed in a pop-up dialog.
+
+.. _figure_measure_angle:
+
+.. figure:: img/measure_angle.png
+   :align: center
+
+   Measure Angle
+
+Interacting with features
+=========================
+
+.. index::
+   see: Select; Selection tools
+   single: Selection tools; Select all
+   single: Selection tools; Invert selection
+   single: Selection tools; Select by expression
+   single: Selection tools; Select by form
+   single: Selection tools; Select by polygon
+   single: Selection tools; Select by freehand
+   single: Selection tools; Select by rectangle
+   single: Selection tools; Select by radius
+   pair: Select; Deselect
+
+.. _`sec_selection`:
+
+Selecting features
+------------------
+
+QGIS provides several tools to select features in the map canvas. Selection
+tools are available in :menuselection:`View --> Select` menu or in the
+:guilabel:`Attributes toolbar`.
+
+.. note::
+
+   Selection tools work with the currently active layer.
+
+Selecting manually in the map canvas
+....................................
+
+To select one or several features with the mouse, you can use one of the following
+tools:
+
+* |selectRectangle| :sup:`Select Features by area or single click`
+* |selectPolygon| :sup:`Select Features by Polygon`
+* |selectFreehand| :sup:`Select Features by Freehand`
+* |selectRadius| :sup:`Select Features by Radius`
+
+.. note:: Except the |selectPolygon| :sup:`Select Features by Polygon` tool, these 
+   manual selection tools allow you to select feature(s) in the map canvas with a
+   single click.
+
+While using the |selectRectangle| :guilabel:`Select Feature(s)` tool,
+holding :kbd:`Shift` or :kbd:`Ctrl` toggles whether feature is selected
+(ie either adds to the current selection or remove from it).
+
+For the other tools, different behaviors can be performed holding:
+
+* :kbd:`Shift`: add features to the current selection
+* :kbd:`Ctrl`: substract features from the current selection
+* :kbd:`Ctrl + Shift`: intersect with current selection, ie only keep
+  overlapping features from the current selection
+* :kbd:`Alt`: select features that are totally within the selection shape.
+  Combined to :kbd:`Shift` or :kbd:`Ctrl` keys, you can add or substract
+  features to/from the current selection.
+
+.. _automatic_selection:
+
+Automatic selection
+...................
+
+The other selection tools, also available from the :ref:`Attribute table 
+<sec_attribute_table>`, perform a selection based on feature's attribute
+or its selection state (note that attribute table and map canvas show the
+same information, so if you select one feature in attribute table, it will
+be selected in map canvas also):
+
+* |expressionSelect| :sup:`Select By Expression...` allows user to select
+  features using expression dialog. 
+* |formSelect| :sup:`Select Features By Value...` or press :kbd:`F3`
+* |deselectAll| :sup:`Deselect Features from All Layers` or press
+  :kbd:`Ctrl+Shift+A` to deselect all selected features in all layers.
+* |selectAll| :sup:`Select All Features` or press :kbd:`Ctrl+A` to select all
+  features in the current layer.
+* |invertSelection| :sup:`Invert Feature Selection` to invert the selection in
+  the current layer.
+
+
+For example, if you want to find regions that are boroughs from
+:file:`regions.shp` of the QGIS sample data, you can use the |expressionSelect|
+:sup:`Select features using an Expression` icon. Then, you open the
+:guilabel:`Fields and Values` menu and choose the field that you want to query.
+Double-click the field 'TYPE_2' and also click **[Load all unique values]**
+in the right panel. From the list, choose and double-click 'Borough'. In the
+:guilabel:`Expression` field, then you'd write the following query:
+
+::
+
+ "TYPE_2"  =  'Borough'
+
+From the expression builder dialog, you can also use the :menuselection:`Function
+list --> Recent (Selection)` to make a selection that you used before. The
+dialog remembers the last 20 used expressions. See :ref:`vector_expressions`
+chapter for more information and some example.
+
+
+.. tip:: **Save your selection into a new file**
+   
+   Users can save selected features into a **New Temporary Scratch Layer** or a
+   **New Vector Layer** using :menuselection:`Edit --> Copy Features` and
+   :menuselection:`Edit --> Paste Features as` in the wanted format.
+
+.. index::
+   single: Selection tools; Select by value
+
+.. _select_by_value:
+
+Select Features By Value
+........................
+
+This selection tool opens the layer's feature form allowing the user to choose,
+for each field, which value to look for, if the search should be case sensitive,
+and the operation that should be used.
+
+.. _figure_filter_form:
+
+.. figure:: img/select_by_value.png
+   :align: center
+
+   Filter/Select features using form dialog
+
+Alongside each field, there is a drop-down list with the operation options to
+control the search behaviour. The common options are:
+
+* :guilabel:`Exclude Field` - The field will not be used for searching
+* :guilabel:`Equal to (=)`
+* :guilabel:`Not equal to`
+* :guilabel:`Is missing (null)`
+* :guilabel:`Is not missing (not null)`
+
+For numeric and datetime fields, the additional options are:
+
+* :guilabel:`Greater than (>)`
+* :guilabel:`Less than (<)`
+* :guilabel:`Greater than or equal to (>=)`
+* :guilabel:`Less than or equal to (<=)`
+* :guilabel:`Between (inclusive)`
+* :guilabel:`Is not between (inclusive)`
+
+For text fields, the additional options are:
+
+* :guilabel:`Contains`
+* :guilabel:`Does not contain`
+* :guilabel:`Starts with`
+* :guilabel:`Ends with`
+
+For the text options above, it is also possible to use the |checkbox|
+:guilabel:`Case sensitive` option.
+
+After setting all search options, you can use the :guilabel:`Select features`
+button to select the matching features. The drop-down options are:
+
+* :guilabel:`Select features`
+* :guilabel:`Add to current selection`
+* :guilabel:`Filter current selection`
+* :guilabel:`Remove from current current selection`
+
+You can also clean all search options using the :guilabel:`Reset form` button.
+
+Once the conditions are set, you can also either:
+
+* :guilabel:`Zoom to features` in the map canvas without the need of a preselection;
+* or :guilabel:`Flash features`, highlighting the concerned features. This is a
+  handy way to identify a feature without selection or using the Identify tool.
+  Note that the flash does not alter the map canvas extent and would be visible only
+  if the feature resides in the current canvas.
+
+.. index::
+   single: Identify features
+.. _`identify`:
+
+Identifying Features
+--------------------
+
+The Identify tool allows you to interact with the map canvas and get information
+on features in a pop-up window. To identify features, use:
+
+* :menuselection:`View --> Identify Features` menu,
+* or press :kbd:`Ctrl + Shift + I` (or |osx| :kbd:`Cmd + Shift + I`),
+* or click the |identify| :sup:`Identify Features` icon on the Attributes toolbar.
+
+Using the Identify Features tool
+................................
+
+QGIS offers two ways to identify features with the |identify|
+:sup:`Identify Features` tool:
+
+* **left click** will identify features according to the mode set in the
+  :guilabel:`Identify Results` panel
+* **right click** will fetch all the snapped features from all the visible layers.
+  This will open a context menu, allowing the user to choose more precisely the
+  features to identify or the action to execute on it.
+
+.. tip:: **Filter the layers to query with the Identify Features tool**
+
+   Uncheck the :guilabel:`Identifiable` column in :menuselection:`Project -->`
+   (or |kde| :menuselection:`Settings -->`), :menuselection:`Project
+   Properties --> Identify layers` menu in front of a layer to avoid it
+   being queried when using the |identify| :sup:`Identify Features` in a mode
+   other than **Current Layer**. This is a handy way to return features from only
+   layers that are of interest for you.
+
+If you click on feature(s), the :guilabel:`Identify Results` dialog will list
+information about the clicked feature(s). The default view is a tree view where
+the first item is the name of the layer and its children are its identified feature(s).
+Each feature is described by the name of a field along with its value.
+This field is the one set in :menuselection:`Layer Properties --> Display`.
+Then follows all the other information about the feature.
+
+Feature informations
+....................
+
+The Identify Results dialog can be customized to display custom fields, but by
+default it will display three kinds of information:
+
+.. index:: Actions
+
+* **Actions**: Actions can be added to the identify feature windows.
+  The action is run by clicking on the action label. By default, only one action
+  is added, namely ``View feature form`` for editing. You can define more actions
+  in the layer's properties dialog (see :ref:`actions_menu`).
+* **Derived**: This information is calculated or derived from other information.
+  This includes:
+
+  * general information about the feature and its geometry: feature id, length or perimeter
+    and area in map units depending on its geometry, the count of spatial parts and
+    the number of the clicked part in case of multi-geometry, the count of vertices in
+    the feature and the number of the closest one to the point clicked
+  * coordinates information: the X and Y (and Z/M if available) coordinate values of the
+    clicked point, the feature closest vertex and its first and last vertices.
+    In case you click on a curved line using the info tool, QGIS will also display the
+    radius of that section in the panel result.
+
+* **Data attributes**: This is the list of attribute fields and values for the
+  feature that has been clicked.
+
+.. note:: Links in feature's attributes are clickable from the :guilabel:`Identify
+   Results` panel and will open in your default web browser.
+   
+.. _figure_identify:
+
+.. figure:: img/identify_features.png
+   :align: center
+
+   Identify Results dialog
+
+The Identify Results dialog
+...........................
+
+At the top of the window, you have seven icons:
+
+* |expandTree| :sup:`Expand tree`
+* |collapseTree| :sup:`Collapse tree`
+* |expandNewTree| :sup:`Default behavior` to define whether next
+  identified features information should be collapsed or expanded
+* |propertyItem| :sup:`View the feature form`
+* |deselectAll| :sup:`Clear Results`
+* |editCopy| :sup:`Copy selected feature to clipboard`
+* |filePrint| :sup:`Print selected HTML response`
+
+At the bottom of the window, you have the :guilabel:`Mode` and :guilabel:`View`
+comboboxes.
+With the :guilabel:`Mode` combobox you can define from which layers features
+should be identified:
+
+* **Current layer** : only features from the selected layer are identified. The
+  layer may not be visible in the canvas.
+* **Top down, stop at first**: for only features from the upper visible layer.
+* **Top down**: for all features from the visible layers. The results are shown in
+  the panel.
+* and **Layer selection**: opens a context menu where the user selects the layer to
+  identify features from. Operates like a right-click. Only the chosen features
+  will be shown in the result panel.
+
+.. note:: **Identify tool configuration**
+
+   You can configure the identify feature in :menuselection:`Project -->
+   Project Properties` in the :guilabel:`Identify layers` tab. The table allows
+   user to select layer(s) that can be used by this tool to identify features
+   (column :guilabel:`Identifiable`). You can also put this layer in read-only
+   mode with the checkbox in the last column.
+
+The :guilabel:`View` can be set as **Tree**, **Table** or **Graph**.
+'Table' and 'Graph' views can only be set for raster layers.
+
+The identify tool allows you to |checkbox|:guilabel:`Auto open a form`.
+If checked, each time a single feature is identified QGIS will open a form
+showing its attributes. This is a handy way to quickly edit a feature's attributes.
+
+Other functions can be found in the context menu of the identified item. For
+example, from the context menu you can:
+
+* View the feature form
+* Zoom to feature
+* Copy feature: Copy all feature geometry and attributes
+* Toggle feature selection: Adds identified feature to selection
+* Copy attribute value: Copy only the value of the attribute that you click on
+* Copy feature attributes: Copy the attributes of the feature
+* Clear result: Remove results in the window
+* Clear highlights: Remove features highlighted on the map
+* Highlight all
+* Highlight layer
+* Activate layer: Choose a layer to be activated
+* Layer properties: Open layer properties window
+* Expand all
+* Collapse all
+
+
 .. index:: Save properties, Save style, QML, SLD
 .. _save_layer_property:
 
 Save and Share Layer Properties
-================================
+===============================
 
 .. _manage_custom_style:
 
@@ -615,7 +1407,6 @@ to duplicate any layer in the map legend.
 
    Right-click on the layer in :guilabel:`Layers Panel` to add, rename
    or remove layer style.
-
 
 .. _store_style:
 
@@ -706,11 +1497,20 @@ with name and description.
    that are of the same type (vector vs raster) as the original layer and, in
    case of vector, have the same geometry type (point, line or polygon).
 
+
+.. _common_widgets:
+
+Common widgets
+==============
+
+In QGIS, there are some options you'll often have to work with. To ease their
+manipulation, QGIS provides you with special widgets that are presented below.
+
 .. index:: Colors
 .. _color-selector:
 
 Color Selector
-==============
+--------------
 
 The :guilabel:`select color` dialog will appear whenever you push
 the |selectColor| icon to choose a color. The features of this dialog
@@ -800,7 +1600,7 @@ can also click the **[Sample color]** button to trigger the picker capability.
 .. _blend-modes:
 
 Blending Modes
-===============
+--------------
 
 QGIS offers different options for special rendering effects with these tools that
 you may previously only know from graphics programs. Blending modes can be applied
@@ -838,338 +1638,11 @@ on layers, on features but also on print layout items:
 * **Subtract**: This blend mode simply subtracts pixel values of one item from the other.
   In case of negative values, black is displayed.
 
-.. index:: Zoom, Pan, Map navigation
-.. _zoom_pan:
-
-Zooming and Panning
-====================
-
-QGIS provides tools to zoom and pan to your area of interest.
-
-Apart from using the |pan| :sup:`pan` and |zoomIn|
-:sup:`zoom-in` / |zoomOut| :sup:`zoom-out` icons on the toolbar
-with the mouse, navigating can also be done with the mouse wheel, spacebar
-and the arrow keys. A :guilabel:`Zoom factor` can be set under the
-:menuselection:`Settings -->` |options| :menuselection:`Options --> Map tools`
-menu to define the scale behavior while zooming.
-
-With the mouse wheel
---------------------
-
-You can press the mouse wheel to pan inside of the main window (on macOS,
-you may need to hold :kbd:`cmd` key).
-You can roll the mouse wheel to zoom in and out on the map; the mouse
-cursor position will be the center of the zoomed area of interest.
-Holding down :kbd:`Ctrl` while rolling the mouse wheel results in a finer zoom.
-
-With the arrow keys
--------------------
-
-Panning the map is possible with the arrow keys.
-Place the mouse cursor inside the map area, and click on the right arrow key
-to pan east, left arrow key to pan west, up arrow key to pan north, and down
-arrow key to pan south.
-
-You can also use the space bar to temporarily cause mouse movements to pan
-the map. The :kbd:`PgUp` and :kbd:`PgDown` keys on your keyboard will cause
-the map display to zoom in or out following the zoom factor set. Pressing
-:kbd:`Ctrl +` or :kbd:`Ctrl -` also performs an immediate zoom in/out
-on the map canvas.
-
-When certain map tools are active (Identify, Measure...), you can perform a zoom by
-holding down :kbd:`Shift` and dragging a rectangle on the map to zoom to that area.
-This is enabled for the map tools which are not selection tools (since they
-use :kbd:`Shift` for adding to selection) nor edit tools.
-
-
-.. index::
-   pair: Tools; Measure
-.. _`sec_measure`:
-
-Measuring
-=========
-
-General information
---------------------
-
-QGIS provides four means of measuring geometries:
-
-* the interactive measurement tools |measure|,
-* measuring in the |calculateField| :sup:`Field Calculator`,
-* derived measures in the :ref:`identify` tool,
-* and a vector analysis tool: :menuselection:`Vector --> Geometry Tools -->
-  Export/Add Geometry Columns`
-
-Measuring works within projected coordinate systems (e.g., UTM) and unprojected
-data. The first three measuring tools behave equally to global project settings:
-
-* If :guilabel:`"on the fly" CRS transformation` (see :ref:`otf_transformation`)
-  is enabled, the default measurement metric is
-  - different from most other GIS - ellipsoidal, using the ellipsoid defined in
-  :menuselection:`File --> Project properties --> General`. This is true both
-  when geographic and projected coordinate systems are defined for the project.
-* If you want to calculate the projected / planimetric area or distance using cartesian
-  maths, the measurement ellipsoid has to be set to "None / Planimetric"
-  (:menuselection:`File --> Project properties --> CRS`). However,
-  with a geographic (= unprojected) CRS defined for the data and project, area and
-  distance measurement will be ellipsoidal.
-* If :guilabel:`"on the fly" CRS transformation` is disabled, the measurement
-  metric is planimetric when the project coordinate system is projected and
-  ellipsoidal when the project coordinate system is unprojected / geographic.
-
-However, neither the identify tool nor the field calculator will transform your
-data to the project CRS before measuring. If you want to achieve this, you have
-to use the vector analysis tool: :menuselection:`Vector --> Geometry Tools -->
-Export/Add Geometry Columns`. Here, measurement is by default planimetric except
-if you choose the ellipsoidal measure.
-
-Measure length, areas and angles interactive
-----------------------------------------------
-   
-Click the |measure| icon in the Attribute toolbar to begin measurements.
-The downward arrow near the icon helps you switch to the convenient tool to measure
-|measure| length, |measureArea| area or |measureAngle| angle.
-The default unit used in the dialog is the one set in :menuselection:`Project -->
-Project Properties --> General` menu.
-
-.. note:: **Configuring the measure tool**
-
-   While measuring length or area, clicking the :guilabel:`Configuration` button
-   at the bottom of the widget helps you define in menu :menuselection:`Settings -->
-   Options --> Map Tools` the rubberband color, the precision of the measurements
-   and the unit behavior. You can also choose your preferred measurement or angle
-   units but keep in mind that those values are superseded in the current project
-   by options made in :menuselection:`Project --> Project Properties --> General` menu.
-
-All measuring modules use the snapping settings from the digitizing module (see
-section :ref:`snapping_tolerance`). So, if you want
-to measure exactly along a line feature, or around a polygon feature, first set
-its layer snapping tolerance. Now, when using the measuring
-tools, each mouse click (within the tolerance setting) will snap to that layer.
-
-.. index::
-   single: Measure; Distances
-   single: Measure; Areas
-   single: Measure; Angles
-
-By default, |measure| :sup:`Measure Line`: QGIS measures real distances
-between given points according to a defined ellipsoid.
-The tool then allows you to click points on the map. Each segment length,
-as well as the total, shows up in the measure window.
-To stop measuring, click your right mouse button.
-
-Note that you can use the drop-down list near the total to interactively change
-the measurement units while measuring. This unit is kept for the widget until
-a new or another project is opened.
-
-The :guilabel:`Info` section in the dialog explains how calculations are made
-according to CRS settings available.
-
-.. %FixMe: currently, validating the Settings --> Options dialog revert any change
-   made on units in the measurement dialog (see http://hub.qgis.org/issues/15436
-   bug or not? should it be documented?)
-
-.. _figure_measure_length:
-
-.. figure:: img/measure_line.png
-   :align: center
-
-   Measure Distance
-
-|measureArea| :sup:`Measure Area`: Areas can also be measured. In the
-measure window, the accumulated area size appears. Right-click to stop drawing.
-The Info section is also available as well as the ability to switch between
-different area units.
-
-.. _figure_measure_area:
-
-.. figure:: img/measure_area.png
-   :align: center
-
-   Measure Area
-
-|measureAngle| :sup:`Measure Angle`: You can also measure angles. The
-cursor becomes cross-shaped. Click to draw the first segment of the angle you
-wish to measure, then move the cursor to draw the desired angle. The measure
-is displayed in a pop-up dialog.
-
-.. _figure_measure_angle:
-
-.. figure:: img/measure_angle.png
-   :align: center
-
-   Measure Angle
-
-.. index::
-   see: Select; Selection tools
-   single: Selection tools; Select all
-   single: Selection tools; Invert selection
-   single: Selection tools; Select by expression
-   single: Selection tools; Select by form
-   single: Selection tools; Select by polygon
-   single: Selection tools; Select by freehand
-   single: Selection tools; Select by rectangle
-   single: Selection tools; Select by radius
-   pair: Select; Deselect
-
-.. _`sec_selection`:
-
-Selecting features
-==================
-
-QGIS provides several tools to select features in the map canvas. Selection
-tools are available in :menuselection:`View --> Select` menu or in the
-:guilabel:`Attributes toolbar`.
-
-.. note::
-
-   Selection tools work with the currently active layer.
-
-Selecting manually in the map canvas
--------------------------------------
-
-To select one or several features with the mouse, you can use one of the following
-tools:
-
-* |selectRectangle| :sup:`Select Features by area or single click`
-* |selectPolygon| :sup:`Select Features by Polygon`
-* |selectFreehand| :sup:`Select Features by Freehand`
-* |selectRadius| :sup:`Select Features by Radius`
-
-.. note:: Except the |selectPolygon| :sup:`Select Features by Polygon` tool, these 
-   manual selection tools allow you to select feature(s) in the map canvas with a
-   single click.
-
-While using the |selectRectangle| :guilabel:`Select Feature(s)` tool,
-holding :kbd:`Shift` or :kbd:`Ctrl` toggles whether feature is selected
-(ie either adds to the current selection or remove from it).
-
-For the other tools, different behaviors can be performed holding:
-
-* :kbd:`Shift`: add features to the current selection
-* :kbd:`Ctrl`: substract features from the current selection
-* :kbd:`Ctrl + Shift`: intersect with current selection, ie only keep
-  overlapping features from the current selection
-* :kbd:`Alt`: select features that are totally within the selection shape.
-  Combined to :kbd:`Shift` or :kbd:`Ctrl` keys, you can add or substract
-  features to/from the current selection.
-
-.. _automatic_selection:
-
-Automatic selection
---------------------
-
-The other selection tools, also available from the :ref:`Attribute table 
-<sec_attribute_table>`, perform a selection based on feature's attribute
-or its selection state (note that attribute table and map canvas show the
-same information, so if you select one feature in attribute table, it will
-be selected in map canvas also):
-
-* |expressionSelect| :sup:`Select By Expression...` allows user to select
-  features using expression dialog. 
-* |formSelect| :sup:`Select Features By Value...` or press :kbd:`F3`
-* |deselectAll| :sup:`Deselect Features from All Layers` or press
-  :kbd:`Ctrl+Shift+A` to deselect all selected features in all layers.
-* |selectAll| :sup:`Select All Features` or press :kbd:`Ctrl+A` to select all
-  features in the current layer.
-* |invertSelection| :sup:`Invert Feature Selection` to invert the selection in
-  the current layer.
-
-
-For example, if you want to find regions that are boroughs from
-:file:`regions.shp` of the QGIS sample data, you can use the |expressionSelect|
-:sup:`Select features using an Expression` icon. Then, you open the
-:guilabel:`Fields and Values` menu and choose the field that you want to query.
-Double-click the field 'TYPE_2' and also click **[Load all unique values]**
-in the right panel. From the list, choose and double-click 'Borough'. In the
-:guilabel:`Expression` field, then you'd write the following query:
-
-::
-
- "TYPE_2"  =  'Borough'
-
-From the expression builder dialog, you can also use the :menuselection:`Function
-list --> Recent (Selection)` to make a selection that you used before. The
-dialog remembers the last 20 used expressions. See :ref:`vector_expressions`
-chapter for more information and some example.
-
-
-.. tip:: **Save your selection into a new file**
-   
-   Users can save selected features into a **New Temporary Scratch Layer** or a
-   **New Vector Layer** using :menuselection:`Edit --> Copy Features` and
-   :menuselection:`Edit --> Paste Features as` in the wanted format.
-
-.. index::
-   single: Selection tools; Select by value
-
-.. _select_by_value:
-
-Select Features By Value
-------------------------
-
-This selection tool opens the layer's feature form allowing the user to choose,
-for each field, which value to look for, if the search should be case sensitive,
-and the operation that should be used.
-
-.. _figure_filter_form:
-
-.. figure:: img/select_by_value.png
-   :align: center
-
-   Filter/Select features using form dialog
-
-Alongside each field, there is a drop-down list with the operation options to
-control the search behaviour. The common options are:
-
-* :guilabel:`Exclude Field` - The field will not be used for searching
-* :guilabel:`Equal to (=)`
-* :guilabel:`Not equal to`
-* :guilabel:`Is missing (null)`
-* :guilabel:`Is not missing (not null)`
-
-For numeric and datetime fields, the additional options are:
-
-* :guilabel:`Greater than (>)`
-* :guilabel:`Less than (<)`
-* :guilabel:`Greater than or equal to (>=)`
-* :guilabel:`Less than or equal to (<=)`
-* :guilabel:`Between (inclusive)`
-* :guilabel:`Is not between (inclusive)`
-
-For text fields, the additional options are:
-
-* :guilabel:`Contains`
-* :guilabel:`Does not contain`
-* :guilabel:`Starts with`
-* :guilabel:`Ends with`
-
-For the text options above, it is also possible to use the |checkbox|
-:guilabel:`Case sensitive` option.
-
-After setting all search options, you can use the :guilabel:`Select features`
-button to select the matching features. The drop-down options are:
-
-* :guilabel:`Select features`
-* :guilabel:`Add to current selection`
-* :guilabel:`Filter current selection`
-* :guilabel:`Remove from current current selection`
-
-You can also clean all search options using the :guilabel:`Reset form` button.
-
-Once the conditions are set, you can also either:
-
-* :guilabel:`Zoom to features` in the map canvas without the need of a preselection;
-* or :guilabel:`Flash features`, highlighting the concerned features. This is a
-  handy way to identify a feature without selection or using the Identify tool.
-  Note that the flash does not alter the map canvas extent and would be visible only
-  if the feature resides in the current canvas.
-
 .. index:: Data-defined override
 .. _data_defined:
 
 Data defined override setup
-===========================
+---------------------------
 
 Beside many options in the vector layer properties dialog or settings in the print
 layout, you can find a |dataDefined| :sup:`Data defined override` icon.
@@ -1209,482 +1682,11 @@ Parameters that can be used with data-defined tools are:
    the icon is red |dataDefineError| or |dataDefineExpressionError|.
 
 
-.. index::
-   single: Identify features
-.. _`identify`:
-
-Identify Features
-=================
-
-The Identify tool allows you to interact with the map canvas and get information
-on features in a pop-up window. To identify features, use:
-
-* :menuselection:`View --> Identify Features` menu,
-* or press :kbd:`Ctrl + Shift + I` (or |osx| :kbd:`Cmd + Shift + I`),
-* or click the |identify| :sup:`Identify Features` icon on the Attributes toolbar.
-
-Using the Identify Features tool
----------------------------------
-
-QGIS offers two ways to identify features with the |identify|
-:sup:`Identify Features` tool:
-
-* **left click** will identify features according to the mode set in the
-  :guilabel:`Identify Results` panel
-* **right click** will fetch all the snapped features from all the visible layers.
-  This will open a context menu, allowing the user to choose more precisely the
-  features to identify or the action to execute on it.
-
-.. tip:: **Filter the layers to query with the Identify Features tool**
-
-   Uncheck the :guilabel:`Identifiable` column in :menuselection:`Project -->`
-   (or |kde| :menuselection:`Settings -->`), :menuselection:`Project
-   Properties --> Identify layers` menu in front of a layer to avoid it
-   being queried when using the |identify| :sup:`Identify Features` in a mode
-   other than **Current Layer**. This is a handy way to return features from only
-   layers that are of interest for you.
-
-If you click on feature(s), the :guilabel:`Identify Results` dialog will list
-information about the clicked feature(s). The default view is a tree view where
-the first item is the name of the layer and its children are its identified feature(s).
-Each feature is described by the name of a field along with its value.
-This field is the one set in :menuselection:`Layer Properties --> Display`.
-Then follows all the other information about the feature.
-
-Feature informations
----------------------
-
-The Identify Results dialog can be customized to display custom fields, but by
-default it will display three kinds of information:
-
-.. index:: Actions
-
-* **Actions**: Actions can be added to the identify feature windows.
-  The action is run by clicking on the action label. By default, only one action
-  is added, namely ``View feature form`` for editing. You can define more actions
-  in the layer's properties dialog (see :ref:`actions_menu`).
-* **Derived**: This information is calculated or derived from other information.
-  This includes:
-
-  * general information about the feature and its geometry: feature id, length or perimeter
-    and area in map units depending on its geometry, the count of spatial parts and
-    the number of the clicked part in case of multi-geometry, the count of vertices in
-    the feature and the number of the closest one to the point clicked
-  * coordinates information: the X and Y (and Z/M if available) coordinate values of the
-    clicked point, the feature closest vertex and its first and last vertices.
-    In case you click on a curved line using the info tool, QGIS will also display the
-    radius of that section in the panel result.
-
-* **Data attributes**: This is the list of attribute fields and values for the
-  feature that has been clicked.
-
-.. note:: Links in feature's attributes are clickable from the :guilabel:`Identify
-   Results` panel and will open in your default web browser.
-   
-.. _figure_identify:
-
-.. figure:: img/identify_features.png
-   :align: center
-
-   Identify Results dialog
-
-The Identify Results dialog
-----------------------------
-
-At the top of the window, you have seven icons:
-
-* |expandTree| :sup:`Expand tree`
-* |collapseTree| :sup:`Collapse tree`
-* |expandNewTree| :sup:`Default behavior` to define whether next
-  identified features information should be collapsed or expanded
-* |propertyItem| :sup:`View the feature form`
-* |deselectAll| :sup:`Clear Results`
-* |editCopy| :sup:`Copy selected feature to clipboard`
-* |filePrint| :sup:`Print selected HTML response`
-
-At the bottom of the window, you have the :guilabel:`Mode` and :guilabel:`View`
-comboboxes.
-With the :guilabel:`Mode` combobox you can define from which layers features
-should be identified:
-
-* **Current layer** : only features from the selected layer are identified. The
-  layer may not be visible in the canvas.
-* **Top down, stop at first**: for only features from the upper visible layer.
-* **Top down**: for all features from the visible layers. The results are shown in
-  the panel.
-* and **Layer selection**: opens a context menu where the user selects the layer to
-  identify features from. Operates like a right-click. Only the chosen features
-  will be shown in the result panel.
-
-.. note:: **Identify tool configuration**
-
-   You can configure the identify feature in :menuselection:`Project -->
-   Project Properties` in the :guilabel:`Identify layers` tab. The table allows
-   user to select layer(s) that can be used by this tool to identify features
-   (column :guilabel:`Identifiable`). You can also put this layer in read-only
-   mode with the checkbox in the last column.
-
-The :guilabel:`View` can be set as **Tree**, **Table** or **Graph**.
-'Table' and 'Graph' views can only be set for raster layers.
-
-The identify tool allows you to |checkbox|:guilabel:`Auto open a form`.
-If checked, each time a single feature is identified QGIS will open a form
-showing its attributes. This is a handy way to quickly edit a feature's attributes.
-
-Other functions can be found in the context menu of the identified item. For
-example, from the context menu you can:
-
-* View the feature form
-* Zoom to feature
-* Copy feature: Copy all feature geometry and attributes
-* Toggle feature selection: Adds identified feature to selection
-* Copy attribute value: Copy only the value of the attribute that you click on
-* Copy feature attributes: Copy the attributes of the feature
-* Clear result: Remove results in the window
-* Clear highlights: Remove features highlighted on the map
-* Highlight all
-* Highlight layer
-* Activate layer: Choose a layer to be activated
-* Layer properties: Open layer properties window
-* Expand all
-* Collapse all
-
-.. index::
-   single: Annotation
-   see: Annotation; Form annotation
-.. _sec_annotations:
-
-Annotation Tools
-================
-
-Annotations are information added to the map canvas and shown within a
-balloon. These information can be of different types and annotations are 
-added using the corresponding tools in the :guilabel:`Attributes Toolbar`:
-
-* |textAnnotation| :sup:`Text Annotation` for custom formatted text;
-* |formAnnotation| :sup:`Html Annotation` to place the content of an :file:`html`
-  file ;
-* |saveAsSVG| :sup:`SVG Annotation` to add an :file:`SVG` symbol;
-* |formAnnotation| :sup:`Form Annotation`: useful to display attributes
-  of a vector layer in a customized :file:`ui` file (see figure_custom_annotation_).
-  This is similar to the :ref:`custom attribute forms <provide_ui_file>`,
-  but displayed in an annotation item. Also see this video
-  https://youtu.be/0pDBuSbQ02o?t=2m25s from Tim Sutton for more information.
-
-.. _figure_custom_annotation:
-
-.. figure:: img/custom_annotation.png
-   :align: center
-
-   Customized qt designer annotation form
-
-.. Todo: Ideally, to sync with the text, this screenshot should not show the
- dialog of form annotation but instead different forms in action, this will be all
- about showing what an annotation looks like.
- Annotation dialog will need to be shown only when it's described (which is done below)
- 
-To add an annotation, select the corresponding tool and click on the map canvas.
-An empty balloon is added. Double-click on it and a dialog opens with various
-options. This dialog is almost the same for all the annotation types:
-
-* at the top, a file selector to fill with the path to a :file:`html`, :file:`svg`
-  or :file:`ui` file depending on the type of annotation. For text annotation,
-  you have instead to enter your message in a textbox and set its rendering with
-  provided font tools;
-* |checkbox| :guilabel:`Fixed map position`: when unchecked, the balloon placement
-  is based on a screen position (instead of the map), meaning that it's always shown
-  regardless the map canvas extent;
-* :guilabel:`Linked layer`: allows the annotation to be associated with a map layer
-  and visible only when that layer is visible; 
-* :guilabel:`Map marker`: using :ref:`QGIS symbols <symbol-selector>`, allows to
-  set the symbol to display at the balloon anchor position (shown only when
-  :guilabel:`Fixed map position` is checked);
-* :guilabel:`Frame style`: Allows to set the frame background color, transparency,
-  stroke color or width... of the balloon using QGIS symbols;
-* :guilabel:`Contents margins`: set interior margins of the annotation frame.
-
-.. _figure_annotation:
-
-.. figure:: img/annotation.png
-   :align: center
-
-   Annotation text dialog
-
-Annotation can be selected when an annotation tool is enabled. Then it can be
-moved by map position (by dragging the map marker) or by moving only the balloon.
-Also the |annotation| :sup:`Move Annotation` tool allows you to move the
-balloon on the map canvas.
-
-To delete an annotation, select it and either press the :kbd:`DEL` or :kbd:`Backspace`
-button or either double-clik and press the **[Delete]** button in its properties dialog.
-
-.. note::
-   If you press :kbd:`Ctrl+T` while an :guilabel:`Annotation` tool (move annotation,
-   text annotation, form annotation) is active, the visibility states of the items
-   are inverted.
-
-.. tip:: **Layout the map with annotations**
-
-  You can print or export annotations with your map to various formats using:
-
-  * map canvas export tools available in :menuselection:`Project` menu;
-  * or :ref:`print layout <create-output>`: in that case you need to check the
-    :guilabel:`Draw map canvas items` in the corresponding map item properties.
-
-.. index::
-   single: Bookmarks
-   see: Spatial bookmarks; Bookmarks
-.. _`sec_bookmarks`:
-
-Spatial Bookmarks
-=================
-
-Spatial Bookmarks allow you to "bookmark" a geographic location and return to
-it later. By default, bookmarks are saved on the computer, meaning that they are available
-from any project in the same computer. If you wish to store the bookmark in the project
-file (:file:`.qgs`) then you can do this by selecting the :guilabel:`In Project` checkbox.
-
-Creating a Bookmark
--------------------
-
-To create a bookmark:
-
-#. Zoom or pan to the area of interest.
-#. Select the menu option :menuselection:`View --> New Bookmark` or press
-   :kbd:`Ctrl-B`. The Spatial Bookmark panel opens with the newly created bookmark.
-#. Enter a descriptive name for the bookmark (up to 255 characters).
-#. Check the :guilabel:`In Project` box if you wish to save the bookmark in the project file.
-#. Press :kbd:`Enter` to add the bookmark or click elsewhere.
-
-Note that you can have multiple bookmarks with the same name.
-
-Working with Bookmarks
-----------------------
-
-To use or manage bookmarks, select the menu option
-:menuselection:`View --> Show Bookmarks`. The :guilabel:`Spatial Bookmarks`
-panel allows you to:
-
-* Zoom to a Bookmark: select the desired bookmark and then click
-  :guilabel:`Zoom To Bookmark`. You can also zoom to a bookmark by
-  double-clicking on it.
-* Delete a Bookmark: select the bookmark and click :guilabel:`Delete Bookmark`.
-  Confirm your choice.
-* Import or Export a bookmark: To share or transfer your bookmarks between
-  computers you can use the :guilabel:`Import/Export Bookmarks` pull down menu
-  in the :guilabel:`Spatial Bookmarks` dialog. All the bookmarks are transferred.
-
-
-.. index:: Nesting projects, Embed layers and groups
-.. _nesting_projects:
-
-Nesting Projects
-================
-
-Sometimes, you'd like to keep in different projects a bunch of layers with the
-same style. You can either create a :ref:`default style <store_style>` for
-these layers or embed them from another project to save you tons of work.
-
-Embed layers and groups from an existing project has some advantages over
-styling:
-
-* all types of layers (vector or raster, local or online...) can be added
-* fetching groups and layers, you can keep the same tree structure of the
-  "background" layers in your different projects
-* While the embedded layers are editable, you can't change their properties
-  such as symbology, labels, forms, default values, actions... This ensures
-  homogeneity throughout the projects
-* modify the items in the original project and changes are propagated to all
-  the other projects.
-
-If you want to embed content from other project files into your project, select
-:menuselection:`Layer --> Embed Layers and Groups` and:
-
-#. Press |browseButton| to look for a project; you can see the content of the
-   project (see figure_embed_dialog_).
-#. Press :kbd:`Ctrl` ( or |osx| :kbd:`Cmd`) and click on the layers and
-   groups you wish to retrieve.
-#. Press **[OK]**. The selected layers and groups are embedded in the Layer
-   panel and can be visualized in the map canvas now. Names of embedded items
-   appear in italic to distinguish them from regular layers and groups.
-
-.. _figure_embed_dialog:
-
-.. figure:: img/embed_dialog.png
-   :align: center
-
-   Select layers and groups to embed
-
-Like any other layer, an embedded layer can be removed from the project by
-right-click on the layer and choose |removeLayer| :sup:`Remove`.
-
-.. tip:: **Change rendering of an embedded layer**
-
- It's not possible to change rendering of an embedded layer, unless you make
- the changes in the original project file. However, right-click on a layer and
- select :guilabel:`Duplicate` creates a layer which is fully-featured and not
- dependent to the original project. You can then safely remove the linked
- layer.
-
-.. index:: Decorations
-.. _decorations:
-
-Decorations
-===========
-
-The Decorations of QGIS include the Grid, the Copyright Label, the North Arrow
-and the Scale Bar. They are used to 'decorate' the map by adding cartographic
-elements.
-
-.. index:: Grid
-.. _grid_decoration:
-
-Grid
-----
-
-|transformed| :sup:`Grid` allows you to add a coordinate grid and coordinate
-annotations to the map canvas.
-
-.. _figure_decorations_grid:
-
-.. figure:: img/grid_dialog.png
-   :align: center
-
-   The Grid Dialog
-
-#. Select from menu :menuselection:`View --> Decorations --> Grid`.
-   The dialog starts (see figure_decorations_grid_).
-#. Activate the |checkbox| :guilabel:`Enable grid` checkbox and set grid
-   definitions according to the layers loaded in the map canvas.
-#. Activate the |checkbox| :guilabel:`Draw annotations` checkbox and set
-   annotation definitions according to the layers loaded in the map canvas.
-#. Click **[Apply]** to verify that it looks as expected or **[OK]** if you're satisfied.
-
-.. index:: Copyright
-.. _copyright_decoration:
-
-Copyright Label
----------------
-
-|copyrightLabel| :sup:`Copyright label` adds a copyright label using the text
-you prefer to the map.
-
-.. _figure_decorations_copyright:
-
-.. figure:: img/copyright.png
-   :align: center
-
-   The Copyright Dialog
-
-#. Select from menu :menuselection:`View --> Decorations --> Copyright Label`.
-   The dialog starts (see figure_decorations_copyright_).
-#. Make sure the |checkbox| :guilabel:`Enable Copyright Label` checkbox is
-   checked.
-#. Enter the text you want to place on the map. You can use HTML as
-   shown in the example.
-#. Choose the placement of the label from the :guilabel:`Placement`
-   |selectString| combo box.
-#. You can refine the placement of the item by setting a Horizontal and/or Vertical
-   `Marging from (Canvas) Edge`. These values can be a distance in **Millimeter** or
-   **Pixels** or set as **Percentage** of the width or height of the map canvas.
-#. You can change the color to apply.
-#. Click **[Apply]** to verify that it looks as expected or **[OK]** if you're satisfied.
-
-In the example above, which is the default, QGIS places a copyright symbol
-followed by the date in the lower right-hand corner of the map canvas.
-
-.. index:: North arrow
-.. _northarrow_decoration:
-
-North Arrow
------------
-
-|northArrow| :sup:`North Arrow` places a simple north arrow on the map canvas.
-Currently, there is only one style available. You can adjust the angle of the
-arrow or let QGIS set the direction automatically.
-If you choose to let QGIS determine the direction, it makes its best guess
-as to how the arrow should be oriented.
-For placement of the arrow, you have four options, corresponding to
-the four corners of the map canvas.
-You can refine the placement of the arrow by setting a Horizontal and/or Vertical
-`Marging from (Canvas) Edge`. These values can be a distance in **Millimeter** or
-**Pixels** or set as **Percentage** of the width or height of the map canvas.
-
-.. _figure_decorations_north:
-
-.. figure:: img/north_arrow_dialog.png
-   :align: center
-
-   The North Arrow Dialog
-
-.. index:: Scale bar
-.. _scalebar_decoration:
-
-Scale Bar
----------
-
-|scaleBar| :sup:`Scale Bar` adds a simple scale bar to the map canvas. You
-can control the style and placement, as well as the labelling of the bar.
-
-.. _figure_decorations_scale:
-
-.. figure:: img/scale_bar_dialog.png
-   :align: center
-
-   The Scale Bar Dialog
-
-QGIS only supports displaying the scale in the same units as your map frame.
-So if the units of your layers are in meters, you can't create a scale bar in
-feet. Likewise, if you are using decimal degrees, you can't create a scale
-bar to display distance in meters.
-
-To add a scale bar:
-
-#. Select from menu :menuselection:`View --> Decorations --> Scale Bar`.
-   The dialog starts (see figure_decorations_scale_).
-#. Make sure the |checkbox| :guilabel:`Enable scale bar` checkbox is checked.
-#. Choose the style from the :guilabel:`Scale bar style` |selectString|
-   combo box.
-#. Select the color for the bar :guilabel:`Color of bar` |selectColor| or use
-   the default black color.
-#. Set the :guilabel:`Size of bar` |selectNumber|.
-#. Optionally, check |checkbox| :guilabel:`Automatically snap to round number
-   on resize` to display values easy-to-read.
-#. Choose the placement from the :guilabel:`Placement` |selectString| combo box.
-#. You can refine the placement of the item by setting a Horizontal and/or Vertical
-   `Marging from (Canvas) Edge`. These values can be a distance in **Millimeter** or
-   **Pixels** or set as **Percentage** of the width or height of the map canvas.
-#. Click **[Apply]** to verify that it looks as expected or **[OK]** if you're satisfied.
-
-
-.. tip::
-
-   **Settings of Decorations**
-
-   When you save a :file:`.qgs` project, any changes you have made to Grid,
-   North Arrow, Scale Bar and Copyright will be saved in the project and restored
-   the next time you load the project.
-
-.. _authentication:
-
-Authentication
-==============
-
-QGIS has facility to store/retrieve authentication credentials in a secure
-manner. Users can securely save credentials into authentication configurations,
-which are stored in a portable database, can be applied to server or database
-connections, and safely referenced by their ID tokens in project or settings
-files. For more information see :ref:`authentication_index`.
-
-A master password needs to be set up when initializing the authentication
-system and its portable database.
-
 .. index:: Variables, Expressions
-
 .. _`general_tools_variables`:
 
 Variables
-=========
+---------
 
 In QGIS, you can use variables to store useful recurrent values (e.g. the
 project's title, or the user's full name) that can be used in expressions.
@@ -1736,6 +1738,21 @@ variables overwritten by lower level ones are strike through.
    and `part 3 <http://nyalldawson
    .net/2015/12/exploring-variables-in-qgis-pt-3-layer-level-variables/>`_
    blog posts.
+
+.. _authentication:
+
+Authentication
+--------------
+
+QGIS has facility to store/retrieve authentication credentials in a secure
+manner. Users can securely save credentials into authentication configurations,
+which are stored in a portable database, can be applied to server or database
+connections, and safely referenced by their ID tokens in project or settings
+files. For more information see :ref:`authentication_index`.
+
+A master password needs to be set up when initializing the authentication
+system and its portable database.
+
 
 .. Substitutions definitions - AVOID EDITING PAST THIS LINE
    This will be automatically updated by the find_set_subst.py script.


### PR DESCRIPTION
in order to:
- have a somehow more (and better?) structure table of content
- group sections by topic (with a kind of red line in the background)
- open room for some old and new features description (map view, introducing 3D, units/fonts/scale(?) widgets...)

This PR does not contain text changes other than adding/renaming some sections titles and necessary blank lines. It's all about moving sections so I'd say there's almost no need to review the text, just comment the following Before -- After screenshot (TOC limited here to two levels for, let's hope, readability)
![image](https://user-images.githubusercontent.com/7983394/38421354-229855de-39a7-11e8-9b03-277a8e6f0563.png)
