### PR TITLE
[Processing] Replace [vector] tag by a more accurate tag

### DIFF
--- a/source/docs/user_manual/processing_algs/gdal/rasterconversion.rst
+++ b/source/docs/user_manual/processing_algs/gdal/rasterconversion.rst
@@ -120,7 +120,7 @@ Parameters
 Outputs
 .......
 
-``Output layer`` [vector]
+``Output layer`` [vector: polygon]
   Output vector layer. Default format is \*.shp.
 
 

--- a/source/docs/user_manual/processing_algs/gdal/rasterextraction.rst
+++ b/source/docs/user_manual/processing_algs/gdal/rasterextraction.rst
@@ -139,8 +139,8 @@ Parameters
 Outputs
 .......
 
-``Output file for contour lines (vector)`` [vector]
-  <put output description here>
+``Contours`` [vector: line]
+  Output file for contour lines (vector)
 
 
 .. Substitutions definitions - AVOID EDITING PAST THIS LINE

--- a/source/docs/user_manual/processing_algs/gdal/vectorconversion.rst
+++ b/source/docs/user_manual/processing_algs/gdal/vectorconversion.rst
@@ -66,7 +66,7 @@ Parameters
 Outputs
 .......
 
-``Output layer`` [vector]
+``Output layer`` [vector: any]
   Output vector layer.
 
 

--- a/source/docs/user_manual/processing_algs/gdal/vectorgeoprocessing.rst
+++ b/source/docs/user_manual/processing_algs/gdal/vectorgeoprocessing.rst
@@ -41,7 +41,7 @@ Parameters
 Outputs
 .......
 
-``Output layer`` [vector]
+``Output layer`` [vector: any]
   Output vector layer.
 
 
@@ -71,7 +71,7 @@ Parameters
 Outputs
 .......
 
-``Output layer`` [vector]
+``Output layer`` [vector: any]
   Output vector layer. By default this is an ESRI Shapefile.
 
 

--- a/source/docs/user_manual/processing_algs/gdal/vectormiscellaneous.rst
+++ b/source/docs/user_manual/processing_algs/gdal/vectormiscellaneous.rst
@@ -31,7 +31,7 @@ Parameters
 Outputs
 .......
 
-``SQL result`` [vector]
+``SQL result`` [vector: any]
   <put output description here>
 
 

--- a/source/docs/user_manual/processing_algs/otb/feature_extraction.rst
+++ b/source/docs/user_manual/processing_algs/otb/feature_extraction.rst
@@ -785,7 +785,7 @@ Parameters
 Outputs
 .......
 
-``Output Detected lines`` [vector]
+``Output Detected lines`` [vector: line]
   <put output description here>
 
 Console usage

--- a/source/docs/user_manual/processing_algs/otb/geometry.rst
+++ b/source/docs/user_manual/processing_algs/otb/geometry.rst
@@ -40,7 +40,7 @@ Parameters
 Outputs
 .......
 
-``Output Vector Data`` [vector]
+``Output Vector Data`` [vector: polygon]
   <put output description here>
 
 Console usage

--- a/source/docs/user_manual/processing_algs/otb/segmentation.rst
+++ b/source/docs/user_manual/processing_algs/otb/segmentation.rst
@@ -57,7 +57,7 @@ Parameters
 Outputs
 .......
 
-``Output Shape`` [vector]
+``Output Shape`` [vector: polygon]
   <put output description here>
 
 Console usage
@@ -218,7 +218,7 @@ Parameters
 Outputs
 .......
 
-``Output GIS vector file`` [vector]
+``Output GIS vector file`` [vector: polygon]
   <put output description here>
 
 Console usage

--- a/source/docs/user_manual/processing_algs/otb/vector_data_manipulation.rst
+++ b/source/docs/user_manual/processing_algs/otb/vector_data_manipulation.rst
@@ -28,7 +28,7 @@ Parameters
 Outputs
 .......
 
