### PR TITLE
Fixes #2743: Standardise the style of keyboard shortcuts

### DIFF
--- a/source/docs/documentation_guidelines/writing.rst
+++ b/source/docs/documentation_guidelines/writing.rst
@@ -107,9 +107,9 @@ You can use some tags inside the text to emphasize some items.
 
   .. code-block:: rst
 
-     :kbd:`ctrl B`
+     :kbd:`Ctrl+B`
 
-  will show :kbd:`Ctrl B`
+  will show :kbd:`Ctrl+B`
 
 
 * **User text**

--- a/source/docs/training_manual/basic_map/symbology.rst
+++ b/source/docs/training_manual/basic_map/symbology.rst
@@ -460,7 +460,7 @@ First, we'll change the canvas to a size appropriate for a small texture.
 
 * Draw a line using the :guilabel:`Pencil` tool:
 
-  * Click once to start the line. Hold :kbd:`ctrl` to make it snap to increments
+  * Click once to start the line. Hold :kbd:`Ctrl` to make it snap to increments
     of 15 degrees.
   * Move the pointer horizontally and place a point with a simple click.
   * Click and snap to the vertex of the line and trace a vertical line, ended

--- a/source/docs/training_manual/create_vector_data/create_new_vector.rst
+++ b/source/docs/training_manual/create_vector_data/create_new_vector.rst
@@ -199,7 +199,7 @@ You can use:
   miss-clicked,
 * :guilabel:`Delete Selected` to get rid of the feature entirely so you can try
   again, and
-* the :menuselection:`Edit --> Undo` menu item or the :kbd:`ctrl + z` keyboard
+* the :menuselection:`Edit --> Undo` menu item or the :kbd:`Ctrl+Z` keyboard
   shortcut to undo mistakes.
 
 |basic| |TY|

--- a/source/docs/training_manual/database_concepts/data_model.rst
+++ b/source/docs/training_manual/database_concepts/data_model.rst
@@ -119,7 +119,7 @@ Should return something like this::
     template1 | postgres | UTF8     | en_ZA.utf8 | en_ZA.utf8 |
     (3 rows)
 
-Type :kbd:`q` to exit.
+Type :kbd:`Q` to exit.
 
 Create a database
 -------------------------------------------------------------------------------
@@ -149,7 +149,7 @@ Which should return something like this:
   template1 | postgres | UTF8     | en_ZA.utf8 | en_ZA.utf8 | =c/postgres: postgres=CTc/postgres
   (4 rows)
 
-Type :kbd:`q` to exit.
+Type :kbd:`Q` to exit.
 
 Starting a database shell session
 -------------------------------------------------------------------------------

--- a/source/docs/training_manual/map_composer/map_composer.rst
+++ b/source/docs/training_manual/map_composer/map_composer.rst
@@ -137,7 +137,7 @@ However, there is also a tool to help position the title relative to the map
 |alignLeft|
 
 * Click the map to select it.
-* Hold in :kbd:`shift` on your keyboard and click on the label so that both the
+* Hold in :kbd:`Shift` on your keyboard and click on the label so that both the
   map and the label are selected.
 * Look for the :guilabel:`Align` button |alignLeft| and click on the
   dropdown arrow next to it to reveal the positioning options and click

--- a/source/docs/training_manual/rasters/data_manipulation.rst
+++ b/source/docs/training_manual/rasters/data_manipulation.rst
@@ -32,7 +32,7 @@ environment.
 The :guilabel:`Load Raster Layer` dialog will open. The data for this project
 is in :kbd:`exercise_data/raster`.
 
-* Either load them all in separately, or hold down :kbd:`ctrl` and click on all
+* Either load them all in separately, or hold down :kbd:`Ctrl` and click on all
   four of them in turn, then open them at the same time.
 
 The first thing you'll notice is that nothing seems to be happening in your

--- a/source/docs/training_manual/spatial_databases/spatial_functions.rst
+++ b/source/docs/training_manual/spatial_databases/spatial_functions.rst
@@ -104,7 +104,7 @@ already connected to the ``address`` database, do so now. Then run:
   \df *point*
 
 This is the command we're looking for: :kbd:`st_pointfromtext`.  To page through
