### PR TITLE
Details the custom widget of the "Refactor Fields" and "Aggregate" algorithms

### DIFF
--- a/source/docs/user_manual/processing_algs/qgis/vectorgeometry.rst
+++ b/source/docs/user_manual/processing_algs/qgis/vectorgeometry.rst
@@ -62,7 +62,7 @@ Features for which ``group by`` expression returns the same value are grouped to
 It is possible to group all source features together using constant value in ``group
 by`` parameter, example: NULL.
 
-It is also possible to group features using multiple fields using Array function,
+It is also possible to group features by multiple fields using Array function,
 example: Array("Field1", "Field2").
 
 Geometries (if present) are combined into one multipart geometry for each group.
@@ -82,9 +82,47 @@ Parameters
 
   Default: *NULL*
 
-``Aggregates`` [fieldsmapping]
-  Summary of all fields of the source layer, aggregation function available,
-  delimiter and output field name
+``Aggregates`` [list]
+  Lists the fields in the output layer with their definitions.
+  
+  By default, the embedded table lists all the fields of the source
+  layer and allows you to edit them:
+
+  * click on the |newAttribute| button to create a new field
+  * click on the |deleteAttribute| to remove a field
+  * use |arrowUp| and |arrowDown| to change the field order
+  * click on |clearText| to reset to the default view
+
+  For each of the fields you'd like to retrieve information from, you need to
+  fill following options:
+
+  ``Input expression`` [expression]
+    Represents a field or an expression from the input layer.
+
+  ``Aggregate function`` [enumeration]
+    The :ref:`function <aggregates_function>` to apply to the input expression
+    in order to return aggregated value.
+
+    Default: *concatenate* (for string data type), *sum* (for numeric data type)
+
+  ``Delimiter`` [string]
+    Represents a text to separate values to aggregate, for example in case of
+    concatenation.
+
+    Default: *,*
+
+  ``Output field name`` [string]
+    Represents the name of the aggregated field in the output layer.
+    By default input field name is kept.
+
+  ``Type`` [enumeration]
+    Sets the data type to apply to the output field.
+
+  ``Length`` [number]
+    Represents the length of the expected output field.
+
+  ``Precision`` [number]
+    Represents the precision of the expected output field.
 
 ``Load fields from layer`` [vector: any]
   You can also load the fields from another layer and use these fields for the
@@ -2508,8 +2546,18 @@ Outputs
    source folder.
 
 .. |32| replace:: :kbd:`NEW in 3.2`
-.. |identify| image:: /static/common/mActionIdentify.png
+.. |arrowDown| image:: /static/common/mActionArrowDown.png
+   :width: 1.5em
+.. |arrowUp| image:: /static/common/mActionArrowUp.png
+   :width: 1.5em
+.. |clearText| image:: /static/common/mIconClearText.png
    :width: 1.5em
 .. |dataDefined| image:: /static/common/mIconDataDefine.png
+   :width: 1.5em
+.. |deleteAttribute| image:: /static/common/mActionDeleteAttribute.png
+   :width: 1.5em
+.. |identify| image:: /static/common/mActionIdentify.png
+   :width: 1.5em
+.. |newAttribute| image:: /static/common/mActionNewAttribute.png
    :width: 1.5em
 .. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/processing_algs/qgis/vectorgeometry.rst
+++ b/source/docs/user_manual/processing_algs/qgis/vectorgeometry.rst
@@ -83,46 +83,45 @@ Parameters
   Default: *NULL*
 
 ``Aggregates`` [list]
-  Lists the fields in the output layer with their definitions.
+  List of the fields in the output layer with their definitions.
   
   By default, the embedded table lists all the fields of the source
   layer and allows you to edit them:
 
-  * click on the |newAttribute| button to create a new field
-  * click on the |deleteAttribute| to remove a field
-  * use |arrowUp| and |arrowDown| to change the field order
-  * click on |clearText| to reset to the default view
+  * click the |newAttribute| button to create a new field
+  * click the |deleteAttribute| to remove a field
+  * use |arrowUp| and |arrowDown| to change the selected field order
+  * click |clearText| to reset to the default view
 
   For each of the fields you'd like to retrieve information from, you need to
-  fill following options:
+  fill the following options:
 
   ``Input expression`` [expression]
-    Represents a field or an expression from the input layer.
+    Field or expression from the input layer.
 
   ``Aggregate function`` [enumeration]
-    The :ref:`function <aggregates_function>` to apply to the input expression
-    in order to return aggregated value.
+    :ref:`Function <aggregates_function>` to use on the input expression
+    to return the aggregated value.
 
     Default: *concatenate* (for string data type), *sum* (for numeric data type)
 
   ``Delimiter`` [string]
-    Represents a text to separate values to aggregate, for example in case of
-    concatenation.
+    Text string to separate values to aggregate, for example in case of concatenation.
 
     Default: *,*
 
   ``Output field name`` [string]
-    Represents the name of the aggregated field in the output layer.
+    Name of the aggregated field in the output layer.
     By default input field name is kept.
 
   ``Type`` [enumeration]