-``Concatenated VectorData`` [vector]
+``Concatenated VectorData`` [vector: any]
   <put output description here>
 
 Console usage

--- a/source/docs/user_manual/processing_algs/qgis/layertools.rst
+++ b/source/docs/user_manual/processing_algs/qgis/layertools.rst
@@ -37,7 +37,7 @@ Parameters
 Outputs
 .......
 
-``Extent`` [vector]
+``Extent`` [vector: polygon]
   Polygon vector layer
 
 

--- a/source/docs/user_manual/processing_algs/qgis/vectorcreation.rst
+++ b/source/docs/user_manual/processing_algs/qgis/vectorcreation.rst
@@ -77,7 +77,7 @@ Parameters
 Outputs
 .......
 
-``Grid`` [vector]
+``Grid`` [vector: any]
   Resulting grid layer
 
 

--- a/source/docs/user_manual/processing_algs/qgis/vectorgeneral.rst
+++ b/source/docs/user_manual/processing_algs/qgis/vectorgeneral.rst
@@ -69,7 +69,7 @@ Parameters
 
 Outputs
 .......
-``Virtual vector`` [vector]
+``Virtual vector`` [vector: any]
   The final virtual vector made by all the source vector chosen
 
 
@@ -154,7 +154,7 @@ Parameters
 
 Outputs
 .......
-``Cleaned`` [vector]
+``Cleaned`` [vector: any]
   The final layer without any duplicated geometries
 
 
@@ -223,7 +223,7 @@ Parameters
 
 Outputs
 .......
-``SQL Output`` [vector]
+``SQL Output`` [vector: any]
   Vector layer created by the query
 
 
@@ -311,7 +311,7 @@ Parameters
 
 Outputs
 .......
-``Joined layer`` [vector]
+``Joined layer`` [vector: any]
   Final vector layer with the attribute table as result of the joining
 
 
@@ -372,7 +372,7 @@ Parameters
 
 Outputs
 .......
-``Joined layer`` [vector]
+``Joined layer`` [vector: any]
   The final vector with all the joined features.
 
 .. _qgisjoinbylocationsummary:
@@ -446,7 +446,7 @@ Parameters
 
 Outputs
 .......
-``Joined layer`` [vector]
+``Joined layer`` [vector: any]
   The final vector with all the joined features.
 
 
@@ -489,7 +489,7 @@ Parameters
 Outputs
 .......
 
-``Merged`` [vector]
+``Merged`` [vector: any]
   Merged vector layer containing all the features and attributes from input layers
 
 See also
@@ -530,7 +530,7 @@ Parameters
 Outputs
 .......
 
-``Output layer`` [vector]
+``Output layer`` [vector: any]
   Sorted vector layer
 
 
@@ -555,7 +555,7 @@ Parameters
 Outputs
 .......
 
-``Reprojected layer`` [vector]
+``Reprojected layer`` [vector: any]
   The resulting reprojected layer.
 
 See also
@@ -578,7 +578,7 @@ Parameters
 Outputs
 .......
 
-``Selection`` [vector]
+``Selection`` [vector: any]
   Vector layer with just the selected features.
 
 

--- a/source/docs/user_manual/processing_algs/qgis/vectorgeometry.rst
+++ b/source/docs/user_manual/processing_algs/qgis/vectorgeometry.rst
@@ -46,7 +46,7 @@ Parameters
 Output
 ......
 
-``Added geom info`` [vector]
+``Added geom info`` [vector: any]
   Copy of the input vector layer with the addition of the geometry fields
 
 
@@ -93,7 +93,7 @@ Parameters
 Output
 ......
 
-``Aggregated`` [vector]
+``Aggregated`` [vector: any]
   Multigeometry vector layer with the aggregated values
 
 See also
@@ -375,7 +375,7 @@ Parameters
 Output
 ......
 
-``Collected`` [vector]
+``Collected`` [vector: any]
 
 See also
 ........
@@ -455,7 +455,7 @@ Parameters
 Output
 ......
 
