### PR TITLE
Add a warning about outdated information in PyQGIS Cookbook

### DIFF
--- a/source/docs/pyqgis_developer_cookbook/authentication.rst
+++ b/source/docs/pyqgis_developer_cookbook/authentication.rst
@@ -15,6 +15,8 @@ Authentication infrastructure
 .. contents::
    :local:
 
+.. warning:: |outofdate|
+
 .. _Authentication_Introduction:
 
 Introduction
@@ -431,4 +433,5 @@ and can be used as in the following snippet:
    please add it also to the substitutions.txt file in the
    source folder.
 
+.. |outofdate| replace:: `Despite our constant efforts, information beyond this line may not be updated for QGIS 3. Refer to https://qgis.org/pyqgis/master for the python API documentation or, give a hand to update the chapters you know about. Thanks.`
 .. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/pyqgis_developer_cookbook/canvas.rst
+++ b/source/docs/pyqgis_developer_cookbook/canvas.rst
@@ -10,6 +10,8 @@
 Using Map Canvas
 ****************
 
+.. warning:: |outofdate|
+
 .. contents::
    :local:
 
@@ -382,4 +384,5 @@ Writing Custom Map Canvas Items
    please add it also to the substitutions.txt file in the
    source folder.
 
+.. |outofdate| replace:: `Despite our constant efforts, information beyond this line may not be updated for QGIS 3. Refer to https://qgis.org/pyqgis/master for the python API documentation or, give a hand to update the chapters you know about. Thanks.`
 .. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/pyqgis_developer_cookbook/communicating.rst
+++ b/source/docs/pyqgis_developer_cookbook/communicating.rst
@@ -8,6 +8,8 @@
 Communicating with the user
 ***************************
 
+.. warning:: |outofdate|
+
 .. contents::
    :local:
 
@@ -183,4 +185,5 @@ save about the execution of your code.
    please add it also to the substitutions.txt file in the
    source folder.
 
+.. |outofdate| replace:: `Despite our constant efforts, information beyond this line may not be updated for QGIS 3. Refer to https://qgis.org/pyqgis/master for the python API documentation or, give a hand to update the chapters you know about. Thanks.`
 .. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/pyqgis_developer_cookbook/composer.rst
+++ b/source/docs/pyqgis_developer_cookbook/composer.rst
@@ -10,6 +10,8 @@
 Map Rendering and Printing
 **************************
 
+.. warning:: |outofdate|
+
 .. contents::
    :local:
 
@@ -287,4 +289,5 @@ The following code fragment renders a composition to a PDF file
    please add it also to the substitutions.txt file in the
    source folder.
 
+.. |outofdate| replace:: `Despite our constant efforts, information beyond this line may not be updated for QGIS 3. Refer to https://qgis.org/pyqgis/master for the python API documentation or, give a hand to update the chapters you know about. Thanks.`
 .. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/pyqgis_developer_cookbook/crs.rst
+++ b/source/docs/pyqgis_developer_cookbook/crs.rst
@@ -8,6 +8,8 @@
 Projections Support
 *******************
 
+.. warning:: |outofdate|
+
 .. contents::
    :local:
 
@@ -112,4 +114,5 @@ transformation, but it is capable to do also inverse transformation.
    please add it also to the substitutions.txt file in the
    source folder.
 
+.. |outofdate| replace:: `Despite our constant efforts, information beyond this line may not be updated for QGIS 3. Refer to https://qgis.org/pyqgis/master for the python API documentation or, give a hand to update the chapters you know about. Thanks.`
 .. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/pyqgis_developer_cookbook/expressions.rst
+++ b/source/docs/pyqgis_developer_cookbook/expressions.rst
@@ -10,6 +10,8 @@
 Expressions, Filtering and Calculating Values
 *********************************************
 
+.. warning:: |outofdate|
+
 .. contents::
    :local:
 
@@ -161,4 +163,5 @@ matches a predicate.
    please add it also to the substitutions.txt file in the
    source folder.
 
+.. |outofdate| replace:: `Despite our constant efforts, information beyond this line may not be updated for QGIS 3. Refer to https://qgis.org/pyqgis/master for the python API documentation or, give a hand to update the chapters you know about. Thanks.`
 .. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/pyqgis_developer_cookbook/geometry.rst
+++ b/source/docs/pyqgis_developer_cookbook/geometry.rst
@@ -10,6 +10,8 @@
 Geometry Handling
 *****************
 
+.. warning:: |outofdate|
+
 .. contents::
    :local:
 
@@ -172,4 +174,5 @@ Additional information can be found in following sources:
    please add it also to the substitutions.txt file in the
    source folder.
 
+.. |outofdate| replace:: `Despite our constant efforts, information beyond this line may not be updated for QGIS 3. Refer to https://qgis.org/pyqgis/master for the python API documentation or, give a hand to update the chapters you know about. Thanks.`
 .. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/pyqgis_developer_cookbook/ide_debugging.rst
+++ b/source/docs/pyqgis_developer_cookbook/ide_debugging.rst
@@ -8,6 +8,8 @@
 IDE settings for writing and debugging plugins
 **********************************************
 