-    Sets the data type to apply to the output field.
+    Data type of the output field.
 
   ``Length`` [number]
-    Represents the length of the expected output field.
+    Length of the output field.
 
   ``Precision`` [number]
-    Represents the precision of the expected output field.
+    Precision of the output field.
 
 ``Load fields from layer`` [vector: any]
   You can also load the fields from another layer and use these fields for the

--- a/source/docs/user_manual/processing_algs/qgis/vectorgeometry.rst
+++ b/source/docs/user_manual/processing_algs/qgis/vectorgeometry.rst
@@ -106,7 +106,7 @@ Parameters
     Default: *concatenate* (for string data type), *sum* (for numeric data type)
 
   ``Delimiter`` [string]
-    Text string to separate values to aggregate, for example in case of concatenation.
+    Text string to separate aggregated values, for example in case of concatenation.
 
     Default: *,*
 

--- a/source/docs/user_manual/processing_algs/qgis/vectortable.rst
+++ b/source/docs/user_manual/processing_algs/qgis/vectortable.rst
@@ -296,8 +296,10 @@ Parameters
 ``Input layer`` [vector: any]
   Layer to edit the attribute table structure
 
-``Fields mapping`` [fieldsmapping]
-  Output fields definitions. The embedded table lists all the fields of the source
+``Fields mapping`` [list]
+  List of output fields  with their definitions.
+
+  The embedded table lists all the fields of the source
   layer and allows you to edit them:
 
   * click on the |newAttribute| button to create a new field
@@ -305,9 +307,27 @@ Parameters
   * use |arrowUp| and |arrowDown| to change the field order
   * click on |clearText| to reset to the default view
 
+  For each of the fields you'd like to reuse, you need to
+  fill following options:
+
+  ``Source expression`` [expression]
+    Represents the field or an expression from the input layer.
+
+  ``Field name`` [string]
+    Represents the name of the field in the output layer.
+    By default input field name is kept.
+
+  ``Type`` [enumeration]
+    Sets the data type to apply to the output field.
+
+  ``Length`` [number]
+    Represents the length of the expected output field.
+
+  ``Precision`` [number]
+    Represents the precision of the expected output field.
 
 ``Load fields from layer`` [vector: any]
-  Load fields from another vector layer to update the field list
+  Load fields from another vector layer to update the field list.
 
 Output
 ......

--- a/source/docs/user_manual/processing_algs/qgis/vectortable.rst
+++ b/source/docs/user_manual/processing_algs/qgis/vectortable.rst
@@ -311,7 +311,7 @@ Parameters
   fill the following options:
 
   ``Source expression`` [expression]
-    Field or an expression from the input layer.
+    Field or expression from the input layer.
 
   ``Field name`` [string]
     Name of the field in the output layer.
@@ -324,7 +324,7 @@ Parameters
     Length of the output field.
 
   ``Precision`` [number]
-    Precision of the expected output field.
+    Precision of the output field.
 
 ``Load fields from layer`` [vector: any]
   Load fields from another vector layer to update the field list.

--- a/source/docs/user_manual/processing_algs/qgis/vectortable.rst
+++ b/source/docs/user_manual/processing_algs/qgis/vectortable.rst
@@ -297,34 +297,34 @@ Parameters
   Layer to edit the attribute table structure
 
 ``Fields mapping`` [list]
-  List of output fields  with their definitions.
+  List of output fields with their definitions.
 
   The embedded table lists all the fields of the source
   layer and allows you to edit them:
 
-  * click on the |newAttribute| button to create a new field
-  * click on the |deleteAttribute| to remove a field
-  * use |arrowUp| and |arrowDown| to change the field order
-  * click on |clearText| to reset to the default view
+  * click the |newAttribute| button to create a new field
+  * click the |deleteAttribute| to remove a field
+  * use |arrowUp| and |arrowDown| to change the selected field order
+  * click |clearText| to reset to the default view
 
   For each of the fields you'd like to reuse, you need to
-  fill following options:
+  fill the following options:
 
   ``Source expression`` [expression]
-    Represents the field or an expression from the input layer.
+    Field or an expression from the input layer.
 
   ``Field name`` [string]
-    Represents the name of the field in the output layer.
+    Name of the field in the output layer.
     By default input field name is kept.
 
   ``Type`` [enumeration]
-    Sets the data type to apply to the output field.
+    Data type of the output field.
 
   ``Length`` [number]
-    Represents the length of the expected output field.
+    Length of the output field.
 
   ``Precision`` [number]
-    Represents the precision of the expected output field.
+    Precision of the expected output field.
 
 ``Load fields from layer`` [vector: any]
   Load fields from another vector layer to update the field list.


### PR DESCRIPTION
This should remove the [fieldsmapping] parameter type (though I did not grep the source to check) and address a point raised in https://github.com/qgis/QGIS-Documentation/pull/2738#issuecomment-400343396 with their removal.
I'm no longer sure it's worth explaining those widgets somewhere else (more than what is done in the parameter section).