### PR TITLE
Add disclaimer to cookbook and training manuals pages

### DIFF
--- a/source/docs/documentation_guidelines/do_translations.rst
+++ b/source/docs/documentation_guidelines/do_translations.rst
@@ -329,6 +329,7 @@ For any question, please contact the `QGIS Community Team
 <qgis-community-team@lists.osgeo.org>`_ or the
 `QGIS Translation Team <qgis-tr@lists.osgeo.org>`_.
 
+
 .. Substitutions definitions - AVOID EDITING PAST THIS LINE
    This will be automatically updated by the find_set_subst.py script.
    If you need to create a new substitution manually,
@@ -353,4 +354,4 @@ For any question, please contact the `QGIS Community Team
    :width: 2em
 .. |selectString| image:: /static/common/selectstring.png
    :width: 2.5em
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/documentation_guidelines/first_contribution.rst
+++ b/source/docs/documentation_guidelines/first_contribution.rst
@@ -405,6 +405,7 @@ of unuseful branches. So keep your repository clean this way:
 
 And do not forget to update the ``master`` branch in your local repository!
 
+
 .. Substitutions definitions - AVOID EDITING PAST THIS LINE
    This will be automatically updated by the find_set_subst.py script.
    If you need to create a new substitution manually,

--- a/source/docs/gentle_gis_introduction/authors_and_contributors.rst
+++ b/source/docs/gentle_gis_introduction/authors_and_contributors.rst
@@ -34,6 +34,7 @@ About the authors & contributors
 |                | time Sibongile used a computer.                                      |
 +----------------+----------------------------------------------------------------------+
 
+
 .. Substitutions definitions - AVOID EDITING PAST THIS LINE
    This will be automatically updated by the find_set_subst.py script.
    If you need to create a new substitution manually,

--- a/source/docs/gentle_gis_introduction/coordinate_reference_systems.rst
+++ b/source/docs/gentle_gis_introduction/coordinate_reference_systems.rst
@@ -486,6 +486,7 @@ What's next?
 
 In the section that follows we will take a closer look at **Map Production**.
 
+
 .. Substitutions definitions - AVOID EDITING PAST THIS LINE
    This will be automatically updated by the find_set_subst.py script.
    If you need to create a new substitution manually,

--- a/source/docs/gentle_gis_introduction/data_capture.rst
+++ b/source/docs/gentle_gis_introduction/data_capture.rst
@@ -431,6 +431,7 @@ What's next?
 In the section that follows we will take a closer look at **raster data** to learn
 all about how image data can be used in a GIS.
 
+
 .. Substitutions definitions - AVOID EDITING PAST THIS LINE
    This will be automatically updated by the find_set_subst.py script.
    If you need to create a new substitution manually,

--- a/source/docs/gentle_gis_introduction/introducing_gis.rst
+++ b/source/docs/gentle_gis_introduction/introducing_gis.rst
@@ -353,6 +353,7 @@ In the sections that follow we are going to go into more detail, showing you how
 to use a GIS Application. All of the tutorials will be done using QGIS. Next up,
 let's look at vectors!
 
+
 .. Substitutions definitions - AVOID EDITING PAST THIS LINE
    This will be automatically updated by the find_set_subst.py script.
    If you need to create a new substitution manually,

--- a/source/docs/gentle_gis_introduction/map_production.rst
+++ b/source/docs/gentle_gis_introduction/map_production.rst
@@ -305,6 +305,7 @@ What's next?
 In the section that follows we will take a closer look at **vector analysis** to
 see how we can use a GIS for more than just making good looking maps!
 
+
 .. Substitutions definitions - AVOID EDITING PAST THIS LINE
    This will be automatically updated by the find_set_subst.py script.
    If you need to create a new substitution manually,

--- a/source/docs/gentle_gis_introduction/raster_data.rst
+++ b/source/docs/gentle_gis_introduction/raster_data.rst
@@ -359,6 +359,7 @@ In the section that follows we will take a closer look at **topology** to see
 how the relationship between vector features can be used to ensure the best data
 quality.
 
+
 .. Substitutions definitions - AVOID EDITING PAST THIS LINE
    This will be automatically updated by the find_set_subst.py script.
    If you need to create a new substitution manually,

--- a/source/docs/gentle_gis_introduction/spatial_analysis_interpolation.rst
+++ b/source/docs/gentle_gis_introduction/spatial_analysis_interpolation.rst
@@ -241,6 +241,7 @@ This is the final worksheet in this series. We encourage you to explore QGIS and
 use the accompanying QGIS manual to discover all the other things you can do with
 GIS software!
 
+
 .. Substitutions definitions - AVOID EDITING PAST THIS LINE
    This will be automatically updated by the find_set_subst.py script.
    If you need to create a new substitution manually,

--- a/source/docs/gentle_gis_introduction/topology.rst
+++ b/source/docs/gentle_gis_introduction/topology.rst
@@ -223,6 +223,7 @@ In the section that follows we will take a closer look at **Coordinate Reference
 Systems** to understand how we relate data from our spherical earth onto flat
 maps!
 
+
 .. Substitutions definitions - AVOID EDITING PAST THIS LINE
    This will be automatically updated by the find_set_subst.py script.
    If you need to create a new substitution manually,

--- a/source/docs/gentle_gis_introduction/vector_attribute_data.rst
+++ b/source/docs/gentle_gis_introduction/vector_attribute_data.rst
@@ -505,6 +505,7 @@ In the section that follows we will take a closer look at **data capture.** We
 will put the things we have learned about vector data and attributes into practice
 by creating new data.
 
+
 .. Substitutions definitions - AVOID EDITING PAST THIS LINE
    This will be automatically updated by the find_set_subst.py script.
    If you need to create a new substitution manually,

--- a/source/docs/gentle_gis_introduction/vector_data.rst
+++ b/source/docs/gentle_gis_introduction/vector_data.rst
@@ -439,6 +439,7 @@ What's next?
 In the section that follows we will take a closer look at **attribute data** to
 see how it can be used to describe vector features.
 
+
 .. Substitutions definitions - AVOID EDITING PAST THIS LINE
    This will be automatically updated by the find_set_subst.py script.
    If you need to create a new substitution manually,

--- a/source/docs/gentle_gis_introduction/vector_spatial_analysis_buffers.rst
+++ b/source/docs/gentle_gis_introduction/vector_spatial_analysis_buffers.rst
@@ -282,6 +282,7 @@ What's next?
 In the section that follows we will take a closer look at **interpolation** as
 an example of spatial analysis you can do with raster data.
 
+
 .. Substitutions definitions - AVOID EDITING PAST THIS LINE
    This will be automatically updated by the find_set_subst.py script.
    If you need to create a new substitution manually,

--- a/source/docs/pyqgis_developer_cookbook/index.rst
+++ b/source/docs/pyqgis_developer_cookbook/index.rst
@@ -41,4 +41,4 @@ PyQGIS Developer Cookbook
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/pyqgis_developer_cookbook/index.rst
+++ b/source/docs/pyqgis_developer_cookbook/index.rst
@@ -1,3 +1,7 @@
+.. only:: html
+
+   |updatedisclaimer|
+
 .. _PyQGIS-Developer-Cookbook:
 
 =========================
@@ -29,3 +33,12 @@ PyQGIS Developer Cookbook
    processing
    network_analysis
    server
+   
+
+.. Substitutions definitions - AVOID EDITING PAST THIS LINE
+   This will be automatically updated by the find_set_subst.py script.
+   If you need to create a new substitution manually,
+   please add it also to the substitutions.txt file in the
+   source folder.
+
+.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/answers/answers.rst
+++ b/source/docs/training_manual/answers/answers.rst
@@ -1124,6 +1124,7 @@ As you can see, our constraint allows nulls to be added into the database.
 
 :ref:`Back to text <backlink-simple-feature-3>`
 
+
 .. Substitutions definitions - AVOID EDITING PAST THIS LINE
    This will be automatically updated by the find_set_subst.py script.
    If you need to create a new substitution manually,
@@ -1136,4 +1137,4 @@ As you can see, our constraint allows nulls to be added into the database.
 .. |largeLandUseArea| replace:: Bontebok National Park
 .. |majorUrbanName| replace:: Swellendam
 .. |moderate| image:: /static/global/moderate.png
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/answers/answers.rst
+++ b/source/docs/training_manual/answers/answers.rst
@@ -1,3 +1,7 @@
+.. only:: html
+
+   |updatedisclaimer|
+
 Answer Sheet
 ===============================================================================
 
@@ -1132,3 +1136,4 @@ As you can see, our constraint allows nulls to be added into the database.
 .. |largeLandUseArea| replace:: Bontebok National Park
 .. |majorUrbanName| replace:: Swellendam
 .. |moderate| image:: /static/global/moderate.png
+.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/appendix/contribute.rst
+++ b/source/docs/training_manual/appendix/contribute.rst
@@ -371,6 +371,7 @@ Thank You!
 Thank you for contributing to this project! By so doing, you are making QGIS
 more accessible to users and adding value to the QGIS project as a whole.
 
+
 .. Substitutions definitions - AVOID EDITING PAST THIS LINE
    This will be automatically updated by the find_set_subst.py script.
    If you need to create a new substitution manually,
@@ -386,4 +387,4 @@ more accessible to users and adding value to the QGIS project as a whole.
 .. |basic| image:: /static/global/basic.png
 .. |hard| image:: /static/global/hard.png
 .. |moderate| image:: /static/global/moderate.png
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/appendix/contribute.rst
+++ b/source/docs/training_manual/appendix/contribute.rst
@@ -1,3 +1,7 @@
+.. only:: html
+
+   |updatedisclaimer|
+
 *******************************************************************************
 Appendix: Contributing To This Manual
 *******************************************************************************
@@ -382,3 +386,4 @@ more accessible to users and adding value to the QGIS project as a whole.
 .. |basic| image:: /static/global/basic.png
 .. |hard| image:: /static/global/hard.png
 .. |moderate| image:: /static/global/moderate.png
+.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/assessment/index.rst
+++ b/source/docs/training_manual/assessment/index.rst
@@ -1,3 +1,7 @@
+.. only:: html
+
+   |updatedisclaimer|
+
 *******************************************************************************
 |MOD| Assessment
 *******************************************************************************
@@ -164,3 +168,4 @@ Final Map
 .. |basic| image:: /static/global/basic.png
 .. |hard| image:: /static/global/hard.png
 .. |moderate| image:: /static/global/moderate.png
+.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/assessment/index.rst
+++ b/source/docs/training_manual/assessment/index.rst
@@ -158,6 +158,7 @@ Final Map
   layers which you feel are the least necessary.
 * Your map must include a title and a legend.
 
+
 .. Substitutions definitions - AVOID EDITING PAST THIS LINE
    This will be automatically updated by the find_set_subst.py script.
    If you need to create a new substitution manually,
@@ -168,4 +169,4 @@ Final Map
 .. |basic| image:: /static/global/basic.png
 .. |hard| image:: /static/global/hard.png
 .. |moderate| image:: /static/global/moderate.png
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/basic_map/index.rst
+++ b/source/docs/training_manual/basic_map/index.rst
@@ -15,6 +15,7 @@ for further demonstrations of QGIS functionality.
    vector_data
    symbology
 
+
 .. Substitutions definitions - AVOID EDITING PAST THIS LINE
    This will be automatically updated by the find_set_subst.py script.
    If you need to create a new substitution manually,
@@ -22,4 +23,4 @@ for further demonstrations of QGIS functionality.
    source folder.
 
 .. |MOD| replace:: Module:
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/basic_map/index.rst
+++ b/source/docs/training_manual/basic_map/index.rst
@@ -1,3 +1,7 @@
+.. only:: html
+
+   |updatedisclaimer|
+
 *******************************************************************************
 |MOD| Creating a Basic Map
 *******************************************************************************
@@ -18,3 +22,4 @@ for further demonstrations of QGIS functionality.
    source folder.
 
 .. |MOD| replace:: Module:
+.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/basic_map/symbology.rst
+++ b/source/docs/training_manual/basic_map/symbology.rst
@@ -1,3 +1,7 @@
+.. only:: html
+
+   |updatedisclaimer|
+
 |LS| Symbology
 ===============================================================================
 
@@ -540,6 +544,7 @@ map.
 .. |hard| image:: /static/global/hard.png
 .. |majorUrbanName| replace:: Swellendam
 .. |moderate| image:: /static/global/moderate.png
+.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
 .. |zoomIn| image:: /static/common/mActionZoomIn.png
    :width: 1.5em
 .. |zoomOut| image:: /static/common/mActionZoomOut.png

--- a/source/docs/training_manual/basic_map/symbology.rst
+++ b/source/docs/training_manual/basic_map/symbology.rst
@@ -526,6 +526,7 @@ map.
 
 .. note::  Did you remember to save your map recently?
 
+
 .. Substitutions definitions - AVOID EDITING PAST THIS LINE
    This will be automatically updated by the find_set_subst.py script.
    If you need to create a new substitution manually,
@@ -544,7 +545,7 @@ map.
 .. |hard| image:: /static/global/hard.png
 .. |majorUrbanName| replace:: Swellendam
 .. |moderate| image:: /static/global/moderate.png
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
 .. |zoomIn| image:: /static/common/mActionZoomIn.png
    :width: 1.5em
 .. |zoomOut| image:: /static/common/mActionZoomOut.png

--- a/source/docs/training_manual/basic_map/vector_data.rst
+++ b/source/docs/training_manual/basic_map/vector_data.rst
@@ -1,3 +1,7 @@
+.. only:: html
+
+   |updatedisclaimer|
+
 |LS| Working with Vector Data
 ===============================================================================
 
@@ -169,3 +173,4 @@ lesson.
 .. |basic| image:: /static/global/basic.png
 .. |openTable| image:: /static/common/mActionOpenTable.png
    :width: 1.5em
+.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/basic_map/vector_data.rst
+++ b/source/docs/training_manual/basic_map/vector_data.rst
@@ -158,6 +158,7 @@ current map is probably not easy to read. It would be preferable to assign your
 own choice of colors and symbols. This is what you'll learn to do in the next
 lesson.
 
+
 .. Substitutions definitions - AVOID EDITING PAST THIS LINE
    This will be automatically updated by the find_set_subst.py script.
    If you need to create a new substitution manually,
@@ -173,4 +174,4 @@ lesson.
 .. |basic| image:: /static/global/basic.png
 .. |openTable| image:: /static/common/mActionOpenTable.png
    :width: 1.5em
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/complete_analysis/analysis_combination.rst
+++ b/source/docs/training_manual/complete_analysis/analysis_combination.rst
@@ -87,6 +87,7 @@ property to develop.
 
 Next you will present these results as part of your second assignment.
 
+
 .. Substitutions definitions - AVOID EDITING PAST THIS LINE
    This will be automatically updated by the find_set_subst.py script.
    If you need to create a new substitution manually,
@@ -99,4 +100,4 @@ Next you will present these results as part of your second assignment.
 .. |WN| replace:: What's Next?
 .. |localCRS| replace:: :kbd:`WGS 84 / UTM 34S`
 .. |moderate| image:: /static/global/moderate.png
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/complete_analysis/analysis_combination.rst
+++ b/source/docs/training_manual/complete_analysis/analysis_combination.rst
@@ -1,3 +1,7 @@
+.. only:: html
+
+   |updatedisclaimer|
+
 |LS| Combining the Analyses
 ===============================================================================
 
@@ -95,3 +99,4 @@ Next you will present these results as part of your second assignment.
 .. |WN| replace:: What's Next?
 .. |localCRS| replace:: :kbd:`WGS 84 / UTM 34S`
 .. |moderate| image:: /static/global/moderate.png
+.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/complete_analysis/analysis_exercise.rst
+++ b/source/docs/training_manual/complete_analysis/analysis_exercise.rst
@@ -761,6 +761,7 @@ appealing raster of your choice (such as the :guilabel:`DEM` or the
 solution area(s), as well as your house. Follow all the best practices for
 cartography in creating your output map.
 
+
 .. Substitutions definitions - AVOID EDITING PAST THIS LINE
    This will be automatically updated by the find_set_subst.py script.
    If you need to create a new substitution manually,
@@ -768,4 +769,4 @@ cartography in creating your output map.
    source folder.
 
 .. |LS| replace:: Lesson:
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/complete_analysis/analysis_exercise.rst
+++ b/source/docs/training_manual/complete_analysis/analysis_exercise.rst
@@ -1,3 +1,7 @@
+.. only:: html
+
+   |updatedisclaimer|
+
 |LS| Supplementary Exercise
 ===============================================================================
 
@@ -764,3 +768,4 @@ cartography in creating your output map.
    source folder.
 
 .. |LS| replace:: Lesson:
+.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/complete_analysis/assignment.rst
+++ b/source/docs/training_manual/complete_analysis/assignment.rst
@@ -26,4 +26,4 @@ are suitable.
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/complete_analysis/assignment.rst
+++ b/source/docs/training_manual/complete_analysis/assignment.rst
@@ -1,3 +1,7 @@
+.. only:: html
+
+   |updatedisclaimer|
+
 Assignment
 ===============================================================================
 
@@ -14,3 +18,12 @@ Write a short explanatory text to accompany it. Include in this text the
 criteria that were used in considering a house for purchase and subsequent
 development, as well as explaining your recommendations for which buildings
 are suitable.
+
+
+.. Substitutions definitions - AVOID EDITING PAST THIS LINE
+   This will be automatically updated by the find_set_subst.py script.
+   If you need to create a new substitution manually,
+   please add it also to the substitutions.txt file in the
+   source folder.
+
+.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/complete_analysis/index.rst
+++ b/source/docs/training_manual/complete_analysis/index.rst
@@ -18,6 +18,7 @@ present the final results.
    assignment
    analysis_exercise
 
+
 .. Substitutions definitions - AVOID EDITING PAST THIS LINE
    This will be automatically updated by the find_set_subst.py script.
    If you need to create a new substitution manually,
@@ -25,4 +26,4 @@ present the final results.
    source folder.
 
 .. |MOD| replace:: Module:
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/complete_analysis/index.rst
+++ b/source/docs/training_manual/complete_analysis/index.rst
@@ -1,3 +1,7 @@
+.. only:: html
+
+   |updatedisclaimer|
+
 *******************************************************************************
 |MOD| Completing the Analysis
 *******************************************************************************
@@ -21,3 +25,4 @@ present the final results.
    source folder.
 
 .. |MOD| replace:: Module:
+.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/complete_analysis/raster_to_vector.rst
+++ b/source/docs/training_manual/complete_analysis/raster_to_vector.rst
@@ -1,3 +1,7 @@
+.. only:: html
+
+   |updatedisclaimer|
+
 |LS| Raster to Vector Conversion
 ===============================================================================
 
@@ -105,3 +109,4 @@ for the residential development.
 .. |TY| replace:: Try Yourself
 .. |WN| replace:: What's Next?
 .. |moderate| image:: /static/global/moderate.png
+.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/complete_analysis/raster_to_vector.rst
+++ b/source/docs/training_manual/complete_analysis/raster_to_vector.rst
@@ -97,6 +97,7 @@ Now that we have the results of the terrain analysis available in vector
 format, they can be used to solve the problem of which buildings we should consider
 for the residential development.
 
+
 .. Substitutions definitions - AVOID EDITING PAST THIS LINE
    This will be automatically updated by the find_set_subst.py script.
    If you need to create a new substitution manually,
@@ -109,4 +110,4 @@ for the residential development.
 .. |TY| replace:: Try Yourself
 .. |WN| replace:: What's Next?
 .. |moderate| image:: /static/global/moderate.png
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/create_vector_data/actions.rst
+++ b/source/docs/training_manual/create_vector_data/actions.rst
@@ -317,6 +317,7 @@ the functions you could incorporate!
 Now that you've done all kinds of vector data creation, you'll learn how to
 analyze this data to solve problems. That's the topic of the next module.
 
+
 .. Substitutions definitions - AVOID EDITING PAST THIS LINE
    This will be automatically updated by the find_set_subst.py script.
    If you need to create a new substitution manually,
@@ -332,4 +333,4 @@ analyze this data to solve problems. That's the topic of the next module.
 .. |basic| image:: /static/global/basic.png
 .. |hard| image:: /static/global/hard.png
 .. |moderate| image:: /static/global/moderate.png
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/create_vector_data/actions.rst
+++ b/source/docs/training_manual/create_vector_data/actions.rst
@@ -1,3 +1,7 @@
+.. only:: html
+
+   |updatedisclaimer|
+
 |LS| Actions
 ===============================================================================
 
@@ -328,3 +332,4 @@ analyze this data to solve problems. That's the topic of the next module.
 .. |basic| image:: /static/global/basic.png
 .. |hard| image:: /static/global/hard.png
 .. |moderate| image:: /static/global/moderate.png
+.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/create_vector_data/create_new_vector.rst
+++ b/source/docs/training_manual/create_vector_data/create_new_vector.rst
@@ -1,3 +1,7 @@
+.. only:: html
+
+   |updatedisclaimer|
+
 |LS| Creating a New Vector Dataset
 ===============================================================================
 
@@ -305,3 +309,4 @@ be useful.
 .. |saveEdits| image:: /static/common/mActionSaveEdits.png
    :width: 1.5em
 .. |schoolAreaType1| replace:: athletics field
+.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/create_vector_data/create_new_vector.rst
+++ b/source/docs/training_manual/create_vector_data/create_new_vector.rst
@@ -276,6 +276,7 @@ example, adjacent polygons know where they are in relation to one another. This
 is called *topology*. In the next lesson you'll see an example of why this can
 be useful.
 
+
 .. Substitutions definitions - AVOID EDITING PAST THIS LINE
    This will be automatically updated by the find_set_subst.py script.
    If you need to create a new substitution manually,
@@ -309,4 +310,4 @@ be useful.
 .. |saveEdits| image:: /static/common/mActionSaveEdits.png
    :width: 1.5em
 .. |schoolAreaType1| replace:: athletics field
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/create_vector_data/forms.rst
+++ b/source/docs/training_manual/create_vector_data/forms.rst
@@ -1,3 +1,7 @@
+.. only:: html
+
+   |updatedisclaimer|
+
 |LS| Forms
 ===============================================================================
 
@@ -242,3 +246,4 @@ that you define. This is the subject of the next lesson.
    :width: 1.5em
 .. |majorUrbanName| replace:: Swellendam
 .. |moderate| image:: /static/global/moderate.png
+.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/create_vector_data/forms.rst
+++ b/source/docs/training_manual/create_vector_data/forms.rst
@@ -228,6 +228,7 @@ Opening a form on identifying a feature is one of the standard actions that
 QGIS can perform. However, you can also direct it to perform custom actions
 that you define. This is the subject of the next lesson.
 
+
 .. Substitutions definitions - AVOID EDITING PAST THIS LINE
    This will be automatically updated by the find_set_subst.py script.
    If you need to create a new substitution manually,
@@ -246,4 +247,4 @@ that you define. This is the subject of the next lesson.
    :width: 1.5em
 .. |majorUrbanName| replace:: Swellendam
 .. |moderate| image:: /static/global/moderate.png
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/create_vector_data/index.rst
+++ b/source/docs/training_manual/create_vector_data/index.rst
@@ -1,3 +1,7 @@
+.. only:: html
+
+   |updatedisclaimer|
+
 *******************************************************************************
 |MOD| Creating Vector Data
 *******************************************************************************
@@ -21,3 +25,4 @@ learn how to modify existing vector data and create new datasets entirely.
    source folder.
 
 .. |MOD| replace:: Module:
+.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/create_vector_data/index.rst
+++ b/source/docs/training_manual/create_vector_data/index.rst
@@ -25,4 +25,4 @@ learn how to modify existing vector data and create new datasets entirely.
    source folder.
 
 .. |MOD| replace:: Module:
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/create_vector_data/topo_editing.rst
+++ b/source/docs/training_manual/create_vector_data/topo_editing.rst
@@ -1,3 +1,7 @@
+.. only:: html
+
+   |updatedisclaimer|
+
 |LS| Feature Topology
 ===============================================================================
 
@@ -311,3 +315,4 @@ so that attribute editing is simpler and more effective.
    :width: 1.5em
 .. |undo| image:: /static/common/mActionUndo.png
    :width: 1.5em
+.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/create_vector_data/topo_editing.rst
+++ b/source/docs/training_manual/create_vector_data/topo_editing.rst
@@ -281,6 +281,7 @@ Now you know how to digitize the shape of the objects easily, but adding in the
 attributes is still a bit of a headache! Next we'll show you how to use forms
 so that attribute editing is simpler and more effective.
 
+
 .. Substitutions definitions - AVOID EDITING PAST THIS LINE
    This will be automatically updated by the find_set_subst.py script.
    If you need to create a new substitution manually,
@@ -315,4 +316,4 @@ so that attribute editing is simpler and more effective.
    :width: 1.5em
 .. |undo| image:: /static/common/mActionUndo.png
    :width: 1.5em
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/database_concepts/adding_data.rst
+++ b/source/docs/training_manual/database_concepts/adding_data.rst
@@ -190,6 +190,7 @@ and/or create new models to contain that data.
 Now that you've added some data, you'll learn how to use queries to access this
 data in various ways.
 
+
 .. Substitutions definitions - AVOID EDITING PAST THIS LINE
    This will be automatically updated by the find_set_subst.py script.
    If you need to create a new substitution manually,
@@ -203,4 +204,4 @@ data in various ways.
 .. |basic| image:: /static/global/basic.png
 .. |hard| image:: /static/global/hard.png
 .. |moderate| image:: /static/global/moderate.png
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/database_concepts/adding_data.rst
+++ b/source/docs/training_manual/database_concepts/adding_data.rst
@@ -1,3 +1,7 @@
+.. only:: html
+
+   |updatedisclaimer|
+
 |LS| Adding Data to the Model
 ===============================================================================
 
@@ -199,3 +203,4 @@ data in various ways.
 .. |basic| image:: /static/global/basic.png
 .. |hard| image:: /static/global/hard.png
 .. |moderate| image:: /static/global/moderate.png
+.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/database_concepts/data_model.rst
+++ b/source/docs/training_manual/database_concepts/data_model.rst
@@ -410,6 +410,7 @@ scratch.
 
 Next you'll learn how to use the DBMS to add new data.
 
+
 .. Substitutions definitions - AVOID EDITING PAST THIS LINE
    This will be automatically updated by the find_set_subst.py script.
    If you need to create a new substitution manually,
@@ -421,4 +422,4 @@ Next you'll learn how to use the DBMS to add new data.
 .. |TY| replace:: Try Yourself
 .. |WN| replace:: What's Next?
 .. |moderate| image:: /static/global/moderate.png
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/database_concepts/data_model.rst
+++ b/source/docs/training_manual/database_concepts/data_model.rst
@@ -1,3 +1,7 @@
+.. only:: html
+
+   |updatedisclaimer|
+
 |LS| Implementing the Data Model
 ===============================================================================
 
@@ -417,3 +421,4 @@ Next you'll learn how to use the DBMS to add new data.
 .. |TY| replace:: Try Yourself
 .. |WN| replace:: What's Next?
 .. |moderate| image:: /static/global/moderate.png
+.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/database_concepts/db_intro.rst
+++ b/source/docs/training_manual/database_concepts/db_intro.rst
@@ -1,3 +1,7 @@
+.. only:: html
+
+   |updatedisclaimer|
+
 |LS| Introduction to Databases
 ===============================================================================
 
@@ -390,3 +394,4 @@ database to implement the theory we've covered.
 .. |WN| replace:: What's Next?
 .. |basic| image:: /static/global/basic.png
 .. |moderate| image:: /static/global/moderate.png
+.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/database_concepts/db_intro.rst
+++ b/source/docs/training_manual/database_concepts/db_intro.rst
@@ -382,6 +382,7 @@ structures.
 Now that we've looked at how databases work in theory, let's create a new
 database to implement the theory we've covered.
 
+
 .. Substitutions definitions - AVOID EDITING PAST THIS LINE
    This will be automatically updated by the find_set_subst.py script.
    If you need to create a new substitution manually,
@@ -394,4 +395,4 @@ database to implement the theory we've covered.
 .. |WN| replace:: What's Next?
 .. |basic| image:: /static/global/basic.png
 .. |moderate| image:: /static/global/moderate.png
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/database_concepts/index.rst
+++ b/source/docs/training_manual/database_concepts/index.rst
@@ -1,3 +1,7 @@
+.. only:: html
+
+   |updatedisclaimer|
+
 *******************************************************************************
 |MOD| Database Concepts with PostgreSQL 
 *******************************************************************************
@@ -24,3 +28,4 @@ learning about other typical RDBMS functions.
    source folder.
 
 .. |MOD| replace:: Module:
+.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/database_concepts/index.rst
+++ b/source/docs/training_manual/database_concepts/index.rst
@@ -21,6 +21,7 @@ learning about other typical RDBMS functions.
    views
    rules
 
+
 .. Substitutions definitions - AVOID EDITING PAST THIS LINE
    This will be automatically updated by the find_set_subst.py script.
    If you need to create a new substitution manually,
@@ -28,4 +29,4 @@ learning about other typical RDBMS functions.
    source folder.
 
 .. |MOD| replace:: Module:
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/database_concepts/queries.rst
+++ b/source/docs/training_manual/database_concepts/queries.rst
@@ -1,3 +1,7 @@
+.. only:: html
+
+   |updatedisclaimer|
+
 |LS| Queries
 ===============================================================================
 
@@ -302,3 +306,4 @@ Next you'll see how to create views from the queries that you've written.
 .. |TY| replace:: Try Yourself
 .. |WN| replace:: What's Next?
 .. |moderate| image:: /static/global/moderate.png
+.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/database_concepts/queries.rst
+++ b/source/docs/training_manual/database_concepts/queries.rst
@@ -295,6 +295,7 @@ that allows you to extract useful information from it.
 
 Next you'll see how to create views from the queries that you've written.
 
+
 .. Substitutions definitions - AVOID EDITING PAST THIS LINE
    This will be automatically updated by the find_set_subst.py script.
    If you need to create a new substitution manually,
@@ -306,4 +307,4 @@ Next you'll see how to create views from the queries that you've written.
 .. |TY| replace:: Try Yourself
 .. |WN| replace:: What's Next?
 .. |moderate| image:: /static/global/moderate.png
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/database_concepts/rules.rst
+++ b/source/docs/training_manual/database_concepts/rules.rst
@@ -1,3 +1,7 @@
+.. only:: html
+
+   |updatedisclaimer|
+
 |LS| Rules
 ===============================================================================
 
@@ -79,3 +83,4 @@ which takes these database concepts and applies them to GIS data.
 .. |IC| replace:: In Conclusion
 .. |LS| replace:: Lesson:
 .. |WN| replace:: What's Next?
+.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/database_concepts/rules.rst
+++ b/source/docs/training_manual/database_concepts/rules.rst
@@ -74,6 +74,7 @@ changes in other parts of the database.
 The next module will introduce you to Spatial Database using PostGIS,
 which takes these database concepts and applies them to GIS data.
 
+
 .. Substitutions definitions - AVOID EDITING PAST THIS LINE
    This will be automatically updated by the find_set_subst.py script.
    If you need to create a new substitution manually,
@@ -83,4 +84,4 @@ which takes these database concepts and applies them to GIS data.
 .. |IC| replace:: In Conclusion
 .. |LS| replace:: Lesson:
 .. |WN| replace:: What's Next?
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/database_concepts/views.rst
+++ b/source/docs/training_manual/database_concepts/views.rst
@@ -93,6 +93,7 @@ Using views, you can save a query and access its results as if it were a table.
 Sometimes, when changing data, you want your changes to have effects elsewhere
 in the database. The next lesson will show you how to do this.
 
+
 .. Substitutions definitions - AVOID EDITING PAST THIS LINE
    This will be automatically updated by the find_set_subst.py script.
    If you need to create a new substitution manually,
@@ -102,4 +103,4 @@ in the database. The next lesson will show you how to do this.
 .. |IC| replace:: In Conclusion
 .. |LS| replace:: Lesson:
 .. |WN| replace:: What's Next?
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/database_concepts/views.rst
+++ b/source/docs/training_manual/database_concepts/views.rst
@@ -1,3 +1,7 @@
+.. only:: html
+
+   |updatedisclaimer|
+
 |LS| Views
 ===============================================================================
 
@@ -98,3 +102,4 @@ in the database. The next lesson will show you how to do this.
 .. |IC| replace:: In Conclusion
 .. |LS| replace:: Lesson:
 .. |WN| replace:: What's Next?
+.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/databases/db_browser.rst
+++ b/source/docs/training_manual/databases/db_browser.rst
@@ -91,6 +91,7 @@ how to add layers to your map based on a query filter.
 Next you'll see how to work with the DB Manager interface in QGIS for a more
 complete set of database management tasks.
 
+
 .. Substitutions definitions - AVOID EDITING PAST THIS LINE
    This will be automatically updated by the find_set_subst.py script.
    If you need to create a new substitution manually,
@@ -102,4 +103,4 @@ complete set of database management tasks.
 .. |LS| replace:: Lesson:
 .. |WN| replace:: What's Next?
 .. |basic| image:: /static/global/basic.png
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/databases/db_browser.rst
+++ b/source/docs/training_manual/databases/db_browser.rst
@@ -1,3 +1,7 @@
+.. only:: html
+
+   |updatedisclaimer|
+
 |LS| Working with Databases in the QGIS Browser 
 ===============================================================================
 
@@ -98,3 +102,4 @@ complete set of database management tasks.
 .. |LS| replace:: Lesson:
 .. |WN| replace:: What's Next?
 .. |basic| image:: /static/global/basic.png
+.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/databases/db_manager.rst
+++ b/source/docs/training_manual/databases/db_manager.rst
@@ -286,4 +286,4 @@ Next, we will look at how to use many of these same techniques with
 .. |basic| image:: /static/global/basic.png
 .. |dbManager| image:: /static/common/dbmanager.png
    :width: 1.5em
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/databases/db_manager.rst
+++ b/source/docs/training_manual/databases/db_manager.rst
@@ -1,3 +1,7 @@
+.. only:: html
+
+   |updatedisclaimer|
+
 |LS| Using DB Manager to work with Spatial Databases in QGIS 
 ===============================================================================
 
@@ -282,3 +286,4 @@ Next, we will look at how to use many of these same techniques with
 .. |basic| image:: /static/global/basic.png
 .. |dbManager| image:: /static/common/dbmanager.png
    :width: 1.5em
+.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/databases/index.rst
+++ b/source/docs/training_manual/databases/index.rst
@@ -19,6 +19,7 @@ spatial database implementations including spatialite.
    db_manager
    spatialite
 
+
 .. Substitutions definitions - AVOID EDITING PAST THIS LINE
    This will be automatically updated by the find_set_subst.py script.
    If you need to create a new substitution manually,
@@ -26,4 +27,4 @@ spatial database implementations including spatialite.
    source folder.
 
 .. |MOD| replace:: Module:
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/databases/index.rst
+++ b/source/docs/training_manual/databases/index.rst
@@ -1,3 +1,7 @@
+.. only:: html
+
+   |updatedisclaimer|
+
 *******************************************************************************
 |MOD| Using Spatial Databases in QGIS 
 *******************************************************************************
@@ -22,3 +26,4 @@ spatial database implementations including spatialite.
    source folder.
 
 .. |MOD| replace:: Module:
+.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/databases/spatialite.rst
+++ b/source/docs/training_manual/databases/spatialite.rst
@@ -70,6 +70,7 @@ and you can use this same technique to import data into your new spatialite DB.
 You have seen how to create spatialite databases and add tables to them and to
 use these tables as layers in QGIS. 
 
+
 .. Substitutions definitions - AVOID EDITING PAST THIS LINE
    This will be automatically updated by the find_set_subst.py script.
    If you need to create a new substitution manually,
@@ -82,4 +83,4 @@ use these tables as layers in QGIS.
 .. |basic| image:: /static/global/basic.png
 .. |newSpatiaLiteLayer| image:: /static/common/mActionNewSpatiaLiteLayer.png
    :width: 1.5em
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/databases/spatialite.rst
+++ b/source/docs/training_manual/databases/spatialite.rst
@@ -1,3 +1,7 @@
+.. only:: html
+
+   |updatedisclaimer|
+
 |LS| Working with spatialite databases in QGIS 
 ===============================================================================
 While PostGIS is generally used on a server to provide spatial database
@@ -78,3 +82,4 @@ use these tables as layers in QGIS.
 .. |basic| image:: /static/global/basic.png
 .. |newSpatiaLiteLayer| image:: /static/common/mActionNewSpatiaLiteLayer.png
    :width: 1.5em
+.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/forestry/basic_lidar.rst
+++ b/source/docs/training_manual/forestry/basic_lidar.rst
@@ -1,3 +1,7 @@
+.. only:: html
+
+   |updatedisclaimer|
+
 |LS| DEM from LiDAR Data
 ===============================================================================
 
@@ -147,3 +151,4 @@ In the next, and final step in this module, lesson you will use the hillshade ra
 .. |LS| replace:: Lesson:
 .. |WN| replace:: What's Next?
 .. |basic| image:: /static/global/basic.png
+.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/forestry/basic_lidar.rst
+++ b/source/docs/training_manual/forestry/basic_lidar.rst
@@ -140,6 +140,7 @@ Using LiDAR data to get a DEM, specially in forested areas, gives good results w
 
 In the next, and final step in this module, lesson you will use the hillshade raster and the forest inventory results to create a map presentation of the results.
 
+
 .. Substitutions definitions - AVOID EDITING PAST THIS LINE
    This will be automatically updated by the find_set_subst.py script.
    If you need to create a new substitution manually,
@@ -151,4 +152,4 @@ In the next, and final step in this module, lesson you will use the hillshade ra
 .. |LS| replace:: Lesson:
 .. |WN| replace:: What's Next?
 .. |basic| image:: /static/global/basic.png
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/forestry/forest_maps.rst
+++ b/source/docs/training_manual/forestry/forest_maps.rst
@@ -401,4 +401,4 @@ then use it to your enhance your data and maps visibility.
    :width: 1.5em
 .. |select| image:: /static/common/mActionSelect.png
    :width: 1.5em
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/forestry/forest_maps.rst
+++ b/source/docs/training_manual/forestry/forest_maps.rst
@@ -1,3 +1,7 @@
+.. only:: html
+
+   |updatedisclaimer|
+
 |LS| Creating Detailed Maps with the Atlas Tool
 ===============================================================================
 
@@ -397,3 +401,4 @@ then use it to your enhance your data and maps visibility.
    :width: 1.5em
 .. |select| image:: /static/common/mActionSelect.png
    :width: 1.5em
+.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/forestry/forestry_intro.rst
+++ b/source/docs/training_manual/forestry/forestry_intro.rst
@@ -29,6 +29,7 @@ The general sample data (aerial images, LiDAR data, basic maps) has been obtaine
    Before using the techniques described here on your own data, always ensure you have
    proper backups!
 
+
 .. Substitutions definitions - AVOID EDITING PAST THIS LINE
    This will be automatically updated by the find_set_subst.py script.
    If you need to create a new substitution manually,
@@ -36,4 +37,4 @@ The general sample data (aerial images, LiDAR data, basic maps) has been obtaine
    source folder.
 
 .. |LS| replace:: Lesson:
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/forestry/forestry_intro.rst
+++ b/source/docs/training_manual/forestry/forestry_intro.rst
@@ -1,3 +1,7 @@
+.. only:: html
+
+   |updatedisclaimer|
+
 |LS| Forestry Module Presentation
 ===============================================================================
 
@@ -32,3 +36,4 @@ The general sample data (aerial images, LiDAR data, basic maps) has been obtaine
    source folder.
 
 .. |LS| replace:: Lesson:
+.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/forestry/index.rst
+++ b/source/docs/training_manual/forestry/index.rst
@@ -30,6 +30,7 @@ The development of this module has been sponsored by the European Union.
    basic_lidar
    results_map
 
+
 .. Substitutions definitions - AVOID EDITING PAST THIS LINE
    This will be automatically updated by the find_set_subst.py script.
    If you need to create a new substitution manually,
@@ -37,4 +38,4 @@ The development of this module has been sponsored by the European Union.
    source folder.
 
 .. |MOD| replace:: Module:
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/forestry/index.rst
+++ b/source/docs/training_manual/forestry/index.rst
@@ -1,3 +1,7 @@
+.. only:: html
+
+   |updatedisclaimer|
+
 *******************************************************************************
 |MOD| Forestry Application
 *******************************************************************************
@@ -33,3 +37,4 @@ The development of this module has been sponsored by the European Union.
    source folder.
 
 .. |MOD| replace:: Module:
+.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/forestry/map_georeferencing.rst
+++ b/source/docs/training_manual/forestry/map_georeferencing.rst
@@ -97,6 +97,7 @@ As you have seen, georeferencing a paper map is a relatively straight forward op
 
 In the next lesson, you will digitize the forest stands in your map as polygons and add the inventory data to them.
 
+
 .. Substitutions definitions - AVOID EDITING PAST THIS LINE
    This will be automatically updated by the find_set_subst.py script.
    If you need to create a new substitution manually,
@@ -108,4 +109,4 @@ In the next lesson, you will digitize the forest stands in your map as polygons 
 .. |LS| replace:: Lesson:
 .. |WN| replace:: What's Next?
 .. |basic| image:: /static/global/basic.png
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/forestry/map_georeferencing.rst
+++ b/source/docs/training_manual/forestry/map_georeferencing.rst
@@ -1,3 +1,7 @@
+.. only:: html
+
+   |updatedisclaimer|
+
 |LS| Georeferencing a Map
 ===============================================================================
 
@@ -104,3 +108,4 @@ In the next lesson, you will digitize the forest stands in your map as polygons 
 .. |LS| replace:: Lesson:
 .. |WN| replace:: What's Next?
 .. |basic| image:: /static/global/basic.png
+.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/forestry/parameters_calculation.rst
+++ b/source/docs/training_manual/forestry/parameters_calculation.rst
@@ -1,3 +1,7 @@
+.. only:: html
+
+   |updatedisclaimer|
+
 |LS| Calculating the Forest Parameters
 ===============================================================================
 
@@ -140,3 +144,4 @@ In the following lesson, you will first create a hillshade background from a LiD
 .. |LS| replace:: Lesson:
 .. |WN| replace:: What's Next?
 .. |basic| image:: /static/global/basic.png
+.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/forestry/parameters_calculation.rst
+++ b/source/docs/training_manual/forestry/parameters_calculation.rst
@@ -133,6 +133,7 @@ You managed to calculate forest estimates for the whole forest using the informa
 
 In the following lesson, you will first create a hillshade background from a LiDAR dataset which you will use to prepare a map presentation with the forest results you just calculated.
 
+
 .. Substitutions definitions - AVOID EDITING PAST THIS LINE
    This will be automatically updated by the find_set_subst.py script.
    If you need to create a new substitution manually,
@@ -144,4 +145,4 @@ In the following lesson, you will first create a hillshade background from a LiD
 .. |LS| replace:: Lesson:
 .. |WN| replace:: What's Next?
 .. |basic| image:: /static/global/basic.png
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/forestry/results_map.rst
+++ b/source/docs/training_manual/forestry/results_map.rst
@@ -1,3 +1,7 @@
+.. only:: html
+
+   |updatedisclaimer|
+
 |LS| Map Presentation
 ===============================================================================
 
@@ -88,3 +92,4 @@ Through this module you have seen how a basic forest inventory can be planned an
 .. |LS| replace:: Lesson:
 .. |TY| replace:: Try Yourself
 .. |basic| image:: /static/global/basic.png
+.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/forestry/results_map.rst
+++ b/source/docs/training_manual/forestry/results_map.rst
@@ -81,6 +81,7 @@ Save your QGIS project for future references.
 
 Through this module you have seen how a basic forest inventory can be planned and presented with QGIS. Many more forest analysis are possible with the variety of tools that you can access, but hopefully this manual has given you a good starting point to explore how you could achieve the specific results you need.
 
+
 .. Substitutions definitions - AVOID EDITING PAST THIS LINE
    This will be automatically updated by the find_set_subst.py script.
    If you need to create a new substitution manually,
@@ -92,4 +93,4 @@ Through this module you have seen how a basic forest inventory can be planned an
 .. |LS| replace:: Lesson:
 .. |TY| replace:: Try Yourself
 .. |basic| image:: /static/global/basic.png
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/forestry/stands_digitazing.rst
+++ b/source/docs/training_manual/forestry/stands_digitazing.rst
@@ -270,4 +270,4 @@ You could start doing different analysis with your brand new dataset, but you mi
 .. |TY| replace:: Try Yourself
 .. |WN| replace:: What's Next?
 .. |basic| image:: /static/global/basic.png
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/forestry/stands_digitazing.rst
+++ b/source/docs/training_manual/forestry/stands_digitazing.rst
@@ -1,3 +1,7 @@
+.. only:: html
+
+   |updatedisclaimer|
+
 |LS| Digitizing Forest Stands
 ===============================================================================
 
@@ -266,3 +270,4 @@ You could start doing different analysis with your brand new dataset, but you mi
 .. |TY| replace:: Try Yourself
 .. |WN| replace:: What's Next?
 .. |basic| image:: /static/global/basic.png
+.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/forestry/systematic_sampling.rst
+++ b/source/docs/training_manual/forestry/systematic_sampling.rst
@@ -114,6 +114,7 @@ You just saw how easily you can create a systematic sampling design to be used i
 
 In the next lesson you will see how to use the Atlas capabilities in QGIS to automatically generate detailed maps that the field teams will be using to navigate to the sample plots assigned to them.
 
+
 .. Substitutions definitions - AVOID EDITING PAST THIS LINE
    This will be automatically updated by the find_set_subst.py script.
    If you need to create a new substitution manually,
@@ -125,4 +126,4 @@ In the next lesson you will see how to use the Atlas capabilities in QGIS to aut
 .. |LS| replace:: Lesson:
 .. |WN| replace:: What's Next?
 .. |basic| image:: /static/global/basic.png
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/forestry/systematic_sampling.rst
+++ b/source/docs/training_manual/forestry/systematic_sampling.rst
@@ -1,3 +1,7 @@
+.. only:: html
+
+   |updatedisclaimer|
+
 |LS| Systematic Sampling Design
 ===============================================================================
 
@@ -121,3 +125,4 @@ In the next lesson you will see how to use the Atlas capabilities in QGIS to aut
 .. |LS| replace:: Lesson:
 .. |WN| replace:: What's Next?
 .. |basic| image:: /static/global/basic.png
+.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/forestry/updating_stands.rst
+++ b/source/docs/training_manual/forestry/updating_stands.rst
@@ -1,3 +1,7 @@
+.. only:: html
+
+   |updatedisclaimer|
+
 |LS| Updating Forest Stands
 ===============================================================================
 
@@ -182,3 +186,4 @@ The forest stands you digitized will be used for planning forestry operations in
 .. |TY| replace:: Try Yourself
 .. |WN| replace:: What's Next?
 .. |basic| image:: /static/global/basic.png
+.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/forestry/updating_stands.rst
+++ b/source/docs/training_manual/forestry/updating_stands.rst
@@ -174,6 +174,7 @@ You have seen how to interpret CIR images to digitize forest stands. Of course i
 
 The forest stands you digitized will be used for planning forestry operations in the future, but you still need to get more information about the forest. In the next lesson, you will see how to plan a set of sampling plots to inventory the forest area you just digitized, and get the overall estimate of forest parameters.
 
+
 .. Substitutions definitions - AVOID EDITING PAST THIS LINE
    This will be automatically updated by the find_set_subst.py script.
    If you need to create a new substitution manually,
@@ -186,4 +187,4 @@ The forest stands you digitized will be used for planning forestry operations in
 .. |TY| replace:: Try Yourself
 .. |WN| replace:: What's Next?
 .. |basic| image:: /static/global/basic.png
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/foreword/foreword.rst
+++ b/source/docs/training_manual/foreword/foreword.rst
@@ -147,10 +147,11 @@ version which is part of the QGIS documentation website (http://docs.qgis.org).
 
 Tim Sutton, May 2012
 
+
 .. Substitutions definitions - AVOID EDITING PAST THIS LINE
    This will be automatically updated by the find_set_subst.py script.
    If you need to create a new substitution manually,
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/foreword/foreword.rst
+++ b/source/docs/training_manual/foreword/foreword.rst
@@ -1,3 +1,7 @@
+.. only:: html
+
+   |updatedisclaimer|
+
 Foreword
 ========
 
@@ -142,3 +146,11 @@ version which is part of the QGIS documentation website (http://docs.qgis.org).
 
 
 Tim Sutton, May 2012
+
+.. Substitutions definitions - AVOID EDITING PAST THIS LINE
+   This will be automatically updated by the find_set_subst.py script.
+   If you need to create a new substitution manually,
+   please add it also to the substitutions.txt file in the
+   source folder.
+
+.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/foreword/index.rst
+++ b/source/docs/training_manual/foreword/index.rst
@@ -12,10 +12,11 @@ Course Introduction
    foreword
    preparing_data
 
+
 .. Substitutions definitions - AVOID EDITING PAST THIS LINE
    This will be automatically updated by the find_set_subst.py script.
    If you need to create a new substitution manually,
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/foreword/index.rst
+++ b/source/docs/training_manual/foreword/index.rst
@@ -1,3 +1,7 @@
+.. only:: html
+
+   |updatedisclaimer|
+
 *******************************************************************************
 Course Introduction
 *******************************************************************************
@@ -7,3 +11,11 @@ Course Introduction
 
    foreword
    preparing_data
+
+.. Substitutions definitions - AVOID EDITING PAST THIS LINE
+   This will be automatically updated by the find_set_subst.py script.
+   If you need to create a new substitution manually,
+   please add it also to the substitutions.txt file in the
+   source folder.
+
+.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/foreword/preparing_data.rst
+++ b/source/docs/training_manual/foreword/preparing_data.rst
@@ -1,3 +1,7 @@
+.. only:: html
+
+   |updatedisclaimer|
+
 Preparing Exercise Data
 =======================
 
@@ -225,5 +229,6 @@ The tokens you need to replace are as follows:
 .. |basic| image:: /static/global/basic.png
 .. |hard| image:: /static/global/hard.png
 .. |majorUrbanName| replace:: Swellendam
+.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
 .. |zoomFullExtent| image:: /static/common/mActionZoomFullExtent.png
    :width: 1.5em

--- a/source/docs/training_manual/foreword/preparing_data.rst
+++ b/source/docs/training_manual/foreword/preparing_data.rst
@@ -219,6 +219,7 @@ The tokens you need to replace are as follows:
 * :kbd:`localCRS`: this defaults to :kbd:`WGS 84 / UTM 34S`. You should replace
   this with the correct CRS for your region.
 
+
 .. Substitutions definitions - AVOID EDITING PAST THIS LINE
    This will be automatically updated by the find_set_subst.py script.
    If you need to create a new substitution manually,
@@ -229,6 +230,6 @@ The tokens you need to replace are as follows:
 .. |basic| image:: /static/global/basic.png
 .. |hard| image:: /static/global/hard.png
 .. |majorUrbanName| replace:: Swellendam
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
 .. |zoomFullExtent| image:: /static/common/mActionZoomFullExtent.png
    :width: 1.5em

--- a/source/docs/training_manual/grass/grass_setup.rst
+++ b/source/docs/training_manual/grass/grass_setup.rst
@@ -181,6 +181,7 @@ easier by using existing layers in QGIS as data sources for GRASS.
 Now that the data is imported into GRASS, we can look at the advanced analysis
 operations that GRASS offers.
 
+
 .. Substitutions definitions - AVOID EDITING PAST THIS LINE
    This will be automatically updated by the find_set_subst.py script.
    If you need to create a new substitution manually,
@@ -198,4 +199,4 @@ operations that GRASS offers.
    :width: 1.5em
 .. |hard| image:: /static/global/hard.png
 .. |srtmFileName| replace:: :kbd:`srtm_41_19.tif`
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/grass/grass_setup.rst
+++ b/source/docs/training_manual/grass/grass_setup.rst
@@ -1,3 +1,7 @@
+.. only:: html
+
+   |updatedisclaimer|
+
 |LS| GRASS Setup
 ===============================================================================
 
@@ -194,3 +198,4 @@ operations that GRASS offers.
    :width: 1.5em
 .. |hard| image:: /static/global/hard.png
 .. |srtmFileName| replace:: :kbd:`srtm_41_19.tif`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/grass/grass_tools.rst
+++ b/source/docs/training_manual/grass/grass_tools.rst
@@ -1,3 +1,7 @@
+.. only:: html
+
+   |updatedisclaimer|
+
 |LS| GRASS Tools
 ===============================================================================
 
@@ -138,3 +142,4 @@ organizes tools by type.
 .. |grassRegionEdit| image:: /static/common/grass_region_edit.png
    :width: 1.5em
 .. |moderate| image:: /static/global/moderate.png
+.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/grass/grass_tools.rst
+++ b/source/docs/training_manual/grass/grass_tools.rst
@@ -129,6 +129,7 @@ Tools` dialog and scroll down the :guilabel:`Modules List`. Or for a more
 structured approach, look under the :guilabel:`Modules Tree` tab, which
 organizes tools by type.
 
