### PR TITLE
Update Edit menu items

### DIFF
--- a/source/docs/user_manual/introduction/qgis_gui.rst
+++ b/source/docs/user_manual/introduction/qgis_gui.rst
@@ -128,43 +128,43 @@ layers attributes or geometry (see :ref:`editingvector` for details).
 ====================================================================  ====================  =================================   ===================================
 Menu Option                                                           Shortcut              Toolbar                             Reference
 ====================================================================  ====================  =================================   ===================================
-|undo| :guilabel:`Undo`                                               :kbd:`Ctrl+Z`         :guilabel:`Digitizing`              see :ref:`sec_edit_existing_layer`
-|redo| :guilabel:`Redo`                                               :kbd:`Ctrl+Shift+Z`   :guilabel:`Digitizing`              see :ref:`sec_edit_existing_layer`
-|editCut| :guilabel:`Cut Features`                                    :kbd:`Ctrl+X`         :guilabel:`Digitizing`              see :ref:`sec_edit_existing_layer`
-|editCopy| :guilabel:`Copy Features`                                  :kbd:`Ctrl+C`         :guilabel:`Digitizing`              see :ref:`sec_edit_existing_layer`
-|editPaste| :guilabel:`Paste Features`                                :kbd:`Ctrl+V`         :guilabel:`Digitizing`              see :ref:`sec_edit_existing_layer`
+|undo| :guilabel:`Undo`                                               :kbd:`Ctrl+Z`         :guilabel:`Digitizing`              see :ref:`undoredo_edits`
+|redo| :guilabel:`Redo`                                               :kbd:`Ctrl+Shift+Z`   :guilabel:`Digitizing`              see :ref:`undoredo_edits`
+|editCut| :guilabel:`Cut Features`                                    :kbd:`Ctrl+X`         :guilabel:`Digitizing`              see :ref:`clipboard_feature`
+|editCopy| :guilabel:`Copy Features`                                  :kbd:`Ctrl+C`         :guilabel:`Digitizing`              see :ref:`clipboard_feature`
+|editPaste| :guilabel:`Paste Features`                                :kbd:`Ctrl+V`         :guilabel:`Digitizing`              see :ref:`clipboard_feature`
 :menuselection:`Paste features as -->`                                \                     \                                   see :ref:`sec_attribute_table`
 :menuselection:`Select -->`                                           \                     :guilabel:`Attributes`              see :ref:`sec_selection`
 |newTableRow| :guilabel:`Add Record`                                  :kbd:`Ctrl+.`         :guilabel:`Digitizing`              \
-|capturePoint| :guilabel:`Add Point Feature`                          :kbd:`Ctrl+.`         :guilabel:`Digitizing`              see :ref:`sec_edit_existing_layer`
-|capturePoint| :guilabel:`Add Line Feature`                           :kbd:`Ctrl+.`         :guilabel:`Digitizing`              see :ref:`sec_edit_existing_layer`
-|capturePolygon| :guilabel:`Add Polygon Feature`                      :kbd:`Ctrl+.`         :guilabel:`Digitizing`              see :ref:`sec_edit_existing_layer`
+|capturePoint| :guilabel:`Add Point Feature`                          :kbd:`Ctrl+.`         :guilabel:`Digitizing`              see :ref:`add_feature`
+|capturePoint| :guilabel:`Add Line Feature`                           :kbd:`Ctrl+.`         :guilabel:`Digitizing`              see :ref:`add_feature`
+|capturePolygon| :guilabel:`Add Polygon Feature`                      :kbd:`Ctrl+.`         :guilabel:`Digitizing`              see :ref:`add_feature`
 |circularStringCurvePoint| :guilabel:`Add Circular String`            \                     :guilabel:`Digitizing`              see :ref:`sec_edit_existing_layer`
 |circularStringRadius| :guilabel:`Add Circular String by Radius`      \                     :guilabel:`Digitizing`              see :ref:`sec_edit_existing_layer`
 :menuselection:`Add Circle -->`                                       \                     :guilabel:`Shape Digitizing`        \
 :menuselection:`Add Rectangle -->`                                    \                     :guilabel:`Shape Digitizing`        \
 :menuselection:`Add Regular Polygon -->`                              \                     :guilabel:`Shape Digitizing`        \
 :menuselection:`Add Ellipse -->`                                      \                     :guilabel:`Shape Digitizing`        \
