### PR TITLE
Use Symbology instead of Style for layer properties tab

### DIFF
--- a/source/docs/training_manual/basic_map/symbology.rst
+++ b/source/docs/training_manual/basic_map/symbology.rst
@@ -37,7 +37,7 @@ begin by changing the color of the :guilabel:`landuse` layer.
 
 In the :guilabel:`Properties` window:
 
-* Select the :guilabel:`Style` tab at the extreme left:
+* Select the :guilabel:`Symbology` tab at the extreme left:
 
 .. image:: img/layer_properties_style.png
    :align: center
@@ -71,7 +71,7 @@ areas so as to make the map less visually cluttered.
 * Open the :guilabel:`Layer Properties` window for the :guilabel:`landuse`
   layer.
 
-Under the :guilabel:`Style` tab, you will see the same kind of dialog as
+Under the :guilabel:`Symbology` tab, you will see the same kind of dialog as
 before. This time, however, you're doing more than just quickly changing the
 color.
 
@@ -265,7 +265,7 @@ not rendered above another.
 When you're done, remember to save the symbol itself so as not to lose your
 work if you change the symbol again in the future. You can save your current
 symbol style by clicking the :guilabel:`Save Style ...` button under the
-:guilabel:`Style` tab of the :guilabel:`Layer Properties` dialog. Generally, you
+:guilabel:`Symbology` tab of the :guilabel:`Layer Properties` dialog. Generally, you
 should save as :guilabel:`QGIS Layer Style File`.
 
 Save your style under :kbd:`exercise_data/styles`.  You can load a
@@ -479,7 +479,7 @@ First, we'll change the canvas to a size appropriate for a small texture.
 In QGIS:
 
 * Open the :guilabel:`Layer Properties` for the :file:`landuse` layer.
-* In the :guilabel:`Style` tab, change the symbol structure by selecting ``SVG Fill``
+* In the :guilabel:`Symbology` tab, change the symbol structure by selecting ``SVG Fill``
   as :guilabel:`Symbol Layer Type` option, as shown below.
 * Click the |browseButton| :guilabel:`Browse` button to select your SVG image.
   It's added to the symbol tree and you can now customize its different

--- a/source/docs/training_manual/basic_map/symbology.rst
+++ b/source/docs/training_manual/basic_map/symbology.rst
@@ -37,7 +37,7 @@ begin by changing the color of the :guilabel:`landuse` layer.
 
 In the :guilabel:`Properties` window:
 
-* Select the :guilabel:`Symbology` tab at the extreme left:
+* Select the :guilabel:`Symbology` tab:
 
 .. image:: img/layer_properties_style.png
    :align: center

--- a/source/docs/training_manual/complete_analysis/analysis_exercise.rst
+++ b/source/docs/training_manual/complete_analysis/analysis_exercise.rst
@@ -123,7 +123,7 @@ Changing the symbology of vector layers
 
 * In the :guilabel:`Layers list`, right-click on the :guilabel:`Streets` layer.
 * Select :guilabel:`Properties` from the menu that appears.
-* Switch to the :guilabel:`Style` tab in the dialog that appears.
+* Switch to the :guilabel:`Symbology` tab in the dialog that appears.
 * Click on the button labelled :guilabel:`Change`, with a square showing the
   current color of the :guilabel:`Streets` layer.
 * Select a new color in the dialog that appears.
@@ -139,7 +139,7 @@ Changing the symbology of raster layers
 Raster layer symbology is somewhat different.
 
 * Open the :guilabel:`Properties` dialog for the :guilabel:`Rainfall` raster.
