### PR TITLE
Mention release version next to newer algorithms (or parameters)

### DIFF
--- a/source/docs/user_manual/processing_algs/qgis/vectorgeometry.rst
+++ b/source/docs/user_manual/processing_algs/qgis/vectorgeometry.rst
@@ -1277,7 +1277,7 @@ Parameters
 ``Input layer`` [vector: any]
   Input vector layer
 
-``Create point on surface for each part`` [boolean]
+``Create point on surface for each part`` [boolean] |32|
   If checked a point for each different part of the geometry will be created.
 
   Default: *False*
@@ -1469,8 +1469,8 @@ Output
 
 .. _qgisprojectpointcartesian:
 
-Project points (Cartesian)
---------------------------
+Project points (Cartesian) |32|
+-------------------------------
 Projects point geometries by a specified distance and bearing (azimuth), creating
 a new point layer with the projected points.
 
@@ -2182,6 +2182,7 @@ Outputs
    please add it also to the substitutions.txt file in the
    source folder.
 
+.. |32| replace:: :kbd:`NEW in 3.2`
 .. |identify| image:: /static/common/mActionIdentify.png
    :width: 1.5em
 .. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/working_with_vector/expression.rst
+++ b/source/docs/user_manual/working_with_vector/expression.rst
@@ -245,43 +245,43 @@ Color Functions
 
 This group contains functions for manipulating colors.
 
-========================== ==========================================================
- Function                   Description
-========================== ==========================================================
- color_cmyk                 Returns a string representation of a color based on
-                            its cyan, magenta, yellow and black components
- color_cmyka                Returns a string representation of a color based on
-                            its cyan, magenta, yellow, black and alpha (transparency)
-                            components
- color_grayscale_average    Applies a grayscale filter and returns a string
-                            representation from a provided color
- color_hsl                  Returns a string representation of a color based on
-                            its hue, saturation, and lightness attributes
- color_hsla                 Returns a string representation of a color based on its
-                            hue, saturation, lightness and alpha (transparency)
-                            attributes
- color_hsv                  Returns a string representation of a color based on
-                            its hue, saturation, and value attributes
- color_hsva                 Returns a string representation of a color based on
-                            its hue, saturation, value and alpha (transparency)
-                            attributes
- color_mix_rgb              Returns a string representing a color mixing the red,
-                            green, blue, and alpha values of two provided colors
-                            based on a given ratio
- color_part                 Returns a specific component from a color string,
-                            eg the red component or alpha component
- color_rgb                  Returns a string representation of a color based on
-                            its red, green, and blue components
- color_rgba                 Returns a string representation of a color based on
-                            its red, green, blue, and alpha (transparency) components
- create_ramp                Returns a gradient ramp from a map of color strings and steps
- darker                     Returns a darker (or lighter) color string
- lighter                    Returns a lighter (or darker) color string
- project_color              Returns a color from the project's color scheme
- ramp_color                 Returns a string representing a color from a color ramp
- set_color_part             Sets a specific color component for a color string,
-                            eg the red component or alpha component
-========================== ==========================================================
+============================== ==========================================================
+ Function                       Description
+============================== ==========================================================
+ color_cmyk                     Returns a string representation of a color based on
+                                its cyan, magenta, yellow and black components
+ color_cmyka                    Returns a string representation of a color based on
+                                its cyan, magenta, yellow, black and alpha (transparency)
+                                components
+ color_grayscale_average |32|   Applies a grayscale filter and returns a string
+                                representation from a provided color
+ color_hsl                      Returns a string representation of a color based on
+                                its hue, saturation, and lightness attributes
+ color_hsla                     Returns a string representation of a color based on its
+                                hue, saturation, lightness and alpha (transparency)
+                                attributes
+ color_hsv                      Returns a string representation of a color based on
+                                its hue, saturation, and value attributes
+ color_hsva                     Returns a string representation of a color based on
+                                its hue, saturation, value and alpha (transparency)
+                                attributes
+ color_mix_rgb |32|             Returns a string representing a color mixing the red,
+                                green, blue, and alpha values of two provided colors
+                                based on a given ratio
+ color_part                     Returns a specific component from a color string,
+                                eg the red component or alpha component
+ color_rgb                      Returns a string representation of a color based on
+                                its red, green, and blue components
+ color_rgba                     Returns a string representation of a color based on
+                                its red, green, blue, and alpha (transparency) components
+ create_ramp                    Returns a gradient ramp from a map of color strings and steps
+ darker                         Returns a darker (or lighter) color string
+ lighter                        Returns a lighter (or darker) color string
+ project_color                  Returns a color from the project's color scheme
+ ramp_color                     Returns a string representing a color from a color ramp
+ set_color_part                 Sets a specific color component for a color string,
+                                eg the red component or alpha component
+============================== ==========================================================
 
 
 Conditional Functions