-the list, use the down arrow, then press :kbd:`q` to quit back to the psql shell.
+the list, use the down arrow, then press :kbd:`Q` to quit back to the psql shell.
 
 Try running this command:
 

--- a/source/docs/user_manual/introduction/general_tools.rst
+++ b/source/docs/user_manual/introduction/general_tools.rst
@@ -614,9 +614,9 @@ should be displayed` checkbox. Any layer subsequently added to the map will be o
 Stopping Rendering
 ^^^^^^^^^^^^^^^^^^
 
-To stop the map drawing, press the :kbd:`ESC` key. This will halt the refresh of
+To stop the map drawing, press the :kbd:`Esc` key. This will halt the refresh of
 the map canvas and leave the map partially drawn. It may take a bit of time
-between pressing :kbd:`ESC` and the time the map drawing is halted.
+between pressing :kbd:`Esc` and the time the map drawing is halted.
 
 .. note::
    It is currently not possible to stop rendering --- this was disabled in the Qt4
@@ -694,7 +694,7 @@ arrow key to pan south.
 You can also use the space bar to temporarily cause mouse movements to pan
 the map. The :kbd:`PgUp` and :kbd:`PgDown` keys on your keyboard will cause
 the map display to zoom in or out following the zoom factor set. Pressing
-:kbd:`Ctrl +` or :kbd:`Ctrl -` also performs an immediate zoom in/out
+:kbd:`Ctrl++` or :kbd:`Ctrl+-` also performs an immediate zoom in/out
 on the map canvas.
 
 When certain map tools are active (Identify, Measure...), you can perform a zoom by
@@ -723,7 +723,7 @@ To create a bookmark:
 
 #. Zoom or pan to the area of interest.
 #. Select the menu option :menuselection:`View --> New Bookmark` or press
-   :kbd:`Ctrl-B`. The Spatial Bookmark panel opens with the newly created bookmark.
+   :kbd:`Ctrl+B`. The Spatial Bookmark panel opens with the newly created bookmark.
 #. Enter a descriptive name for the bookmark (up to 255 characters).
 #. Check the :guilabel:`In Project` box if you wish to save the bookmark in the project file.
 #. Press :kbd:`Enter` to add the bookmark or click elsewhere.
@@ -993,7 +993,7 @@ moved by map position (by dragging the map marker) or by moving only the balloon
 Also the |annotation| :sup:`Move Annotation` tool allows you to move the
 balloon on the map canvas.
 
-To delete an annotation, select it and either press the :kbd:`DEL` or :kbd:`Backspace`
+To delete an annotation, select it and either press the :kbd:`Del` or :kbd:`Backspace`
 button or either double-click and press the **[Delete]** button in its properties dialog.
 
 .. note::
@@ -1179,7 +1179,7 @@ For the other tools, different behaviors can be performed holding:
 
 * :kbd:`Shift`: add features to the current selection
 * :kbd:`Ctrl`: substract features from the current selection
-* :kbd:`Ctrl + Shift`: intersect with current selection, ie only keep
+* :kbd:`Ctrl+Shift`: intersect with current selection, ie only keep
   overlapping features from the current selection
 * :kbd:`Alt`: select features that are totally within the selection shape.
   Combined to :kbd:`Shift` or :kbd:`Ctrl` keys, you can add or substract
@@ -1307,7 +1307,7 @@ The Identify tool allows you to interact with the map canvas and get information
 on features in a pop-up window. To identify features, use:
 
 * :menuselection:`View --> Identify Features` menu,
-* or press :kbd:`Ctrl + Shift + I` (or |osx| :kbd:`Cmd + Shift + I`),
+* or press :kbd:`Ctrl+Shift+I` (or |osx| :kbd:`Cmd+Shift+I`),
 * or click the |identify| :sup:`Identify Features` icon on the Attributes toolbar.
 
 Using the Identify Features tool

--- a/source/docs/user_manual/print_composer/composer_items/composer_items_shape.rst
+++ b/source/docs/user_manual/print_composer/composer_items/composer_items_shape.rst
@@ -149,7 +149,7 @@ selected node can be moved either by dragging it or by using the arrow keys.
 Moreover, in this mode, you are able to add nodes to an existing shape:
 double-click on a segment and a node is added at the place you click.
 Finally, you can remove the currently selected node by
-hitting the :kbd:`DEL` key.
+hitting the :kbd:`Del` key.
 
 
 .. Substitutions definitions - AVOID EDITING PAST THIS LINE

--- a/source/docs/user_manual/working_with_vector/editing_geometry_attributes.rst
+++ b/source/docs/user_manual/working_with_vector/editing_geometry_attributes.rst
@@ -211,7 +211,7 @@ With the automatic tracing mode, you can speed up the digitization process as
 you no longer need to manually place all the vertices during digitization:
 
 #. Enable the |tracing| :sup:`Tracing` tool by pushing the icon or pressing
-   :kbd:`t` key;
+   :kbd:`T` key;
 #. :ref:`Snap to <snapping_tolerance>` a vertex or segment of a feature you
    want to trace along;
 #. Move the mouse over another vertex or segment you'd like to snap and, instead
@@ -237,9 +237,9 @@ and a negative value does the opposite.
    potentially long tracing structure preparation and large memory overhead.
    After zooming in or disabling some layers the tracing is enabled again.
 
-.. tip:: **Quickly enable or disable automatic tracing by pressing** :kbd:`t` **key**
+.. tip:: **Quickly enable or disable automatic tracing by pressing** :kbd:`T` **key**
 
-   By pressing :kbd:`t` key, tracing can be enabled/disabled anytime even while
+   By pressing :kbd:`T` key, tracing can be enabled/disabled anytime even while
    digitizing one feature, so it is possible to digitize some parts of the feature
    with tracing enabled and other parts with tracing disabled.
    Tools behave as usual when tracing is disabled.
@@ -434,7 +434,7 @@ when hovering vertices.
   hold down :kbd:`Ctrl`.
 
 * **Batch vertex selection mode**:
-  The batch selection mode can be activated by pressing :kbd:`Shift + R`.
+  The batch selection mode can be activated by pressing :kbd:`Shift+R`.
   Select a first node with one single click, and then hover **without clicking**
   another vertex. This will dynamically select all the nodes in
   between using the shortest path (for polygons).
@@ -444,7 +444,7 @@ when hovering vertices.
   .. figure:: img/vertex_batch_selection_mode.png
      :align: center
 
-     Batch vertex selection using :kbd:`Shift + R`
+     Batch vertex selection using :kbd:`Shift+R`
 
 
   Press :kbd:`Ctrl` will invert the selection, selecting the longest path
@@ -1219,19 +1219,19 @@ To speed up the use of Advanced Digitizing Panel, there are a couple of keyboard
 shorcuts available:
 
 +----------+-------------------+-------------------------------+---------------------------------------+
-| Key      | Simple            | :kbd:`Ctrl +` or :kbd:`Alt +` | :kbd:`Shift +`                        |
+| Key      | Simple            | :kbd:`Ctrl+` or :kbd:`Alt+` | :kbd:`Shift+`                        |
 +==========+===================+===============================+=======================================+
-| :kbd:`d` | Set distance      | Lock distance                 | \                                     |
+| :kbd:`D` | Set distance      | Lock distance                 | \                                     |
 +----------+-------------------+-------------------------------+---------------------------------------+
-| :kbd:`a` | Set angle         | Lock angle                    | Toggle relative angle to last segment |
+| :kbd:`A` | Set angle         | Lock angle                    | Toggle relative angle to last segment |
 +----------+-------------------+-------------------------------+---------------------------------------+
-| :kbd:`x` | Set x coordinate  | Lock x coordinate             | Toggle relative x to last vertex      |
+| :kbd:`X` | Set x coordinate  | Lock x coordinate             | Toggle relative x to last vertex      |
 +----------+-------------------+-------------------------------+---------------------------------------+
-| :kbd:`y` | Set y coordinate  | Lock y coordinate             | Toggle relative y to last vertex      |
+| :kbd:`Y` | Set y coordinate  | Lock y coordinate             | Toggle relative y to last vertex      |
 +----------+-------------------+-------------------------------+---------------------------------------+
-| :kbd:`c` | Toggle construction mode                                                                  |
+| :kbd:`C` | Toggle construction mode                                                                  |
 +----------+-------------------------------------------------------------------------------------------+
-| :kbd:`p` | Toggle perpendicular and parallel modes                                                   |
+| :kbd:`P` | Toggle perpendicular and parallel modes                                                   |
 +----------+-------------------------------------------------------------------------------------------+
 
 Absolute reference digitizing
@@ -1266,7 +1266,7 @@ You can continue digitizing by free hand, adding a new pair of coordinates, or
 you can type the segment's **length** (distance) and **angle**.
 
 If you want to draw a segment of a given length, click the :guilabel:`d