+.. warning:: |outofdate|
+
 .. contents::
    :local:
 
@@ -255,11 +257,11 @@ And when the application hits your breakpoint you can type in the console!
     Add testing information
 
 
-
 .. Substitutions definitions - AVOID EDITING PAST THIS LINE
    This will be automatically updated by the find_set_subst.py script.
    If you need to create a new substitution manually,
    please add it also to the substitutions.txt file in the
    source folder.
 
+.. |outofdate| replace:: `Despite our constant efforts, information beyond this line may not be updated for QGIS 3. Refer to https://qgis.org/pyqgis/master for the python API documentation or, give a hand to update the chapters you know about. Thanks.`
 .. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/pyqgis_developer_cookbook/index.rst
+++ b/source/docs/pyqgis_developer_cookbook/index.rst
@@ -32,7 +32,7 @@ PyQGIS Developer Cookbook
    processing
    network_analysis
    server
-   
+
 
 .. Substitutions definitions - AVOID EDITING PAST THIS LINE
    This will be automatically updated by the find_set_subst.py script.

--- a/source/docs/pyqgis_developer_cookbook/loadlayer.rst
+++ b/source/docs/pyqgis_developer_cookbook/loadlayer.rst
@@ -8,6 +8,8 @@
 Loading Layers
 **************
 
+.. warning:: |outofdate|
+
 .. contents::
    :local:
 
@@ -288,4 +290,5 @@ For a list of loaded layers and layer ids, use:
    please add it also to the substitutions.txt file in the
    source folder.
 
+.. |outofdate| replace:: `Despite our constant efforts, information beyond this line may not be updated for QGIS 3. Refer to https://qgis.org/pyqgis/master for the python API documentation or, give a hand to update the chapters you know about. Thanks.`
 .. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/pyqgis_developer_cookbook/loadproject.rst
+++ b/source/docs/pyqgis_developer_cookbook/loadproject.rst
@@ -8,6 +8,8 @@
 Loading Projects
 ****************
 
+.. warning:: |outofdate|
+
 Sometimes you need to load an existing project from a plugin or (more often)
 when developing a stand-alone QGIS Python application (see: :ref:`pythonapplications`).
 
@@ -65,4 +67,5 @@ use to check if the operation was successful.
    please add it also to the substitutions.txt file in the
    source folder.
 
+.. |outofdate| replace:: `Despite our constant efforts, information beyond this line may not be updated for QGIS 3. Refer to https://qgis.org/pyqgis/master for the python API documentation or, give a hand to update the chapters you know about. Thanks.`
 .. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/pyqgis_developer_cookbook/network_analysis.rst
+++ b/source/docs/pyqgis_developer_cookbook/network_analysis.rst
@@ -8,6 +8,8 @@
 Network analysis library
 ************************
 
+.. warning:: |outofdate|
+
 .. contents::
    :local:
 
@@ -512,4 +514,5 @@ Here is an example
    please add it also to the substitutions.txt file in the
    source folder.
 
+.. |outofdate| replace:: `Despite our constant efforts, information beyond this line may not be updated for QGIS 3. Refer to https://qgis.org/pyqgis/master for the python API documentation or, give a hand to update the chapters you know about. Thanks.`
 .. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/pyqgis_developer_cookbook/pluginlayer.rst
+++ b/source/docs/pyqgis_developer_cookbook/pluginlayer.rst
@@ -10,6 +10,8 @@
 Using Plugin Layers
 *******************
 
+.. warning:: |outofdate|
+
 If your plugin uses its own methods to render a map layer, writing your own
 layer type based on QgsPluginLayer might be the best way to implement that.
 
@@ -80,4 +82,5 @@ You can also add code for displaying custom information in the layer properties
    please add it also to the substitutions.txt file in the
    source folder.
 
+.. |outofdate| replace:: `Despite our constant efforts, information beyond this line may not be updated for QGIS 3. Refer to https://qgis.org/pyqgis/master for the python API documentation or, give a hand to update the chapters you know about. Thanks.`
 .. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/pyqgis_developer_cookbook/plugins.rst
+++ b/source/docs/pyqgis_developer_cookbook/plugins.rst
@@ -10,6 +10,8 @@
 Developing Python Plugins
 *************************
 
+.. warning:: |outofdate|
+
 .. contents::
    :local:
 
@@ -601,4 +603,5 @@ Information and requirements are here: `plugins.qgis.org <https://plugins.qgis.o
    please add it also to the substitutions.txt file in the
    source folder.
 
+.. |outofdate| replace:: `Despite our constant efforts, information beyond this line may not be updated for QGIS 3. Refer to https://qgis.org/pyqgis/master for the python API documentation or, give a hand to update the chapters you know about. Thanks.`
 .. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/pyqgis_developer_cookbook/processing.rst
+++ b/source/docs/pyqgis_developer_cookbook/processing.rst
@@ -9,6 +9,8 @@
 Writing a Processing plugin
 ****************************
 
+.. warning:: |outofdate|
+
 .. contents::
    :local:
 