-``Converted`` [vector]
+``Converted`` [vector: any]
   Converted vector layer depending on the parameters chosen
 
 See also
@@ -749,7 +749,7 @@ Parameters
 
 Output
 ......
-``Z/M Dropped`` [vector]
+``Z/M Dropped`` [vector: any]
   Cleaned vector layer without M and/or Z values
 
 
@@ -870,7 +870,7 @@ and bisector angle of vertex for the original geometry.
 
 Parameters
 ..........
-``Input layer`` [vector]
+``Input layer`` [vector: line, polygon]
   Vector layer in input to extract the vertices from
 
 ``Vertex indices`` [number]
@@ -988,7 +988,7 @@ Parameters
 
   Default: *$geometry*
 
-``Modified geometry`` [vector]
+``Modified geometry`` [vector: any]
   Vector layer resulting from the expression added
 
 
@@ -1328,7 +1328,7 @@ Parameters
 Output
 ......
 
-``Orthogonalized`` [vector]
+``Orthogonalized`` [vector: polygon, line]
   Final layer with angles adjusted depending on the parameters chosen
 
 
@@ -1581,13 +1581,13 @@ compatible with data providers that require multipart features.
 Parameters
 ..........
 
-``Input layer`` [vector]
+``Input layer`` [vector: any]
   Input vector layer
 
 Output
 ......
 
-``Multiparts`` [vector]
+``Multiparts`` [vector: any]
   Multiparts vector layer
 
 See also
@@ -1737,10 +1737,10 @@ Parameters
 Outputs
 .......
 
-``Non null geometries`` [vector]
+``Non null geometries`` [vector: any]
   Vector layer without NULL geometries
 
-``Null geometries`` [vector]
+``Null geometries`` [vector: any]
   Vector layer with only NULL geometries
 
 
@@ -1796,7 +1796,7 @@ Parameters
 Outputs
 .......
 
-``Rotated`` [vector]
+``Rotated`` [vector: any]
   Vector layer with rotated geometries
 
 
@@ -1890,7 +1890,7 @@ Parameters
 Output
 ......
 
-``M Added`` [vector]
+``M Added`` [vector: any]
   Vector layer in output with M value
 
 
@@ -1917,7 +1917,7 @@ Parameters
 Output
 ......
 
-``Z Added`` [vector]
+``Z Added`` [vector: any]
   Vector layer in output with Z value
 
 
@@ -2090,7 +2090,7 @@ Parameters
 Outputs
 .......
 
-``Smoothed`` [vector]
+``Smoothed`` [vector: polygon, line]
   The smoothed vector layer.
 
 
@@ -2138,7 +2138,7 @@ Parameters
 Outputs
 .......
 
-``Snapped geometry`` [vector]
+``Snapped geometry`` [vector: any]
   Vector layer with snapped geometries
 
 
@@ -2186,7 +2186,7 @@ Parameters
 Outputs
 .......
 
-``Snapped`` [vector]
+``Snapped`` [vector: any]
   Vector layer with snapped geometries
 
 
@@ -2313,7 +2313,7 @@ Parameters
 Outputs
 .......
 
-``Translated`` [vector]
+``Translated`` [vector: any]
   Translated (offset) vector layer
 
 

--- a/source/docs/user_manual/processing_algs/qgis/vectoroverlay.rst
+++ b/source/docs/user_manual/processing_algs/qgis/vectoroverlay.rst
@@ -53,7 +53,7 @@ Parameters
 Output
 ......
 
-``Clipped`` [vector]
+``Clipped`` [vector: any]
   Layer containing features from the input layer split by the clip layer.
 
 See also
@@ -93,7 +93,7 @@ Parameters
 Output
 ......
 
-``Difference`` [vector]
+``Difference`` [vector: any]
   Layer containing the differences feature of the input layer.
 
 See also
@@ -127,7 +127,7 @@ Parameters
 Output
 ......
 
-``Extracted`` [vector]
+``Extracted`` [vector: any]
   Layer containing the clipped features.
 
 