@@ -605,7 +605,7 @@ This group contains functions that operate on geometry objects (e.g., length, ar
 |                        | Curve or (Multi-)Linestring geometry with an      |
 |                        | extension specified by x and y                    |
 +------------------------+---------------------------------------------------+
-| flip_coordinates       | Returns a copy of the geometry with the x and y   |
+| flip_coordinates |32|  | Returns a copy of the geometry with the x and y   |
 |                        | coordinates swapped                               |
 +------------------------+---------------------------------------------------+
 | geom_from_gml          | Returns a geometry created from a GML             |
@@ -1151,91 +1151,91 @@ It means that some functions may not be available according to the context:
 To use these functions in an expression, they should be preceded by @ character
 (e.g, @row_number). Are concerned:
 
-======================= =======================================================
- Function                Description
-======================= =======================================================
- atlas_feature           Returns the current atlas feature (as feature object)
- atlas_featureid         Returns the current atlas feature ID
- atlas_featurenumber     Returns the current atlas feature number in the layout
- atlas_filename          Returns the current atlas file name
- atlas_geometry          Returns the current atlas feature geometry
- atlas_layerid           Returns the current atlas coverage layer ID
- atlas_layername         Returns the current atlas coverage layer name
- atlas_pagename          Returns the current atlas page name
- atlas_totalfeatures     Returns the total number of features in atlas
- cluster_color           Returns the color of symbols within a cluster, or NULL
-                         if symbols have mixed colors
- cluster_size            Returns the number of symbols contained within a cluster
- geometry_part_count     Returns the number of parts in rendered feature's geometry
- geometry_part_num       Returns the current geometry part number for feature being rendered
- geometry_point_count    Returns the number of points in the rendered geometry's part
- geometry_point_num      Returns the current point number in the rendered geometry's part
- grid_axis               Returns the current grid annotation axis
-                         (eg, 'x' for longitude, 'y' for latitude)
- grid_number             Returns the current grid annotation value
- item_id                 Returns the layout item user ID
-                         (not necessarily unique)
- item_uuid               Returns the layout item unique ID
- layer                   Returns the current layer
- layer_id                Returns the ID of current layer
- layer_name              Returns the name of current layer
- layout_dpi              Returns the composition resolution (DPI)
- layout_name             Returns the layout name
- layout_numpages         Returns the number of pages in the layout
- layout_page             Returns the page number of the current item in the layout
- layout_pageheight       Returns the active page height in the layout (in mm)
- layout_pagewidth        Returns the active page width in the layout (in mm)
- map_crs                 Returns the Coordinate reference system of the current map
- map_crs_definition      Returns the full definition of the Coordinate reference
-                         system of the current map
- map_extent              Returns the geometry representing the current extent of the map
- map_extent_center       Returns the point feature at the center of the map
- map_extent_height       Returns the current height of the map
- map_extent_width        Returns the current width of the map
- map_id                  Returns the ID of current map destination.
-                         This will be 'canvas' for canvas renders, and
-                         the item ID for layout map renders
- map_rotation            Returns the current rotation of the map
- map_scale               Returns the current scale of the map
- map_units               Returns the units of map measurements
- parent                  Returns attributes and geometry from the parent feature when
-                         in the filter of the "aggregate" expression function
- project_abstract        Returns the project abstract, taken from project metadata
- project_author          Returns the project author, taken from project metadata
- project_creation_date   Returns the project creation date, taken from project metadata
- project_identifier      Returns the project identifier, taken from project metadata
- project_keywords        Returns the project keywords, taken from project metadata
- project_crs             Returns the Coordinate reference system of the project
- project_crs_definition  Returns the full definition of the Coordinate reference
-                         system of the project
- project_filename        Returns the filename of current project
- project_folder          Returns the folder for current project
- project_path            Returns the full path (including file name)
-                         of current project
- project_title           Returns the title of current project
- qgis_locale             Returns the current language of QGIS
- qgis_os_name            Returns the current Operating system name,
-                         eg 'windows', 'linux' or 'osx'
- qgis_platform           Returns QGIS platform, eg 'desktop' or 'server'
- qgis_release_name       Returns current QGIS release name
- qgis_short_version      Returns current QGIS version short string
- qgis_version            Returns current QGIS version string
- qgis_version_no         Returns current QGIS version number
- snapping_results        Gives access to snapping results while digitizing a
-                         feature (only available in add feature)
- symbol_angle            Returns the angle of the symbol used to render
-                         the feature (valid for marker symbols only)
- symbol_color            Returns the color of the symbol used to render
-                         the feature
- user_account_name       Returns the current user's operating system
-                         account name
- user_full_name          Returns the current user's operating system
-                         user name
- row_number              Stores the number of the current row
- value                   Returns the current value
- with_variable           Allows setting a variable for usage within an expression
-                         and avoid recalculating the same value repeatedly
-======================= =======================================================
+============================ =======================================================
+ Function                     Description
+============================ =======================================================
+ atlas_feature                Returns the current atlas feature (as feature object)
+ atlas_featureid              Returns the current atlas feature ID
+ atlas_featurenumber          Returns the current atlas feature number in the layout
+ atlas_filename               Returns the current atlas file name
+ atlas_geometry               Returns the current atlas feature geometry
+ atlas_layerid                Returns the current atlas coverage layer ID
+ atlas_layername              Returns the current atlas coverage layer name
+ atlas_pagename               Returns the current atlas page name
+ atlas_totalfeatures          Returns the total number of features in atlas
+ cluster_color                Returns the color of symbols within a cluster, or NULL
+                              if symbols have mixed colors
+ cluster_size                 Returns the number of symbols contained within a cluster
+ geometry_part_count          Returns the number of parts in rendered feature's geometry
+ geometry_part_num            Returns the current geometry part number for feature being rendered
+ geometry_point_count         Returns the number of points in the rendered geometry's part
+ geometry_point_num           Returns the current point number in the rendered geometry's part
+ grid_axis                    Returns the current grid annotation axis
+                              (eg, 'x' for longitude, 'y' for latitude)
+ grid_number                  Returns the current grid annotation value
+ item_id                      Returns the layout item user ID
+                              (not necessarily unique)
+ item_uuid                    Returns the layout item unique ID
+ layer                        Returns the current layer
+ layer_id                     Returns the ID of current layer
+ layer_name                   Returns the name of current layer
+ layout_dpi                   Returns the composition resolution (DPI)
+ layout_name                  Returns the layout name
+ layout_numpages              Returns the number of pages in the layout
+ layout_page                  Returns the page number of the current item in the layout
+ layout_pageheight            Returns the active page height in the layout (in mm)
+ layout_pagewidth             Returns the active page width in the layout (in mm)
+ map_crs                      Returns the Coordinate reference system of the current map
+ map_crs_definition           Returns the full definition of the Coordinate reference
+                              system of the current map
+ map_extent                   Returns the geometry representing the current extent of the map
+ map_extent_center            Returns the point feature at the center of the map
+ map_extent_height            Returns the current height of the map
+ map_extent_width             Returns the current width of the map
+ map_id                       Returns the ID of current map destination.
+                              This will be 'canvas' for canvas renders, and
+                              the item ID for layout map renders
+ map_rotation                 Returns the current rotation of the map
+ map_scale                    Returns the current scale of the map
+ map_units                    Returns the units of map measurements
+ parent                       Returns attributes and geometry from the parent feature when
+                              in the filter of the "aggregate" expression function
+ project_abstract |32|        Returns the project abstract, taken from project metadata
+ project_author |32|          Returns the project author, taken from project metadata
+ project_creation_date |32|   Returns the project creation date, taken from project metadata
+ project_identifier |32|      Returns the project identifier, taken from project metadata
+ project_keywords |32|        Returns the project keywords, taken from project metadata
+ project_crs                  Returns the Coordinate reference system of the project
+ project_crs_definition       Returns the full definition of the Coordinate reference
+                              system of the project
+ project_filename             Returns the filename of current project
+ project_folder               Returns the folder for current project
+ project_path                 Returns the full path (including file name)
+                              of current project
+ project_title                Returns the title of current project
+ qgis_locale                  Returns the current language of QGIS
+ qgis_os_name                 Returns the current Operating system name,
+                              eg 'windows', 'linux' or 'osx'
+ qgis_platform                Returns QGIS platform, eg 'desktop' or 'server'
+ qgis_release_name            Returns current QGIS release name
+ qgis_short_version           Returns current QGIS version short string
+ qgis_version                 Returns current QGIS version string
+ qgis_version_no              Returns current QGIS version number
+ snapping_results             Gives access to snapping results while digitizing a
+                              feature (only available in add feature)
+ symbol_angle                 Returns the angle of the symbol used to render
+                              the feature (valid for marker symbols only)
+ symbol_color                 Returns the color of the symbol used to render
+                              the feature
+ user_account_name            Returns the current user's operating system
+                              account name
+ user_full_name               Returns the current user's operating system
+                              user name
+ row_number                   Stores the number of the current row
+ value                        Returns the current value
+ with_variable                Allows setting a variable for usage within an expression
+                              and avoid recalculating the same value repeatedly
+============================ =======================================================
 
 **Some examples:**
 
@@ -1331,6 +1331,7 @@ it can be found whenever you work with expressions.
    please add it also to the substitutions.txt file in the
    source folder.
 
+.. |32| replace:: :kbd:`NEW in 3.2`
 .. |calculateField| image:: /static/common/mActionCalculateField.png
    :width: 1.5em
 .. |dataDefined| image:: /static/common/mIconDataDefine.png

--- a/source/substitutions.txt
+++ b/source/substitutions.txt
@@ -15,6 +15,8 @@
    :width: 1.5em
 .. |3d| image:: /static/common/3d.png
    :width: 1.5em
+.. |32| replace:: :kbd:`NEW in 3.2`
+.. |34| replace:: :kbd:`NEW in 3.4`
 .. |action| image:: /static/common/action.png
    :width: 2em
 .. |actionRun| image:: /static/common/mAction.png


### PR DESCRIPTION
This is an attempt to implement a fix that helps readers to identify which algorithms or parameters are newer than the version they use (see [discussion](http://osgeo-org.1560.x6.nabble.com/QGIS-Developer-Documentation-and-algorithm-news-td5358055.html#a5358340)) 