+
 .. Substitutions definitions - AVOID EDITING PAST THIS LINE
    This will be automatically updated by the find_set_subst.py script.
    If you need to create a new substitution manually,
@@ -142,4 +143,4 @@ organizes tools by type.
 .. |grassRegionEdit| image:: /static/common/grass_region_edit.png
    :width: 1.5em
 .. |moderate| image:: /static/global/moderate.png
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/grass/index.rst
+++ b/source/docs/training_manual/grass/index.rst
@@ -17,6 +17,7 @@ QGIS allows you to make use of GRASS' powerful GIS tools directly.
    grass_setup
    grass_tools
 
+
 .. Substitutions definitions - AVOID EDITING PAST THIS LINE
    This will be automatically updated by the find_set_subst.py script.
    If you need to create a new substitution manually,
@@ -24,4 +25,4 @@ QGIS allows you to make use of GRASS' powerful GIS tools directly.
    source folder.
 
 .. |MOD| replace:: Module:
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/grass/index.rst
+++ b/source/docs/training_manual/grass/index.rst
@@ -1,3 +1,7 @@
+.. only:: html
+
+   |updatedisclaimer|
+
 *******************************************************************************
 |MOD| GRASS
 *******************************************************************************
@@ -20,3 +24,4 @@ QGIS allows you to make use of GRASS' powerful GIS tools directly.
    source folder.
 
 .. |MOD| replace:: Module:
+.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/index.rst
+++ b/source/docs/training_manual/index.rst
@@ -43,10 +43,11 @@ Indices and tables
 * :ref:`modindex`
 * :ref:`search`
 
+
 .. Substitutions definitions - AVOID EDITING PAST THIS LINE
    This will be automatically updated by the find_set_subst.py script.
    If you need to create a new substitution manually,
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/index.rst
+++ b/source/docs/training_manual/index.rst
@@ -1,3 +1,6 @@
+.. only:: html
+
+   |updatedisclaimer|
 
 .. _QGIS-training-manual-index-reference:
 
@@ -39,3 +42,11 @@ Indices and tables
 * :ref:`genindex`
 * :ref:`modindex`
 * :ref:`search`
+
+.. Substitutions definitions - AVOID EDITING PAST THIS LINE
+   This will be automatically updated by the find_set_subst.py script.
+   If you need to create a new substitution manually,
+   please add it also to the substitutions.txt file in the
+   source folder.
+
+.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/introduction/index.rst
+++ b/source/docs/training_manual/introduction/index.rst
@@ -1,3 +1,7 @@
+.. only:: html
+
+   |updatedisclaimer|
+
 *******************
 |MOD| The Interface
 *******************
@@ -17,3 +21,4 @@
    source folder.
 
 .. |MOD| replace:: Module:
+.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/introduction/index.rst
+++ b/source/docs/training_manual/introduction/index.rst
@@ -14,6 +14,7 @@
    preparation
    overview
 
+
 .. Substitutions definitions - AVOID EDITING PAST THIS LINE
    This will be automatically updated by the find_set_subst.py script.
    If you need to create a new substitution manually,
@@ -21,4 +22,4 @@
    source folder.
 
 .. |MOD| replace:: Module:
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/introduction/intro.rst
+++ b/source/docs/training_manual/introduction/intro.rst
@@ -119,6 +119,7 @@ Here are only some of the reasons:
 Now that you know why you want to use QGIS, we can show you how. The first
 lesson will guide you in creating your first QGIS map.
 
+
 .. Substitutions definitions - AVOID EDITING PAST THIS LINE
    This will be automatically updated by the find_set_subst.py script.
    If you need to create a new substitution manually,
@@ -129,4 +130,4 @@ lesson will guide you in creating your first QGIS map.
 .. |basic| image:: /static/global/basic.png
 .. |hard| image:: /static/global/hard.png
 .. |moderate| image:: /static/global/moderate.png
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/introduction/intro.rst
+++ b/source/docs/training_manual/introduction/intro.rst
@@ -1,3 +1,7 @@
+.. only:: html
+
+   |updatedisclaimer|
+
 |LS| A Brief Introduction
 ===============================================================================
 
@@ -125,3 +129,4 @@ lesson will guide you in creating your first QGIS map.
 .. |basic| image:: /static/global/basic.png
 .. |hard| image:: /static/global/hard.png
 .. |moderate| image:: /static/global/moderate.png
+.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/introduction/overview.rst
+++ b/source/docs/training_manual/introduction/overview.rst
@@ -131,6 +131,7 @@ Try to find each of these tools on your screen. What is their purpose?
 Now you've seen how the QGIS interface works, you can use the tools available
 to you and start improving on your map! This is the topic of the next lesson.
 
+
 .. Substitutions definitions - AVOID EDITING PAST THIS LINE
    This will be automatically updated by the find_set_subst.py script.
    If you need to create a new substitution manually,
@@ -145,7 +146,7 @@ to you and start improving on your map! This is the topic of the next lesson.
    :width: 1.5em
 .. |measure| image:: /static/common/mActionMeasure.png
    :width: 1.5em
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
 .. |whatsThis| image:: /static/common/whats_this.png
    :width: 1.5em
 .. |zoomToLayer| image:: /static/common/mActionZoomToLayer.png

--- a/source/docs/training_manual/introduction/overview.rst
+++ b/source/docs/training_manual/introduction/overview.rst
@@ -1,3 +1,7 @@
+.. only:: html
+
+   |updatedisclaimer|
+
 |LS| An Overview of the Interface
 ===============================================================================
 
@@ -141,6 +145,7 @@ to you and start improving on your map! This is the topic of the next lesson.
    :width: 1.5em
 .. |measure| image:: /static/common/mActionMeasure.png
    :width: 1.5em
+.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
 .. |whatsThis| image:: /static/common/whats_this.png
    :width: 1.5em
 .. |zoomToLayer| image:: /static/common/mActionZoomToLayer.png

--- a/source/docs/training_manual/introduction/preparation.rst
+++ b/source/docs/training_manual/introduction/preparation.rst
@@ -1,3 +1,7 @@
+.. only:: html
+
+   |updatedisclaimer|
+
 |LS| Adding your first layer
 ===============================================================================
 
@@ -79,3 +83,4 @@ layout of the QGIS interface. This is the topic of the next lesson.
 .. |basic| image:: /static/global/basic.png
 .. |fileSaveAs| image:: /static/common/mActionFileSaveAs.png
    :width: 1.5em
+.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/introduction/preparation.rst
+++ b/source/docs/training_manual/introduction/preparation.rst
@@ -68,6 +68,7 @@ button, but what about all the others? How does this interface work? Before we
 go on with the more involved stuff, let's first take a good look at the general
 layout of the QGIS interface. This is the topic of the next lesson.
 
+
 .. Substitutions definitions - AVOID EDITING PAST THIS LINE
    This will be automatically updated by the find_set_subst.py script.
    If you need to create a new substitution manually,
@@ -83,4 +84,4 @@ layout of the QGIS interface. This is the topic of the next lesson.
 .. |basic| image:: /static/global/basic.png
 .. |fileSaveAs| image:: /static/common/mActionFileSaveAs.png
    :width: 1.5em
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/map_composer/day_1_assignment.rst
+++ b/source/docs/training_manual/map_composer/day_1_assignment.rst
@@ -1,3 +1,7 @@
+.. only:: html
+
+   |updatedisclaimer|
+
 Assignment 1
 ===============================================================================
 
@@ -42,3 +46,4 @@ start to finish, using both raster and vector data sources.
 .. |IC| replace:: In Conclusion
 .. |basic| image:: /static/global/basic.png
 .. |moderate| image:: /static/global/moderate.png
+.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/map_composer/day_1_assignment.rst
+++ b/source/docs/training_manual/map_composer/day_1_assignment.rst
@@ -37,6 +37,7 @@ analysis. This will include creating and editing vector data; analyzing vector
 data; using and analyzing raster data; and using GIS to solve a problem from
 start to finish, using both raster and vector data sources.
 
+
 .. Substitutions definitions - AVOID EDITING PAST THIS LINE
    This will be automatically updated by the find_set_subst.py script.
    If you need to create a new substitution manually,
@@ -46,4 +47,4 @@ start to finish, using both raster and vector data sources.
 .. |IC| replace:: In Conclusion
 .. |basic| image:: /static/global/basic.png
 .. |moderate| image:: /static/global/moderate.png
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/map_composer/index.rst
+++ b/source/docs/training_manual/map_composer/index.rst
@@ -1,3 +1,7 @@
+.. only:: html
+
+   |updatedisclaimer|
+
 *******************************************************************************
 |MOD| Creating Maps
 *******************************************************************************
@@ -18,3 +22,4 @@ quality maps with all the requisite map components.
    source folder.
 
 .. |MOD| replace:: Module:
+.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/map_composer/index.rst
+++ b/source/docs/training_manual/map_composer/index.rst
@@ -15,6 +15,7 @@ quality maps with all the requisite map components.
    map_composer
    day_1_assignment
 
+
 .. Substitutions definitions - AVOID EDITING PAST THIS LINE
    This will be automatically updated by the find_set_subst.py script.
    If you need to create a new substitution manually,
@@ -22,4 +23,4 @@ quality maps with all the requisite map components.
    source folder.
 
 .. |MOD| replace:: Module:
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/map_composer/map_composer.rst
+++ b/source/docs/training_manual/map_composer/map_composer.rst
@@ -296,6 +296,7 @@ Congratulations on your first completed QGIS map project!
 On the next page, you will be given an assignment to complete. This will allow
 you to practice the techniques you have learned so far.
 
+
 .. Substitutions definitions - AVOID EDITING PAST THIS LINE
    This will be automatically updated by the find_set_subst.py script.
    If you need to create a new substitution manually,
@@ -331,7 +332,7 @@ you to practice the techniques you have learned so far.
    :width: 1.5em
 .. |signMinus| image:: /static/common/symbologyRemove.png
    :width: 1.5em
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
 .. |zoomFullExtent| image:: /static/common/mActionZoomFullExtent.png
    :width: 1.5em
 .. |zoomIn| image:: /static/common/mActionZoomIn.png

--- a/source/docs/training_manual/map_composer/map_composer.rst
+++ b/source/docs/training_manual/map_composer/map_composer.rst
@@ -1,3 +1,7 @@
+.. only:: html
+
+   |updatedisclaimer|
+
 |LS| Using Print Layout
 ===============================================================================
 
@@ -327,6 +331,7 @@ you to practice the techniques you have learned so far.
    :width: 1.5em
 .. |signMinus| image:: /static/common/symbologyRemove.png
    :width: 1.5em
+.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
 .. |zoomFullExtent| image:: /static/common/mActionZoomFullExtent.png
    :width: 1.5em
 .. |zoomIn| image:: /static/common/mActionZoomIn.png

--- a/source/docs/training_manual/online_resources/index.rst
+++ b/source/docs/training_manual/online_resources/index.rst
@@ -20,6 +20,7 @@ Services (WMS) and Web Feature Services (WFS).
    wms
    wfs
 
+
 .. Substitutions definitions - AVOID EDITING PAST THIS LINE
    This will be automatically updated by the find_set_subst.py script.
    If you need to create a new substitution manually,
@@ -27,4 +28,4 @@ Services (WMS) and Web Feature Services (WFS).
    source folder.
 
 .. |MOD| replace:: Module:
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/online_resources/index.rst
+++ b/source/docs/training_manual/online_resources/index.rst
@@ -1,3 +1,7 @@
+.. only:: html
+
+   |updatedisclaimer|
+
 *******************************************************************************
 |MOD| Online Resources
 *******************************************************************************
@@ -23,3 +27,4 @@ Services (WMS) and Web Feature Services (WFS).
    source folder.
 
 .. |MOD| replace:: Module:
+.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/online_resources/wfs.rst
+++ b/source/docs/training_manual/online_resources/wfs.rst
@@ -1,3 +1,7 @@
+.. only:: html
+
+   |updatedisclaimer|
+
 |LS| Web Feature Services
 ===============================================================================
 
@@ -165,5 +169,6 @@ Next, you'll see how to use QGIS Server to provide OGC services.
 .. |WN| replace:: What's Next?
 .. |basic| image:: /static/global/basic.png
 .. |moderate| image:: /static/global/moderate.png
+.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
 .. |wfs| image:: /static/common/mActionAddWfsLayer.png
    :width: 1.5em

--- a/source/docs/training_manual/online_resources/wfs.rst
+++ b/source/docs/training_manual/online_resources/wfs.rst
@@ -157,6 +157,7 @@ instead of a WMS.
 
 Next, you'll see how to use QGIS Server to provide OGC services.
 
+
 .. Substitutions definitions - AVOID EDITING PAST THIS LINE
    This will be automatically updated by the find_set_subst.py script.
    If you need to create a new substitution manually,
@@ -169,6 +170,6 @@ Next, you'll see how to use QGIS Server to provide OGC services.
 .. |WN| replace:: What's Next?
 .. |basic| image:: /static/global/basic.png
 .. |moderate| image:: /static/global/moderate.png
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
 .. |wfs| image:: /static/common/mActionAddWfsLayer.png
    :width: 1.5em

--- a/source/docs/training_manual/online_resources/wms.rst
+++ b/source/docs/training_manual/online_resources/wms.rst
@@ -220,6 +220,7 @@ that it's also possible to add features (such as the other vector layers you
 added before). Adding features from remote servers is possible by using a Web
 Feature Service (WFS). That's the topic of the next lesson.
 
+
 .. Substitutions definitions - AVOID EDITING PAST THIS LINE
    This will be automatically updated by the find_set_subst.py script.
    If you need to create a new substitution manually,
@@ -236,6 +237,6 @@ Feature Service (WFS). That's the topic of the next lesson.
 .. |hard| image:: /static/global/hard.png
 .. |majorUrbanName| replace:: Swellendam
 .. |moderate| image:: /static/global/moderate.png
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
 .. |wms| image:: /static/common/mActionAddWmsLayer.png
    :width: 1.5em

--- a/source/docs/training_manual/online_resources/wms.rst
+++ b/source/docs/training_manual/online_resources/wms.rst
@@ -1,3 +1,7 @@
+.. only:: html
+
+   |updatedisclaimer|
+
 .. _`wms-services`:
 
 |LS| Web Mapping Services
@@ -232,5 +236,6 @@ Feature Service (WFS). That's the topic of the next lesson.
 .. |hard| image:: /static/global/hard.png
 .. |majorUrbanName| replace:: Swellendam
 .. |moderate| image:: /static/global/moderate.png
+.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
 .. |wms| image:: /static/common/mActionAddWmsLayer.png
    :width: 1.5em

--- a/source/docs/training_manual/processing/batch_conversion.rst
+++ b/source/docs/training_manual/processing/batch_conversion.rst
@@ -54,4 +54,4 @@ Click on *OK* and the batch process will be run. If everything went fine, all yo
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/processing/batch_conversion.rst
+++ b/source/docs/training_manual/processing/batch_conversion.rst
@@ -1,3 +1,7 @@
+.. only:: html
+
+   |updatedisclaimer|
+
 The batch processing interface
 ================================
 
@@ -42,3 +46,12 @@ If you select the first option, only the current cell will be filled. If you sel
 The last column sets whether or not to add the resulting layers to the current QGIS project. Leave the default *Yes* option, so you can see your results in this case.
 
 Click on *OK* and the batch process will be run. If everything went fine, all your layers will have been processed, and 3 new layers would have been created.
+
+
+.. Substitutions definitions - AVOID EDITING PAST THIS LINE
+   This will be automatically updated by the find_set_subst.py script.
+   If you need to create a new substitution manually,
+   please add it also to the substitutions.txt file in the
+   source folder.
+
+.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/processing/batch_modeler.rst
+++ b/source/docs/training_manual/processing/batch_modeler.rst
@@ -30,4 +30,4 @@ Click on *OK* and you should get 5 new layers with watersheds corresponding to t
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/processing/batch_modeler.rst
+++ b/source/docs/training_manual/processing/batch_modeler.rst
@@ -1,3 +1,7 @@
+.. only:: html
+
+   |updatedisclaimer|
+
 Models in the batch processing interface
 =========================================
 
@@ -18,3 +22,12 @@ Add rows up to a total of 5. Select the DEM file corresponding to this lesson as
 As you see the batch processing interface can be run not just to run the same process on different datasets but also on the same dataset with different parameters.
 
 Click on *OK* and you should get 5 new layers with watersheds corresponding to the specified 5 threshold values.
+
+
+.. Substitutions definitions - AVOID EDITING PAST THIS LINE
+   This will be automatically updated by the find_set_subst.py script.
+   If you need to create a new substitution manually,
+   please add it also to the substitutions.txt file in the
+   source folder.
+
+.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/processing/crs.rst
+++ b/source/docs/training_manual/processing/crs.rst
@@ -1,3 +1,7 @@
+.. only:: html
+
+   |updatedisclaimer|
+
 CRSs. Reprojecting
 ============================================================
 