@@ -173,7 +173,7 @@ Parameters
 Output
 ......
 
-``Intersection`` [vector]
+``Intersection`` [vector: any]
   Layer containing the intersected features.
 
 See also
@@ -251,7 +251,7 @@ Parameters
 Output
 ......
 
-``Split`` [vector]
+``Split`` [vector: polygon, line]
   Output layer with split lines or polygons from input layer.
 
 
@@ -286,7 +286,7 @@ Parameters
 Output
 ......
 
-``Symmetrical difference`` [vector]
+``Symmetrical difference`` [vector: any]
   Layer containing the symmetrical differences feature of the input layer.
 
 See also
@@ -328,7 +328,7 @@ Parameters
 Output
 ......
 
-``Union`` [vector]
+``Union`` [vector: any]
   Layer containing the union of the layers
 
 

--- a/source/docs/user_manual/processing_algs/qgis/vectorselection.rst
+++ b/source/docs/user_manual/processing_algs/qgis/vectorselection.rst
@@ -56,10 +56,10 @@ Parameters
 Outputs
 .......
 
-``Extracted (attribute)`` [vector]
+``Extracted (attribute)`` [vector: any]
   Vector layer with matching features
 
-``Extracted (non-matching)`` [vector]
+``Extracted (non-matching)`` [vector: any]
   Vector layer with not matching features
 
 
@@ -86,10 +86,10 @@ Parameters
 Outputs
 .......
 
-``Matching features`` [vector]
+``Matching features`` [vector: any]
   Vector layer with matching features
 
-``Non-matching`` [vector]
+``Non-matching`` [vector: any]
   Vector layer with not matching features
 
 
@@ -127,7 +127,7 @@ Parameters
 Output
 ......
 
-``Extracted (location)``
+``Extracted (location)`` [vector: any]
   Vector layer of the spatial intersection
 
 
@@ -163,7 +163,7 @@ Parameters
 Output
 ......
 
-``Extracted (random)`` [vector]
+``Extracted (random)`` [vector: any]
   Vector layer containing random selected features
 
 
@@ -204,7 +204,7 @@ Parameters
 Output
 ......
 
-``Extracted (random stratified)`` [vector]
+``Extracted (random stratified)`` [vector: any]
   Random vector layer
 
 

--- a/source/docs/user_manual/processing_algs/qgis/vectortable.rst
+++ b/source/docs/user_manual/processing_algs/qgis/vectortable.rst
@@ -75,7 +75,7 @@ Parameters
 Output
 ......
 
-``Incremented`` [vector]
+``Incremented`` [vector: any]
   Vector layer with auto incremental field
 
 
@@ -123,7 +123,7 @@ Parameters
 Output
 ......
 
-``Added`` [vector]
+``Added`` [vector: any]
   Vector layer with new field added
 
 
@@ -160,7 +160,7 @@ Parameters
 Output
 ......
 
-``Layer with index field`` [vector]
+``Layer with index field`` [vector: any]
   Vector layer with the numeric field containing indexes
 
 ``Class summary`` [table]
@@ -227,7 +227,7 @@ Parameters
 Output
 ......
 
-``Calculated`` [vector]
+``Calculated`` [vector: any]
   Vector layer with the new calculated field
 
 
@@ -250,7 +250,7 @@ Parameters
 Output
 ......
 
-``Fields dropped`` [vector:any]
+``Fields dropped`` [vector: any]
   Vector layer without the field(s) chosen
 
 
@@ -312,7 +312,7 @@ Parameters
 Output
 ......
 
-``Refactored`` [vector]
+``Refactored`` [vector: any]
   Output layer with refactored fields
 
 
@@ -339,7 +339,7 @@ Parameters
 Output
 ......
 
-``Float from text`` [vector]
+``Float from text`` [vector: any]
   Output vector layer with string field converted into float
 
 