@@ -63,4 +65,5 @@ To create a set of processing scripts, follow these steps:
    please add it also to the substitutions.txt file in the
    source folder.
 
+.. |outofdate| replace:: `Despite our constant efforts, information beyond this line may not be updated for QGIS 3. Refer to https://qgis.org/pyqgis/master for the python API documentation or, give a hand to update the chapters you know about. Thanks.`
 .. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/pyqgis_developer_cookbook/raster.rst
+++ b/source/docs/pyqgis_developer_cookbook/raster.rst
@@ -11,6 +11,8 @@
  Using Raster Layers
 *********************
 
+.. warning:: |outofdate|
+
 .. contents::
    :local:
 
@@ -213,4 +215,5 @@ keys, and band values as values.
    please add it also to the substitutions.txt file in the
    source folder.
 
+.. |outofdate| replace:: `Despite our constant efforts, information beyond this line may not be updated for QGIS 3. Refer to https://qgis.org/pyqgis/master for the python API documentation or, give a hand to update the chapters you know about. Thanks.`
 .. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/pyqgis_developer_cookbook/releasing.rst
+++ b/source/docs/pyqgis_developer_cookbook/releasing.rst
@@ -8,6 +8,8 @@
  Releasing your plugin
 ***********************
 
+.. warning:: |outofdate|
+
 .. contents::
    :local:
 
@@ -144,4 +146,5 @@ look like.
    please add it also to the substitutions.txt file in the
    source folder.
 
+.. |outofdate| replace:: `Despite our constant efforts, information beyond this line may not be updated for QGIS 3. Refer to https://qgis.org/pyqgis/master for the python API documentation or, give a hand to update the chapters you know about. Thanks.`
 .. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/pyqgis_developer_cookbook/server.rst
+++ b/source/docs/pyqgis_developer_cookbook/server.rst
@@ -10,6 +10,8 @@
 QGIS Server Python Plugins
 ****************************
 
+.. warning:: |outofdate|
+
 .. contents::
    :local:
 
@@ -518,4 +520,5 @@ to completely disable the cache.
    please add it also to the substitutions.txt file in the
    source folder.
 
+.. |outofdate| replace:: `Despite our constant efforts, information beyond this line may not be updated for QGIS 3. Refer to https://qgis.org/pyqgis/master for the python API documentation or, give a hand to update the chapters you know about. Thanks.`
 .. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/pyqgis_developer_cookbook/settings.rst
+++ b/source/docs/pyqgis_developer_cookbook/settings.rst
@@ -10,6 +10,8 @@
 Reading And Storing Settings
 ****************************
 
+.. warning:: |outofdate|
+
 Many times it is useful for a plugin to save some variables so that the user
 does not have to enter or select them again next time the plugin is run.
 
@@ -101,4 +103,5 @@ We can make difference between several types of settings:
    please add it also to the substitutions.txt file in the
    source folder.
 
+.. |outofdate| replace:: `Despite our constant efforts, information beyond this line may not be updated for QGIS 3. Refer to https://qgis.org/pyqgis/master for the python API documentation or, give a hand to update the chapters you know about. Thanks.`
 .. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/pyqgis_developer_cookbook/snippets.rst
+++ b/source/docs/pyqgis_developer_cookbook/snippets.rst
@@ -6,6 +6,8 @@
 Code Snippets
 *************
 
+.. warning:: |outofdate|
+
 .. contents::
    :local:
 
@@ -96,4 +98,5 @@ field of the selected feature(s)) and can be called by
    please add it also to the substitutions.txt file in the
    source folder.
 
+.. |outofdate| replace:: `Despite our constant efforts, information beyond this line may not be updated for QGIS 3. Refer to https://qgis.org/pyqgis/master for the python API documentation or, give a hand to update the chapters you know about. Thanks.`
 .. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/pyqgis_developer_cookbook/vector.rst
+++ b/source/docs/pyqgis_developer_cookbook/vector.rst
@@ -8,6 +8,8 @@
 Using Vector Layers
 *******************
 
+.. warning:: |outofdate|
+
 .. contents::
    :local:
 
@@ -1253,4 +1255,5 @@ Further Topics
    please add it also to the substitutions.txt file in the
    source folder.
 
+.. |outofdate| replace:: `Despite our constant efforts, information beyond this line may not be updated for QGIS 3. Refer to https://qgis.org/pyqgis/master for the python API documentation or, give a hand to update the chapters you know about. Thanks.`
 .. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/substitutions.txt
+++ b/source/substitutions.txt
@@ -1,4 +1,5 @@
 .. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |outofdate| replace:: `Despite our constant efforts, information beyond this line may not be updated for QGIS 3. Refer to https://qgis.org/pyqgis/master for the python API documentation or, give a hand to update the chapters you know about. Thanks.`
 .. |nix| image:: /static/common/nix.png
    :width: 1em
 .. |kde| image:: /static/common/kde.png


### PR DESCRIPTION
Because people think that information in the Cookbook are already updated and vainly tried the recipes, it could be nice to alarm them on
this. (fixes #2754)