-(distance)` text box (keyboard shortcut :kbd:`d`), type the distance value (in
+(distance)` text box (keyboard shortcut :kbd:`D`), type the distance value (in
 map units) and press :kbd:`Enter` or click the |locked| button on the right to
 lock the mouse in the map canvas to the length of the segment.
 In the map canvas, the clicked point is surrounded by a circle whose radius is
@@ -1278,7 +1278,7 @@ the value entered in the distance text box.
    Fixed length segment
 
 Finally, you can also choose the angle of the segment. As described before ,
-click the :guilabel:`a (angle)` text box (keyboard shortcut :kbd:`a`), type the
+click the :guilabel:`a (angle)` text box (keyboard shortcut :kbd:`A`), type the
 angle value (in degrees), and press :kbd:`Enter` or click the |locked| buttons
 on the right to lock it. In this way the segment will follow the desired angle:
 
@@ -1294,12 +1294,12 @@ Instead of using absolute values of angles or coordinates, you can also use
 values relative to the last digitized vertex or segment.
 
 For angles, you can click the |delta| button on the left of the :guilabel:`a`
-text box (or press :kbd:`Shift + a`) to toggle relative angles to the previous
+text box (or press :kbd:`Shift+A`) to toggle relative angles to the previous
 segment. With that option on, angles are measured between the last segment
 and the mouse pointer.
 
 For coordinates, click the |delta| buttons to the left of the :guilabel:`x` or