@@ -53,3 +57,12 @@ Open the *Reproject layer* algorithm.
 .. image:: img/crs/reprojection.png
 
 Select any of the layers as input, and select EPSG:23029 as the destination CRS. Run the algorithm and you will get a new layer, identical to the input one, but with a different CRS. It will appear on the same region of the canvas, like the other ones, since QGIS will reproject it on the fly, but its original coordinates are different. You can see that by running the *Export/Add geometry columns* algorithm using this new layer as input, and veryfing that the added coordinates are different to the ones in the attribute tables of both of the two layers that we had computed before.
+
+
+.. Substitutions definitions - AVOID EDITING PAST THIS LINE
+   This will be automatically updated by the find_set_subst.py script.
+   If you need to create a new substitution manually,
+   please add it also to the substitutions.txt file in the
+   source folder.
+
+.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/processing/crs.rst
+++ b/source/docs/training_manual/processing/crs.rst
@@ -65,4 +65,4 @@ Select any of the layers as input, and select EPSG:23029 as the destination CRS.
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/processing/cutting_merging.rst
+++ b/source/docs/training_manual/processing/cutting_merging.rst
@@ -1,3 +1,7 @@
+.. only:: html
+
+   |updatedisclaimer|
+
 Clipping and merging raster layers
 ============================================================
 
@@ -75,3 +79,12 @@ Reprojecting the converted slope layer back with the *Reproject raster layer*, w
 .. warning:: todo: Add image
 
 The reprojection processes might have caused the final layer to contain data outside the bounding box that we calculated in one of the first steps. This can be solved by clipping it again, as we did to obtain the base DEM.
+
+
+.. Substitutions definitions - AVOID EDITING PAST THIS LINE
+   This will be automatically updated by the find_set_subst.py script.
+   If you need to create a new substitution manually,
+   please add it also to the substitutions.txt file in the
+   source folder.
+
+.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/processing/cutting_merging.rst
+++ b/source/docs/training_manual/processing/cutting_merging.rst
@@ -87,4 +87,4 @@ The reprojection processes might have caused the final layer to contain data out
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/processing/extents.rst
+++ b/source/docs/training_manual/processing/extents.rst
@@ -1,3 +1,7 @@
+.. only:: html
+
+   |updatedisclaimer|
+
 Defining extents
 ============================================================
 
@@ -52,3 +56,12 @@ You will get a rasterized layer that covers exactly the area covered by the orig
 In some cases, the last option, *Use min covering extent from input layers*, might not be available. This will happen in those algorithm that do not have input layers, but just parameters of other types. In that case, you will have to enter the value manually or use any of the other options.
 
 Notice that, when a selection exist, the extent of the layer is that of the whole set of features, and the selection is not used to compute the extent, even though the rasterization is executed on the selected items only. In that case, you might want to actually create a new layer from the selection, and then use it as input.
+
+
+.. Substitutions definitions - AVOID EDITING PAST THIS LINE
+   This will be automatically updated by the find_set_subst.py script.
+   If you need to create a new substitution manually,
+   please add it also to the substitutions.txt file in the
+   source folder.
+
+.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/processing/extents.rst
+++ b/source/docs/training_manual/processing/extents.rst
@@ -64,4 +64,4 @@ Notice that, when a selection exist, the extent of the layer is that of the whol
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/processing/first_alg.rst
+++ b/source/docs/training_manual/processing/first_alg.rst
@@ -1,3 +1,7 @@
+.. only:: html
+
+   |updatedisclaimer|
+
 Running our first algorithm. The  toolbox
 ============================================================
 
@@ -84,3 +88,12 @@ Try yourself saving it using different file formats (use, for instance,
 :file:`shp` and :file:`geojson` as extensions). Also, if you do not want the
 layer to be loaded in QGIS after it is generated, you can check off the checkbox
 that is found below the output path box.
+
+
+.. Substitutions definitions - AVOID EDITING PAST THIS LINE
+   This will be automatically updated by the find_set_subst.py script.
+   If you need to create a new substitution manually,
+   please add it also to the substitutions.txt file in the
+   source folder.
+
+.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/processing/first_alg.rst
+++ b/source/docs/training_manual/processing/first_alg.rst
@@ -96,4 +96,4 @@ that is found below the output path box.
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/processing/first_saga_alg.rst
+++ b/source/docs/training_manual/processing/first_saga_alg.rst
@@ -1,3 +1,7 @@
+.. only:: html
+
+   |updatedisclaimer|
+
 Running an external algorithm
 ============================================================
 
@@ -54,3 +58,12 @@ We are using  width and height values that is larger than the specified extent, 
 Understanding this kind of problems will help you solve them and find an explanation to what is happening. As you can see in the error message, a test is performed to check that the connection with SAGA is working correctly, indicating you that there might be a problem in how the algorithm was executed. This applies not only to SAGA, but also to other external applications as well.
 
 In the next lesson we will introduce the processing log, where information about commands run by geoalgorithms is kept, and you will see how to get more detail when issues like this appear.
+
+
+.. Substitutions definitions - AVOID EDITING PAST THIS LINE
+   This will be automatically updated by the find_set_subst.py script.
+   If you need to create a new substitution manually,
+   please add it also to the substitutions.txt file in the
+   source folder.
+
+.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/processing/first_saga_alg.rst
+++ b/source/docs/training_manual/processing/first_saga_alg.rst
@@ -66,4 +66,4 @@ In the next lesson we will introduce the processing log, where information about
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/processing/generalize.rst
+++ b/source/docs/training_manual/processing/generalize.rst
@@ -29,4 +29,4 @@ This second option can be applied e.g. to contour lines resulting from a coarse 
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/processing/generalize.rst
+++ b/source/docs/training_manual/processing/generalize.rst
@@ -1,3 +1,7 @@
+.. only:: html
+
+   |updatedisclaimer|
+
 Vector simplification and smoothing
 ====================================
 
@@ -17,3 +21,12 @@ We can also do the reverse, and make a layer more complex, smoothing out sharp c
 Try to apply this second command both to original vector and to the one from the first analysis, and see the difference. Note that adjacency is not lost.
 
 This second option can be applied e.g. to contour lines resulting from a coarse raster, to GPS tracks with sparse vertices, etc.
+
+
+.. Substitutions definitions - AVOID EDITING PAST THIS LINE
+   This will be automatically updated by the find_set_subst.py script.
+   If you need to create a new substitution manually,
+   please add it also to the substitutions.txt file in the
+   source folder.
+
+.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/processing/geomorpho.rst
+++ b/source/docs/training_manual/processing/geomorpho.rst
@@ -31,4 +31,4 @@ The probability of a landslide will be very roughly related to both rainfall and
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/processing/geomorpho.rst
+++ b/source/docs/training_manual/processing/geomorpho.rst
@@ -1,3 +1,7 @@
+.. only:: html
+
+   |updatedisclaimer|
+
 Predicting landslides
 ==========================================
 
@@ -19,3 +23,12 @@ The probability of a landslide will be very roughly related to both rainfall and
 
 - :menuselection:`SAGA --> Raster calculator` rain, slope: ``(a*b)/100`` (or: :menuselection:`GRASS --> r.mapcalc`)
 - then let's calculate what are the municipalities with the greatest predicted risk of rainfall: :menuselection:`SAGA --> Raster statistics with polygons` (the parameters of interest are *Maximum* and *Mean*)
+
+
+.. Substitutions definitions - AVOID EDITING PAST THIS LINE
+   This will be automatically updated by the find_set_subst.py script.
+   If you need to create a new substitution manually,
+   please add it also to the substitutions.txt file in the
+   source folder.
+
+.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/processing/hooks.rst
+++ b/source/docs/training_manual/processing/hooks.rst
@@ -1,3 +1,7 @@
+.. only:: html
+
+   |updatedisclaimer|
+
 Pre- and post-execution script hooks
 ====================================
 
@@ -75,3 +79,12 @@ check them for geometry errors. If at least one feature contains an invalid geom
 
 To activate this hook we need enter its filename in the *Pre-execution script file* option in the Processing configuration dialog. 
 The hook will be executed before running any Processing algorithm.
+
+
+.. Substitutions definitions - AVOID EDITING PAST THIS LINE
+   This will be automatically updated by the find_set_subst.py script.
+   If you need to create a new substitution manually,
+   please add it also to the substitutions.txt file in the
+   source folder.
+
+.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/processing/hooks.rst
+++ b/source/docs/training_manual/processing/hooks.rst
@@ -87,4 +87,4 @@ The hook will be executed before running any Processing algorithm.
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/processing/html.rst
+++ b/source/docs/training_manual/processing/html.rst
@@ -33,4 +33,4 @@ Some algorithms generate text that cannot be divided into other more detailed ou
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/processing/html.rst
+++ b/source/docs/training_manual/processing/html.rst
@@ -1,3 +1,7 @@
+.. only:: html
+
+   |updatedisclaimer|
+
 HTML outputs
 ============================================================
 
@@ -23,5 +27,10 @@ This is the *Results viewer*. It keeps all the HTML result generated during the 
 Some algorithms generate text that cannot be divided into other more detailed outputs. That is the case if, for instance, the algorithm captures the text output from an external process. In other cases, the output is presented as text, but internally is divided into several smaller outputs, usually in the form of numeric values. The algorithm that we have just executed is one of them. Each one of those values is handled as a single output, and stored in a variable. This has no importance at all now, but once we move to the graphical modeler, you will see that it will allow us to use those values as numeric inputs for other algorithms. 
 
 
+.. Substitutions definitions - AVOID EDITING PAST THIS LINE
+   This will be automatically updated by the find_set_subst.py script.
+   If you need to create a new substitution manually,
+   please add it also to the substitutions.txt file in the
+   source folder.
 
-
+.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/processing/hydro.rst
+++ b/source/docs/training_manual/processing/hydro.rst
@@ -97,4 +97,4 @@ We will use both the basin calculations procedure and the statistics calculation
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/processing/hydro.rst
+++ b/source/docs/training_manual/processing/hydro.rst
@@ -1,3 +1,7 @@
+.. only:: html
+
+   |updatedisclaimer|
+
 Hydrological analysis
 ============================================================
 
@@ -85,3 +89,12 @@ The resulting statistics are the following ones.
 .. image:: img/hydro/stats.png 
 
 We will use both the basin calculations procedure and the statistics calculation in other lessons, to find out how other elements can help us automate both of them and work more effectively.
+
+
+.. Substitutions definitions - AVOID EDITING PAST THIS LINE
+   This will be automatically updated by the find_set_subst.py script.
+   If you need to create a new substitution manually,
+   please add it also to the substitutions.txt file in the
+   source folder.
+
+.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/processing/index.rst
+++ b/source/docs/training_manual/processing/index.rst
@@ -1,3 +1,7 @@
+.. only:: html
+
+   |updatedisclaimer|
+
 .. QGIS processing guide documentation master file, created by
    sphinx-quickstart on Thu Jun 13 00:05:30 2013.
    You can adapt this file completely to your liking, but it should at least
@@ -49,3 +53,12 @@ Contents:
    r_syntax
    r_syntax-table
    geomorpho
+
+
+.. Substitutions definitions - AVOID EDITING PAST THIS LINE
+   This will be automatically updated by the find_set_subst.py script.
+   If you need to create a new substitution manually,
+   please add it also to the substitutions.txt file in the
+   source folder.
+
+.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/processing/index.rst
+++ b/source/docs/training_manual/processing/index.rst
@@ -61,4 +61,4 @@ Contents:
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/processing/interp_contour.rst
+++ b/source/docs/training_manual/processing/interp_contour.rst
@@ -1,3 +1,7 @@
+.. only:: html
+
+   |updatedisclaimer|
+
 Interpolation and contouring
 =============================
 
@@ -36,3 +40,12 @@ Various methods to draw contour lines [always step= 10] on the *stddev* raster:
 - :menuselection:`GRASS --> r.contour.step`
 - :menuselection:`GDAL --> Contour`
 - :menuselection:`SAGA --> Contour lines from grid` [**NB:** in some older SAGA versions, output shp is not valid, known bug]
+
+
+.. Substitutions definitions - AVOID EDITING PAST THIS LINE
+   This will be automatically updated by the find_set_subst.py script.
+   If you need to create a new substitution manually,
+   please add it also to the substitutions.txt file in the
+   source folder.
+
+.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/processing/interp_contour.rst
+++ b/source/docs/training_manual/processing/interp_contour.rst
@@ -48,4 +48,4 @@ Various methods to draw contour lines [always step= 10] on the *stddev* raster:
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/processing/interpolation.rst
+++ b/source/docs/training_manual/processing/interpolation.rst
@@ -1,3 +1,7 @@
+.. only:: html
+
+   |updatedisclaimer|
+
 Interpolation
 ============================================================
 