--- a/source/docs/user_manual/processing_algs/r/home_range_analysis.rst
+++ b/source/docs/user_manual/processing_algs/r/home_range_analysis.rst
@@ -31,7 +31,7 @@ Parameters
 Outputs
 .......
 
-``Home_ranges`` [vector]
+``Home_ranges`` [vector: any]
   <put output description here>
 
 Console usage
@@ -79,7 +79,7 @@ Parameters
 Outputs
 .......
 
-``Home_ranges`` [vector]
+``Home_ranges`` [vector: any]
   <put output description here>
 
 Console usage
@@ -117,7 +117,7 @@ Parameters
 Outputs
 .......
 
-``Home_ranges`` [vector]
+``Home_ranges`` [vector: polygon]
   <put output description here>
 
 Console usage

--- a/source/docs/user_manual/processing_algs/saga/grid_analysis.rst
+++ b/source/docs/user_manual/processing_algs/saga/grid_analysis.rst
@@ -518,10 +518,10 @@ Parameters
 Outputs
 .......
 
-``Profile (points)`` [vector]
+``Profile (points)`` [vector: point]
   <put output description here>
 
-``Profile (lines)`` [vector]
+``Profile (lines)`` [vector: line]
   <put output description here>
 
 Console usage

--- a/source/docs/user_manual/processing_algs/saga/imagery_segmentation.rst
+++ b/source/docs/user_manual/processing_algs/saga/imagery_segmentation.rst
@@ -140,7 +140,7 @@ Outputs
 ``Seeds Grid`` [raster]
   <put output description here>
 
-``Seeds`` [vector]
+``Seeds`` [vector: point]
   <put output description here>
 
 Console usage
@@ -303,7 +303,7 @@ Outputs
 ``Segments`` [raster]
   <put output description here>
 
-``Seed Points`` [vector]
+``Seed Points`` [vector: point]
   <put output description here>
 
 ``Borders`` [raster]

--- a/source/docs/user_manual/processing_algs/saga/shapes_grid.rst
+++ b/source/docs/user_manual/processing_algs/saga/shapes_grid.rst
@@ -47,7 +47,7 @@ Parameters
 Outputs
 .......
 
-``Result`` [vector]
+``Result`` [vector: point]
   The resulting layer.
 
 Console usage
@@ -93,7 +93,7 @@ Parameters
 Outputs
 .......
 
-``Result`` [vector]
+``Result`` [vector: any]
   <put output description here>
 
 Console usage
@@ -171,7 +171,7 @@ Parameters
 Outputs
 .......
 
-``Contour Lines`` [vector]
+``Contour Lines`` [vector: line]
   <put output description here>
 
 Console usage
@@ -240,7 +240,7 @@ Parameters
 Outputs
 .......
 
-``Gradient Vectors`` [vector]
+``Gradient Vectors`` [vector: line]
   <put output description here>
 
 Console usage
@@ -309,7 +309,7 @@ Parameters
 Outputs
 .......
 
-``Gradient Vectors`` [vector]
+``Gradient Vectors`` [vector: line]
   <put output description here>
 
 Console usage
@@ -375,7 +375,7 @@ Parameters
 Outputs
 .......
 
-``Gradient Vectors`` [vector]
+``Gradient Vectors`` [vector: line]
   <put output description here>
 
 Console usage
@@ -453,7 +453,7 @@ Parameters
 Outputs
 .......
 
-``Statistics`` [vector]
+``Statistics`` [vector: polygon]
   <put output description here>
 
 Console usage
@@ -488,7 +488,7 @@ Parameters
 Outputs
 .......
 
-``Points`` [vector]
+``Points`` [vector: point]
   <put output description here>
 
 Console usage
@@ -538,7 +538,7 @@ Parameters
 Outputs
 .......
 
-``Shapes`` [vector]
+``Shapes`` [vector: point]
   <put output description here>
 
 Console usage
@@ -568,10 +568,10 @@ Parameters
 Outputs
 .......
 
-``Minima`` [vector]
+``Minima`` [vector: point]
   <put output description here>
 