-:guilabel:`y` text boxes (or press :kbd:`Shift + x` or :kbd:`Shift + y`) to
+:guilabel:`y` text boxes (or press :kbd:`Shift+X` or :kbd:`Shift+Y`) to
 toggle relative coordinates to the previous vertex. With these options on,
 coordinates measurement will consider the last vertex to be the x and y axes
 origin.
@@ -1321,7 +1321,7 @@ All the tools described above can be combined with the |cadPerpendicular|
 allow drawing segments perfectly perpendicular or parallel to another segment.
 
 To draw a *perpendicular* segment, during the editing click the
-|cadPerpendicular| :sup:`Perpendicular` icon (keyboard shortcut :kbd:`p`) to
+|cadPerpendicular| :sup:`Perpendicular` icon (keyboard shortcut :kbd:`P`) to
 activate it. Before drawing the perpendicular line,
 click on the segment of an existing feature that you want to be perpendicular
 to (the line of the existing feature will be colored in light orange); you
@@ -1333,7 +1333,7 @@ should see a blue dotted line where your feature will be snapped:
    Perpendicular digitizing
 
 To draw a *parallel* feature, the steps are the same: click on the
-|cadParallel| :sup:`Parallel` icon (keyboard shortcut :kbd:`p` twice), click on
+|cadParallel| :sup:`Parallel` icon (keyboard shortcut :kbd:`P` twice), click on
 the segment you want to use as reference and start drawing your feature:
 
 .. figure:: img/advanced_digitizing_parallel.png
@@ -1348,7 +1348,7 @@ Construction mode
 -----------------
 
 You can enable and disable *construction* mode by clicking on the
-|cadConstruction| :sup:`Construction` icon or with the :kbd:`c` keyboard
+|cadConstruction| :sup:`Construction` icon or with the :kbd:`C` keyboard
 shortcut. While in construction mode, clicking the map canvas won't add new
 vertexes, but will capture the clicks' positions so that you can use them as
 reference points to then lock distance, angle or x and y relative values.
