### PR TITLE
Update description of the plugin author email metadata tag

### DIFF
--- a/source/docs/pyqgis_developer_cookbook/plugins.rst
+++ b/source/docs/pyqgis_developer_cookbook/plugins.rst
@@ -152,7 +152,7 @@ description            True      short text which describes the plugin, no HTML 
 about                  True      longer text which describes the plugin in details, no HTML allowed
 version                True      short string with the version dotted notation
 author                 True      author name
-email                  True      email of the author, not shown in the QGIS plugin manager or in the website unless by a registered logged in user, so only visible to other plugin authors and plugin website administrators
+email                  True      email of the author, not shown in the website unless by a registered logged in user, but accessible in the Plugin Manager after the plugin is installed
 changelog              False     string, can be multiline, no HTML allowed
 experimental           False     boolean flag, `True` or `False`
 deprecated             False     boolean flag, `True` or `False`, applies to the whole plugin and not just to the uploaded version

--- a/source/docs/pyqgis_developer_cookbook/plugins.rst
+++ b/source/docs/pyqgis_developer_cookbook/plugins.rst
@@ -152,7 +152,7 @@ description            True      short text which describes the plugin, no HTML 
 about                  True      longer text which describes the plugin in details, no HTML allowed
 version                True      short string with the version dotted notation
 author                 True      author name
-email                  True      email of the author, not shown in the website unless by a registered logged in user, but accessible in the Plugin Manager after the plugin is installed
+email                  True      email of the author, only shown on the website to logged in users, but visible in the Plugin Manager after the plugin is installed
 changelog              False     string, can be multiline, no HTML allowed
 experimental           False     boolean flag, `True` or `False`
 deprecated             False     boolean flag, `True` or `False`, applies to the whole plugin and not just to the uploaded version


### PR DESCRIPTION
Fix a mistaken statement that the email addresses are not visible in the Plugin Manager. A better wording welcome... 

See also:
 - https://issues.qgis.org/issues/19239  
 - http://osgeo-org.1560.x6.nabble.com/Qgis-community-team-Plugin-author-emails-after-the-GDPR-apocalypse-td5368840.html
 - http://osgeo-org.1560.x6.nabble.com/How-do-I-specify-multiple-plugin-authors-td5239517.html

CC @timlinux @pcav @tomchadwin @elpaso