-``Maxima`` [vector]
+``Maxima`` [vector: point]
   <put output description here>
 
 Console usage
@@ -626,7 +626,7 @@ Parameters
 Outputs
 .......
 
-``Polygons`` [vector]
+``Polygons`` [vector: polygon]
   <put output description here>
 
 Console usage

--- a/source/docs/user_manual/processing_algs/saga/shapes_lines.rst
+++ b/source/docs/user_manual/processing_algs/saga/shapes_lines.rst
@@ -34,7 +34,7 @@ Parameters
 Outputs
 .......
 
-``Lines`` [vector]
+``Lines`` [vector: line]
   The resulting layer.
 
 Console usage
@@ -64,7 +64,7 @@ Parameters
 Outputs
 .......
 
-``Lines`` [vector]
+``Lines`` [vector: line]
   The resulting layer.
 
 Console usage
@@ -113,7 +113,7 @@ Parameters
 Outputs
 .......
 
-``Dissolved Lines`` [vector]
+``Dissolved Lines`` [vector: line]
   <put output description here>
 
 Console usage
@@ -156,7 +156,7 @@ Parameters
 Outputs
 .......
 
-``Intersection`` [vector]
+``Intersection`` [vector: line]
   <put output description here>
 
 Console usage
@@ -194,14 +194,14 @@ Parameters
   Default: *True*
 
 ``Length`` [boolean]
-  Determines whether to calculate total line lenght.
+  Determines whether to calculate total line length.
 
   Default: *True*
 
 Outputs
 .......
 
-``Lines with Property Attributes`` [vector]
+``Lines with Property Attributes`` [vector: line]
   The resulting layer.
 
 Console usage
@@ -220,7 +220,7 @@ Line simplification
 Description
 ...........
 
-Simplyfies the geometry of a lines layer.
+Simplifies the geometry of a lines layer.
 
 Parameters
 ..........
@@ -236,7 +236,7 @@ Parameters
 Outputs
 .......
 
-``Simplified Lines`` [vector]
+``Simplified Lines`` [vector: line]
   The resulting layer.
 
 Console usage

--- a/source/docs/user_manual/processing_algs/saga/shapes_points.rst
+++ b/source/docs/user_manual/processing_algs/saga/shapes_points.rst
@@ -28,7 +28,7 @@ Parameters
 Outputs
 .......
 
-``Output`` [vector]
+``Output`` [vector: point]
   Resulting layer with the updated attribute table.
 
 Console usage
@@ -66,7 +66,7 @@ Parameters
 Outputs
 .......
 
-``Result`` [vector]
+``Result`` [vector: point]
   The resulting layer.
 
 Console usage
@@ -176,7 +176,7 @@ Parameters
 Outputs
 .......
 
-``Clipped Points`` [vector]
+``Clipped Points`` [vector: point]
   <put output description here>
 
 Console usage
@@ -216,7 +216,7 @@ Parameters
 Outputs
 .......
 
-``Points`` [vector]
+``Points`` [vector: point]
   The resulting layer.
 
 Console usage
@@ -246,7 +246,7 @@ Parameters
 Outputs
 .......
 
-``Points`` [vector]
+``Points`` [vector: point]
   <put output description here>
 
 Console usage
@@ -287,10 +287,10 @@ Parameters
 Outputs
 .......
 
-``Convex Hull`` [vector]
+``Convex Hull`` [vector: polygon]
   <put output description here>
 
-``Minimum Bounding Box`` [vector]
+``Minimum Bounding Box`` [vector: polygon]
   <put output description here>
 
 Console usage
@@ -434,7 +434,7 @@ Parameters
 Outputs
 .......
 
-``Filtered Points`` [vector]
+``Filtered Points`` [vector: point]
   <put output description here>
 
 Console usage
@@ -472,7 +472,7 @@ Parameters
 Outputs
 .......
 
-``Thinned Points`` [vector]
+``Thinned Points`` [vector: point]
   <put output description here>
 
 Console usage