-|moveFeature| :guilabel:`Move Feature(s)`                             \                     :guilabel:`Digitizing`              see :ref:`sec_edit_existing_layer`
-|moveFeatureCopy| :guilabel:`Copy and Move Feature(s)`                \                     :guilabel:`Digitizing`              \
-|deleteSelected| :guilabel:`Delete Selected`                          \                     :guilabel:`Digitizing`              see :ref:`sec_edit_existing_layer`
+|moveFeature| :guilabel:`Move Feature(s)`                             \                     :guilabel:`Advanced Digitizing`     see :ref:`move_feature`
+|moveFeatureCopy| :guilabel:`Copy and Move Feature(s)`                \                     :guilabel:`Advanced Digitizing`     see :ref:`move_feature`
+|deleteSelected| :guilabel:`Delete Selected`                          \                     :guilabel:`Digitizing`              see :ref:`delete_feature`
 |multiEdit| :guilabel:`Modify Attributes of Selected Features`        \                     :guilabel:`Digitizing`              see :ref:`calculate_fields_values`
-|rotateFeature| :guilabel:`Rotate Feature(s)`                         \                     :guilabel:`Advanced Digitizing`     see :ref:`sec_advanced_edit`
-|simplifyFeatures| :guilabel:`Simplify Feature`                       \                     :guilabel:`Advanced Digitizing`     see :ref:`sec_advanced_edit`
-|addRing| :guilabel:`Add Ring`                                        \                     :guilabel:`Advanced Digitizing`     see :ref:`sec_advanced_edit`
-|addPart| :guilabel:`Add Part`                                        \                     :guilabel:`Advanced Digitizing`     see :ref:`sec_advanced_edit`
-|fillRing| :guilabel:`Fill Ring`                                      \                     :guilabel:`Advanced Digitizing`     see :ref:`sec_advanced_edit`
-|deleteRing| :guilabel:`Delete Ring`                                  \                     :guilabel:`Advanced Digitizing`     see :ref:`sec_advanced_edit`
-|deletePart| :guilabel:`Delete Part`                                  \                     :guilabel:`Advanced Digitizing`     see :ref:`sec_advanced_edit`
-|reshape| :guilabel:`Reshape Features`                                \                     :guilabel:`Advanced Digitizing`     see :ref:`sec_advanced_edit`
-|offsetCurve| :guilabel:`Offset Curve`                                \                     :guilabel:`Advanced Digitizing`     see :ref:`sec_advanced_edit`
-|splitFeatures| :guilabel:`Split Features`                            \                     :guilabel:`Advanced Digitizing`     see :ref:`sec_advanced_edit`
-|splitParts| :guilabel:`Split Parts`                                  \                     :guilabel:`Advanced Digitizing`     see :ref:`sec_advanced_edit`
-|mergeFeatures| :guilabel:`Merge Selected Features`                   \                     :guilabel:`Advanced Digitizing`     see :ref:`sec_advanced_edit`
-|mergeFeatAttributes| :guilabel:`Merge Attr. of Selected Features`    \                     :guilabel:`Advanced Digitizing`     see :ref:`sec_advanced_edit`
-|nodeTool| :guilabel:`Vertex Tool`                                    \                     :guilabel:`Digitizing`              see :ref:`sec_edit_existing_layer`
-|rotatePointSymbols| :guilabel:`Rotate Point Symbols`                 \                     :guilabel:`Advanced Digitizing`     see :ref:`sec_advanced_edit`
-|offsetPointSymbols| :guilabel:`Offset Point Symbols`                 \                     :guilabel:`Advanced Digitizing`     see :ref:`sec_advanced_edit`
+|rotateFeature| :guilabel:`Rotate Feature(s)`                         \                     :guilabel:`Advanced Digitizing`     see :ref:`rotate_feature`
+|simplifyFeatures| :guilabel:`Simplify Feature`                       \                     :guilabel:`Advanced Digitizing`     see :ref:`simplify_feature`
+|addRing| :guilabel:`Add Ring`                                        \                     :guilabel:`Advanced Digitizing`     see :ref:`add_ring`
+|addPart| :guilabel:`Add Part`                                        \                     :guilabel:`Advanced Digitizing`     see :ref:`add_part`
+|fillRing| :guilabel:`Fill Ring`                                      \                     :guilabel:`Advanced Digitizing`     see :ref:`fill_ring`
+|deleteRing| :guilabel:`Delete Ring`                                  \                     :guilabel:`Advanced Digitizing`     see :ref:`delete_ring`
+|deletePart| :guilabel:`Delete Part`                                  \                     :guilabel:`Advanced Digitizing`     see :ref:`delete_part`
+|reshape| :guilabel:`Reshape Features`                                \                     :guilabel:`Advanced Digitizing`     see :ref:`reshape_feature`
+|offsetCurve| :guilabel:`Offset Curve`                                \                     :guilabel:`Advanced Digitizing`     see :ref:`offset_curve`
+|splitFeatures| :guilabel:`Split Features`                            \                     :guilabel:`Advanced Digitizing`     see :ref:`split_feature`
+|splitParts| :guilabel:`Split Parts`                                  \                     :guilabel:`Advanced Digitizing`     see :ref:`split_part`
+|mergeFeatures| :guilabel:`Merge Selected Features`                   \                     :guilabel:`Advanced Digitizing`     see :ref:`mergeselectedfeatures`
+|mergeFeatAttributes| :guilabel:`Merge Attr. of Selected Features`    \                     :guilabel:`Advanced Digitizing`     see :ref:`mergeattributesfeatures`
+|nodeTool| :guilabel:`Vertex Tool`                                    \                     :guilabel:`Digitizing`              see :ref:`vertex_tool`
+|rotatePointSymbols| :guilabel:`Rotate Point Symbols`                 \                     :guilabel:`Advanced Digitizing`     see :ref:`rotate_symbol`
+|offsetPointSymbols| :guilabel:`Offset Point Symbols`                 \                     :guilabel:`Advanced Digitizing`     see :ref:`offset_symbol`
 ====================================================================  ====================  =================================   ===================================
 
 Depending on the selected layer geometry type, some of the tools may look different:
@@ -260,8 +260,8 @@ Menu Option                                                   Shortcut          
 |editPaste| :guilabel:`Paste style`                           \                     \                                  see :ref:`save_layer_property`
 |openTable| :guilabel:`Open Attribute Table`                  :kbd:`F6`             :guilabel:`Attributes`             see :ref:`sec_attribute_table`
 |toggleEditing| :guilabel:`Toggle Editing`                    \                     :guilabel:`Digitizing`             see :ref:`sec_edit_existing_layer`
-|fileSave| :guilabel:`Save Layer Edits`                       \                     :guilabel:`Digitizing`             see :ref:`sec_edit_existing_layer`
-|allEdits| :menuselection:`Current Edits -->`                 \                     :guilabel:`Digitizing`             see :ref:`sec_edit_existing_layer`
+|fileSave| :guilabel:`Save Layer Edits`                       \                     :guilabel:`Digitizing`             see :ref:`save_feature_edits`
+|allEdits| :menuselection:`Current Edits -->`                 \                     :guilabel:`Digitizing`             see :ref:`save_feature_edits`
 :menuselection:`Save As...`                                   \                     \                                  see :ref:`general_saveas`
 :menuselection:`Save As Layer Definition File...`             \                     \                                  \
 |removeLayer| :guilabel:`Remove Layer/Group`                  :kbd:`Ctrl+D`         \                                  \

--- a/source/docs/user_manual/introduction/qgis_gui.rst
+++ b/source/docs/user_manual/introduction/qgis_gui.rst
@@ -122,6 +122,9 @@ Under |osx| macOS, the :guilabel:`Exit QGIS` command corresponds to
 Edit
 ----
 
+The :menuselection:`Edit` menu presents most of the native tools needed to edit
+layers attributes or geometry (see :ref:`editingvector` for details).
+
 ====================================================================  ====================  =================================   ===================================
 Menu Option                                                           Shortcut              Toolbar                             Reference
 ====================================================================  ====================  =================================   ===================================
@@ -132,7 +135,10 @@ Menu Option                                                           Shortcut  
 |editPaste| :guilabel:`Paste Features`                                :kbd:`Ctrl+V`         :guilabel:`Digitizing`              see :ref:`sec_edit_existing_layer`
 :menuselection:`Paste features as -->`                                \                     \                                   see :ref:`sec_attribute_table`
 :menuselection:`Select -->`                                           \                     :guilabel:`Attributes`              see :ref:`sec_selection`
-|capturePoint| :guilabel:`Add Feature`                                :kbd:`Ctrl+.`         :guilabel:`Digitizing`              see :ref:`sec_edit_existing_layer`
+|newTableRow| :guilabel:`Add Record`                                  :kbd:`Ctrl+.`         :guilabel:`Digitizing`              \
+|capturePoint| :guilabel:`Add Point Feature`                          :kbd:`Ctrl+.`         :guilabel:`Digitizing`              see :ref:`sec_edit_existing_layer`
+|capturePoint| :guilabel:`Add Line Feature`                           :kbd:`Ctrl+.`         :guilabel:`Digitizing`              see :ref:`sec_edit_existing_layer`
+|capturePolygon| :guilabel:`Add Polygon Feature`                      :kbd:`Ctrl+.`         :guilabel:`Digitizing`              see :ref:`sec_edit_existing_layer`
 |circularStringCurvePoint| :guilabel:`Add Circular String`            \                     :guilabel:`Digitizing`              see :ref:`sec_edit_existing_layer`
 |circularStringRadius| :guilabel:`Add Circular String by Radius`      \                     :guilabel:`Digitizing`              see :ref:`sec_edit_existing_layer`
 :menuselection:`Add Circle -->`                                       \                     :guilabel:`Shape Digitizing`        \