-* Switch to the :guilabel:`Style` tab. You'll notice that this style dialog is
+* Switch to the :guilabel:`Symbology` tab. You'll notice that this dialog is
   very different from the version used for vector layers.
 * Ensure that the button :guilabel:`Use standard deviation` is selected.
 * Change the value in the associated box to :kbd:`2.00` (it should be set to
@@ -346,7 +346,7 @@ as follows.
 
 * Open the layer :guilabel:`Properties` dialog (as usual, via the right-click
   menu of the layer).
-* Click on the :guilabel:`Style` tab.
+* Click on the :guilabel:`Symbology` tab.
 * Where it says :guilabel:`Grayscale` (in the :guilabel:`Color map` dropdown
   menu), change it to :guilabel:`Pseudocolor`.
 * Ensure that the :guilabel:`Use standard deviation` radio button is selected. 
@@ -409,7 +409,7 @@ correctly). To properly display raster data with only two classes (:kbd:`1` and
 Setting the style for the reclassified layers
 -------------------------------------------------------------------------------
 
-* Open the :guilabel:`Style` tab in the layer's :guilabel:`Properties` dialog
+* Open the :guilabel:`Symbology` tab in the layer's :guilabel:`Properties` dialog
   as usual.
 * Under the heading :guilabel:`Load min / max values from band`, select the
   :guilabel:`Actual (slower)` radio button.

--- a/source/docs/training_manual/forestry/results_map.rst
+++ b/source/docs/training_manual/forestry/results_map.rst
@@ -32,8 +32,8 @@ For the :kbd:`forest_stands_2012_results` layer:
 
 Now you can use a saved style for this layer:
 
-* Go to the :guilabel:`Style` tab.
-* Click on :guilabel:`Load Style`.
+* Go to the :guilabel:`Symbology` tab.
+* Click on :menuselection:`Style --> Load Style...`.
 * Select the :kbd:`forest_stands_2012_results.qml` from the :kbd:`exercise_data\\forestry\\results\\` folder.
 * Click :guilabel:`OK`.
 

--- a/source/docs/training_manual/forestry/stands_digitazing.rst
+++ b/source/docs/training_manual/forestry/stands_digitazing.rst
@@ -97,7 +97,7 @@ Now you can remove the :guilabel:`rautjarvi_green_polygon` layer from the TOC.
 Change the symbology of the centroids layer as:
 
 * Open the :guilabel:`Layer Properties` for :guilabel:`green_centroids`.
-* Go to the :guilabel:`Style` tab.
+* Go to the :guilabel:`Symbology` tab.
 * Set the :guilabel:`Unit` to Map unit.
 * Set the :guilabel:`Size` to 1.
 

--- a/source/docs/training_manual/rasters/changing_symbology.rst
+++ b/source/docs/training_manual/rasters/changing_symbology.rst
@@ -42,7 +42,7 @@ purposes, and we will learn more about how this works as we continue.
 * Open the :guilabel:`Layer Properties` dialog for the :guilabel:`SRTM` layer
   by right-clicking on the layer in the Layer tree and selecting
   :guilabel:`Properties` option.
-* Switch to the :guilabel:`Style` tab.
+* Switch to the :guilabel:`Symbology` tab.
 
 .. image:: img/dem_layer_properties.png
    :align: center

--- a/source/docs/training_manual/vector_classification/classification.rst
+++ b/source/docs/training_manual/vector_classification/classification.rst
@@ -22,7 +22,7 @@ are numerous different landuse areas on the map.
 -------------------------------------------------------------------------------
 
 * Open the :guilabel:`Layer Properties` dialog for the :guilabel:`landuse` layer.
-* Go to the :guilabel:`Style` tab.
+* Go to the :guilabel:`Symbology` tab.
 * Click on the dropdown that says :guilabel:`Single Symbol` and change it to
   :guilabel:`Categorized`:
 
@@ -53,7 +53,7 @@ Now our landuse polygons are appropriately colored and are classified so that
 areas with the same land use are the same color. You may wish to remove the
 black border from the :guilabel:`landuse` layer:
 
-* Open :guilabel:`Layer Properties`, go to the :guilabel:`Style` tab and select
+* Open :guilabel:`Layer Properties`, go to the :guilabel:`Symbology` tab and select
   :guilabel:`Symbol`.
 * Change the symbol by removing the border from the :guilabel:`Simple Fill`
   layer and click :guilabel:`OK`.
@@ -116,12 +116,12 @@ town that it is administered by. Now we will use ratio classification to
 classify the farms by area.
 
 * Save your landuse symbology (if you want to keep it) by clicking on the
-  :guilabel:`Save Style ...` button in the :guilabel:`Style` dialog.
+  :guilabel:`Save Style ...` button in the :guilabel:`Style` drop-down menu.
 
 We're going to reclassify the layer, so existing classes will be lost if not
 saved.
 
-* Close the :guilabel:`Style` dialog.
+* Close the :guilabel:`Layer Properties` dialog.
 * Open the Attributes Table for the :guilabel:`landuse` layer.
 
 We want to classify the landuse areas by size, but there's a problem: they don't
@@ -181,7 +181,7 @@ column header to refresh the data). Save the edits and click :guilabel:`Ok`.
 .. note::  These areas are in degrees. Later, we will compute them in
    square meters.
 
-* Open the :guilabel:`Layer properties` dialog's :guilabel:`Style` tab.
+* Open the :guilabel:`Layer properties` dialog's :guilabel:`Symbology` tab.
 * Change the classification style from :guilabel:`Categorized` to
   :guilabel:`Graduated`.
 
@@ -245,7 +245,7 @@ unfortunately normal classification only takes one attribute into account.
 That's where rule-based classification comes in handy.
 
 * Open the :guilabel:`Layer Properties` dialog for the :guilabel:`landuse` layer.