@@ -529,7 +529,7 @@ Parameters
 Outputs
 .......
 
-``Result`` [vector]
+``Result`` [vector: point]
   <put output description here>
 
 Console usage
@@ -569,7 +569,7 @@ Parameters
 Outputs
 .......
 
-``Output`` [vector]
+``Output`` [vector: point]
   <put output description here>
 
 Console usage

--- a/source/docs/user_manual/processing_algs/saga/shapes_polygons.rst
+++ b/source/docs/user_manual/processing_algs/saga/shapes_polygons.rst
@@ -28,7 +28,7 @@ Parameters
 Outputs
 .......
 
-``Polygons`` [vector]
+``Polygons`` [vector: polygon]
   The resulting layer.
 
 Console usage
@@ -58,7 +58,7 @@ Parameters
 Outputs
 .......
 
-``Points`` [vector]
+``Points`` [vector: point]
   The resulting layer.
 
 Console usage
@@ -86,7 +86,7 @@ Parameters
   Input layer.
 
 ``Centroids for each part`` [boolean]
-  Determites whether centroids should be calculated for each part of multipart
+  Determines whether centroids should be calculated for each part of multipart
   polygon or not.
 
   Default: *True*
@@ -94,7 +94,7 @@ Parameters
 Outputs
 .......
 
-``Centroids`` [vector]
+``Centroids`` [vector: point]
   The resulting layer.
 
 Console usage
@@ -151,7 +151,7 @@ Parameters
 Outputs
 .......
 
-``Dissolved Polygons`` [vector]
+``Dissolved Polygons`` [vector: polygon]
   <put output description here>
 
 Console usage
@@ -184,7 +184,7 @@ Parameters
 Outputs
 .......
 
-``Intersection`` [vector]
+``Intersection`` [vector: line]
   <put output description here>
 
 Console usage
@@ -219,7 +219,7 @@ Parameters
 Outputs
 .......
 
-``Polygon Parts`` [vector]
+``Polygon Parts`` [vector: polygon]
   <put output description here>
 
 Console usage
@@ -269,7 +269,7 @@ Parameters
 Outputs
 .......
 
-``Polygons with Property Attributes`` [vector]
+``Polygons with Property Attributes`` [vector: polygon]
   <put output description here>
 
 Console usage
@@ -308,7 +308,7 @@ Parameters
 Outputs
 .......
 
-``Shape Index`` [vector]
+``Shape Index`` [vector: polygon]
   The resulting layer.
 
 Console usage
@@ -338,10 +338,10 @@ Parameters
 Outputs
 .......
 
-``Edges`` [vector]
+``Edges`` [vector: line]
   Resulting line layer with polygons boundaries.
 
-``Nodes`` [vector]
+``Nodes`` [vector: point]
   Resulting line layer with polygons nodes.
 
 Console usage

--- a/source/docs/user_manual/processing_algs/saga/shapes_tools.rst
+++ b/source/docs/user_manual/processing_algs/saga/shapes_tools.rst
@@ -55,7 +55,7 @@ Parameters
 Outputs
 .......
 
-``Graticule`` [vector]
+``Graticule`` [vector: polygon, line]
   The resulting layer.
 
 Console usage
@@ -93,13 +93,13 @@ Parameters
 
   Default: *0*
 
-``Cutting polygons`` [vector: any]
+``Cutting polygons`` [vector: polygon]
   <put parameter description here>
 
 Outputs
 .......
 
-``Result`` [vector]
+``Result`` [vector: any]
   <put output description here>
 
 ``Extent`` [vector]
@@ -138,7 +138,7 @@ Parameters
 Outputs
 .......
 
-``Extents`` [vector]
+``Extents`` [vector: polygon]
   The resulting layer.
 
 Console usage
@@ -180,7 +180,7 @@ Parameters
 Outputs
 .......
 
-``Merged Layer`` [vector]
+``Merged Layer`` [vector: any]
   The resulting layer.
 
 Console usage