@@ -140,6 +146,7 @@ Menu Option                                                           Shortcut  
 :menuselection:`Add Regular Polygon -->`                              \                     :guilabel:`Shape Digitizing`        \
 :menuselection:`Add Ellipse -->`                                      \                     :guilabel:`Shape Digitizing`        \
 |moveFeature| :guilabel:`Move Feature(s)`                             \                     :guilabel:`Digitizing`              see :ref:`sec_edit_existing_layer`
+|moveFeatureCopy| :guilabel:`Copy and Move Feature(s)`                \                     :guilabel:`Digitizing`              \
 |deleteSelected| :guilabel:`Delete Selected`                          \                     :guilabel:`Digitizing`              see :ref:`sec_edit_existing_layer`
 |multiEdit| :guilabel:`Modify Attributes of Selected Features`        \                     :guilabel:`Digitizing`              see :ref:`calculate_fields_values`
 |rotateFeature| :guilabel:`Rotate Feature(s)`                         \                     :guilabel:`Advanced Digitizing`     see :ref:`sec_advanced_edit`
@@ -160,20 +167,16 @@ Menu Option                                                           Shortcut  
 |offsetPointSymbols| :guilabel:`Offset Point Symbols`                 \                     :guilabel:`Advanced Digitizing`     see :ref:`sec_advanced_edit`
 ====================================================================  ====================  =================================   ===================================
 
-After activating |toggleEditing| :sup:`Toggle editing` mode for a layer,
-you will enable the ``Add Feature`` icon in the :menuselection:`Edit` menu
-depending on the layer type (point, line or polygon).
+Depending on the selected layer geometry type, some of the tools may look different:
 
-Edit (extra)
-------------
+.. :tabularcolumns: |l|c|c|c|
 
-=======================================================  ====================  =============================  =====================================
-Menu Option                                              Shortcut              Toolbar                        Reference
-=======================================================  ====================  =============================  =====================================
-|capturePoint| :guilabel:`Add Feature`                   \                     :guilabel:`Digitizing`         see :ref:`sec_edit_existing_layer`
-|captureLine| :guilabel:`Add Feature`                    \                     :guilabel:`Digitizing`         see :ref:`sec_edit_existing_layer`
-|capturePolygon| :guilabel:`Add Feature`                 \                     :guilabel:`Digitizing`         see :ref:`sec_edit_existing_layer`
-=======================================================  ====================  =============================  =====================================
+=====================================  ========================  ========================  ==========================
+Menu Option                            Point                     Polyline                  Polygon
+=====================================  ========================  ========================  ==========================
+:guilabel:`Move Feature(s)`            |moveFeaturePoint|        |moveFeatureLine|         |moveFeature|
+:guilabel:`Copy and Move Feature(s)`   |moveFeatureCopyPoint|    |moveFeatureCopyLine|     |moveFeatureCopy|
+=====================================  ========================  ========================  ==========================
 
 .. _view_menu:
 
@@ -766,6 +769,16 @@ open the Plugin Manager dialog.
    :width: 1.5em
 .. |moveFeature| image:: /static/common/mActionMoveFeature.png
    :width: 1.5em
+.. |moveFeatureCopy| image:: /static/common/mActionMoveFeatureCopy.png
+   :width: 1.5em
+.. |moveFeatureCopyLine| image:: /static/common/mActionMoveFeatureCopyLine.png
+   :width: 1.5em
+.. |moveFeatureCopyPoint| image:: /static/common/mActionMoveFeatureCopyPoint.png
+   :width: 1.5em
+.. |moveFeatureLine| image:: /static/common/mActionMoveFeatureLine.png
+   :width: 1.5em
+.. |moveFeaturePoint| image:: /static/common/mActionMoveFeaturePoint.png
+   :width: 1.5em
 .. |multiEdit| image:: /static/common/mActionMultiEdit.png
    :width: 1.5em
 .. |newBookmark| image:: /static/common/mActionNewBookmark.png