@@ -54,3 +58,12 @@ And for a smoother result (less accurate but better for rendering in the backgro
 With the above parameters you will get the following result
 
 .. image:: img/interpolation/filtered_raster.png
+
+
+.. Substitutions definitions - AVOID EDITING PAST THIS LINE
+   This will be automatically updated by the find_set_subst.py script.
+   If you need to create a new substitution manually,
+   please add it also to the substitutions.txt file in the
+   source folder.
+
+.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/processing/interpolation.rst
+++ b/source/docs/training_manual/processing/interpolation.rst
@@ -66,4 +66,4 @@ With the above parameters you will get the following result
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/processing/interpolation_cross.rst
+++ b/source/docs/training_manual/processing/interpolation_cross.rst
@@ -1,3 +1,7 @@
+.. only:: html
+
+   |updatedisclaimer|
+
 More interpolation 
 ===================
 
@@ -54,3 +58,12 @@ Interpolating that layer will get you a raster layer with the estimated error in
 You can also get the same information (difference between original point values and interpolated ones) directly with :menuselection:`GRASS --> v.sample`.
 
 Your results might differ from these ones, since there is a random component introduced when running the random selection, at the beginning of this lesson.
+
+
+.. Substitutions definitions - AVOID EDITING PAST THIS LINE
+   This will be automatically updated by the find_set_subst.py script.
+   If you need to create a new substitution manually,
+   please add it also to the substitutions.txt file in the
+   source folder.
+
+.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/processing/interpolation_cross.rst
+++ b/source/docs/training_manual/processing/interpolation_cross.rst
@@ -66,4 +66,4 @@ Your results might differ from these ones, since there is a random component int
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/processing/intro.rst
+++ b/source/docs/training_manual/processing/intro.rst
@@ -1,3 +1,7 @@
+.. only:: html
+
+   |updatedisclaimer|
+
 Introduction
 ============
 
@@ -14,3 +18,12 @@ For a more systematic description of all the framework components and their usag
 All the exercises in this guide use free data set that can be downloaded from the `QGIS website <http://qgis.org/downloads/data/>`_. The zip file to download contains several folders corresponding to each one of the lessons in this guide. In each of them you will find a QGIS project file. Just open it and you will be ready to start the lesson.
 
 Enjoy!
+
+
+.. Substitutions definitions - AVOID EDITING PAST THIS LINE
+   This will be automatically updated by the find_set_subst.py script.
+   If you need to create a new substitution manually,
+   please add it also to the substitutions.txt file in the
+   source folder.
+
+.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/processing/intro.rst
+++ b/source/docs/training_manual/processing/intro.rst
@@ -26,4 +26,4 @@ Enjoy!
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/processing/iterative.rst
+++ b/source/docs/training_manual/processing/iterative.rst
@@ -51,10 +51,11 @@ For each layer, the black and white color palette, (or whatever palette you are 
 
 If you enter an output filename, resulting files will be named using that filename and a number corresponding to each iteration as suffix.
 
+
 .. Substitutions definitions - AVOID EDITING PAST THIS LINE
    This will be automatically updated by the find_set_subst.py script.
    If you need to create a new substitution manually,
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/processing/iterative.rst
+++ b/source/docs/training_manual/processing/iterative.rst
@@ -1,3 +1,7 @@
+.. only:: html
+
+   |updatedisclaimer|
+
 Iterative execution of algorithms
 ==================================
 
@@ -46,3 +50,11 @@ Here's the result that you will get if you run the clipping algorithm as explain
 For each layer, the black and white color palette, (or whatever palette you are using), is adjusted differently, from its minimum to its maximum values. That's the reason why you can see the different pieces and the colors do not seem to match in the border between layers. Values, however, do match.
 
 If you enter an output filename, resulting files will be named using that filename and a number corresponding to each iteration as suffix.
+
+.. Substitutions definitions - AVOID EDITING PAST THIS LINE
+   This will be automatically updated by the find_set_subst.py script.
+   If you need to create a new substitution manually,
+   please add it also to the substitutions.txt file in the
+   source folder.
+
+.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/processing/iterative_model.rst
+++ b/source/docs/training_manual/processing/iterative_model.rst
@@ -1,3 +1,7 @@
+.. only:: html
+
+   |updatedisclaimer|
+
 More iterative execution of algorithms
 =======================================
 
@@ -32,3 +36,12 @@ We can make this example more complex by extending the model and computing some 
 .. image:: img/iterative_model/model2.png
 
 If you now run the model, apart from the tables you will get a set of pages with statistics. These pages will be available in the results dialog.
+
+
+.. Substitutions definitions - AVOID EDITING PAST THIS LINE
+   This will be automatically updated by the find_set_subst.py script.
+   If you need to create a new substitution manually,
+   please add it also to the substitutions.txt file in the
+   source folder.
+
+.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/processing/iterative_model.rst
+++ b/source/docs/training_manual/processing/iterative_model.rst
@@ -44,4 +44,4 @@ If you now run the model, apart from the tables you will get a set of pages with
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/processing/john_snow.rst
+++ b/source/docs/training_manual/processing/john_snow.rst
@@ -1,3 +1,7 @@
+.. only:: html
+
+   |updatedisclaimer|
+
 First analysis example
 ============================================================
 
@@ -52,3 +56,12 @@ Remember that, to get the output extent, you do not have to type it. Click on th
 Select the streets raster layer and its extent will be automatically added to the text field. You must do the same with the cellsize, selecting the cellsize of that layer as well.
 
 Combining with the pumps layer, we see that there is one pump clearly in the hotspot where the maximum density of death cases is found.
+
+
+.. Substitutions definitions - AVOID EDITING PAST THIS LINE
+   This will be automatically updated by the find_set_subst.py script.
+   If you need to create a new substitution manually,
+   please add it also to the substitutions.txt file in the
+   source folder.
+
+.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/processing/john_snow.rst
+++ b/source/docs/training_manual/processing/john_snow.rst
@@ -64,4 +64,4 @@ Combining with the pumps layer, we see that there is one pump clearly in the hot
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/processing/log.rst
+++ b/source/docs/training_manual/processing/log.rst
@@ -31,6 +31,7 @@ For instance, try the following. Open the data corresponding to the first chapte
 
 You can also modify the algorithm. Just copy it, open the :menuselection:`Plugins --> Python console`, click on :menuselection:`Import class --> Import Processing class`, then paste it to re-run the analysis; change the text at will. To display the resulting file, type :kbd:`iface.addVectorLayer('/path/filename.shp', 'Layer name in legend', 'ogr')`. Otherwise, you can use :kbd:`processing.runandload`.
 
+
 .. Substitutions definitions - AVOID EDITING PAST THIS LINE
    This will be automatically updated by the find_set_subst.py script.
    If you need to create a new substitution manually,
@@ -38,4 +39,4 @@ You can also modify the algorithm. Just copy it, open the :menuselection:`Plugin
    source folder.
 
 .. |hard| image:: /static/global/hard.png
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/processing/log.rst
+++ b/source/docs/training_manual/processing/log.rst
@@ -1,3 +1,7 @@
+.. only:: html
+
+   |updatedisclaimer|
+
 The processing log
 ====================
 
@@ -34,3 +38,4 @@ You can also modify the algorithm. Just copy it, open the :menuselection:`Plugin
    source folder.
 
 .. |hard| image:: /static/global/hard.png
+.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/processing/modeler_hydro.rst
+++ b/source/docs/training_manual/processing/modeler_hydro.rst
@@ -1,3 +1,7 @@
+.. only:: html
+
+   |updatedisclaimer|
+
 More complex models
 ============================================================
 
@@ -44,3 +48,12 @@ Threshold = 100,000
 .. image:: img/modeler_hydro/result_2.png
 
 Threshold = 1,0000,000
+
+
+.. Substitutions definitions - AVOID EDITING PAST THIS LINE
+   This will be automatically updated by the find_set_subst.py script.
+   If you need to create a new substitution manually,
+   please add it also to the substitutions.txt file in the
+   source folder.
+
+.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/processing/modeler_hydro.rst
+++ b/source/docs/training_manual/processing/modeler_hydro.rst
@@ -56,4 +56,4 @@ Threshold = 1,0000,000
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/processing/modeler_hydro_calculator.rst
+++ b/source/docs/training_manual/processing/modeler_hydro_calculator.rst
@@ -58,4 +58,4 @@ Our new model is now finished.
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/processing/modeler_hydro_calculator.rst
+++ b/source/docs/training_manual/processing/modeler_hydro_calculator.rst
@@ -1,3 +1,7 @@
+.. only:: html
+
+   |updatedisclaimer|
+
 Numeric calculations in the modeler
 ============================================================
 
@@ -48,3 +52,10 @@ We are not using the numeric input that we added to the model, so it can be remo
 Our new model is now finished.
 
 
+.. Substitutions definitions - AVOID EDITING PAST THIS LINE
+   This will be automatically updated by the find_set_subst.py script.
+   If you need to create a new substitution manually,
+   please add it also to the substitutions.txt file in the
+   source folder.
+
+.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/processing/modeler_hydro_twi.rst
+++ b/source/docs/training_manual/processing/modeler_hydro_twi.rst
@@ -48,4 +48,4 @@ As you see, using a model in another model is nothing special, and you can add i
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/processing/modeler_hydro_twi.rst
+++ b/source/docs/training_manual/processing/modeler_hydro_twi.rst
@@ -1,3 +1,7 @@
+.. only:: html
+
+   |updatedisclaimer|
+
 A model within a model
 ======================
 
@@ -36,3 +40,12 @@ This is how the final model should look like:
 .. warning:: todo: Add image
 
 As you see, using a model in another model is nothing special, and you can add it just like you add another algorithm, as long as the model is saved in the models folder and is available in the toolbox.
+
+
+.. Substitutions definitions - AVOID EDITING PAST THIS LINE
+   This will be automatically updated by the find_set_subst.py script.
+   If you need to create a new substitution manually,
+   please add it also to the substitutions.txt file in the
+   source folder.
+
+.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/processing/modeler_only.rst
+++ b/source/docs/training_manual/processing/modeler_only.rst
@@ -1,3 +1,7 @@
+.. only:: html
+
+   |updatedisclaimer|
+
 Using modeler-only tools for creating a model
 =============================================
 
@@ -48,3 +52,12 @@ Now we have to edit the rasterize algorithm, so it uses the output of the calcul
 The final algorithm should look like this:
 
 .. image:: img/modeler_only/final.png
+
+
+.. Substitutions definitions - AVOID EDITING PAST THIS LINE
+   This will be automatically updated by the find_set_subst.py script.
+   If you need to create a new substitution manually,
+   please add it also to the substitutions.txt file in the
+   source folder.
+
+.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/processing/modeler_only.rst
+++ b/source/docs/training_manual/processing/modeler_only.rst
@@ -60,4 +60,4 @@ The final algorithm should look like this:
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/processing/modeler_twi.rst
+++ b/source/docs/training_manual/processing/modeler_twi.rst
@@ -1,3 +1,7 @@
+.. only:: html
+
+   |updatedisclaimer|
+
 Starting with the graphical modeler
 ============================================================
 
@@ -108,3 +112,10 @@ As you can see, the parameters dialog, contain the input that you added to the m
 Run it using the DEM as input and you will get the TWI layer in just one single step.
 
 
+.. Substitutions definitions - AVOID EDITING PAST THIS LINE
+   This will be automatically updated by the find_set_subst.py script.
+   If you need to create a new substitution manually,
+   please add it also to the substitutions.txt file in the
+   source folder.
+
+.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/processing/modeler_twi.rst
+++ b/source/docs/training_manual/processing/modeler_twi.rst
@@ -118,4 +118,4 @@ Run it using the DEM as input and you will get the TWI layer in just one single 
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/processing/more_backends.rst
+++ b/source/docs/training_manual/processing/more_backends.rst
@@ -1,3 +1,7 @@
+.. only:: html
+
+   |updatedisclaimer|
+
 Other programs
 ===================
 
@@ -96,3 +100,12 @@ Dissolve features based on a common attribute:
 .. _LecoS: http://conservationecology.wordpress.com/qgis-plugins-and-scripts/lecos-land-cover-statistics/
 .. _lwgeom: https://plugins.qgis.org/plugins/processinglwgeomprovider/
 .. _Animove: http://www.faunalia.eu/en/animove.html
+
+
+.. Substitutions definitions - AVOID EDITING PAST THIS LINE
+   This will be automatically updated by the find_set_subst.py script.
+   If you need to create a new substitution manually,
+   please add it also to the substitutions.txt file in the
+   source folder.
+
+.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/processing/more_backends.rst
+++ b/source/docs/training_manual/processing/more_backends.rst
@@ -108,4 +108,4 @@ Dissolve features based on a common attribute:
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/processing/no_data.rst
+++ b/source/docs/training_manual/processing/no_data.rst
@@ -1,3 +1,7 @@
+.. only:: html
+
+   |updatedisclaimer|
+
 The raster calculator. No-data values
 ============================================================
 
@@ -91,3 +95,12 @@ The no-data value comes from the 0/0 expression. Since that is an undetermined v
 Now you just have to multiply it by the slope layer included in the project, and you will get the desired result.
 
 All that can be done in a single operation with the calculator. We leave that as an exercise for the reader.
+
+
+.. Substitutions definitions - AVOID EDITING PAST THIS LINE
+   This will be automatically updated by the find_set_subst.py script.
+   If you need to create a new substitution manually,
+   please add it also to the substitutions.txt file in the
+   source folder.
+
+.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/processing/no_data.rst
+++ b/source/docs/training_manual/processing/no_data.rst
@@ -103,4 +103,4 @@ All that can be done in a single operation with the calculator. We leave that as
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/processing/r_intro.rst
+++ b/source/docs/training_manual/processing/r_intro.rst
@@ -1,3 +1,7 @@
+.. only:: html
+
+   |updatedisclaimer|
+
 .. _r-intro:
 
 ****************************
@@ -217,3 +221,12 @@ Beware that Processing uses some special syntax to get the results out of R:
   the result should be sent to R output (Result viewer)
 * ``+`` after a plot to call overlay plots. For example ``plot(Layer[[X]],
   Layer[[Y]]) + abline(h=mean(Layer[[X]]))``
+
+
+.. Substitutions definitions - AVOID EDITING PAST THIS LINE
+   This will be automatically updated by the find_set_subst.py script.
+   If you need to create a new substitution manually,
+   please add it also to the substitutions.txt file in the
+   source folder.
+
+.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/processing/r_intro.rst
+++ b/source/docs/training_manual/processing/r_intro.rst
@@ -229,4 +229,4 @@ Beware that Processing uses some special syntax to get the results out of R:
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/processing/r_syntax-table.rst
+++ b/source/docs/training_manual/processing/r_syntax-table.rst
@@ -105,4 +105,4 @@ look at the :ref:`R Syntax chapter <r-syntax>`.
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/processing/r_syntax-table.rst
+++ b/source/docs/training_manual/processing/r_syntax-table.rst
@@ -1,3 +1,7 @@
+.. only:: html
+
+   |updatedisclaimer|
+
 .. _r-syntax-table:
 
 **************************************
@@ -93,3 +97,12 @@ Examples
 
 In order to better understand all the input and output parameters, please have a
 look at the :ref:`R Syntax chapter <r-syntax>`.
+
+
+.. Substitutions definitions - AVOID EDITING PAST THIS LINE
+   This will be automatically updated by the find_set_subst.py script.
+   If you need to create a new substitution manually,
+   please add it also to the substitutions.txt file in the
+   source folder.
+
+.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/processing/r_syntax.rst
+++ b/source/docs/training_manual/processing/r_syntax.rst
@@ -1,3 +1,7 @@
+.. only:: html
+
+   |updatedisclaimer|
+
 .. _r-syntax:
 
 *******************************
@@ -200,3 +204,12 @@ the script takes a field of the vector layer in input and creates a *QQ Plot* to
 test the normality of the distribution.
 
 The plot is automatically added to the *Result Viewer* of Processing.
+
+
+.. Substitutions definitions - AVOID EDITING PAST THIS LINE
+   This will be automatically updated by the find_set_subst.py script.
+   If you need to create a new substitution manually,
+   please add it also to the substitutions.txt file in the
+   source folder.
+
+.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/processing/r_syntax.rst
+++ b/source/docs/training_manual/processing/r_syntax.rst
@@ -212,4 +212,4 @@ The plot is automatically added to the *Result Viewer* of Processing.
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/processing/second_alg.rst
+++ b/source/docs/training_manual/processing/second_alg.rst
@@ -1,3 +1,7 @@
+.. only:: html
+
+   |updatedisclaimer|
+
 More algorithms and data types
 ============================================================
 
@@ -69,3 +73,12 @@ Now when you run an algorithm, just use the filename instead of the full path. F
 
 
 Try yourself the *Create grid* algorithm with different grid sizes, and also with different types of grids.
+
+
+.. Substitutions definitions - AVOID EDITING PAST THIS LINE
+   This will be automatically updated by the find_set_subst.py script.
+   If you need to create a new substitution manually,
+   please add it also to the substitutions.txt file in the
+   source folder.
+
+.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/processing/second_alg.rst
+++ b/source/docs/training_manual/processing/second_alg.rst
@@ -81,4 +81,4 @@ Try yourself the *Create grid* algorithm with different grid sizes, and also wit
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/processing/selection.rst
+++ b/source/docs/training_manual/processing/selection.rst
@@ -1,3 +1,7 @@
+.. only:: html
+
+   |updatedisclaimer|
+
 Selection
 ============================================================
 
@@ -31,3 +35,12 @@ Since the selection is not part of the data itself, but something that only exis
 The selection we have just made, like most of the ones created by the rest of the selection algorithms, can also be done manually from QGIS, so you might be wondering what is the point on using an algorithm for that. Although now this might not make much sense to you, we will later see how to create models and scripts. If you want to make a selection in the middle of a model (which defines a processing workflow), only a geoalgorithm can be added to a model, and other QGIS elements and operations cannot be added. That is the reason why some processing algorithms duplicate functionality that is also available in other QGIS elements.
 
 By now, just remember that selections can be made using processing geoalgorithms, and that algorithms will only use the selected features if a selection exists, or all features otherwise.
+
+
+.. Substitutions definitions - AVOID EDITING PAST THIS LINE
+   This will be automatically updated by the find_set_subst.py script.
+   If you need to create a new substitution manually,
+   please add it also to the substitutions.txt file in the
+   source folder.
+
+.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/processing/selection.rst
+++ b/source/docs/training_manual/processing/selection.rst
@@ -43,4 +43,4 @@ By now, just remember that selections can be made using processing geoalgorithms
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/processing/set_up.rst
+++ b/source/docs/training_manual/processing/set_up.rst
@@ -55,4 +55,4 @@ which we will do in the next lesson.
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/processing/set_up.rst
+++ b/source/docs/training_manual/processing/set_up.rst
@@ -1,3 +1,7 @@
+.. only:: html
+
+   |updatedisclaimer|
+
 Setting-up the processing framework
 ====================================
 
@@ -43,3 +47,12 @@ is explained in a later chapter in this manual.
 If you have reached this point, now you are ready to use geoalgorithms. There is
 no need to configure anything else by now. We can already run our first algorithm,
 which we will do in the next lesson.
+
+
+.. Substitutions definitions - AVOID EDITING PAST THIS LINE
+   This will be automatically updated by the find_set_subst.py script.
+   If you need to create a new substitution manually,
+   please add it also to the substitutions.txt file in the
+   source folder.
+
+.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/processing/solar.rst
+++ b/source/docs/training_manual/processing/solar.rst
@@ -41,4 +41,4 @@ Finally, we convert to a vector:
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/processing/solar.rst
+++ b/source/docs/training_manual/processing/solar.rst
@@ -1,3 +1,7 @@
+.. only:: html
+
+   |updatedisclaimer|
+
 Planning a solar farm
 ======================
 
@@ -29,3 +33,12 @@ Finally, we convert to a vector:
 - :menuselection:`GRASS --> r.to.vect` [Feature type: area; Smooth corners: yes]
 
 **Exercise for the reader**: repeat the analysis, replacing GRASS commands with analogous from other programs.
+
+
+.. Substitutions definitions - AVOID EDITING PAST THIS LINE
+   This will be automatically updated by the find_set_subst.py script.
+   If you need to create a new substitution manually,
+   please add it also to the substitutions.txt file in the
+   source folder.
+
+.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/processing/vector_calculator.rst
+++ b/source/docs/training_manual/processing/vector_calculator.rst
@@ -62,4 +62,4 @@ A python field calculator is available in the *Advanced Python field calculator*
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/processing/vector_calculator.rst
+++ b/source/docs/training_manual/processing/vector_calculator.rst
@@ -1,3 +1,7 @@
+.. only:: html
+
+   |updatedisclaimer|
+
 Vector calculator
 ============================================================
 
@@ -50,3 +54,12 @@ The parameters window should look like this.
 A python field calculator is available in the *Advanced Python field calculator*, which will not be detailed here
 
 .. image:: img/vector_calculator/advanced.png
+
+
+.. Substitutions definitions - AVOID EDITING PAST THIS LINE
+   This will be automatically updated by the find_set_subst.py script.
+   If you need to create a new substitution manually,
+   please add it also to the substitutions.txt file in the
+   source folder.
+
+.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/processing/warning.rst
+++ b/source/docs/training_manual/processing/warning.rst
@@ -35,4 +35,4 @@ It is available online `here <http://www.spatialanalysisonline.com/>`_
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/processing/warning.rst
+++ b/source/docs/training_manual/processing/warning.rst
@@ -1,3 +1,7 @@
+.. only:: html
+
+   |updatedisclaimer|
+
 An important warning before starting
 ============================================================
 
@@ -24,3 +28,11 @@ Michael John De Smith, Michael F. Goodchild, Paul A. Longley
 
 It is available online `here <http://www.spatialanalysisonline.com/>`_
 
+
+.. Substitutions definitions - AVOID EDITING PAST THIS LINE
+   This will be automatically updated by the find_set_subst.py script.
+   If you need to create a new substitution manually,
+   please add it also to the substitutions.txt file in the
+   source folder.
+
+.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/qgis_plugins/fetching_plugins.rst
+++ b/source/docs/training_manual/qgis_plugins/fetching_plugins.rst
@@ -110,6 +110,7 @@ Installing plugins in QGIS is simple and effective!
 
 Next we'll introduce you to some useful plugins as examples.
 
+
 .. Substitutions definitions - AVOID EDITING PAST THIS LINE
    This will be automatically updated by the find_set_subst.py script.
    If you need to create a new substitution manually,
@@ -121,4 +122,4 @@ Next we'll introduce you to some useful plugins as examples.
 .. |LS| replace:: Lesson:
 .. |WN| replace:: What's Next?
 .. |basic| image:: /static/global/basic.png
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/qgis_plugins/fetching_plugins.rst
+++ b/source/docs/training_manual/qgis_plugins/fetching_plugins.rst
@@ -1,3 +1,7 @@
+.. only:: html
+
+   |updatedisclaimer|
+
 |LS| Installing and Managing Plugins
 ===============================================================================
 
@@ -117,3 +121,4 @@ Next we'll introduce you to some useful plugins as examples.
 .. |LS| replace:: Lesson:
 .. |WN| replace:: What's Next?
 .. |basic| image:: /static/global/basic.png
+.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/qgis_plugins/index.rst
+++ b/source/docs/training_manual/qgis_plugins/index.rst
@@ -15,6 +15,7 @@ you'll be shown how to activate and use plugins.
    fetching_plugins
    plugin_examples
 
+
 .. Substitutions definitions - AVOID EDITING PAST THIS LINE
    This will be automatically updated by the find_set_subst.py script.
    If you need to create a new substitution manually,
@@ -22,4 +23,4 @@ you'll be shown how to activate and use plugins.
    source folder.
 
 .. |MOD| replace:: Module:
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/qgis_plugins/index.rst
+++ b/source/docs/training_manual/qgis_plugins/index.rst
@@ -1,3 +1,7 @@
+.. only:: html
+
+   |updatedisclaimer|
+
 *******************************************************************************
 |MOD| Plugins
 *******************************************************************************
@@ -18,3 +22,4 @@ you'll be shown how to activate and use plugins.
    source folder.
 
 .. |MOD| replace:: Module:
+.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/qgis_plugins/plugin_examples.rst
+++ b/source/docs/training_manual/qgis_plugins/plugin_examples.rst
@@ -1,3 +1,7 @@
+.. only:: html
+
+   |updatedisclaimer|
+
 |LS| Useful QGIS Plugins
 ===============================================================================
 
@@ -162,3 +166,4 @@ time.
 .. |basic| image:: /static/global/basic.png
 .. |majorUrbanName| replace:: Swellendam
 .. |moderate| image:: /static/global/moderate.png
+.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/qgis_plugins/plugin_examples.rst
+++ b/source/docs/training_manual/qgis_plugins/plugin_examples.rst
@@ -153,6 +153,7 @@ optimum use of them.
 Next we'll look at how to use layers that are hosted on remote servers in real
 time.
 
+
 .. Substitutions definitions - AVOID EDITING PAST THIS LINE
    This will be automatically updated by the find_set_subst.py script.
    If you need to create a new substitution manually,
@@ -166,4 +167,4 @@ time.
 .. |basic| image:: /static/global/basic.png
 .. |majorUrbanName| replace:: Swellendam
 .. |moderate| image:: /static/global/moderate.png
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/qgis_server/index.rst
+++ b/source/docs/training_manual/qgis_server/index.rst
@@ -28,4 +28,4 @@ For an introduction to what QGIS Server is (see the :ref:`label_qgisserver` sect
    source folder.
 
 .. |MOD| replace:: Module:
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/qgis_server/index.rst
+++ b/source/docs/training_manual/qgis_server/index.rst
@@ -1,3 +1,7 @@
+.. only:: html
+
+   |updatedisclaimer|
+
 .. _training_qgis_server:
 
 *******************************************************************************
@@ -24,3 +28,4 @@ For an introduction to what QGIS Server is (see the :ref:`label_qgisserver` sect
    source folder.
 
 .. |MOD| replace:: Module:
+.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/qgis_server/install.rst
+++ b/source/docs/training_manual/qgis_server/install.rst
@@ -1,3 +1,7 @@
+.. only:: html
+
+   |updatedisclaimer|
+
 .. index:: QGIS Server; WMS Server; WFS Server; WCS Server
 
 .. _`label_qgisserver_tutorial`:
@@ -341,3 +345,4 @@ The topic of the next lesson is to learn how to access QGIS Server WMS services.
 .. |LS| replace:: Lesson:
 .. |WN| replace:: What's Next?
 .. |moderate| image:: /static/global/moderate.png
+.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/qgis_server/install.rst
+++ b/source/docs/training_manual/qgis_server/install.rst
@@ -334,6 +334,7 @@ Now that you've installed QGIS Server and it's accesible through the HTTP
 protocol, we need to learn how to access some of the services it can offer.
 The topic of the next lesson is to learn how to access QGIS Server WMS services.
 
+
 .. Substitutions definitions - AVOID EDITING PAST THIS LINE
    This will be automatically updated by the find_set_subst.py script.
    If you need to create a new substitution manually,
@@ -345,4 +346,4 @@ The topic of the next lesson is to learn how to access QGIS Server WMS services.
 .. |LS| replace:: Lesson:
 .. |WN| replace:: What's Next?
 .. |moderate| image:: /static/global/moderate.png
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/qgis_server/wms.rst
+++ b/source/docs/training_manual/qgis_server/wms.rst
@@ -1,3 +1,7 @@
+.. only:: html
+
+   |updatedisclaimer|
+
 |LS| Serving WMS
 ===============================================================================
 
@@ -318,3 +322,4 @@ Next, you'll see how to use QGIS as a frontend for the famous GRASS GIS.
 .. |TY| replace:: Try Yourself
 .. |WN| replace:: What's Next?
 .. |moderate| image:: /static/global/moderate.png
+.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/qgis_server/wms.rst
+++ b/source/docs/training_manual/qgis_server/wms.rst
@@ -310,6 +310,7 @@ You learned how use QGIS Server to provide WMS Services.
 
 Next, you'll see how to use QGIS as a frontend for the famous GRASS GIS.
 
+
 .. Substitutions definitions - AVOID EDITING PAST THIS LINE
    This will be automatically updated by the find_set_subst.py script.
    If you need to create a new substitution manually,
@@ -322,4 +323,4 @@ Next, you'll see how to use QGIS as a frontend for the famous GRASS GIS.
 .. |TY| replace:: Try Yourself
 .. |WN| replace:: What's Next?
 .. |moderate| image:: /static/global/moderate.png
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/rasters/changing_symbology.rst
+++ b/source/docs/training_manual/rasters/changing_symbology.rst
@@ -161,6 +161,7 @@ The SRTM dataset was obtained from `http://srtm.csi.cgiar.org/
 Now that we can see our data displayed properly, let's investigate how we can
 analyze it further.
 
+
 .. Substitutions definitions - AVOID EDITING PAST THIS LINE
    This will be automatically updated by the find_set_subst.py script.
    If you need to create a new substitution manually,
@@ -174,4 +175,4 @@ analyze it further.
 .. |WN| replace:: What's Next?
 .. |basic| image:: /static/global/basic.png
 .. |srtmFileName| replace:: :kbd:`srtm_41_19.tif`
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/rasters/changing_symbology.rst
+++ b/source/docs/training_manual/rasters/changing_symbology.rst
@@ -1,3 +1,7 @@
+.. only:: html
+
+   |updatedisclaimer|
+
 |LS| Changing Raster Symbology
 ===============================================================================
 
@@ -170,3 +174,4 @@ analyze it further.
 .. |WN| replace:: What's Next?
 .. |basic| image:: /static/global/basic.png
 .. |srtmFileName| replace:: :kbd:`srtm_41_19.tif`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/rasters/data_manipulation.rst
+++ b/source/docs/training_manual/rasters/data_manipulation.rst
@@ -1,3 +1,7 @@
+.. only:: html
+
+   |updatedisclaimer|
+
 |LS| Working with Raster Data
 ===============================================================================
 
@@ -164,3 +168,4 @@ symbolization is useful in the case of rasters as well.
    :width: 1.5em
 .. |basic| image:: /static/global/basic.png
 .. |hard| image:: /static/global/hard.png
+.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/rasters/data_manipulation.rst
+++ b/source/docs/training_manual/rasters/data_manipulation.rst
@@ -154,6 +154,7 @@ QGIS makes it easy to include raster data into your existing projects.
 Next, we'll use raster data that isn't aerial imagery, and see how
 symbolization is useful in the case of rasters as well.
 
+
 .. Substitutions definitions - AVOID EDITING PAST THIS LINE
    This will be automatically updated by the find_set_subst.py script.
    If you need to create a new substitution manually,
@@ -168,4 +169,4 @@ symbolization is useful in the case of rasters as well.
    :width: 1.5em
 .. |basic| image:: /static/global/basic.png
 .. |hard| image:: /static/global/hard.png
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/rasters/index.rst
+++ b/source/docs/training_manual/rasters/index.rst
@@ -1,3 +1,7 @@
+.. only:: html
+
+   |updatedisclaimer|
+
 *******************************************************************************
 |MOD| Rasters
 *******************************************************************************
@@ -20,3 +24,4 @@ directly. In this module, you'll see how it's done in QGIS.
    source folder.
 
 .. |MOD| replace:: Module:
+.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/rasters/index.rst
+++ b/source/docs/training_manual/rasters/index.rst
@@ -17,6 +17,7 @@ directly. In this module, you'll see how it's done in QGIS.
    changing_symbology
    terrain_analysis
 
+
 .. Substitutions definitions - AVOID EDITING PAST THIS LINE
    This will be automatically updated by the find_set_subst.py script.
    If you need to create a new substitution manually,
@@ -24,4 +25,4 @@ directly. In this module, you'll see how it's done in QGIS.
    source folder.
 
 .. |MOD| replace:: Module:
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/rasters/terrain_analysis.rst
+++ b/source/docs/training_manual/rasters/terrain_analysis.rst
@@ -1,3 +1,7 @@
+.. only:: html
+
+   |updatedisclaimer|
+
 |LS| Terrain Analysis
 ===============================================================================
 
@@ -318,3 +322,4 @@ problem? That's the topic for the next lesson, starting in the next module.
 .. |WN| replace:: What's Next?
 .. |basic| image:: /static/global/basic.png
 .. |moderate| image:: /static/global/moderate.png
+.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/rasters/terrain_analysis.rst
+++ b/source/docs/training_manual/rasters/terrain_analysis.rst
@@ -309,6 +309,7 @@ suitable plots, and the raster analysis that shows you the potentially suitable
 terrain. How can these be combined to arrive at a final result for this
 problem? That's the topic for the next lesson, starting in the next module.
 
+
 .. Substitutions definitions - AVOID EDITING PAST THIS LINE
    This will be automatically updated by the find_set_subst.py script.
    If you need to create a new substitution manually,
@@ -322,4 +323,4 @@ problem? That's the topic for the next lesson, starting in the next module.
 .. |WN| replace:: What's Next?
 .. |basic| image:: /static/global/basic.png
 .. |moderate| image:: /static/global/moderate.png
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/spatial_databases/geometry.rst
+++ b/source/docs/training_manual/spatial_databases/geometry.rst
@@ -269,6 +269,7 @@ actually enter these statements manually, but having a general idea of their
 structure will help you when using a GIS, especially if you encounter errors
 that would otherwise seem cryptic.
 
+
 .. Substitutions definitions - AVOID EDITING PAST THIS LINE
    This will be automatically updated by the find_set_subst.py script.
    If you need to create a new substitution manually,
@@ -280,4 +281,4 @@ that would otherwise seem cryptic.
 .. |TY| replace:: Try Yourself
 .. |hard| image:: /static/global/hard.png
 .. |moderate| image:: /static/global/moderate.png
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/spatial_databases/geometry.rst
+++ b/source/docs/training_manual/spatial_databases/geometry.rst
@@ -1,3 +1,7 @@
+.. only:: html
+
+   |updatedisclaimer|
+
 |LS| Geometry Construction
 ===============================================================================
 
@@ -276,3 +280,4 @@ that would otherwise seem cryptic.
 .. |TY| replace:: Try Yourself
 .. |hard| image:: /static/global/hard.png
 .. |moderate| image:: /static/global/moderate.png
+.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/spatial_databases/import_export.rst
+++ b/source/docs/training_manual/spatial_databases/import_export.rst
@@ -94,6 +94,7 @@ use these functions (or others like them) on a regular basis.
 
 Next we'll look at how to query the data we've created before.
 
+
 .. Substitutions definitions - AVOID EDITING PAST THIS LINE
    This will be automatically updated by the find_set_subst.py script.
    If you need to create a new substitution manually,
@@ -103,4 +104,4 @@ Next we'll look at how to query the data we've created before.
 .. |IC| replace:: In Conclusion
 .. |LS| replace:: Lesson:
 .. |WN| replace:: What's Next?
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/spatial_databases/import_export.rst
+++ b/source/docs/training_manual/spatial_databases/import_export.rst
@@ -1,3 +1,7 @@
+.. only:: html
+
+   |updatedisclaimer|
+
 |LS| Import and Export
 ===============================================================================
 
@@ -99,3 +103,4 @@ Next we'll look at how to query the data we've created before.
 .. |IC| replace:: In Conclusion
 .. |LS| replace:: Lesson:
 .. |WN| replace:: What's Next?
+.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/spatial_databases/index.rst
+++ b/source/docs/training_manual/spatial_databases/index.rst
@@ -1,3 +1,7 @@
+.. only:: html
+
+   |updatedisclaimer|
+
 *******************************************************************************
 |MOD| Spatial Database Concepts with PostGIS
 *******************************************************************************
@@ -40,3 +44,4 @@ See also `PostGIS online <http://postgisonline.org/>`_.
    source folder.
 
 .. |MOD| replace:: Module:
+.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/spatial_databases/index.rst
+++ b/source/docs/training_manual/spatial_databases/index.rst
@@ -37,6 +37,7 @@ See also `PostGIS online <http://postgisonline.org/>`_.
    spatial_queries
    geometry
 
+
 .. Substitutions definitions - AVOID EDITING PAST THIS LINE
    This will be automatically updated by the find_set_subst.py script.
    If you need to create a new substitution manually,
@@ -44,4 +45,4 @@ See also `PostGIS online <http://postgisonline.org/>`_.
    source folder.
 
 .. |MOD| replace:: Module:
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/spatial_databases/simple_feature_model.rst
+++ b/source/docs/training_manual/spatial_databases/simple_feature_model.rst
@@ -199,6 +199,7 @@ software.
 
 Next you'll see how to import data into, and export data from, your database.
 
+
 .. Substitutions definitions - AVOID EDITING PAST THIS LINE
    This will be automatically updated by the find_set_subst.py script.
    If you need to create a new substitution manually,
@@ -214,4 +215,4 @@ Next you'll see how to import data into, and export data from, your database.
 .. |basic| image:: /static/global/basic.png
 .. |hard| image:: /static/global/hard.png
 .. |moderate| image:: /static/global/moderate.png
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/spatial_databases/simple_feature_model.rst
+++ b/source/docs/training_manual/spatial_databases/simple_feature_model.rst
@@ -1,3 +1,7 @@
+.. only:: html
+
+   |updatedisclaimer|
+
 |LS| Simple Feature Model
 ===============================================================================
 
@@ -210,3 +214,4 @@ Next you'll see how to import data into, and export data from, your database.
 .. |basic| image:: /static/global/basic.png
 .. |hard| image:: /static/global/hard.png
 .. |moderate| image:: /static/global/moderate.png
+.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/spatial_databases/spatial_functions.rst
+++ b/source/docs/training_manual/spatial_databases/spatial_functions.rst
@@ -241,6 +241,7 @@ you'll be able to make use of PostGIS' extensive spatial functions.
 
 Next you'll learn how spatial features are represented in a database.
 
+
 .. Substitutions definitions - AVOID EDITING PAST THIS LINE
    This will be automatically updated by the find_set_subst.py script.
    If you need to create a new substitution manually,
@@ -250,4 +251,4 @@ Next you'll learn how spatial features are represented in a database.
 .. |IC| replace:: In Conclusion
 .. |LS| replace:: Lesson:
 .. |WN| replace:: What's Next?
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/spatial_databases/spatial_functions.rst
+++ b/source/docs/training_manual/spatial_databases/spatial_functions.rst
@@ -1,3 +1,7 @@
+.. only:: html
+
+   |updatedisclaimer|
+
 |LS| PostGIS Setup
 ===============================================================================
 
@@ -246,3 +250,4 @@ Next you'll learn how spatial features are represented in a database.
 .. |IC| replace:: In Conclusion
 .. |LS| replace:: Lesson:
 .. |WN| replace:: What's Next?
+.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/spatial_databases/spatial_queries.rst
+++ b/source/docs/training_manual/spatial_databases/spatial_queries.rst
@@ -1,3 +1,7 @@
+.. only:: html
+
+   |updatedisclaimer|
+
 |LS| Spatial Queries
 ===============================================================================
 
@@ -379,3 +383,4 @@ how to create them using PostGIS.
 .. |TY| replace:: Try Yourself
 .. |WN| replace:: What's Next?
 .. |moderate| image:: /static/global/moderate.png
+.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/spatial_databases/spatial_queries.rst
+++ b/source/docs/training_manual/spatial_databases/spatial_queries.rst
@@ -372,6 +372,7 @@ from PostGIS.
 Next we're going to investigate the structures of more complex geometries and
 how to create them using PostGIS.
 
+
 .. Substitutions definitions - AVOID EDITING PAST THIS LINE
    This will be automatically updated by the find_set_subst.py script.
    If you need to create a new substitution manually,
@@ -383,4 +384,4 @@ how to create them using PostGIS.
 .. |TY| replace:: Try Yourself
 .. |WN| replace:: What's Next?
 .. |moderate| image:: /static/global/moderate.png
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/vector_analysis/basic_analysis.rst
+++ b/source/docs/training_manual/vector_analysis/basic_analysis.rst
@@ -1,3 +1,7 @@
+.. only:: html
+
+   |updatedisclaimer|
+
 |LS| Vector Analysis
 ===============================================================================
 
@@ -430,3 +434,4 @@ the road from one point to another.
 .. |basic| image:: /static/global/basic.png
 .. |majorUrbanName| replace:: Swellendam
 .. |moderate| image:: /static/global/moderate.png
+.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/vector_analysis/basic_analysis.rst
+++ b/source/docs/training_manual/vector_analysis/basic_analysis.rst
@@ -420,6 +420,7 @@ easily.
 In the next lesson, we'll look at how to calculate the shortest distance along
 the road from one point to another.
 
+
 .. Substitutions definitions - AVOID EDITING PAST THIS LINE
    This will be automatically updated by the find_set_subst.py script.
    If you need to create a new substitution manually,
@@ -434,4 +435,4 @@ the road from one point to another.
 .. |basic| image:: /static/global/basic.png
 .. |majorUrbanName| replace:: Swellendam
 .. |moderate| image:: /static/global/moderate.png
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/vector_analysis/index.rst
+++ b/source/docs/training_manual/vector_analysis/index.rst
@@ -35,6 +35,7 @@ locate suitable farm properties for this new residential development.
    network_analysis
    spatial_statistics
 
+
 .. Substitutions definitions - AVOID EDITING PAST THIS LINE
    This will be automatically updated by the find_set_subst.py script.
    If you need to create a new substitution manually,
@@ -43,4 +44,4 @@ locate suitable farm properties for this new residential development.
 
 .. |MOD| replace:: Module:
 .. |majorUrbanName| replace:: Swellendam
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/vector_analysis/index.rst
+++ b/source/docs/training_manual/vector_analysis/index.rst
@@ -1,3 +1,7 @@
+.. only:: html
+
+   |updatedisclaimer|
+
 *******************************************************************************
 |MOD| Vector Analysis
 *******************************************************************************
@@ -39,3 +43,4 @@ locate suitable farm properties for this new residential development.
 
 .. |MOD| replace:: Module:
 .. |majorUrbanName| replace:: Swellendam
+.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/vector_analysis/network_analysis.rst
+++ b/source/docs/training_manual/vector_analysis/network_analysis.rst
@@ -205,6 +205,7 @@ shortest-path problems.
 
 Next you'll see how to run spatial statistics algorithms on vector datasets.
 
+
 .. Substitutions definitions - AVOID EDITING PAST THIS LINE
    This will be automatically updated by the find_set_subst.py script.
    If you need to create a new substitution manually,
@@ -220,4 +221,4 @@ Next you'll see how to run spatial statistics algorithms on vector datasets.
 .. |moderate| image:: /static/global/moderate.png
 .. |splitFeatures| image:: /static/common/mActionSplitFeatures.png
    :width: 1.5em
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/vector_analysis/network_analysis.rst
+++ b/source/docs/training_manual/vector_analysis/network_analysis.rst
@@ -1,3 +1,7 @@
+.. only:: html
+
+   |updatedisclaimer|
+
 |LS| Network Analysis
 ===============================================================================
 
@@ -216,3 +220,4 @@ Next you'll see how to run spatial statistics algorithms on vector datasets.
 .. |moderate| image:: /static/global/moderate.png
 .. |splitFeatures| image:: /static/common/mActionSplitFeatures.png
    :width: 1.5em
+.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/vector_analysis/reproject_transform.rst
+++ b/source/docs/training_manual/vector_analysis/reproject_transform.rst
@@ -1,3 +1,7 @@
+.. only:: html
+
+   |updatedisclaimer|
+
 |LS| Reprojecting and Transforming Data
 ===============================================================================
 
@@ -286,3 +290,4 @@ vector analysis tools.
 .. |hard| image:: /static/global/hard.png
 .. |majorUrbanName| replace:: Swellendam
 .. |moderate| image:: /static/global/moderate.png
+.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/vector_analysis/reproject_transform.rst
+++ b/source/docs/training_manual/vector_analysis/reproject_transform.rst
@@ -275,6 +275,7 @@ Further information on Coordinate Reference Systems is available `here
 In the next lesson you'll learn how to analyze vector data using QGIS' various
 vector analysis tools.
 
+
 .. Substitutions definitions - AVOID EDITING PAST THIS LINE
    This will be automatically updated by the find_set_subst.py script.
    If you need to create a new substitution manually,
@@ -290,4 +291,4 @@ vector analysis tools.
 .. |hard| image:: /static/global/hard.png
 .. |majorUrbanName| replace:: Swellendam
 .. |moderate| image:: /static/global/moderate.png
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/vector_analysis/spatial_statistics.rst
+++ b/source/docs/training_manual/vector_analysis/spatial_statistics.rst
@@ -1,3 +1,7 @@
+.. only:: html
+
+   |updatedisclaimer|
+
 |LS| Spatial Statistics
 ===============================================================================
 
@@ -488,3 +492,4 @@ rasters? That's what we'll do in the next module!
 .. |localCRS| replace:: :kbd:`WGS 84 / UTM 34S`
 .. |moderate| image:: /static/global/moderate.png
 .. |srtmFileName| replace:: :kbd:`srtm_41_19.tif`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/vector_analysis/spatial_statistics.rst
+++ b/source/docs/training_manual/vector_analysis/spatial_statistics.rst
@@ -477,6 +477,7 @@ of datasets.
 Now that we've covered vector analysis, why not see what can be done with
 rasters? That's what we'll do in the next module!
 
+
 .. Substitutions definitions - AVOID EDITING PAST THIS LINE
    This will be automatically updated by the find_set_subst.py script.
    If you need to create a new substitution manually,
@@ -492,4 +493,4 @@ rasters? That's what we'll do in the next module!
 .. |localCRS| replace:: :kbd:`WGS 84 / UTM 34S`
 .. |moderate| image:: /static/global/moderate.png
 .. |srtmFileName| replace:: :kbd:`srtm_41_19.tif`
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/vector_classification/attribute_data.rst
+++ b/source/docs/training_manual/vector_classification/attribute_data.rst
@@ -46,6 +46,7 @@ Different attributes are useful for different purposes. Some of them can be
 represented directly as text for the map user to see. You'll learn how to do
 this in the next lesson.
 
+
 .. Substitutions definitions - AVOID EDITING PAST THIS LINE
    This will be automatically updated by the find_set_subst.py script.
    If you need to create a new substitution manually,
@@ -57,4 +58,4 @@ this in the next lesson.
 .. |LS| replace:: Lesson:
 .. |WN| replace:: What's Next?
 .. |basic| image:: /static/global/basic.png
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/vector_classification/attribute_data.rst
+++ b/source/docs/training_manual/vector_classification/attribute_data.rst
@@ -1,3 +1,7 @@
+.. only:: html
+
+   |updatedisclaimer|
+
 |LS| Attribute Data
 ===============================================================================
 
@@ -53,3 +57,4 @@ this in the next lesson.
 .. |LS| replace:: Lesson:
 .. |WN| replace:: What's Next?
 .. |basic| image:: /static/global/basic.png
+.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/vector_classification/classification.rst
+++ b/source/docs/training_manual/vector_classification/classification.rst
@@ -311,6 +311,7 @@ Now we have a nice-looking map, but how are we going to get it out of QGIS and
 into a format we can print out, or make into an image or PDF? That's the topic
 of the next lesson!
 
+
 .. Substitutions definitions - AVOID EDITING PAST THIS LINE
    This will be automatically updated by the find_set_subst.py script.
    If you need to create a new substitution manually,
@@ -328,4 +329,4 @@ of the next lesson!
 .. |moderate| image:: /static/global/moderate.png
 .. |signPlus| image:: /static/common/symbologyAdd.png
    :width: 1.5em
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/vector_classification/classification.rst
+++ b/source/docs/training_manual/vector_classification/classification.rst
@@ -1,3 +1,7 @@
+.. only:: html
+
+   |updatedisclaimer|
+
 |LS| Classification
 ===============================================================================
 
@@ -324,3 +328,4 @@ of the next lesson!
 .. |moderate| image:: /static/global/moderate.png
 .. |signPlus| image:: /static/common/symbologyAdd.png
    :width: 1.5em
+.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/vector_classification/index.rst
+++ b/source/docs/training_manual/vector_classification/index.rst
@@ -1,3 +1,7 @@
+.. only:: html
+
+   |updatedisclaimer|
+
 *******************************************************************************
 |MOD| Classifying Vector Data
 *******************************************************************************
@@ -21,3 +25,4 @@ features.
    source folder.
 
 .. |MOD| replace:: Module:
+.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/vector_classification/index.rst
+++ b/source/docs/training_manual/vector_classification/index.rst
@@ -18,6 +18,7 @@ features.
    label_tool
    classification
 
+
 .. Substitutions definitions - AVOID EDITING PAST THIS LINE
    This will be automatically updated by the find_set_subst.py script.
    If you need to create a new substitution manually,
@@ -25,4 +26,4 @@ features.
    source folder.
 
 .. |MOD| replace:: Module:
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/vector_classification/label_tool.rst
+++ b/source/docs/training_manual/vector_classification/label_tool.rst
@@ -333,6 +333,7 @@ Now that you know how attributes can make a visual difference for your map, how
 about using them to change the symbology of objects themselves? That's the
 topic for the next lesson!
 
+
 .. Substitutions definitions - AVOID EDITING PAST THIS LINE
    This will be automatically updated by the find_set_subst.py script.
    If you need to create a new substitution manually,
@@ -366,4 +367,4 @@ topic for the next lesson!
    :width: 1.5em
 .. |toggleEditing| image:: /static/common/mActionToggleEditing.png
    :width: 1.5em
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/vector_classification/label_tool.rst
+++ b/source/docs/training_manual/vector_classification/label_tool.rst
@@ -1,3 +1,7 @@
+.. only:: html
+
+   |updatedisclaimer|
+
 |LS| The Label Tool
 ===============================================================================
 
@@ -362,3 +366,4 @@ topic for the next lesson!
    :width: 1.5em
 .. |toggleEditing| image:: /static/common/mActionToggleEditing.png
    :width: 1.5em
+.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/appendices/appendices.rst
+++ b/source/docs/user_manual/appendices/appendices.rst
@@ -784,10 +784,11 @@ recommend releasing these examples in parallel under your choice of
 free software license, such as the GNU General Public License,
 to permit their use in free software.
 
+
 .. Substitutions definitions - AVOID EDITING PAST THIS LINE
    This will be automatically updated by the find_set_subst.py script.
    If you need to create a new substitution manually,
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/auth_system/auth_considerations.rst
+++ b/source/docs/user_manual/auth_system/auth_considerations.rst
@@ -78,10 +78,11 @@ at run-time.
 
 .. _licensing and exporting: http://www.opensslfoundation.com/export/README.blurb
 
+
 .. Substitutions definitions - AVOID EDITING PAST THIS LINE
    This will be automatically updated by the find_set_subst.py script.
    If you need to create a new substitution manually,
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/auth_system/auth_overview.rst
+++ b/source/docs/user_manual/auth_system/auth_overview.rst
@@ -284,6 +284,7 @@ since management of the master password hashing and auth database encryption
 should be handled by the main app, and not via Python.
 See :ref:`authentication_security_considerations` concerning Python access.
 
+
 .. Substitutions definitions - AVOID EDITING PAST THIS LINE
    This will be automatically updated by the find_set_subst.py script.
    If you need to create a new substitution manually,
@@ -298,4 +299,4 @@ See :ref:`authentication_security_considerations` concerning Python access.
    :width: 1.5em
 .. |symbologyEdit| image:: /static/common/symbologyEdit.png
    :width: 1.5em
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/auth_system/auth_workflows.rst
+++ b/source/docs/user_manual/auth_system/auth_workflows.rst
@@ -422,4 +422,4 @@ save the configuration to the database.
    :width: 1.5em
 .. |transformSettings| image:: /static/common/mActionTransformSettings.png
    :width: 1.5em
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/auth_system/index.rst
+++ b/source/docs/user_manual/auth_system/index.rst
@@ -15,10 +15,11 @@ Authentication System
    auth_workflows
    auth_considerations
 
+
 .. Substitutions definitions - AVOID EDITING PAST THIS LINE
    This will be automatically updated by the find_set_subst.py script.
    If you need to create a new substitution manually,
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/grass_integration/grass_integration.rst
+++ b/source/docs/user_manual/grass_integration/grass_integration.rst
@@ -939,4 +939,4 @@ https://qgis.org/en/site/getinvolved/development/addinggrasstools.html.
    :width: 2.5em
 .. |showPluginManager| image:: /static/common/mActionShowPluginManager.png
    :width: 1.5em
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/index.rst
+++ b/source/docs/user_manual/index.rst
@@ -45,4 +45,4 @@ QGIS User Guide
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/introduction/general_tools.rst
+++ b/source/docs/user_manual/introduction/general_tools.rst
@@ -1921,7 +1921,7 @@ Parameters that can be used with data-defined tools are:
    :width: 1.5em
 .. |unchecked| image:: /static/common/checkbox_unchecked.png
    :width: 1.3em
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
 .. |zoomActual| image:: /static/common/mActionZoomActual.png
    :width: 1.5em
 .. |zoomIn| image:: /static/common/mActionZoomIn.png

--- a/source/docs/user_manual/introduction/getting_started.rst
+++ b/source/docs/user_manual/introduction/getting_started.rst
@@ -497,6 +497,6 @@ Other ways to produce output files are:
    :width: 1em
 .. |saveMapAsImage| image:: /static/common/mActionSaveMapAsImage.png
    :width: 1.5em
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
 .. |win| image:: /static/common/win.png
    :width: 1em

--- a/source/docs/user_manual/introduction/qgis_configuration.rst
+++ b/source/docs/user_manual/introduction/qgis_configuration.rst
@@ -879,6 +879,7 @@ finished your configuration, simply **[Close]** the dialog to have your changes
 applied. You can also **[Save]** the changes as an :file:`.XML` file
 and **[Load]** them into another QGIS installation.
 
+
 .. Substitutions definitions - AVOID EDITING PAST THIS LINE
    This will be automatically updated by the find_set_subst.py script.
    If you need to create a new substitution manually,
@@ -921,6 +922,6 @@ and **[Load]** them into another QGIS installation.
    :width: 1.5em
 .. |signPlus| image:: /static/common/symbologyAdd.png
    :width: 1.5em
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
 .. |win| image:: /static/common/win.png
    :width: 1em

--- a/source/docs/user_manual/introduction/qgis_gui.rst
+++ b/source/docs/user_manual/introduction/qgis_gui.rst
@@ -801,7 +801,7 @@ loading, processing tools...)
    :width: 1.5em
 .. |undo| image:: /static/common/mActionUndo.png
    :width: 1.5em
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
 .. |whatsThis| image:: /static/common/whats_this.png
    :width: 1.5em
 .. |zoomActual| image:: /static/common/mActionZoomActual.png

--- a/source/docs/user_manual/literature_web/literature_and_web_references.rst
+++ b/source/docs/user_manual/literature_web/literature_and_web_references.rst
@@ -29,4 +29,4 @@ POSTGIS-PROJECT. Spatial support for postgresql. http://postgis.refractions.net/
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/managing_data_source/create_layers.rst
+++ b/source/docs/user_manual/managing_data_source/create_layers.rst
@@ -569,4 +569,4 @@ used in conjunction with this spatial index syntax.
    :width: 2.5em
 .. |showPluginManager| image:: /static/common/mActionShowPluginManager.png
    :width: 1.5em
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/managing_data_source/index.rst
+++ b/source/docs/user_manual/managing_data_source/index.rst
@@ -22,4 +22,4 @@
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/managing_data_source/opening_data.rst
+++ b/source/docs/user_manual/managing_data_source/opening_data.rst
@@ -882,4 +882,4 @@ Description of these capabilities and how-to are provided in chapter
 .. |radioButtonOn| image:: /static/common/radiobuttonon.png
 .. |selectString| image:: /static/common/selectstring.png
    :width: 2.5em
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/managing_data_source/supported_data.rst
+++ b/source/docs/user_manual/managing_data_source/supported_data.rst
@@ -596,4 +596,4 @@ the name **db2.bat** and including it in the directory **%OSGEO4W_ROOT%/etc/ini*
    :width: 1em
 .. |setProjection| image:: /static/common/mActionSetProjection.png
    :width: 1.5em
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/plugins/core_plugins.rst
+++ b/source/docs/user_manual/plugins/core_plugins.rst
@@ -66,4 +66,4 @@ Icon                    Plugin                        Description               
    :width: 1.5em
 .. |topologyChecker| image:: /static/common/mActionTopologyChecker.png
    :width: 1.5em
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/plugins/index.rst
+++ b/source/docs/user_manual/plugins/index.rst
@@ -23,10 +23,11 @@ Plugins
    plugins_offline_editing
    plugins_topology_checker
 
+
 .. Substitutions definitions - AVOID EDITING PAST THIS LINE
    This will be automatically updated by the find_set_subst.py script.
    If you need to create a new substitution manually,
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/plugins/plugins.rst
+++ b/source/docs/user_manual/plugins/plugins.rst
@@ -250,6 +250,6 @@ directly from their repository.
    :width: 1.5em
 .. |transformSettings| image:: /static/common/mActionTransformSettings.png
    :width: 1.5em
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
 .. |win| image:: /static/common/win.png
    :width: 1em

--- a/source/docs/user_manual/plugins/plugins_coordinate_capture.rst
+++ b/source/docs/user_manual/plugins/plugins_coordinate_capture.rst
@@ -58,4 +58,4 @@ coordinates on the map canvas for two selected coordinate reference systems (CRS
    :width: 1em
 .. |tracking| image:: /static/common/tracking.png
    :width: 1.5em
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/plugins/plugins_db_manager.rst
+++ b/source/docs/user_manual/plugins/plugins_db_manager.rst
@@ -77,6 +77,7 @@ and only that portion will be executed when you press :kbd:`F5` or click the
    Layers** before opening the SQL Window. See :ref:`vector_virtual_layers` for
    instructions on the SQL syntax to use.
 
+
 .. Substitutions definitions - AVOID EDITING PAST THIS LINE
    This will be automatically updated by the find_set_subst.py script.
    If you need to create a new substitution manually,
@@ -85,4 +86,4 @@ and only that portion will be executed when you press :kbd:`F5` or click the
 
 .. |dbManager| image:: /static/common/dbmanager.png
    :width: 1.5em
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/plugins/plugins_evis.rst
+++ b/source/docs/user_manual/plugins/plugins_evis.rst
@@ -542,6 +542,7 @@ A complete sample XML file with three queries is displayed below:
     </query>
    </doc>
 
+
 .. Substitutions definitions - AVOID EDITING PAST THIS LINE
    This will be automatically updated by the find_set_subst.py script.
    If you need to create a new substitution manually,
@@ -557,4 +558,4 @@ A complete sample XML file with three queries is displayed below:
 .. |radioButtonOn| image:: /static/common/radiobuttonon.png
 .. |selectString| image:: /static/common/selectstring.png
    :width: 2.5em
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/plugins/plugins_geometry_checker.rst
+++ b/source/docs/user_manual/plugins/plugins_geometry_checker.rst
@@ -114,4 +114,4 @@ by attribute value`.
 
 .. |checkbox| image:: /static/common/checkbox.png
    :width: 1.3em
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/plugins/plugins_georeferencer.rst
+++ b/source/docs/user_manual/plugins/plugins_georeferencer.rst
@@ -249,6 +249,7 @@ After all GCPs have been collected and all transformation settings are defined,
 just press the |startGeoref| :sup:`Start georeferencing` button to create
 the new georeferenced raster.
 
+
 .. Substitutions definitions - AVOID EDITING PAST THIS LINE
    This will be automatically updated by the find_set_subst.py script.
    If you need to create a new substitution manually,
@@ -287,7 +288,7 @@ the new georeferenced raster.
    :width: 1.5em
 .. |transformSettings| image:: /static/common/mActionTransformSettings.png
    :width: 1.5em
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
 .. |zoomIn| image:: /static/common/mActionZoomIn.png
    :width: 1.5em
 .. |zoomLast| image:: /static/common/mActionZoomLast.png

--- a/source/docs/user_manual/plugins/plugins_metasearch.rst
+++ b/source/docs/user_manual/plugins/plugins_metasearch.rst
@@ -191,6 +191,7 @@ You can fine tune MetaSearch with the following :guilabel:`settings`:
 .. _`CSW (Catalog Service for the Web)`: http://www.opengeospatial.org/standards/cat
 .. _`OGC (Open Geospatial Consortium)`: http://www.opengeospatial.org
 
+
 .. Substitutions definitions - AVOID EDITING PAST THIS LINE
    This will be automatically updated by the find_set_subst.py script.
    If you need to create a new substitution manually,
@@ -199,4 +200,4 @@ You can fine tune MetaSearch with the following :guilabel:`settings`:
 
 .. |metasearch| image:: /static/common/MetaSearch.png
    :width: 1.5em
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/plugins/plugins_offline_editing.rst
+++ b/source/docs/user_manual/plugins/plugins_offline_editing.rst
@@ -41,6 +41,7 @@ Using the plugin
 
    Create an offline project from PostGIS or WFS layers
 
+
 .. Substitutions definitions - AVOID EDITING PAST THIS LINE
    This will be automatically updated by the find_set_subst.py script.
    If you need to create a new substitution manually,
@@ -53,4 +54,4 @@ Using the plugin
    :width: 1.5em
 .. |offlineEditingSync| image:: /static/common/offline_editing_sync.png
    :width: 1.5em
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/plugins/plugins_topology_checker.rst
+++ b/source/docs/user_manual/plugins/plugins_topology_checker.rst
@@ -96,4 +96,4 @@ On **polygon layers**, the following rules are available:
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/plugins/python_console.rst
+++ b/source/docs/user_manual/plugins/python_console.rst
@@ -177,6 +177,7 @@ the Python console behavior:
    Console from the close button. This allows you to save the geometry to be
    restored to the next start.
 
+
 .. Substitutions definitions - AVOID EDITING PAST THIS LINE
    This will be automatically updated by the find_set_subst.py script.
    If you need to create a new substitution manually,
@@ -195,4 +196,4 @@ the Python console behavior:
    :width: 1.5em
 .. |iconeShowEditorConsole| image:: /static/common/iconShowEditorConsole.png
    :width: 1.5em
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/preamble/contributors.rst
+++ b/source/docs/user_manual/preamble/contributors.rst
@@ -147,4 +147,4 @@ Ukrainian             Alexander Bruy
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/preamble/conventions.rst
+++ b/source/docs/user_manual/preamble/conventions.rst
@@ -101,6 +101,7 @@ Screenshots that appear throughout the user guide have been created on
 different platforms; the platform is indicated by the
 platform-specific icon at the end of the figure caption.
 
+
 .. Substitutions definitions - AVOID EDITING PAST THIS LINE
    This will be automatically updated by the find_set_subst.py script.
    If you need to create a new substitution manually,
@@ -126,6 +127,6 @@ platform-specific icon at the end of the figure caption.
 .. |selectString| image:: /static/common/selectstring.png
    :width: 2.5em
 .. |slider| image:: /static/common/slider.png
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
 .. |win| image:: /static/common/win.png
    :width: 1em

--- a/source/docs/user_manual/preamble/features.rst
+++ b/source/docs/user_manual/preamble/features.rst
@@ -201,10 +201,11 @@ More info:
 http://www.cyberciti.biz/faq/linux-increase-the-maximum-number-of-open-files/
 http://linuxaria.com/article/open-files-in-linux?lang=en
 
+
 .. Substitutions definitions - AVOID EDITING PAST THIS LINE
    This will be automatically updated by the find_set_subst.py script.
    If you need to create a new substitution manually,
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/preamble/foreword.rst
+++ b/source/docs/user_manual/preamble/foreword.rst
@@ -49,4 +49,4 @@ also can find it in Appendix :ref:`gpl_appendix`.
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/preamble/help_and_support.rst
+++ b/source/docs/user_manual/preamble/help_and_support.rst
@@ -153,4 +153,4 @@ more. Check it out, there are some goodies inside!
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/preamble/preamble.rst
+++ b/source/docs/user_manual/preamble/preamble.rst
@@ -58,10 +58,11 @@ any later version published by the Free Software Foundation; with no
 Invariant Sections, no Front-Cover Texts and no Back-Cover Texts. A
 copy of the license is included in Appendix :ref:`gfl_appendix`.
 
+
 .. Substitutions definitions - AVOID EDITING PAST THIS LINE
    This will be automatically updated by the find_set_subst.py script.
    If you need to create a new substitution manually,
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/preamble/whats_new.rst
+++ b/source/docs/user_manual/preamble/whats_new.rst
@@ -20,10 +20,11 @@ You may also review the visual changelogs at http://qgis.org/en/site/forusers/vi
 .. |QGIS_CURRENT| replace:: QGIS 2.18
 .. _QGIS_CURRENT: http://docs.qgis.org/2.18/en/docs/
 
+
 .. Substitutions definitions - AVOID EDITING PAST THIS LINE
    This will be automatically updated by the find_set_subst.py script.
    If you need to create a new substitution manually,
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/print_composer/composer_items/composer_attribute_table.rst
+++ b/source/docs/user_manual/print_composer/composer_items/composer_attribute_table.rst
@@ -320,4 +320,4 @@ the following functionalities (see figure_layout_table_frames_):
    :width: 1.5em
 .. |signPlus| image:: /static/common/symbologyAdd.png
    :width: 1.5em
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/print_composer/composer_items/composer_html_frame.rst
+++ b/source/docs/user_manual/print_composer/composer_items/composer_html_frame.rst
@@ -155,4 +155,4 @@ following functionalities (see figure_layout_html_breaks_):
    :width: 1.3em
 .. |dataDefined| image:: /static/common/mIconDataDefine.png
    :width: 1.5em
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/print_composer/composer_items/composer_image.rst
+++ b/source/docs/user_manual/print_composer/composer_items/composer_image.rst
@@ -127,4 +127,4 @@ You can also apply a declination :guilabel:`Offset` to the picture rotation.
    :width: 1.3em
 .. |dataDefined| image:: /static/common/mIconDataDefine.png
    :width: 1.5em
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/print_composer/composer_items/composer_items_options.rst
+++ b/source/docs/user_manual/print_composer/composer_items/composer_items_options.rst
@@ -275,6 +275,7 @@ remove it.
 
 More information on variables usage in the :ref:`general_tools_variables` section.
 
+
 .. Substitutions definitions - AVOID EDITING PAST THIS LINE
    This will be automatically updated by the find_set_subst.py script.
    If you need to create a new substitution manually,
@@ -312,4 +313,4 @@ More information on variables usage in the :ref:`general_tools_variables` sectio
 .. |signPlus| image:: /static/common/symbologyAdd.png
    :width: 1.5em
 .. |slider| image:: /static/common/slider.png
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/print_composer/composer_items/composer_items_shape.rst
+++ b/source/docs/user_manual/print_composer/composer_items/composer_items_shape.rst
@@ -151,6 +151,7 @@ double-click on a segment and a node is added at the place you click.
 Finally, you can remove the currently selected node by
 hitting the :kbd:`DEL` key.
 
+
 .. Substitutions definitions - AVOID EDITING PAST THIS LINE
    This will be automatically updated by the find_set_subst.py script.
    If you need to create a new substitution manually,
@@ -177,4 +178,4 @@ hitting the :kbd:`DEL` key.
    :ltrim:
 .. |editNodesShape| image:: /static/common/mActionEditNodesShape.png
    :width: 1.5em
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/print_composer/composer_items/composer_label.rst
+++ b/source/docs/user_manual/print_composer/composer_items/composer_label.rst
@@ -92,4 +92,4 @@ Appearance
    :width: 1.5em
 .. |logo| image:: /static/common/logo.png
    :width: 1.5em
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/print_composer/composer_items/composer_legend.rst
+++ b/source/docs/user_manual/print_composer/composer_items/composer_legend.rst
@@ -208,4 +208,4 @@ column or line can be customized through this dialog.
    :width: 1.5em
 .. |sum| image:: /static/common/mActionSum.png
    :width: 1.5em
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/print_composer/composer_items/composer_map.rst
+++ b/source/docs/user_manual/print_composer/composer_items/composer_map.rst
@@ -350,4 +350,4 @@ drawing over the selected map frame. You can customize it with:
    :width: 1.5em
 .. |signPlus| image:: /static/common/symbologyAdd.png
    :width: 1.5em
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/print_composer/composer_items/composer_scale_bar.rst
+++ b/source/docs/user_manual/print_composer/composer_items/composer_scale_bar.rst
@@ -146,4 +146,4 @@ Fill colors are only used for *Single Box* and *Double Box* styles.
 
 .. |scaleBar| image:: /static/common/mActionScaleBar.png
    :width: 1.5em
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/print_composer/composer_items/index.rst
+++ b/source/docs/user_manual/print_composer/composer_items/index.rst
@@ -23,10 +23,11 @@ Layout Items
    composer_html_frame
    composer_items_shape
 
+
 .. Substitutions definitions - AVOID EDITING PAST THIS LINE
    This will be automatically updated by the find_set_subst.py script.
    If you need to create a new substitution manually,
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/print_composer/create_output.rst
+++ b/source/docs/user_manual/print_composer/create_output.rst
@@ -432,4 +432,4 @@ the image file format set in :guilabel:`Atlas` panel or to SVG file.
    :width: 2.5em
 .. |unchecked| image:: /static/common/checkbox_unchecked.png
    :width: 1.3em
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/print_composer/index.rst
+++ b/source/docs/user_manual/print_composer/index.rst
@@ -21,10 +21,11 @@ geographical information produced with QGIS that can be included in reports or p
    composer_items/index
    create_output
 
+
 .. Substitutions definitions - AVOID EDITING PAST THIS LINE
    This will be automatically updated by the find_set_subst.py script.
    If you need to create a new substitution manually,
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/print_composer/overview_composer.rst
+++ b/source/docs/user_manual/print_composer/overview_composer.rst
@@ -878,7 +878,7 @@ the actions done after the selected one will be removed.
    :width: 1.5em
 .. |unlocked| image:: /static/common/unlocked.png
    :width: 1.5em
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
 .. |vectorGrid| image:: /static/common/vector_grid.png
    :width: 1.5em
 .. |zoomActual| image:: /static/common/mActionZoomActual.png

--- a/source/docs/user_manual/processing/3rdParty.rst
+++ b/source/docs/user_manual/processing/3rdParty.rst
@@ -384,10 +384,11 @@ to execute the algorithm each time. If the latter approach is the behavior
 you prefer, just check the :guilabel:`Use min covering region` option in the
 GRASS configuration parameters.
 
+
 .. Substitutions definitions - AVOID EDITING PAST THIS LINE
    This will be automatically updated by the find_set_subst.py script.
    If you need to create a new substitution manually,
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/processing/batch.rst
+++ b/source/docs/user_manual/processing/batch.rst
@@ -134,6 +134,7 @@ To execute the batch process once you have introduced all the necessary values,
 just click on **[OK]**. Progress of the global batch task will be shown in the
 progress bar in the lower part of the dialog.
 
+
 .. Substitutions definitions - AVOID EDITING PAST THIS LINE
    This will be automatically updated by the find_set_subst.py script.
    If you need to create a new substitution manually,
@@ -142,4 +143,4 @@ progress bar in the lower part of the dialog.
 
 .. |browseButton| image:: /static/common/browsebutton.png
    :width: 2.3em
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/processing/configuration.rst
+++ b/source/docs/user_manual/processing/configuration.rst
@@ -79,4 +79,4 @@ when covering particular algorithm providers.
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/processing/console.rst
+++ b/source/docs/user_manual/processing/console.rst
@@ -398,10 +398,11 @@ entries named :guilabel:`Pre-execution script file` and :guilabel:`Post-executio
 script file` where the filename of the scripts to be run in each case can be
 entered.
 
+
 .. Substitutions definitions - AVOID EDITING PAST THIS LINE
    This will be automatically updated by the find_set_subst.py script.
    If you need to create a new substitution manually,
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/processing/history.rst
+++ b/source/docs/user_manual/processing/history.rst
@@ -64,10 +64,11 @@ might add comments or additional information to log if
 they detect potential problems with the data, in order to warn you.
 Make sure you check those messages in the log if you are having unexpected results.
 
+
 .. Substitutions definitions - AVOID EDITING PAST THIS LINE
    This will be automatically updated by the find_set_subst.py script.
    If you need to create a new substitution manually,
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/processing/index.rst
+++ b/source/docs/user_manual/processing/index.rst
@@ -21,10 +21,11 @@ QGIS processing framework
     scripts
     3rdParty
 
+
 .. Substitutions definitions - AVOID EDITING PAST THIS LINE
    This will be automatically updated by the find_set_subst.py script.
    If you need to create a new substitution manually,
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/processing/intro.rst
+++ b/source/docs/user_manual/processing/intro.rst
@@ -77,4 +77,4 @@ In the following sections, we will review each one of these elements in detail.
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/processing/modeler.rst
+++ b/source/docs/user_manual/processing/modeler.rst
@@ -305,4 +305,4 @@ not appear in the list of algorithms that you can find in the modeler dialog.
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/processing/scripts.rst
+++ b/source/docs/user_manual/processing/scripts.rst
@@ -250,10 +250,11 @@ entries named :guilabel:`Pre-execution script file` and :guilabel:`Post-executio
 script file` where the filename of the scripts to be run in each case can be
 entered.
 
+
 .. Substitutions definitions - AVOID EDITING PAST THIS LINE
    This will be automatically updated by the find_set_subst.py script.
    If you need to create a new substitution manually,
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/processing/toolbox.rst
+++ b/source/docs/user_manual/processing/toolbox.rst
@@ -360,4 +360,4 @@ to a temporary file and deleted once you exit QGIS).
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/processing_algs/gdal/index.rst
+++ b/source/docs/user_manual/processing_algs/gdal/index.rst
@@ -23,10 +23,11 @@ and `GDAL/OGR vector utilities <http://www.gdal.org/ogr_utilities.html>`_ .
      vectorgeoprocessing
      vectormiscellaneous
 
+
 .. Substitutions definitions - AVOID EDITING PAST THIS LINE
    This will be automatically updated by the find_set_subst.py script.
    If you need to create a new substitution manually,
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/processing_algs/gdal/rasteranalysis.rst
+++ b/source/docs/user_manual/processing_algs/gdal/rasteranalysis.rst
@@ -1032,10 +1032,11 @@ See also
 ........
 `GDAL DEM utility <http://www.gdal.org/gdaldem.html#gdaldem_TRI>`__
 
+
 .. Substitutions definitions - AVOID EDITING PAST THIS LINE
    This will be automatically updated by the find_set_subst.py script.
    If you need to create a new substitution manually,
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/processing_algs/gdal/rasterconversion.rst
+++ b/source/docs/user_manual/processing_algs/gdal/rasterconversion.rst
@@ -316,10 +316,11 @@ Outputs
 ``Output layer`` [raster]
   <put output description here>
 
+
 .. Substitutions definitions - AVOID EDITING PAST THIS LINE
    This will be automatically updated by the find_set_subst.py script.
    If you need to create a new substitution manually,
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/processing_algs/gdal/rasterextraction.rst
+++ b/source/docs/user_manual/processing_algs/gdal/rasterextraction.rst
@@ -142,10 +142,11 @@ Outputs
 ``Output file for contour lines (vector)`` [vector]
   <put output description here>
 
+
 .. Substitutions definitions - AVOID EDITING PAST THIS LINE
    This will be automatically updated by the find_set_subst.py script.
    If you need to create a new substitution manually,
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/processing_algs/gdal/rastermiscellaneous.rst
+++ b/source/docs/user_manual/processing_algs/gdal/rastermiscellaneous.rst
@@ -245,10 +245,11 @@ Outputs
   be created if it doesn't already exist, otherwise it will append to the
   existing file.
 
+
 .. Substitutions definitions - AVOID EDITING PAST THIS LINE
    This will be automatically updated by the find_set_subst.py script.
    If you need to create a new substitution manually,
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/processing_algs/gdal/rasterprojections.rst
+++ b/source/docs/user_manual/processing_algs/gdal/rasterprojections.rst
@@ -116,10 +116,11 @@ Outputs
 ``Output layer`` [raster]
   <put output description here>
 
+
 .. Substitutions definitions - AVOID EDITING PAST THIS LINE
    This will be automatically updated by the find_set_subst.py script.
    If you need to create a new substitution manually,
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/processing_algs/gdal/vectorconversion.rst
+++ b/source/docs/user_manual/processing_algs/gdal/vectorconversion.rst
@@ -69,10 +69,11 @@ Outputs
 ``Output layer`` [vector]
   Output vector layer.
 
+
 .. Substitutions definitions - AVOID EDITING PAST THIS LINE
    This will be automatically updated by the find_set_subst.py script.
    If you need to create a new substitution manually,
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/processing_algs/gdal/vectorgeoprocessing.rst
+++ b/source/docs/user_manual/processing_algs/gdal/vectorgeoprocessing.rst
@@ -74,10 +74,11 @@ Outputs
 ``Output layer`` [vector]
   Output vector layer. By default this is an ESRI Shapefile.
 
+
 .. Substitutions definitions - AVOID EDITING PAST THIS LINE
    This will be automatically updated by the find_set_subst.py script.
    If you need to create a new substitution manually,
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/processing_algs/gdal/vectormiscellaneous.rst
+++ b/source/docs/user_manual/processing_algs/gdal/vectormiscellaneous.rst
@@ -425,10 +425,11 @@ Outputs
   Name of the output HTML-file that includes the file information.
   If no HTML-file is defined the output will be written into a temporary file.
 
+
 .. Substitutions definitions - AVOID EDITING PAST THIS LINE
    This will be automatically updated by the find_set_subst.py script.
    If you need to create a new substitution manually,
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/processing_algs/index.rst
+++ b/source/docs/user_manual/processing_algs/index.rst
@@ -26,4 +26,4 @@ Processing providers and algorithms
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/processing_algs/lidartools/lastools.rst
+++ b/source/docs/user_manual/processing_algs/lidartools/lastools.rst
@@ -1785,4 +1785,4 @@ See also
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/processing_algs/otb/calibration.rst
+++ b/source/docs/user_manual/processing_algs/otb/calibration.rst
@@ -77,4 +77,4 @@ See also
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/processing_algs/otb/feature_extraction.rst
+++ b/source/docs/user_manual/processing_algs/otb/feature_extraction.rst
@@ -974,4 +974,4 @@ See also
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/processing_algs/otb/geometry.rst
+++ b/source/docs/user_manual/processing_algs/otb/geometry.rst
@@ -862,4 +862,4 @@ See also
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/processing_algs/otb/image_filtering.rst
+++ b/source/docs/user_manual/processing_algs/otb/image_filtering.rst
@@ -470,4 +470,4 @@ See also
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/processing_algs/otb/image_manipulation.rst
+++ b/source/docs/user_manual/processing_algs/otb/image_manipulation.rst
@@ -612,4 +612,4 @@ See also
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/processing_algs/otb/index.rst
+++ b/source/docs/user_manual/processing_algs/otb/index.rst
@@ -32,10 +32,11 @@ or SAR (TerraSarX, ERS, Palsar) are available.
      stereo
      vector_data_manipulation
 
+
 .. Substitutions definitions - AVOID EDITING PAST THIS LINE
    This will be automatically updated by the find_set_subst.py script.
    If you need to create a new substitution manually,
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/processing_algs/otb/learning.rst
+++ b/source/docs/user_manual/processing_algs/otb/learning.rst
@@ -1585,4 +1585,4 @@ See also
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/processing_algs/otb/miscellaneous.rst
+++ b/source/docs/user_manual/processing_algs/otb/miscellaneous.rst
@@ -265,4 +265,4 @@ See also
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/processing_algs/otb/segmentation.rst
+++ b/source/docs/user_manual/processing_algs/otb/segmentation.rst
@@ -944,4 +944,4 @@ See also
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/processing_algs/otb/stereo.rst
+++ b/source/docs/user_manual/processing_algs/otb/stereo.rst
@@ -232,4 +232,4 @@ See also
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/processing_algs/otb/vector_data_manipulation.rst
+++ b/source/docs/user_manual/processing_algs/otb/vector_data_manipulation.rst
@@ -48,4 +48,4 @@ See also
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/processing_algs/qgis/cartography.rst
+++ b/source/docs/user_manual/processing_algs/qgis/cartography.rst
@@ -72,10 +72,11 @@ Outputs
 ``Colored`` [vector: polygon]
   Polygon vector layer with the addition of the ``color_id`` column.
 
+
 .. Substitutions definitions - AVOID EDITING PAST THIS LINE
    This will be automatically updated by the find_set_subst.py script.
    If you need to create a new substitution manually,
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/processing_algs/qgis/database.rst
+++ b/source/docs/user_manual/processing_algs/qgis/database.rst
@@ -286,10 +286,11 @@ See also
 ........
 For some SQL query examples see :ref:`PostGIS SQL Query Examples <qgis_postgis_execute_sql_example>`.
 
+
 .. Substitutions definitions - AVOID EDITING PAST THIS LINE
    This will be automatically updated by the find_set_subst.py script.
    If you need to create a new substitution manually,
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/processing_algs/qgis/filetools.rst
+++ b/source/docs/user_manual/processing_algs/qgis/filetools.rst
@@ -38,4 +38,4 @@ Output
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/processing_algs/qgis/graphics.rst
+++ b/source/docs/user_manual/processing_algs/qgis/graphics.rst
@@ -252,4 +252,4 @@ Output
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/processing_algs/qgis/index.rst
+++ b/source/docs/user_manual/processing_algs/qgis/index.rst
@@ -36,10 +36,11 @@ algorithms.
      vectorselection
      vectortable
 
+
 .. Substitutions definitions - AVOID EDITING PAST THIS LINE
    This will be automatically updated by the find_set_subst.py script.
    If you need to create a new substitution manually,
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/processing_algs/qgis/interpolation.rst
+++ b/source/docs/user_manual/processing_algs/qgis/interpolation.rst
@@ -296,4 +296,4 @@ Output
    :width: 1.5em
 .. |signPlus| image:: /static/common/symbologyAdd.png
    :width: 1.5em
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/processing_algs/qgis/layertools.rst
+++ b/source/docs/user_manual/processing_algs/qgis/layertools.rst
@@ -40,10 +40,11 @@ Outputs
 ``Extent`` [vector]
   Polygon vector layer
 
+
 .. Substitutions definitions - AVOID EDITING PAST THIS LINE
    This will be automatically updated by the find_set_subst.py script.
    If you need to create a new substitution manually,
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/processing_algs/qgis/modelertools.rst
+++ b/source/docs/user_manual/processing_algs/qgis/modelertools.rst
@@ -130,4 +130,4 @@ See also
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/processing_algs/qgis/rasteranalysis.rst
+++ b/source/docs/user_manual/processing_algs/qgis/rasteranalysis.rst
@@ -211,4 +211,4 @@ Parameters
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/processing_algs/qgis/rasterterrainanalysis.rst
+++ b/source/docs/user_manual/processing_algs/qgis/rasterterrainanalysis.rst
@@ -290,10 +290,11 @@ Outputs
 ``Slope`` [raster]
   Slope raster layer
 
+
 .. Substitutions definitions - AVOID EDITING PAST THIS LINE
    This will be automatically updated by the find_set_subst.py script.
    If you need to create a new substitution manually,
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/processing_algs/qgis/rastertools.rst
+++ b/source/docs/user_manual/processing_algs/qgis/rastertools.rst
@@ -119,4 +119,4 @@ Parameters
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/processing_algs/qgis/vectoranalysis.rst
+++ b/source/docs/user_manual/processing_algs/qgis/vectoranalysis.rst
@@ -467,4 +467,4 @@ Outputs
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/processing_algs/qgis/vectorcreation.rst
+++ b/source/docs/user_manual/processing_algs/qgis/vectorcreation.rst
@@ -424,10 +424,11 @@ Outputs
 ``Regular points`` [vector: point]
   Regular point layer in output
 
+
 .. Substitutions definitions - AVOID EDITING PAST THIS LINE
    This will be automatically updated by the find_set_subst.py script.
    If you need to create a new substitution manually,
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/processing_algs/qgis/vectorgeneral.rst
+++ b/source/docs/user_manual/processing_algs/qgis/vectorgeneral.rst
@@ -607,4 +607,4 @@ Parameters
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/processing_algs/qgis/vectorgeometry.rst
+++ b/source/docs/user_manual/processing_algs/qgis/vectorgeometry.rst
@@ -2217,4 +2217,4 @@ Outputs
 .. |32| replace:: :kbd:`NEW in 3.2`
 .. |identify| image:: /static/common/mActionIdentify.png
    :width: 1.5em
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/processing_algs/qgis/vectoroverlay.rst
+++ b/source/docs/user_manual/processing_algs/qgis/vectoroverlay.rst
@@ -338,4 +338,4 @@ Output
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/processing_algs/qgis/vectorselection.rst
+++ b/source/docs/user_manual/processing_algs/qgis/vectorselection.rst
@@ -403,4 +403,4 @@ Parameters
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/processing_algs/qgis/vectortable.rst
+++ b/source/docs/user_manual/processing_algs/qgis/vectortable.rst
@@ -321,4 +321,4 @@ Output
    :width: 1.5em
 .. |newAttribute| image:: /static/common/mActionNewAttribute.png
    :width: 1.5em
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/processing_algs/r/basic_statistics.rst
+++ b/source/docs/user_manual/processing_algs/r/basic_statistics.rst
@@ -117,4 +117,4 @@ See also
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/processing_algs/r/home_range_analysis.rst
+++ b/source/docs/user_manual/processing_algs/r/home_range_analysis.rst
@@ -178,4 +178,4 @@ See also
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/processing_algs/r/index.rst
+++ b/source/docs/user_manual/processing_algs/r/index.rst
@@ -23,10 +23,11 @@ displays of data from custom data sets
      raster_processing
      vector_processing
 
+
 .. Substitutions definitions - AVOID EDITING PAST THIS LINE
    This will be automatically updated by the find_set_subst.py script.
    If you need to create a new substitution manually,
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/processing_algs/r/point_pattern_analysis.rst
+++ b/source/docs/user_manual/processing_algs/r/point_pattern_analysis.rst
@@ -370,4 +370,4 @@ See also
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/processing_algs/r/raster_processing.rst
+++ b/source/docs/user_manual/processing_algs/r/raster_processing.rst
@@ -83,4 +83,4 @@ See also
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/processing_algs/r/vector_processing.rst
+++ b/source/docs/user_manual/processing_algs/r/vector_processing.rst
@@ -51,4 +51,4 @@ See also
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/processing_algs/saga/geostatistics.rst
+++ b/source/docs/user_manual/processing_algs/saga/geostatistics.rst
@@ -1665,4 +1665,4 @@ See also
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/processing_algs/saga/grid_analysis.rst
+++ b/source/docs/user_manual/processing_algs/saga/grid_analysis.rst
@@ -680,4 +680,4 @@ See also
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/processing_algs/saga/grid_calculus.rst
+++ b/source/docs/user_manual/processing_algs/saga/grid_calculus.rst
@@ -941,4 +941,4 @@ See also
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/processing_algs/saga/grid_filter.rst
+++ b/source/docs/user_manual/processing_algs/saga/grid_filter.rst
@@ -526,4 +526,4 @@ See also
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/processing_algs/saga/grid_gridding.rst
+++ b/source/docs/user_manual/processing_algs/saga/grid_gridding.rst
@@ -516,4 +516,4 @@ See also
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/processing_algs/saga/grid_spline.rst
+++ b/source/docs/user_manual/processing_algs/saga/grid_spline.rst
@@ -515,4 +515,4 @@ See also
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/processing_algs/saga/grid_tools.rst
+++ b/source/docs/user_manual/processing_algs/saga/grid_tools.rst
@@ -1075,4 +1075,4 @@ See also
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/processing_algs/saga/grid_visualization.rst
+++ b/source/docs/user_manual/processing_algs/saga/grid_visualization.rst
@@ -209,4 +209,4 @@ See also
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/processing_algs/saga/imagery_classification.rst
+++ b/source/docs/user_manual/processing_algs/saga/imagery_classification.rst
@@ -244,4 +244,4 @@ See also
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/processing_algs/saga/imagery_rga.rst
+++ b/source/docs/user_manual/processing_algs/saga/imagery_rga.rst
@@ -59,4 +59,4 @@ See also
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/processing_algs/saga/imagery_segmentation.rst
+++ b/source/docs/user_manual/processing_algs/saga/imagery_segmentation.rst
@@ -326,4 +326,4 @@ See also
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/processing_algs/saga/imagery_tools.rst
+++ b/source/docs/user_manual/processing_algs/saga/imagery_tools.rst
@@ -118,4 +118,4 @@ See also
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/processing_algs/saga/index.rst
+++ b/source/docs/user_manual/processing_algs/saga/index.rst
@@ -47,10 +47,11 @@ libraries.
      terrain_analysis_morphometry
      terrain_analysis_profiles
 
+
 .. Substitutions definitions - AVOID EDITING PAST THIS LINE
    This will be automatically updated by the find_set_subst.py script.
    If you need to create a new substitution manually,
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/processing_algs/saga/kriging.rst
+++ b/source/docs/user_manual/processing_algs/saga/kriging.rst
@@ -596,4 +596,4 @@ See also
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/processing_algs/saga/shapes_grid.rst
+++ b/source/docs/user_manual/processing_algs/saga/shapes_grid.rst
@@ -646,4 +646,4 @@ See also
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/processing_algs/saga/shapes_lines.rst
+++ b/source/docs/user_manual/processing_algs/saga/shapes_lines.rst
@@ -256,4 +256,4 @@ See also
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/processing_algs/saga/shapes_points.rst
+++ b/source/docs/user_manual/processing_algs/saga/shapes_points.rst
@@ -589,4 +589,4 @@ See also
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/processing_algs/saga/shapes_polygons.rst
+++ b/source/docs/user_manual/processing_algs/saga/shapes_polygons.rst
@@ -361,4 +361,4 @@ See also
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/processing_algs/saga/shapes_tools.rst
+++ b/source/docs/user_manual/processing_algs/saga/shapes_tools.rst
@@ -458,4 +458,4 @@ See also
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/processing_algs/saga/shapes_transect.rst
+++ b/source/docs/user_manual/processing_algs/saga/shapes_transect.rst
@@ -54,4 +54,4 @@ See also
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/processing_algs/saga/simulation_fire_spreading.rst
+++ b/source/docs/user_manual/processing_algs/saga/simulation_fire_spreading.rst
@@ -166,4 +166,4 @@ See also
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/processing_algs/saga/simulation_hydrology.rst
+++ b/source/docs/user_manual/processing_algs/saga/simulation_hydrology.rst
@@ -133,4 +133,4 @@ See also
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/processing_algs/saga/table_calculus.rst
+++ b/source/docs/user_manual/processing_algs/saga/table_calculus.rst
@@ -146,4 +146,4 @@ See also
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/processing_algs/saga/table_tools.rst
+++ b/source/docs/user_manual/processing_algs/saga/table_tools.rst
@@ -139,10 +139,11 @@ Console usage
 See also
 ........
 
+
 .. Substitutions definitions - AVOID EDITING PAST THIS LINE
    This will be automatically updated by the find_set_subst.py script.
    If you need to create a new substitution manually,
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/processing_algs/saga/terrain_analysis_channels.rst
+++ b/source/docs/user_manual/processing_algs/saga/terrain_analysis_channels.rst
@@ -319,4 +319,4 @@ See also
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/processing_algs/saga/terrain_analysis_hydrology.rst
+++ b/source/docs/user_manual/processing_algs/saga/terrain_analysis_hydrology.rst
@@ -1081,4 +1081,4 @@ See also
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/processing_algs/saga/terrain_analysis_lighting.rst
+++ b/source/docs/user_manual/processing_algs/saga/terrain_analysis_lighting.rst
@@ -217,4 +217,4 @@ See also
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/processing_algs/saga/terrain_analysis_morphometry.rst
+++ b/source/docs/user_manual/processing_algs/saga/terrain_analysis_morphometry.rst
@@ -1202,4 +1202,4 @@ See also
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/processing_algs/saga/terrain_analysis_profiles.rst
+++ b/source/docs/user_manual/processing_algs/saga/terrain_analysis_profiles.rst
@@ -154,4 +154,4 @@ See also
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/processing_algs/taudem/basic_grid_analysis_tools.rst
+++ b/source/docs/user_manual/processing_algs/taudem/basic_grid_analysis_tools.rst
@@ -566,10 +566,11 @@ Console usage
 See also
 ........
 
+
 .. Substitutions definitions - AVOID EDITING PAST THIS LINE
    This will be automatically updated by the find_set_subst.py script.
    If you need to create a new substitution manually,
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/processing_algs/taudem/index.rst
+++ b/source/docs/user_manual/processing_algs/taudem/index.rst
@@ -31,10 +31,11 @@ documentation <http://hydrology.usu.edu/taudem/taudem5/documentation.html>`_
      specialized_grid_analysis_tools
      stream_network_analysis_tools
 
+
 .. Substitutions definitions - AVOID EDITING PAST THIS LINE
    This will be automatically updated by the find_set_subst.py script.
    If you need to create a new substitution manually,
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/processing_algs/taudem/specialized_grid_analysis_tools.rst
+++ b/source/docs/user_manual/processing_algs/taudem/specialized_grid_analysis_tools.rst
@@ -1106,4 +1106,4 @@ See also
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/processing_algs/taudem/stream_network_analysis_tools.rst
+++ b/source/docs/user_manual/processing_algs/taudem/stream_network_analysis_tools.rst
@@ -825,10 +825,11 @@ Console usage
 See also
 ........
 
+
 .. Substitutions definitions - AVOID EDITING PAST THIS LINE
    This will be automatically updated by the find_set_subst.py script.
    If you need to create a new substitution manually,
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/working_with_gps/index.rst
+++ b/source/docs/user_manual/working_with_gps/index.rst
@@ -13,12 +13,10 @@ Working with GPS Data
 	live_GPS_tracking
 
 
-
-
 .. Substitutions definitions - AVOID EDITING PAST THIS LINE
    This will be automatically updated by the find_set_subst.py script.
    If you need to create a new substitution manually,
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/working_with_gps/live_GPS_tracking.rst
+++ b/source/docs/user_manual/working_with_gps/live_GPS_tracking.rst
@@ -229,6 +229,7 @@ The live tracking works both with GPSD
 or without it, by connecting the QGIS live tracking tool directly to the device
 (for example ``/dev/rfcomm0``).
 
+
 .. Substitutions definitions - AVOID EDITING PAST THIS LINE
    This will be automatically updated by the find_set_subst.py script.
    If you need to create a new substitution manually,
@@ -248,4 +249,4 @@ or without it, by connecting the QGIS live tracking tool directly to the device
 .. |slider| image:: /static/common/slider.png
 .. |toggleEditing| image:: /static/common/mActionToggleEditing.png
    :width: 1.5em
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/working_with_gps/plugins_gps.rst
+++ b/source/docs/user_manual/working_with_gps/plugins_gps.rst
@@ -317,6 +317,6 @@ system port, then run GPSBabel
    :width: 1em
 .. |showPluginManager| image:: /static/common/mActionShowPluginManager.png
    :width: 1.5em
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
 .. |win| image:: /static/common/win.png
    :width: 1em

--- a/source/docs/user_manual/working_with_ogc/index.rst
+++ b/source/docs/user_manual/working_with_ogc/index.rst
@@ -14,10 +14,11 @@ Working with OGC Data
 	ogc_client_support
 	server/index
 
+
 .. Substitutions definitions - AVOID EDITING PAST THIS LINE
    This will be automatically updated by the find_set_subst.py script.
    If you need to create a new substitution manually,
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/working_with_ogc/ogc_client_support.rst
+++ b/source/docs/user_manual/working_with_ogc/ogc_client_support.rst
@@ -672,6 +672,7 @@ two and view the attribute table.
    engine. There are a number of lists with public URLs, some of them maintained
    and some not.
 
+
 .. Substitutions definitions - AVOID EDITING PAST THIS LINE
    This will be automatically updated by the find_set_subst.py script.
    If you need to create a new substitution manually,
@@ -686,7 +687,7 @@ two and view the attribute table.
    :width: 1.5em
 .. |selectString| image:: /static/common/selectstring.png
    :width: 2.5em
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
 .. |wcs| image:: /static/common/mActionAddWcsLayer.png
    :width: 1.5em
 .. |wfs| image:: /static/common/mActionAddWfsLayer.png

--- a/source/docs/user_manual/working_with_ogc/server/config.rst
+++ b/source/docs/user_manual/working_with_ogc/server/config.rst
@@ -283,10 +283,11 @@ For linux, if you don't have a desktop environment installed (or you prefer the 
    chown root *
    cd .. && fc-cache -f -v
 
+
 .. Substitutions definitions - AVOID EDITING PAST THIS LINE
    This will be automatically updated by the find_set_subst.py script.
    If you need to create a new substitution manually,
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/working_with_ogc/server/getting_started.rst
+++ b/source/docs/user_manual/working_with_ogc/server/getting_started.rst
@@ -495,6 +495,7 @@ paths (in the :guilabel:`General` menu of the
 :menuselection:`Project --> Project Properties` dialog) or to manually modify
 the path to the SVG image so that it represents a valid relative path.
 
+
 .. Substitutions definitions - AVOID EDITING PAST THIS LINE
    This will be automatically updated by the find_set_subst.py script.
    If you need to create a new substitution manually,
@@ -505,4 +506,4 @@ the path to the SVG image so that it represents a valid relative path.
    :width: 1.3em
 .. |signPlus| image:: /static/common/symbologyAdd.png
    :width: 1.5em
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/working_with_ogc/server/index.rst
+++ b/source/docs/user_manual/working_with_ogc/server/index.rst
@@ -46,10 +46,11 @@ Manual <training_qgis_server>` or :ref:`server_plugins`.
   plugins
   config
 
+
 .. Substitutions definitions - AVOID EDITING PAST THIS LINE
    This will be automatically updated by the find_set_subst.py script.
    If you need to create a new substitution manually,
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/working_with_ogc/server/plugins.rst
+++ b/source/docs/user_manual/working_with_ogc/server/plugins.rst
@@ -93,10 +93,11 @@ Test the server with the HelloWorld plugin:
 You can have a look at the default GetCapabilities of the QGIS server at:
 :file:`http://localhost/cgi-bin/qgis_mapserv.fcgi?SERVICE=WMS&VERSION=1.3.0&REQUEST=GetCapabilities`
 
+
 .. Substitutions definitions - AVOID EDITING PAST THIS LINE
    This will be automatically updated by the find_set_subst.py script.
    If you need to create a new substitution manually,
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/working_with_ogc/server/services.rst
+++ b/source/docs/user_manual/working_with_ogc/server/services.rst
@@ -878,10 +878,11 @@ You can see there are several parameters in this request:
 
 * **HIGHLIGHT_LABELBUFFERSIZE**: This parameter controls the label buffer size.
 
+
 .. Substitutions definitions - AVOID EDITING PAST THIS LINE
    This will be automatically updated by the find_set_subst.py script.
    If you need to create a new substitution manually,
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/working_with_projections/working_with_projections.rst
+++ b/source/docs/user_manual/working_with_projections/working_with_projections.rst
@@ -281,4 +281,4 @@ transform. User defaults can be saved by selecting
    :width: 1.5em
 .. |signPlus| image:: /static/common/symbologyAdd.png
    :width: 1.5em
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/working_with_raster/index.rst
+++ b/source/docs/user_manual/working_with_raster/index.rst
@@ -21,4 +21,4 @@ Working with Raster Data
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/working_with_raster/raster_analysis.rst
+++ b/source/docs/user_manual/working_with_raster/raster_analysis.rst
@@ -157,6 +157,7 @@ layers. You can also choose one or more other options (see figure_raster_align_)
 
    Raster Alignment
 
+
 .. Substitutions definitions - AVOID EDITING PAST THIS LINE
    This will be automatically updated by the find_set_subst.py script.
    If you need to create a new substitution manually,
@@ -171,4 +172,4 @@ layers. You can also choose one or more other options (see figure_raster_align_)
    :width: 1.5em
 .. |symbologyEdit| image:: /static/common/symbologyEdit.png
    :width: 1.5em
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/working_with_raster/raster_properties.rst
+++ b/source/docs/user_manual/working_with_raster/raster_properties.rst
@@ -475,6 +475,7 @@ collected.
 
    QGIS Server in Raster Properties
 
+
 .. Substitutions definitions - AVOID EDITING PAST THIS LINE
    This will be automatically updated by the find_set_subst.py script.
    If you need to create a new substitution manually,
@@ -510,4 +511,4 @@ collected.
 .. |signPlus| image:: /static/common/symbologyAdd.png
    :width: 1.5em
 .. |slider| image:: /static/common/slider.png
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/working_with_vector/attribute_table.rst
+++ b/source/docs/user_manual/working_with_vector/attribute_table.rst
@@ -888,6 +888,6 @@ It will appear as a **Many to many relation**.
    :width: 1.5em
 .. |unlink| image:: /static/common/mActionUnlink.png
    :width: 1.5em
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
 .. |zoomToSelected| image:: /static/common/mActionZoomToSelected.png
    :width: 1.5em

--- a/source/docs/user_manual/working_with_vector/editing_geometry_attributes.rst
+++ b/source/docs/user_manual/working_with_vector/editing_geometry_attributes.rst
@@ -1388,4 +1388,4 @@ and angle entered. Repeating the process, several points can be added.
    :width: 1.3em
 .. |undo| image:: /static/common/mActionUndo.png
    :width: 1.5em
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/working_with_vector/expression.rst
+++ b/source/docs/user_manual/working_with_vector/expression.rst
@@ -1333,6 +1333,7 @@ Further information about creating Python code can be found in the
 The function editor is not only limited to working with the field calculator,
 it can be found whenever you work with expressions.
 
+
 .. Substitutions definitions - AVOID EDITING PAST THIS LINE
    This will be automatically updated by the find_set_subst.py script.
    If you need to create a new substitution manually,
@@ -1348,4 +1349,4 @@ it can be found whenever you work with expressions.
    :width: 1.5em
 .. |expressionSelect| image:: /static/common/mIconExpressionSelect.png
    :width: 1.5em
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/working_with_vector/index.rst
+++ b/source/docs/user_manual/working_with_vector/index.rst
@@ -24,4 +24,4 @@
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/working_with_vector/style_library.rst
+++ b/source/docs/user_manual/working_with_vector/style_library.rst
@@ -537,6 +537,7 @@ field either by:
 The magnitude of field can be scaled up or down to an appropriate size for
 viewing the field.
 
+
 .. Substitutions definitions - AVOID EDITING PAST THIS LINE
    This will be automatically updated by the find_set_subst.py script.
    If you need to create a new substitution manually,
@@ -565,4 +566,4 @@ viewing the field.
    :width: 1.5em
 .. |symbologyEdit| image:: /static/common/symbologyEdit.png
    :width: 1.5em
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/working_with_vector/vector_properties.rst
+++ b/source/docs/user_manual/working_with_vector/vector_properties.rst
@@ -3147,4 +3147,4 @@ format of the image. Currently png, jpg and jpeg image formats are supported.
    :width: 1.5em
 .. |toggleEditing| image:: /static/common/mActionToggleEditing.png
    :width: 1.5em
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/substitutions.txt
+++ b/source/substitutions.txt
@@ -1,4 +1,4 @@
-.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
 .. |nix| image:: /static/common/nix.png
    :width: 1em
 .. |kde| image:: /static/common/kde.png


### PR DESCRIPTION
The disclaimer at the top of the user manual pages is weirdly missing in Training manual and PyQGIS Cookbook. Because these docs are really (and particularly the Cookbook) out of date with QGIS 3.x we should mention this to avoid people vainly try code sample, hence the disclaimer message is now `Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.` 
If someone has better wording...