@@ -1360,10 +1360,10 @@ With an existing point in the map canvas and the snapping mode correctly
 activated, you can easily draw other points at given distances and angles from
 it. In addition to the |cad| button, you have to activate also the
 *construction* mode by clicking the |cadConstruction| :sup:`Construction`
-icon or with the :kbd:`c` keyboard shortcut.
+icon or with the :kbd:`C` keyboard shortcut.
 
 Click next to the point from which you want to calculate the distance and click
-on the :guilabel:`d` box (:kbd:`d` shortcut) type the desired distance and press
+on the :guilabel:`d` box (:kbd:`D` shortcut) type the desired distance and press
 :kbd:`Enter` to lock the mouse position in the map canvas:
 
 .. figure:: img/advanced_digitizing_distance_point.png
@@ -1371,17 +1371,17 @@ on the :guilabel:`d` box (:kbd:`d` shortcut) type the desired distance and press
 
    Distance from point
 
-Before adding the new point, press :kbd:`c` to exit the construction mode.
+Before adding the new point, press :kbd:`C` to exit the construction mode.
 Now, you can click on the map canvas, and the point will be placed at
 the distance entered.
 
 You can also use the angle constraint to, for example, create another point at
 the same distance of the original one, but at a particular angle from the newly
 added point. Click the |cadConstruction| :sup:`Construction` icon or with the
-:kbd:`c` keyboard shortcut to enter construction mode. Click the recently added
+:kbd:`C` keyboard shortcut to enter construction mode. Click the recently added
 point, and then the other one to set a direction segment. Then, click on the
-:guilabel:`d` text box (:kbd:`d` shortcut) type the desired distance and press
-:kbd:`Enter`. Click the :guilabel:`a` text box (:kbd:`a` shortcut) type the
+:guilabel:`d` text box (:kbd:`D` shortcut) type the desired distance and press
+:kbd:`Enter`. Click the :guilabel:`a` text box (:kbd:`A` shortcut) type the
 angle you want and press :kbd:`Enter`. The mouse position will be locked both in
 distance and angle.
 
@@ -1390,7 +1390,7 @@ distance and angle.
 
    Distance and angle from points
 
-Before adding the new point, press :kbd:`c` to exit the construction mode. Now,
+Before adding the new point, press :kbd:`C` to exit the construction mode. Now,
 you can click on the map canvas, and the point will be placed at the distance
 and angle entered. Repeating the process, several points can be added.
 

--- a/source/docs/user_manual/working_with_vector/editing_geometry_attributes.rst
+++ b/source/docs/user_manual/working_with_vector/editing_geometry_attributes.rst
@@ -1219,7 +1219,7 @@ To speed up the use of Advanced Digitizing Panel, there are a couple of keyboard
 shorcuts available:
 
 +----------+-------------------+-------------------------------+---------------------------------------+
-| Key      | Simple            | :kbd:`Ctrl+` or :kbd:`Alt+` | :kbd:`Shift+`                        |
+| Key      | Simple            | :kbd:`Ctrl+` or :kbd:`Alt+`   | :kbd:`Shift+`                         |
 +==========+===================+===============================+=======================================+
 | :kbd:`D` | Set distance      | Lock distance                 | \                                     |
 +----------+-------------------+-------------------------------+---------------------------------------+

--- a/source/docs/user_manual/working_with_vector/style_library.rst
+++ b/source/docs/user_manual/working_with_vector/style_library.rst
@@ -178,7 +178,7 @@ choose the ramp type:
  :ref:`color-selector` widgets or by plotting each of its parameters. You can also 
  reposition it using the mouse, the arrow keys (combine with :kbd:`Shift` key for
  a larger move) or the :guilabel:`Relative position` spinbox. Pressing :guilabel:`Delete
- stop` as well as :kbd:`DEL` key removes the selected color stop. 
+ stop` as well as :kbd:`Del` key removes the selected color stop.
 
 You can use the |checkbox| :guilabel:`Invert` option while
 classifying the data with a color ramp. See figure_color_custom_ramp_ for an


### PR DESCRIPTION
* remove spaces from key combinations
* change single letter keys to upper case
* special keys capitalised