@@ -228,7 +228,7 @@ Parameters
 Outputs
 .......
 
-``Cartesian Coordinates`` [vector]
+``Cartesian Coordinates`` [vector: any]
   <put output description here>
 
 Console usage
@@ -261,13 +261,13 @@ Parameters
 Outputs
 .......
 
-``Polygons`` [vector]
+``Polygons`` [vector: polygon]
   <put output description here>
 
-``Lines`` [vector]
+``Lines`` [vector: line]
   <put output description here>
 
-``Duplicated Points`` [vector]
+``Duplicated Points`` [vector: point]
   <put output description here>
 
 Console usage
@@ -335,7 +335,7 @@ Parameters
 Outputs
 .......
 
-``Buffer`` [vector]
+``Buffer`` [vector: polygon]
   The resulting layer.
 
 Console usage
@@ -370,10 +370,10 @@ Parameters
 Outputs
 .......
 
-``Group A`` [vector]
+``Group A`` [vector: any]
   First resulting layer.
 
-``Group B`` [vector]
+``Group B`` [vector: any]
   Second resulting layer.
 
 Console usage
@@ -438,7 +438,7 @@ Parameters
 Outputs
 .......
 
-``Output`` [vector]
+``Output`` [vector: any]
   <put output description here>
 
 Console usage

--- a/source/docs/user_manual/processing_algs/saga/terrain_analysis_channels.rst
+++ b/source/docs/user_manual/processing_algs/saga/terrain_analysis_channels.rst
@@ -45,13 +45,13 @@ Outputs
 ``Drainage Basins`` [raster]
   <put output description here>
 
-``Channels`` [vector]
+``Channels`` [vector: line]
   <put output description here>
 
-``Drainage Basins`` [vector]
+``Drainage Basins`` [vector: polygon]
   <put output description here>
 
-``Junctions`` [vector]
+``Junctions`` [vector: point]
   <put output description here>
 
 Console usage
@@ -131,7 +131,7 @@ Outputs
 ``Channel Direction`` [raster]
   <put output description here>
 
-``Channel Network`` [vector]
+``Channel Network`` [vector: line]
   <put output description here>
 
 Console usage

--- a/source/docs/user_manual/processing_algs/saga/terrain_analysis_profiles.rst
+++ b/source/docs/user_manual/processing_algs/saga/terrain_analysis_profiles.rst
@@ -46,7 +46,7 @@ Parameters
 Outputs
 .......
 
-``Cross Profiles`` [vector]
+``Cross Profiles`` [vector: line]
   <put output description here>
 
 Console usage
@@ -131,10 +131,10 @@ Parameters
 Outputs
 .......
 
-``Profiles`` [vector]
+``Profile`` [vector: line]
   <put output description here>
 
-``Profiles`` [vector]
+``Profiles`` [vector: line]
   <put output description here>
 
 Console usage

--- a/source/docs/user_manual/processing_algs/taudem/stream_network_analysis_tools.rst
+++ b/source/docs/user_manual/processing_algs/taudem/stream_network_analysis_tools.rst
@@ -208,7 +208,7 @@ Parameters
 Outputs
 .......
 
-``Output Outlet Shapefile`` [vector]
+``Output Outlet Shapefile`` [vector: point]
   A point shape file defining points of interest or outlets. This file has one
   point in it for each point in the input outlet shapefile. If the original
   point was located on a stream, then the point was not moved. If the origianl
@@ -663,7 +663,7 @@ Outputs
   in the case where the delineate single watershed option was checked, the
   entire area draining to the stream network is identified with a single ID.
 
-``Stream Reach Shapefile`` [vector]
+``Stream Reach Shapefile`` [vector: line]
   This output is a polyline shapefile giving the links in a stream network. The
   columns in the attribute table are:
 


### PR DESCRIPTION
Not all the occurrences are covered as there are some third-party providers (otb, saga, R) that have it used and I'm not able to find the replacement. 
Wonder what should be the future for the third party providers docs... 