@@ -775,6 +788,8 @@ open the Plugin Manager dialog.
 .. |newMap| image:: /static/common/mActionNewMap.png
    :width: 1.5em
 .. |newReport| image:: /static/common/mActionNewReport.png
+   :width: 1.5em
+.. |newTableRow| image:: /static/common/mActionNewTableRow.png
    :width: 1.5em
 .. |nodeTool| image:: /static/common/mActionNodeTool.png
    :width: 1.5em

--- a/source/docs/user_manual/working_with_vector/editing_geometry_attributes.rst
+++ b/source/docs/user_manual/working_with_vector/editing_geometry_attributes.rst
@@ -264,6 +264,7 @@ unless :guilabel:`Show markers only for selected features` option under
    check that your data source can accept all the changes.
 
 .. index:: Adding features
+.. _add_feature:
 
 Adding Features
 ---------------
@@ -331,6 +332,7 @@ move existing features.
 
 
 .. index:: Vertex tool
+.. _vertex_tool:
 
 Vertex tool
 -----------
@@ -473,6 +475,7 @@ them altogether.
 
    Vertex editor panel showing selected nodes
 
+.. _clipboard_feature:
 
 Cutting, Copying and Pasting Features
 -------------------------------------
@@ -545,6 +548,8 @@ make sure the schemas match.
    the GDAL Shapefile driver starting with GDAL/OGR 1.10 knows to auto-extend string
    and integer fields to dynamically accommodate for the length of the data to be inserted.
 
+.. _delete_feature:
+
 Deleting Selected Features
 --------------------------
 
@@ -594,6 +599,7 @@ To use the undo/redo history widget, simply click to select an operation in
 the history list. All features will be reverted to the state they were in
 after the selected operation.
 
+.. _save_feature_edits:
 
 Saving Edited Layers
 --------------------
@@ -707,6 +713,7 @@ Feature(s)` icon.
 
 .. index::
    single: Digitizing tools; Simplify Feature
+.. _simplify_feature:
 
 Simplify Feature
 ----------------
@@ -736,6 +743,7 @@ To abort feature simplification, you need to click on |simplifyFeatures|
 
 .. index:: Geometryless feature, Multipoint, Multiline, Multipolygon
    single: Digitizing tools; Add Part
+.. _add_part:
 
 Add Part
 --------
@@ -751,6 +759,7 @@ geometry with the |addPart| :sup:`Add Part` tool.
 
 .. index::
    single: Digitizing tools; Delete Part
+.. _delete_part:
 
 Delete Part
 -----------
@@ -764,6 +773,7 @@ To delete a part, simply click within the target part.
 
 .. index::
    single: Digitizing tools; Add Ring
+.. _add_ring:
 
 Add Ring
 --------
@@ -781,6 +791,7 @@ as a ring polygon.
 
 .. index::
    single: Digitizing tools; Fill Ring
+.. _fill_ring:
 
 Fill Ring
 ---------
@@ -794,6 +805,7 @@ first use the |addRing| :sup:`Add Ring` icon and then the
 
 .. index::
    single: Digitizing tools; Delete Ring
+.. _delete_ring:
 
 Delete Ring
 -----------
@@ -806,6 +818,7 @@ change anything when it is used on the outer ring of the polygon.
 .. index::
    single: Digitizing tools; Reshape Feature
    single: Digitizing tools; Extend lines
+.. _reshape_feature:
 
 Reshape Features
 ----------------
@@ -856,6 +869,7 @@ invalid polygon.
 
 .. index::
    single: Digitizing tools; Offset Curves
+.. _offset_curve:
 
 Offset Curves
 -------------
@@ -879,6 +893,7 @@ you to configure some parameters like **Join style**, **Quadrant segments**,
 
 .. index::
    single: Digitizing tools; Split Features
+.. _split_feature:
 
 Split Features
 --------------
@@ -889,6 +904,7 @@ icon on the toolbar. Just draw a line across the feature you want to split.
 
 .. index::
    single: Digitizing tools; Split Parts
+.. _split_part:
 
 Split parts
 -----------
@@ -945,6 +961,7 @@ attributes are made identical.
 
 .. index::
    single: Digitizing tools; Rotate Point Symbols
+.. _rotate_symbol:
 
 Rotate Point Symbols
 --------------------
@@ -983,6 +1000,7 @@ field is updated in the layer's attribute table.
 
 .. index::
    single: Digitizing tools; Offset Point Symbols
+.. _offset_symbol:
 
 Offset Point Symbols
 --------------------


### PR DESCRIPTION
Also update tools references: because many tools have recently moved to another toolbar, using the tool's direct reference instead of the toolbar's ensures we will always reach the tool section and not a wrong chapter