-* Switch to the :guilabel:`Style` tab.
+* Switch to the :guilabel:`Symbology` tab.
 * Switch the classification style to :guilabel:`Rule-based`. You'll get this:
 
 .. image:: img/rule_based_classification.png

--- a/source/docs/user_manual/introduction/getting_started.rst
+++ b/source/docs/user_manual/introduction/getting_started.rst
@@ -346,7 +346,7 @@ We will use:
 #. Zoom to your favourite area with some lakes.
 #. Double click the :file:`lakes` layer in the map legend to open the
    :guilabel:`Properties` dialog.
-#. Click on the :guilabel:`Style` tab and select a blue as fill color.
+#. Click on the :guilabel:`Symbology` tab and select a blue as fill color.
 #. Click on the :guilabel:`Labels` tab and select :guilabel:`Show labels for
    this layer` in the drop-down menu to enable labeling. Then from the
    :guilabel:`Label with` list, choose the ``NAMES`` field as the field containing labels.

--- a/source/docs/user_manual/working_with_raster/raster_properties.rst
+++ b/source/docs/user_manual/working_with_raster/raster_properties.rst
@@ -21,7 +21,7 @@ dialog (see figure_raster_properties_).
 There are several tabs in the dialog:
 
 * :guilabel:`Source`
-* :guilabel:`Style`
+* :guilabel:`Symbology`
 * :guilabel:`Transparency`
 * :guilabel:`Histogram`
 * :guilabel:`Rendering`
@@ -80,8 +80,8 @@ layer <general_saveas>`.
 
 .. _label_symbology:
 
-Style Properties
-----------------
+Symbology Properties
+--------------------
 
 Band rendering
 ..............
@@ -115,7 +115,7 @@ to MinMax' and 'Clip to min max'.
 .. figure:: img/rasterMultibandColor.png
    :align: center
 
-   Raster Style - Multiband color rendering
+   Raster Symbology - Multiband color rendering
 
 This selection offers you a wide range of options to modify the appearance
 of your raster layer. First of all, you have to get the data range from your
@@ -164,7 +164,7 @@ The label appears in the legend of the raster layer then.
 .. figure:: img/rasterPaletted.png
    :align: center
 
-   Raster Style - Paletted Rendering
+   Raster Symbology - Paletted Rendering
 
 .. index:: Contrast enhancement
 
@@ -190,7 +190,7 @@ the :guilabel:`Min` and :guilabel:`Max` values of the bands or use the
 .. figure:: img/rasterSingleBandGray.png
    :align: center
 
-   Raster Style - Singleband gray rendering
+   Raster Symbology - Singleband gray rendering
 
 
 With the :guilabel:`Load min/max values` section, scaling of the color table
@@ -219,7 +219,7 @@ You can also create individual color maps for the single bands here.
 .. figure:: img/rasterSingleBandPseudocolor.png
    :align: center
 
-   Raster Style - Singleband pseudocolor rendering
+   Raster Symbology - Singleband pseudocolor rendering
 
 
 Three types of color interpolation are available:
@@ -290,7 +290,7 @@ matrix through a geometric transformation.
 .. figure:: img/rasterRenderAndRessampling.png
    :align: center
 
-   Raster Style - Color rendering and Resampling settings
+   Raster Symbology - Color rendering and Resampling settings
 
 
 When applying the 'Nearest neighbour' method, the map can have a pixelated
@@ -299,7 +299,7 @@ structure when zooming in. This appearance can be improved by using the
 The effect is a smoother image. This method can be applied, for instance,
 to digital topographic raster maps.
 
-At the bottom of the :guilabel:`Style` tab, you can see a thumbnail of the layer,
+At the bottom of the :guilabel:`Symbology` tab, you can see a thumbnail of the layer,
 its legend symbol, and the palette.
 
 .. index:: Transparency

--- a/source/docs/user_manual/working_with_vector/vector_properties.rst
+++ b/source/docs/user_manual/working_with_vector/vector_properties.rst
@@ -416,7 +416,7 @@ available modes are:
   are 1, 2 or 5 times a power of 10. (based on pretty from the R statistical
   environment http://astrostatistics.psu.edu/datasets/R/html/base/html/pretty.html)
 
-The listbox in the center part of the :guilabel:`Style` tab lists the classes
+The listbox in the center part of the :guilabel:`Symbology` tab lists the classes
 together with their ranges, labels and symbols that will be rendered.
 
 Click on **Classify** button to create classes using the chosen mode. Each


### PR DESCRIPTION
for vector (Fixes #1431) and raster (refs https://github.com/qgis/QGIS/pull/7275)