### PR TITLE
Documents new possibility to search for and zoom to bookmarks in the locator

### DIFF
--- a/source/docs/user_manual/introduction/general_tools.rst
+++ b/source/docs/user_manual/introduction/general_tools.rst
@@ -690,6 +690,7 @@ panel allows you to:
   computers you can use the :guilabel:`Import/Export Bookmarks` pull down menu
   in the :guilabel:`Spatial Bookmarks` dialog. All the bookmarks are transferred.
 
+You can also zoom to saved bookmarks by typing the bookmark name in the :ref:`locator <label_statusbar>`.
 
 .. index:: Decorations
 .. _decorations:


### PR DESCRIPTION
From QGIS 3.2. it is possible to zoom to bookmarks in the new locator. This PR add one line regarding this new possibility to the documentation.
The new feature (https://github.com/qgis/QGIS/pull/6418) is not included in any issues in the QGIS documentation GitHub repository.