### PR TITLE
Homogenize punctuation in QGIS algorithm description

### DIFF
--- a/source/docs/user_manual/processing_algs/gdal/rasteranalysis.rst
+++ b/source/docs/user_manual/processing_algs/gdal/rasteranalysis.rst
@@ -152,7 +152,7 @@ Parameters
   Default: *1*
 
 ``Validity mask`` [raster]
-  Optional.
+  Optional
 
   A mask that defines which areas are to be filled.
 

--- a/source/docs/user_manual/processing_algs/gdal/rasteranalysis.rst
+++ b/source/docs/user_manual/processing_algs/gdal/rasteranalysis.rst
@@ -218,7 +218,7 @@ Parameters
   Field for the interpolation.
 
 ``Output raster type`` [enumeration]
-  Raster file type
+  Raster file type.
 
   Options:
 
@@ -241,7 +241,7 @@ Outputs
 
 ``Output file`` [raster]
 
-Interpolated raster file
+Interpolated raster file.
 
 See also
 ........
@@ -261,7 +261,7 @@ Parameters
 ..........
 
 ``Input layer`` [vector: point]
-  Point vector layer
+  Point vector layer.
 
 ``Metrics`` [enumeration]
   List of available metrics:
@@ -278,29 +278,33 @@ Parameters
   Default: *0*
 
 ``Radius 1`` [number]
-  The first radius (X axis if rotation angle is 0) of search ellipse. Set this parameter to zero to use whole point array
+  The first radius (X axis if rotation angle is 0) of search ellipse.
+  Set this parameter to zero to use whole point array.
 
   Default: *0.0*
 
 ``Radius 2`` [number]
-  The second radius (Y axis if rotation angle is 0) of search ellipse. Set this parameter to zero to use whole point array
+  The second radius (Y axis if rotation angle is 0) of search ellipse.
+  Set this parameter to zero to use whole point array.
 
   Default: *0.0*
 
 ``Angle`` [number]
-  Angle of search ellipse rotation in degrees (counter clockwise)
+  Angle of search ellipse rotation in degrees (counter clockwise).
 
   Default: *0.0*
 
 ``Min points`` [number]
-  Minimum number of data points to use. If less amount of points found the grid node considered empty and will be filled with NODATA marker.
+  Minimum number of data points to use.
+  If less amount of points found the grid node considered empty and
+  will be filled with NODATA marker.
 
-  This is only used if search ellipse is set (both radii are non-zero)
+  This is only used if search ellipse is set (both radii are non-zero).
 
   Default: *0.0*
 
 ``Nodata`` [number]
-  NODATA marker to fill empty points
+  NODATA marker to fill empty points.
 
   Default: *0.0*
 
@@ -310,7 +314,7 @@ Parameters
   Field for the interpolation.
 
 ``Output raster type`` [enumeration]
-  Raster file type
+  Raster file type.
 
   Options:
 
@@ -332,7 +336,7 @@ Outputs
 .......
 
 ``Output file`` [raster]
-  Interpolated raster file
+  Interpolated raster file.
 
 See also
 ........
@@ -345,8 +349,9 @@ Grid (Inverse distance to a power)
 ----------------------------------
 The Inverse Distance to a Power gridding method is a weighted average interpolator.
 
-You should supply the input arrays with the scattered data values including coordinates of every data point and output
-grid geometry. The function will compute interpolated value for the given position in output grid.
+You should supply the input arrays with the scattered data values
+including coordinates of every data point and output grid geometry.
+The function will compute interpolated value for the given position in output grid.
 
 ``Default menu``: :menuselection:`Raster --> Analysis`
 
@@ -354,25 +359,25 @@ Parameters
 ..........
 
 ``Input layer`` [vector: point]
-  Point vector layer
+  Point vector layer.
 
 ``Power`` [number]
-  Weighting power
+  Weighting power.
 
   Default: *2.0*
 
 ``Smothing`` [number]
-  Smoothing parameter
+  Smoothing parameter.
 
   Default: *0.0*
 
 ``Radius 1`` [number]
-  The first radius (X axis if rotation angle is 0) of search ellipse
+  The first radius (X axis if rotation angle is 0) of search ellipse.
 
   Default: *0.0*
 
 ``Radius 2`` [number]
-  The second radius (Y axis if rotation angle is 0) of search ellipse
+  The second radius (Y axis if rotation angle is 0) of search ellipse.
 
   Default: *0.0*
 
@@ -387,7 +392,7 @@ Parameters
   Maximum number of data points to use.
 
   Do not search for more points than this number. If less amount of points found
-  the grid node is considered empty and will be filled with NODATA marker
+  the grid node is considered empty and will be filled with NODATA marker.
 
   Default: *0.0*
 
@@ -395,12 +400,12 @@ Parameters
   Minimum number of data points to use.
 
   If less amount of points found the grid node is considered empty and will be
-  filled with NODATA marker
+  filled with NODATA marker.
 
   Default: *0.0*
 
 ``Nodata`` [number]
-  No data marker to fill empty points
+  No data marker to fill empty points.
 
   Default: *0.0*
 
@@ -410,7 +415,7 @@ Parameters
   Field for the interpolation.
 
 ``Output raster type`` [enumeration]
-  Raster file type
+  Raster file type.
 
   Options:
 
@@ -432,7 +437,7 @@ Outputs
 .......
 
 ``Output file`` [raster]
-  Interpolated raster file
+  Interpolated raster file.
 
 See also
 .........
@@ -452,7 +457,7 @@ Parameters
 ..........
 
 ``Input layer`` [vector: point]
-  Point vector layer
+  Point vector layer.
 
 ``Power`` [number]
   Weighting power
@@ -460,7 +465,7 @@ Parameters
   Default: *2.0*
 
 ``Smothing`` [number]
-  Smoothing parameter
+  Smoothing parameter.
 
   Default: *0.0*
 
@@ -491,7 +496,7 @@ Parameters
   Field for the interpolation.
 
 ``Output raster type`` [enumeration]
-  Raster file type
+  Raster file type.
 
   Options:
 
@@ -513,7 +518,7 @@ Outputs
 .......
 
 ``Output file`` [raster]
-  Interpolated raster file
+  Interpolated raster file.
 
 See also
 ........
@@ -536,7 +541,7 @@ Parameters
 ..........
 
 ``Input layer`` [vector: point]
-  Point vector layer
+  Point vector layer.
 
 ``Search distance`` [number]
   In case the point to be interpolated does not fit into a triangle of the Delaunay
@@ -557,7 +562,7 @@ Parameters
   Field for the interpolation.
 
 ``Output raster type`` [enumeration]
-  Raster file type
+  Raster file type.
 
   Options:
 
@@ -579,7 +584,7 @@ Outputs
 .......
 
 ``Output file`` [raster]
-  Interpolated raster file
+  Interpolated raster file.
 
 See also
 ........
@@ -601,7 +606,7 @@ Parameters
 ..........
 
 ``Input layer`` [vector: point]
-  Point vector layer
+  Point vector layer.
 
 ``Radius 1`` [number]
   The first radius (X axis if rotation angle is 0) of search ellipse.
@@ -652,7 +657,7 @@ Outputs
 .......
 
 ``Output file`` [raster]
-  Interpolated raster file
+  Interpolated raster file.
 
 See also
 ........
@@ -738,15 +743,16 @@ Parameters
 ..........
 
 ``Input layer`` [raster]
-  Raster file in input
+  Raster file in input.
 
 ``How far from black (white)`` [number]
-  Select how far from black, white or custom colors the pixel values can be and still considered near black, white or custom color
+  Select how far from black, white or custom colors the pixel values can be and
+  still considered near black, white or custom color.
 
   Default: *15*
 
 ``Search for nearly white pixels instead of nearly black`` [boolean]
-  Search for nearly white (255) pixels instead of nearly black pixels
+  Search for nearly white (255) pixels instead of nearly black pixels.
 
   Default: *False*
 
@@ -754,7 +760,7 @@ Outputs
 .......
 
 ``Output layer`` [raster]
-  Raster file in output
+  Raster file in output.
 
 See also
 ........
@@ -776,7 +782,7 @@ Parameters
 ..........
 
 ``Input layer`` [raster]
-  Raster in input
+  Raster in input.
 
 ``Values`` [string]
   A list of target pixel values in the source image to be considered target pixels. If not specified, all non-zero
@@ -799,23 +805,23 @@ Parameters
   value is not provided, the output band will be queried for its nodata value.
 
   If the output band does not have a nodata value, then the value 65535 will be used.
-  Distance is interpreted in pixels unless *distunits* GEO is specified
+  Distance is interpreted in pixels unless *distunits* GEO is specified.
 
   Default: *-1*
 
 ``No data (negative value to ignore)`` [number]
-  Specify a nodata value to use for the destination proximity raster
+  Specify a nodata value to use for the destination proximity raster.
 
   Default: *-1*
 
 ``Fixed buf val (negative value to ignore)`` [number]
   Specify a value to be applied to all pixels that are within the -maxdist of target pixels
-  (including the target pixels) instead of a distance value
+  (including the target pixels) instead of a distance value.
 
   Default: *-1*
 
 ``Output raster type`` [enumeration]
-  Raster file type
+  Raster file type.
 
   Options:
 
@@ -837,7 +843,7 @@ Outputs
 .......
 
 ``Output layer`` [raster]
-  Raster file in output
+  Raster file in output.
 
 See also
 ........
@@ -976,7 +982,7 @@ TPI (Topographic Position Index)
 --------------------------------
 Outputs a single-band raster with values computed from the elevation.
 TPI stands for Topographic Position Index, which is defined as the difference between a central pixel and the mean
-of its surrounding cells
+of its surrounding cells.
 
 ``Default menu``: :menuselection:`Raster --> Analysis`
 
@@ -984,15 +990,15 @@ Parameters
 ..........
 
 ``Input layer`` [raster]
-  Elevation raster layer
+  Elevation raster layer.
 
 ``Band number`` [number]
-  The number of a band containing elevation values
+  The number of a band containing elevation values.
 
   Default: *1*
 
 ``Compute edges`` [boolean]
-  Generates edges from the elevation raster
+  Generates edges from the elevation raster.
 
   Default: *False*
 
@@ -1000,7 +1006,7 @@ Outputs
 .......
 
 ``Output file`` [raster]
-  TPI raster in output
+  TPI raster in output.
 
 See also
 ........
@@ -1014,7 +1020,7 @@ TRI (Terrain Ruggedness Index)
 ------------------------------
 Outputs a single-band raster with values computed from the elevation.
 TRI stands for Terrain Ruggedness Index, which is defined as the mean difference between a central pixel and its
-surrounding cells
+surrounding cells.
 
 ``Default menu``: :menuselection:`Raster --> Analysis`
 
@@ -1022,15 +1028,15 @@ Parameters
 ..........
 
 ``Input layer`` [raster]
-  Elevation raster layer
+  Elevation raster layer.
 
 ``Band number`` [number]
-  The number of a band containing elevation values
+  The number of a band containing elevation values.
 
   Default: *1*
 
 ``Compute edges`` [boolean]
-  Generates edges from the elevation raster
+  Generates edges from the elevation raster.
 
   Default: *False*
 
@@ -1038,7 +1044,7 @@ Outputs
 .......
 
 ``Output file`` [raster]
-  TRI raster file
+  TRI raster file.
 
 See also
 ........

--- a/source/docs/user_manual/processing_algs/gdal/rasterconversion.rst
+++ b/source/docs/user_manual/processing_algs/gdal/rasterconversion.rst
@@ -285,7 +285,7 @@ Parameters
   Default: *False*
 
 ``Additional creation parameters`` [string]
-  Optional.
+  Optional
 
   <put parameter description here>
 

--- a/source/docs/user_manual/processing_algs/gdal/rasterconversion.rst
+++ b/source/docs/user_manual/processing_algs/gdal/rasterconversion.rst
@@ -38,7 +38,7 @@ Outputs
 
 PCT to RGB
 ----------
-Convert an 8bit paletted image to 24bit RGB
+Convert an 8bit paletted image to 24bit RGB.
 
 This utility will convert a pseudocolor band on the input file into an output RGB file of the desired format.
 
@@ -48,10 +48,10 @@ Parameters
 ..........
 
 ``Input layer`` [raster]
-  Input 8bit raster image
+  Input 8bit raster image.
 
 ``Band to convert`` [enumeration]
-  Band to convert to RGB
+  Band to convert to RGB.
 
   Options:
 

--- a/source/docs/user_manual/processing_algs/gdal/rasterextraction.rst
+++ b/source/docs/user_manual/processing_algs/gdal/rasterextraction.rst
@@ -39,7 +39,7 @@ Parameters
   Default: *0,1,0,1*
 
 ``Additional creation parameters`` [string]
-  Optional.
+  Optional
 
   <put parameter description here>
 
@@ -87,7 +87,7 @@ Parameters
   Default: *False*
 
 ``Additional creation parameters`` [string]
-  Optional.
+  Optional
 
   <put parameter description here>
 
@@ -125,7 +125,7 @@ Parameters
   Default: *10.0*
 
 ``Attribute name (if not set, no elevation attribute is attached)`` [string]
-  Optional.
+  Optional
 
   Defines the attribute name for the field containing the values of the
   contour lines. If nothing is defines the default name will be 'ELEV'.
@@ -133,7 +133,7 @@ Parameters
   Default: *ELEV*
 
 ``Offset from zero relative to which to interpret intervals`` [number]
-  Optional.
+  Optional
 
   Default: *0.0*
 
@@ -146,7 +146,7 @@ Parameters
   Default: *False*
 
 ``Input pixel value to treat as "nodata"`` [number]
-  Optional.
+  Optional
 
   Default: *Not set*
 

--- a/source/docs/user_manual/processing_algs/gdal/rasterextraction.rst
+++ b/source/docs/user_manual/processing_algs/gdal/rasterextraction.rst
@@ -154,7 +154,7 @@ Outputs
 .......
 
 ``Contours`` [vector: line]
-  Output file for contour lines
+  Output file for contour lines.
 
 
 .. Substitutions definitions - AVOID EDITING PAST THIS LINE

--- a/source/docs/user_manual/processing_algs/gdal/rastermiscellaneous.rst
+++ b/source/docs/user_manual/processing_algs/gdal/rastermiscellaneous.rst
@@ -185,10 +185,11 @@ Parameters
 ..........
 
 ``Input layer`` [raster]
-  Raster layer in input
+  Raster layer in input.
 
 ``Suppress GCP info`` [boolean]
-  Suppress ground control points list printing. It may be useful for datasets with huge amount of GCPs, such as L1B AVHRR or HDF4 MODIS which contain thousands of them.
+  Suppress ground control points list printing. It may be useful for datasets with huge amount of GCPs,
+  such as L1B AVHRR or HDF4 MODIS which contain thousands of them.
 
   Default: *False*
 
@@ -201,7 +202,7 @@ Outputs
 .......
 
 ``Layer information`` [html]
-  Raster information in output
+  Raster information in output.
 
 See also
 ........

--- a/source/docs/user_manual/processing_algs/gdal/rastermiscellaneous.rst
+++ b/source/docs/user_manual/processing_algs/gdal/rastermiscellaneous.rst
@@ -225,7 +225,7 @@ Parameters
   The input raster files. Can be multiple files.
 
 ``Field name to hold the file path to the indexed rasters`` [string]
-  Optional.
+  Optional
 
   The output field name to hold the file path/location to the indexed rasters.
 
@@ -245,7 +245,7 @@ Parameters
   Default: *False*
 
 ``Transform geometries to the given CRS`` [crs]
-  Optional.
+  Optional
 
   Geometries of input files will be transformed to the desired target coordinate
   reference system.
@@ -253,10 +253,10 @@ Parameters
   system as the input rasters.
 
 ``The name of the field to store the SRS of each tile`` [string]
-  Optional.
+  Optional
 
 ``The format in which the CRS of each tile must be written`` [enumeration]
-  Optional.
+  Optional
 
   Possible values are:
 

--- a/source/docs/user_manual/processing_algs/gdal/rasterprojections.rst
+++ b/source/docs/user_manual/processing_algs/gdal/rasterprojections.rst
@@ -84,7 +84,7 @@ Parameters
   Default: *0*
 
 ``Additional creation parameters`` [string]
-  Optional.
+  Optional
 
   <put parameter description here>
 

--- a/source/docs/user_manual/processing_algs/gdal/vectorconversion.rst
+++ b/source/docs/user_manual/processing_algs/gdal/vectorconversion.rst
@@ -57,7 +57,7 @@ Parameters
   Default: *0*
 
 ``Creation Options`` [string]
-  Optional.
+  Optional
 
   <put parameter description here>
 

--- a/source/docs/user_manual/processing_algs/gdal/vectorgeoprocessing.rst
+++ b/source/docs/user_manual/processing_algs/gdal/vectorgeoprocessing.rst
@@ -30,7 +30,7 @@ Parameters
   It has to be defined in target CRS units.
 
 ``Additional creation Options`` [string]
-  Optional.
+  Optional
 
   <put parameter description here>
 
@@ -60,7 +60,7 @@ Parameters
   Layer to be used as clipping extent for the input vector layer.
 
 ``Additional creation Options`` [string]
-  Optional.
+  Optional
 
   <put parameter description here>
 

--- a/source/docs/user_manual/processing_algs/gdal/vectormiscellaneous.rst
+++ b/source/docs/user_manual/processing_algs/gdal/vectormiscellaneous.rst
@@ -95,7 +95,7 @@ Parameters
   Default: *EPSG:4326*
 
 ``Schema name`` [string]
-  Optional.
+  Optional
 
   Defines the schema to which the database table will be assigned to.
   By default, 'public' is chosen.
@@ -103,13 +103,13 @@ Parameters
   Default: *public*
 
 ``Table name, leave blank to use input name`` [string]
-  Optional.
+  Optional
 
   Defines a name for the table that will be imported into the database.
   By default the table name is the name of the input vector file.
 
 ``Primary Key`` [string]
-  Optional.
+  Optional
 
   Defines which attribute field will be the primary key of the database table.
   By default this is 'id'.
@@ -117,7 +117,7 @@ Parameters
   Default: *id*
 
 ``Geometry column name`` [string]
-  Optional.
+  Optional
 
   Defines in which attribute field of the database there will be the geometry
   information. By default it will be taken from the 'geom' column.
@@ -135,13 +135,13 @@ Parameters
   Default: *0*
 
 ``Distance tolerance for simplification`` [string]
-  Optional.
+  Optional
 
   Defines a distance tolerance for the simplification of the vector geometries
   to be imported. By default no simplification there is no simplification.
 
 ``Maximum distance between 2 nodes (densification)`` [string]
-  Optional.
+  Optional
 
   The maximum distance between two nodes. Used to create intermediate points.
   By default there is no maximum distance.
@@ -157,13 +157,13 @@ Parameters
   Default: *False*
 
 ``Select features using a SQL "WHERE" statement (Ex: column="value")`` [string]
-  Optional.
+  Optional
 
   Defines with a SQL "WHERE" statement which features should be selected for the
   output table.
 
 ``Group N features per transaction (Default: 20000)`` [string]
-  Optional.
+  Optional
 
   You can group the input features in transactions where N defines the size.
   By default N limits the transaction size to 20000 features.
@@ -215,7 +215,7 @@ Parameters
   Default: *True*
 
 ``Additional creation options`` [string]
-  Optional.
+  Optional
 
   <put parameter description here>
 
@@ -293,28 +293,28 @@ Parameters
   Default: *(not set)*
 
 ``Schema name`` [string]
-  Optional.
+  Optional
 
   <put parameter description here>
 
   Default: *public*
 
 ``Table name, leave blank to use input name`` [string]
-  Optional.
+  Optional
 
   <put parameter description here>
 
   Default: *(not set)*
 
 ``Primary Key`` [string]
-  Optional.
+  Optional
 
   <put parameter description here>
 
   Default: *id*
 
 ``Geometry column name`` [string]
-  Optional.
+  Optional
 
   <put parameter description here>
 
@@ -331,14 +331,14 @@ Parameters
   Default: *0*
 
 ``Distance tolerance for simplification`` [string]
-  Optional.
+  Optional
 
   <put parameter description here>
 
   Default: *(not set)*
 
 ``Maximum distance between 2 nodes (densification)`` [string]
-  Optional.
+  Optional
 
   <put parameter description here>
 
@@ -355,14 +355,14 @@ Parameters
   Default: *False*
 
 ``Select features using a SQL "WHERE" statement (Ex: column="value")`` [string]
-  Optional.
+  Optional
 
   <put parameter description here>
 
   Default: *(not set)*
 
 ``Group "n" features per transaction (Default: 20000)`` [string]
-  Optional.
+  Optional
 
   <put parameter description here>
 
@@ -399,7 +399,7 @@ Parameters
   Default: *False*
 
 ``Additional creation options`` [string]
-  Optional.
+  Optional
 
   <put parameter description here>
 

--- a/source/docs/user_manual/processing_algs/lidartools/lastools.rst
+++ b/source/docs/user_manual/processing_algs/lidartools/lastools.rst
@@ -529,7 +529,7 @@ Parameters
   Default: *False*
 
 ``input LAS/LAZ file`` [file]
-  Optional.
+  Optional
 
   <put parameter description here>
 
@@ -1309,7 +1309,7 @@ Parameters
   Default: *False*
 
 ``input LAS/LAZ file`` [file]
-  Optional.
+  Optional
 
   <put parameter description here>
 
@@ -1351,7 +1351,7 @@ Parameters
   Default: *False*
 
 ``input LAS/LAZ file`` [file]
-  Optional.
+  Optional
 
   <put parameter description here>
 
@@ -1479,7 +1479,7 @@ Parameters
   Default: *False*
 
 ``input LAS/LAZ file`` [file]
-  Optional.
+  Optional
 
   <put parameter description here>
 
@@ -1521,37 +1521,37 @@ Parameters
   Default: *True*
 
 ``input LAS/LAZ file`` [file]
-  Optional.
+  Optional
 
   <put parameter description here>
 
 ``2nd file`` [file]
-  Optional.
+  Optional
 
   <put parameter description here>
 
 ``3rd file`` [file]
-  Optional.
+  Optional
 
   <put parameter description here>
 
 ``4th file`` [file]
-  Optional.
+  Optional
 
   <put parameter description here>
 
 ``5th file`` [file]
-  Optional.
+  Optional
 
   <put parameter description here>
 
 ``6th file`` [file]
-  Optional.
+  Optional
 
   <put parameter description here>
 
 ``7th file`` [file]
-  Optional.
+  Optional
 
   <put parameter description here>
 
@@ -1588,7 +1588,7 @@ Parameters
   Default: *False*
 
 ``input LAS/LAZ file`` [file]
-  Optional.
+  Optional
 
   <put parameter description here>
 
@@ -1659,7 +1659,7 @@ Parameters
   Default: *False*
 
 ``input LAS/LAZ file`` [file]
-  Optional.
+  Optional
 
   <put parameter description here>
 
@@ -1696,7 +1696,7 @@ Parameters
   Default: *False*
 
 ``input LAS/LAZ file`` [file]
-  Optional.
+  Optional
 
   <put parameter description here>
 
@@ -1738,7 +1738,7 @@ Parameters
   Default: *False*
 
 ``Input ASCII file`` [file]
-  Optional.
+  Optional
 
   <put parameter description here>
 

--- a/source/docs/user_manual/processing_algs/otb/calibration.rst
+++ b/source/docs/user_manual/processing_algs/otb/calibration.rst
@@ -50,7 +50,7 @@ Parameters
   Default: *True*
 
 ``Relative Spectral Response File`` [file]
-  Optional.
+  Optional
 
   <put parameter description here>
 

--- a/source/docs/user_manual/processing_algs/otb/geometry.rst
+++ b/source/docs/user_manual/processing_algs/otb/geometry.rst
@@ -31,7 +31,7 @@ Parameters
   Default: *0*
 
 ``Projection`` [string]
-  Optional.
+  Optional
 
   <put parameter description here>
 
@@ -167,7 +167,7 @@ Parameters
   Default: *0*
 
 ``Model ortho-image`` [raster]
-  Optional.
+  Optional
 
   <put parameter description here>
 

--- a/source/docs/user_manual/processing_algs/otb/learning.rst
+++ b/source/docs/user_manual/processing_algs/otb/learning.rst
@@ -145,7 +145,7 @@ Parameters
   <put parameter description here>
 
 ``Field name`` [string]
-  Optional.
+  Optional
 
   <put parameter description here>
 
@@ -340,7 +340,7 @@ Parameters
   <put parameter description here>
 
 ``Input Mask`` [raster]
-  Optional.
+  Optional
 
   <put parameter description here>
 
@@ -348,7 +348,7 @@ Parameters
   <put parameter description here>
 
 ``Statistics file`` [file]
-  Optional.
+  Optional
 
   <put parameter description here>
 
@@ -388,7 +388,7 @@ Parameters
   <put parameter description here>
 
 ``ValidityMask`` [raster]
-  Optional.
+  Optional
 
   <put parameter description here>
 
@@ -494,7 +494,7 @@ Parameters
   <put parameter description here>
 
 ``Input XML image statistics file`` [file]
-  Optional.
+  Optional
 
   <put parameter description here>
 
@@ -656,7 +656,7 @@ Parameters
   <put parameter description here>
 
 ``Input XML image statistics file`` [file]
-  Optional.
+  Optional
 
   <put parameter description here>
 
@@ -741,7 +741,7 @@ Parameters
   <put parameter description here>
 
 ``Input XML image statistics file`` [file]
-  Optional.
+  Optional
 
   <put parameter description here>
 
@@ -853,7 +853,7 @@ Parameters
   <put parameter description here>
 
 ``Input XML image statistics file`` [file]
-  Optional.
+  Optional
 
   <put parameter description here>
 
@@ -973,7 +973,7 @@ Parameters
   <put parameter description here>
 
 ``Input XML image statistics file`` [file]
-  Optional.
+  Optional
 
   <put parameter description here>
 
@@ -1078,7 +1078,7 @@ Parameters
   <put parameter description here>
 
 ``Input XML image statistics file`` [file]
-  Optional.
+  Optional
 
   <put parameter description here>
 
@@ -1168,7 +1168,7 @@ Parameters
   <put parameter description here>
 
 ``Input XML image statistics file`` [file]
-  Optional.
+  Optional
 
   <put parameter description here>
 
@@ -1275,7 +1275,7 @@ Parameters
   <put parameter description here>
 
 ``Input XML image statistics file`` [file]
-  Optional.
+  Optional
 
   <put parameter description here>
 
@@ -1395,7 +1395,7 @@ Parameters
   <put parameter description here>
 
 ``Input XML image statistics file`` [file]
-  Optional.
+  Optional
 
   <put parameter description here>
 
@@ -1535,7 +1535,7 @@ Parameters
   Default: *128*
 
 ``Validity Mask`` [raster]
-  Optional.
+  Optional
 
   <put parameter description here>
 

--- a/source/docs/user_manual/processing_algs/otb/miscellaneous.rst
+++ b/source/docs/user_manual/processing_algs/otb/miscellaneous.rst
@@ -228,12 +228,12 @@ Parameters
   Default: *512*
 
 ``Image logo`` [raster]
-  Optional.
+  Optional
 
   <put parameter description here>
 
 ``Image legend`` [raster]
-  Optional.
+  Optional
 
   <put parameter description here>
 

--- a/source/docs/user_manual/processing_algs/otb/segmentation.rst
+++ b/source/docs/user_manual/processing_algs/otb/segmentation.rst
@@ -26,7 +26,7 @@ Parameters
   <put parameter description here>
 
 ``Mask expression`` [string]
-  Optional.
+  Optional
 
   <put parameter description here>
 
@@ -43,7 +43,7 @@ Parameters
   Default: *2*
 
 ``OBIA Expression`` [string]
-  Optional.
+  Optional
 
   <put parameter description here>
 
@@ -85,7 +85,7 @@ Parameters
   <put parameter description here>
 
 ``Spatial image`` [raster]
-  Optional.
+  Optional
 
   <put parameter description here>
 
@@ -115,7 +115,7 @@ Parameters
   Default: *500*
 
 ``Directory where to write temporary files`` [file]
-  Optional.
+  Optional
 
   <put parameter description here>
 
@@ -347,7 +347,7 @@ Parameters
   Default: *0*
 
 ``Mask Image`` [raster]
-  Optional.
+  Optional
 
   <put parameter description here>
 
@@ -392,7 +392,7 @@ Parameters
   Default: *1*
 
 ``OGR options for layer creation`` [string]
-  Optional.
+  Optional
 
   <put parameter description here>
 
@@ -479,7 +479,7 @@ Parameters
   Default: *0*
 
 ``Mask Image`` [raster]
-  Optional.
+  Optional
 
   <put parameter description here>
 
@@ -524,7 +524,7 @@ Parameters
   Default: *1*
 
 ``OGR options for layer creation`` [string]
-  Optional.
+  Optional
 
   <put parameter description here>
 
@@ -616,7 +616,7 @@ Parameters
   Default: *0*
 
 ``Mask Image`` [raster]
-  Optional.
+  Optional
 
   <put parameter description here>
 
@@ -661,7 +661,7 @@ Parameters
   Default: *1*
 
 ``OGR options for layer creation`` [string]
-  Optional.
+  Optional
 
   <put parameter description here>
 
@@ -748,7 +748,7 @@ Parameters
   Default: *0*
 
 ``Mask Image`` [raster]
-  Optional.
+  Optional
 
   <put parameter description here>
 
@@ -793,7 +793,7 @@ Parameters
   Default: *1*
 
 ``OGR options for layer creation`` [string]
-  Optional.
+  Optional
 
   <put parameter description here>
 
@@ -870,7 +870,7 @@ Parameters
   Default: *0*
 
 ``Mask Image`` [raster]
-  Optional.
+  Optional
 
   <put parameter description here>
 
@@ -915,7 +915,7 @@ Parameters
   Default: *1*
 
 ``OGR options for layer creation`` [string]
-  Optional.
+  Optional
 
   <put parameter description here>
 

--- a/source/docs/user_manual/processing_algs/otb/stereo.rst
+++ b/source/docs/user_manual/processing_algs/otb/stereo.rst
@@ -26,7 +26,7 @@ Parameters
   <put parameter description here>
 
 ``Couples list`` [string]
-  Optional.
+  Optional
 
   <put parameter description here>
 
@@ -190,12 +190,12 @@ Parameters
   Default: *0.6*
 
 ``Input left mask`` [raster]
-  Optional.
+  Optional
 
   <put parameter description here>
 
 ``Input right mask`` [raster]
-  Optional.
+  Optional
 
   <put parameter description here>
 

--- a/source/docs/user_manual/processing_algs/qgis/cartography.rst
+++ b/source/docs/user_manual/processing_algs/qgis/cartography.rst
@@ -35,13 +35,13 @@ Parameters
 ..........
 
 ``Input layer`` [vector: polygon]
-  Polygon vector layer
+  Polygon vector layer.
 
 ``Minimum number of colors`` [number]
-  Minimum colors number to assign
+  Minimum colors number to assign.
 
 ``Minimum distance between features`` [number]
-  Prevent nearby (but non-touching) features from being assigned equal colors
+  Prevent nearby (but non-touching) features from being assigned equal colors.
 
 ``Balance color assignment`` [enumeration]
   Options:
@@ -49,7 +49,7 @@ Parameters
   * by feature count
 
     Attempts to assign colors so that the count of features assigned to each
-    individual color index is balanced
+    individual color index is balanced.
 
   * by assigned area
 

--- a/source/docs/user_manual/processing_algs/qgis/database.rst
+++ b/source/docs/user_manual/processing_algs/qgis/database.rst
@@ -163,17 +163,17 @@ Parameters
 ..........
 
 ``Input layers`` [vector: any] [list]
-  All the vector layers to import into the GeoPackage database
+  All the vector layers to import into the GeoPackage database.
 
 ``Overwrite existing GeoPackage`` [boolean]
-  Replaces an existing database with a new one
+  Replaces an existing database with a new one.
 
   Default: *False*
 
 Outputs
 .......
 ``Destination GeoPackage``
-  If not specified the GeoPackage database will be save in the temporary folder.
+  If not specified the GeoPackage database will be saved in the temporary folder.
 
 
 .. _qgisimportintospatialite:

--- a/source/docs/user_manual/processing_algs/qgis/database.rst
+++ b/source/docs/user_manual/processing_algs/qgis/database.rst
@@ -32,23 +32,23 @@ Parameters
   will be shown in the combobox.
 
 ``Schema (schema name)`` [string]
-  Optional.
+  Optional
 
   Name of the schema to store the data. It can be a new one or already exist.
 
   Default: *public*
 
 ``Table to import to (leave blank to use layer name)`` [string]
-  Optional.
+  Optional
 
   Defines a table name for the imported vector file.
   If nothing is added, the layer name will be used.
 
 ``Primary key field`` [tablefield: any]
-  Optional. A column with **unique** values can be used as Primary key for the
-  database.
+  Optional
 
   Sets the primary key field from an existing field in the vector layer.
+  A column with **unique** values can be used as Primary key for the database.
 
 ``Geometry column`` [string]
   Defines the name of the geometry column in the new PostGIS table.
@@ -57,7 +57,7 @@ Parameters
   Default: *geom*
 
 ``Encoding`` [string]
-  Optional.
+  Optional
 
   Defines the encoding of the layer in the new PostGIS table.
 
@@ -199,13 +199,13 @@ Parameters
   `sqlite` file.
 
 ``Table to import to (leave blank to use layer name)`` [string]
-  Optional.
+  Optional
 
   Defines a table name for the imported vector file.
   If nothing is added, the layer name will be used.
 
 ``Primary key field`` [tablefield: any]
-  Optional.
+  Optional
 
   Sets the primary key field from an existing field in the vector layer.
 
@@ -216,7 +216,7 @@ Parameters
   Default: *geom*
 
 ``Encoding`` [string]
-  Optional.
+  Optional
 
   Defines the encoding of the layer in the new SpatiaLite table.
 

--- a/source/docs/user_manual/processing_algs/qgis/filetools.rst
+++ b/source/docs/user_manual/processing_algs/qgis/filetools.rst
@@ -23,13 +23,13 @@ Parameters
 ..........
 
 ``URL`` [string]
-  Valid URL as a string character
+  Valid URL as a string character.
 
 Output
 ......
 
 ``File destination`` [file]
-  Downloaded file of the chosen URL
+  Downloaded file of the chosen URL.
 
 
 .. Substitutions definitions - AVOID EDITING PAST THIS LINE

--- a/source/docs/user_manual/processing_algs/qgis/graphics.rst
+++ b/source/docs/user_manual/processing_algs/qgis/graphics.rst
@@ -23,20 +23,19 @@ Parameters
 ..........
 
 ``Input layer`` [vector: any]
-  Input vector layer to use for the plot
+  Input vector layer to use for the plot.
 
 ``Category field name`` [tablefield: any]
-  Categorical field to use for grouping the bars (X axis)
+  Categorical field to use for grouping the bars (X axis).
 
 ``Value field`` [tablefield: any]
-  Value to use for the plot (Y axis)
+  Value to use for the plot (Y axis).
 
 Output
 ......
 
 ``Bar plot`` [html]
-  ``html`` file of the plot available in the :menuselection:`Processing --> Result Viewer`
-
+  ``html`` file of the plot available in the :menuselection:`Processing --> Result Viewer`.
 
 
 .. _qgisboxplot:
@@ -50,13 +49,13 @@ Parameters
 ..........
 
 ``Input layer`` [vector: any]
-  Input vector layer to use for the plot
+  Input vector layer to use for the plot.
 
 ``Category field name`` [tablefield: any]
-  Categorical field to use for grouping the boxes (X axis)
+  Categorical field to use for grouping the boxes (X axis).
 
 ``Value field`` [tablefield: any]
-  Value to use for the plot (Y axis)
+  Value to use for the plot (Y axis).
 
 ``Additional statistic lines`` [enumeration]
   Additional statistics information to add to the plot. Options available are:
@@ -71,7 +70,7 @@ Output
 ......
 
 ``Box plot`` [html]
-  ``html`` file of the plot available in the :menuselection:`Processing --> Result Viewer`
+  ``html`` file of the plot available in the :menuselection:`Processing --> Result Viewer`.
 
 
 
@@ -86,19 +85,19 @@ Parameters
 ..........
 
 ``Input table`` [vector: any]
-  Input vector layer to use for the plot
+  Input vector layer to use for the plot.
 
 ``Category name field`` [tablefield: any]
-  Categorical field to use for grouping the boxes (X axis)
+  Categorical field to use for grouping the boxes (X axis).
 
 ``Value field`` [tablefield: any]
-  Value to use for the plot (Y axis)
+  Value to use for the plot (Y axis).
 
 Output
 ......
 
 ``Plot`` [html]
-  ``html`` file of the plot available in the :menuselection:`Processing --> Result Viewer`
+  ``html`` file of the plot available in the :menuselection:`Processing --> Result Viewer`.
 
 
 
@@ -116,19 +115,19 @@ Parameters
 ..........
 
 ``Input layer`` [vector: any]
-  Input vector layer to use for the plot
+  Input vector layer to use for the plot.
 
 ``Category field name`` [tablefield: any]
-  Categorical field to group the features
+  Categorical field to group the features.
 
 ``Value field`` [tablefield: numeric]
-  Value to use for the plot
+  Value to use for the plot.
 
 Output
 ......
 
 ``Polar plot`` [html]
-  ``html`` file of the plot available in the :menuselection:`Processing --> Result Viewer`
+  ``html`` file of the plot available in the :menuselection:`Processing --> Result Viewer`.
 
 
 
@@ -142,13 +141,13 @@ Parameters
 ..........
 
 ``Input layer`` [raster]
-  Input raster layer to use for the plot
+  Input raster layer to use for the plot.
 
 ``Band number`` [raster band]
-  Raster band to use for the histogram
+  Raster band to use for the histogram.
 
 ``number of bins`` [number]
-  Total bins of the histogram
+  Total bins of the histogram.
 
   Default: *10*
 
@@ -156,7 +155,7 @@ Output
 ......
 
 ``Histogram`` [html]
-  ``html`` file of the plot available in the :menuselection:`Processing --> Result Viewer`
+  ``html`` file of the plot available in the :menuselection:`Processing --> Result Viewer`.
 
 
 
@@ -172,13 +171,13 @@ Parameters
 ..........
 
 ``Input layer`` [vector: any]
-  Input vector layer to use for the plot
+  Input vector layer to use for the plot.
 
 ``Category field name`` [tablefield: any]
-  Field to use for the histogram
+  Field to use for the histogram.
 
 ``number of bins`` [number]
-  Total bins of the histogram
+  Total bins of the histogram.
 
   Default: *10*
 
@@ -186,7 +185,7 @@ Output
 ......
 
 ``Histogram`` [html]
-  ``html`` file of the plot available in the :menuselection:`Processing --> Result Viewer`
+  ``html`` file of the plot available in the :menuselection:`Processing --> Result Viewer`.
 
 
 
@@ -201,19 +200,19 @@ Parameters
 ..........
 
 ``Input layer`` [vector: any]
-  Input vector layer to use for the plot
+  Input vector layer to use for the plot.
 
 ``X attribute`` [tablefield: any]
-  Field to use for the x axis
+  Field to use for the x axis.
 
 ``Y attribute`` [tablefield: any]
-  Field to use for the y axis
+  Field to use for the y axis.
 
 Output
 ......
 
 ``Scatterplot`` [html]
-  ``html`` file of the plot available in the :menuselection:`Processing --> Result Viewer`
+  ``html`` file of the plot available in the :menuselection:`Processing --> Result Viewer`.
 
 
 
@@ -228,22 +227,22 @@ Parameters
 ..........
 
 ``Input layer`` [vector: any]
-  Input vector layer to use for the plot
+  Input vector layer to use for the plot.
 
 ``X attribute`` [tablefield: any]
-  Field to use for the x axis
+  Field to use for the x axis.
 
 ``Y attribute`` [tablefield: any]
-  Field to use for the y axis
+  Field to use for the y axis.
 
 ``Z attribute`` [tablefield: any]
-  Field to use for the z axis
+  Field to use for the z axis.
 
 Output
 ......
 
 ``Scatterplot`` [html]
-  ``html`` file of the plot available in the :menuselection:`Processing --> Result Viewer`
+  ``html`` file of the plot available in the :menuselection:`Processing --> Result Viewer`.
 
 
 .. Substitutions definitions - AVOID EDITING PAST THIS LINE

--- a/source/docs/user_manual/processing_algs/qgis/interpolation.rst
+++ b/source/docs/user_manual/processing_algs/qgis/interpolation.rst
@@ -27,7 +27,7 @@ Parameters
 ..........
 
 ``Point layer`` [vector: point]
-  Point vector layer to use for the heatmap
+  Point vector layer to use for the heatmap.
 
 ``Radius (layer units)`` [number]
   Heatmap search radius (or kernel bandwidth) in map units. The radius
@@ -103,7 +103,7 @@ Parameters
 Output
 ......
 ``Heatmap`` [raster]
-  Raster layer with kernel density values
+  Raster layer with kernel density values.
 
 
 Example: Creating a Heatmap
@@ -128,8 +128,9 @@ In Figure_Heatmap_data_processing_, the airports of Alaska are shown.
    from the list of point layers loaded in the current project.
 #. Change the :guilabel:`Radius` to ``1000000`` meters.
 #. Change the :guilabel:`Pixel size X` to ``1000``. The :guilabel:`Pixel size Y`,
-    :guilabel:`Rows` and :guilabel:`Columns` will be automatically updated.
-#. Click on **[Run in Background]**  to create and load the airports heatmap (see Figure_Heatmap_created_processing_).
+   :guilabel:`Rows` and :guilabel:`Columns` will be automatically updated.
+#. Click on **[Run in Background]**  to create and load the airports heatmap
+   (see Figure_Heatmap_created_processing_).
 
 .. _figure_heatmap_settings_processing:
 
@@ -190,7 +191,7 @@ Parameters
 ..........
 
 ``Vector layer`` [vector: point]
-  Point vector layer to use for the interpolation
+  Point vector layer to use for the interpolation.
 
 ``Interpolation attribute`` [tablefield: numeric]
   Field used for the interpolation. Once you have chosen the layer and the field
@@ -201,10 +202,10 @@ Parameters
   ``Type`` column of the table.
 
 ``Use Z-coordinate for interpolation`` [boolean]
-  Uses the layer's stored Z values
+  Uses the layer's stored Z values.
 
 ``Distance coefficient Power`` [number]
-  Sets the distance coefficient for the interpolation
+  Sets the distance coefficient for the interpolation.
 
   Default: *2.0*
 
@@ -222,7 +223,7 @@ Parameters
 Output
 ......
 ``Interpolated`` [raster]
-  Raster layer of interpolated values
+  Raster layer of interpolated values.
 
 
 .. _qgistininterpolation:
@@ -243,7 +244,7 @@ Parameters
 ..........
 
 ``Vector layer`` [vector: point]
-  Point vector layer to use for the interpolation
+  Point vector layer to use for the interpolation.
 
 ``Interpolation attribute`` [tablefield: numeric]
   Field used for the interpolation. Once you have chosen the layer and the field
@@ -254,7 +255,7 @@ Parameters
   ``Type`` column of the table.
 
 ``Use Z-coordinate for interpolation`` [boolean]
-  Uses the layer's stored Z values
+  Uses the layer's stored Z values.
 
 ``Interpolation method`` [enumeration]
   There are two different choices:
@@ -278,10 +279,10 @@ Parameters
 Output
 ......
 ``Interpolated`` [raster]
-  Raster layer of triangulated values
+  Raster layer of triangulated values.
 
 ``Triangulation`` [vector: line]
-  Triangulation lines as vector layer
+  Triangulation lines as vector layer.
 
 
 .. Substitutions definitions - AVOID EDITING PAST THIS LINE

--- a/source/docs/user_manual/processing_algs/qgis/layertools.rst
+++ b/source/docs/user_manual/processing_algs/qgis/layertools.rst
@@ -32,13 +32,13 @@ Parameters
 ..........
 
 ``Input layer`` [vector: any]
-  Vector layer
+  Vector layer.
 
 Outputs
 .......
 
 ``Extent`` [vector: polygon]
-  Polygon vector layer
+  Polygon vector layer.
 
 
 .. Substitutions definitions - AVOID EDITING PAST THIS LINE

--- a/source/docs/user_manual/processing_algs/qgis/modelertools.rst
+++ b/source/docs/user_manual/processing_algs/qgis/modelertools.rst
@@ -22,10 +22,10 @@ Parameters
 ..........
 
 ``Layer`` [layer: any]
-  Layer to load in the legend
+  Layer to load in the legend.
 
 ``Loaded layer name`` [string]
-  Name of the loaded layer
+  Name of the loaded layer.
 
 
 .. _qgisrenamelayer:
@@ -37,10 +37,10 @@ Parameters
 ..........
 
 ``Layer`` [layer: any]
-  Layer to rename
+  Layer to rename.
 
 ``New name`` [string]
-  Name of the layer
+  Name of the layer.
 
 
 .. _qgisstringconcatenation:
@@ -53,10 +53,10 @@ Parameters
 ..........
 
 ``Input 1`` [string]
-  First string to concatenate
+  First string to concatenate.
 
 ``Input 2`` [string]
-  Second string to concatenate
+  Second string to concatenate.
 
 
 .. _qgisvariabledistancebuffer:
@@ -72,14 +72,14 @@ Parameters
 ..........
 
 ``Input layer`` [vector: any]
-  Input vector layer
+  Input vector layer.
 
 ``Distance field`` [tablefield: numeric]
-  Attribute for the distance radius of the buffer
+  Attribute for the distance radius of the buffer.
 
 ``Segments`` [number]
   Controls the number of line segments to use to approximate a quarter circle when
-  creating rounded offsets
+  creating rounded offsets.
 
   Default: *5*
 
@@ -108,7 +108,7 @@ Parameters
 
 ``Miter limit`` [number]
   Only applicable for mitered join styles, and controls the maximum distance from
-  the offset curve to use when creating a mitered join
+  the offset curve to use when creating a mitered join.
 
   Default: *2.0*
 
@@ -116,7 +116,7 @@ Outputs
 .......
 
 ``Buffer`` [vector: polygon]
-  Buffer polygon vector layer
+  Buffer polygon vector layer.
 
 See also
 ........

--- a/source/docs/user_manual/processing_algs/qgis/rasteranalysis.rst
+++ b/source/docs/user_manual/processing_algs/qgis/rasteranalysis.rst
@@ -55,20 +55,20 @@ Parameters
   Default: *NDVI*
 
 ``Reference layers(s)(used for automated extent, cellsize and CRS)`` [raster] [list]
-  Optional.
+  Optional
 
   Layer(s) that will be used to fetch extent, cell size and CRS. Choosing the
   layer in this box avoids to fill all the other parameters by hand.
 
 ``Cell size (use 0 or empty to set it automatically)`` [number]
-  Optional.
+  Optional
 
   Cell size of the output raster layer. If the cell size is not specified, the
   minimum cell size of selected reference layer(s) will be used. The cell size is
   assumed to be the same in both X and Y axes.
 
 ``Output extent (xmin, xmax, ymin, ymax)`` [extent]
-  Optional.
+  Optional
 
   Extent of the output raster layer. If the extent is not specified, the minimum
   extent that covers selected reference layer(s) will be used.
@@ -187,7 +187,7 @@ Parameters
   Overlaying vector layer where unique raster values will be appended
 
 ``Output column prefix`` [string]
-  Optional.
+  Optional
 
   Prefix string for output columns
 

--- a/source/docs/user_manual/processing_algs/qgis/rasterterrainanalysis.rst
+++ b/source/docs/user_manual/processing_algs/qgis/rasterterrainanalysis.rst
@@ -199,7 +199,7 @@ Parameters
   Default: *False*
 
 ``Relief colors`` [table widget]
-  Optional.
+  Optional
 
   Use the following table widget if you want to choose the relief colors manually.
   You can add as many color classes as you want: for each class you can choose

--- a/source/docs/user_manual/processing_algs/qgis/rasterterrainanalysis.rst
+++ b/source/docs/user_manual/processing_algs/qgis/rasterterrainanalysis.rst
@@ -38,7 +38,7 @@ Parameters
 ..........
 
 ``Elevation layer`` [raster]
-  Digital Terrain Model raster layer
+  Digital Terrain Model raster layer.
 
 ``Z factor`` [number]
   Vertical exaggeration. This parameter is useful when the Z units differ from
@@ -51,7 +51,7 @@ Outputs
 .......
 
 ``Aspect`` [raster]
-  Aspect raster layer
+  Aspect raster layer.
 
 
 .. _qgishillshade:
@@ -91,7 +91,7 @@ Parameters
 ..........
 
 ``Elevation layer`` [raster]
-  Digital Terrain Model raster layer
+  Digital Terrain Model raster layer.
 
 ``Z factor`` [number]
   You can use this parameter to exaggerate the final result in order to give it
@@ -116,7 +116,7 @@ Outputs
 .......
 
 ``Hillshade`` [raster]
-  Hillshade raster layer
+  Hillshade raster layer.
 
 
 .. _qgishypsometriccurves:
@@ -184,7 +184,7 @@ Parameters
 ..........
 
 ``Elevation layer`` [raster]
-  Digital Terrain Model raster layer
+  Digital Terrain Model raster layer.
 
 ``Z factor`` [number]
   You can use this parameter to exaggerate the final result in order to give it
@@ -219,7 +219,7 @@ Outputs
 .......
 
 ``Relief`` [raster]
-  Relief raster layer
+  Relief raster layer.
 
 
 .. _qgisruggednessindex:
@@ -242,7 +242,7 @@ Parameters
 ..........
 
 ``Elevation layer`` [raster]
-  Digital Terrain Model raster layer
+  Digital Terrain Model raster layer.
 
 ``Z factor`` [number]
   You can use this parameter to exaggerate the final result in order to give it
@@ -254,7 +254,7 @@ Outputs
 .......
 
 ``Ruggedness`` [raster]
-  Ruggedness raster layer
+  Ruggedness raster layer.
 
 
 .. _qgisslope:
@@ -276,7 +276,7 @@ Parameters
 ..........
 
 ``Elevation raster`` [raster]
-  Digital Terrain Model raster layer
+  Digital Terrain Model raster layer.
 
 ``Z factor`` [number]
   You can use this parameter to exaggerate the final result in order to give it
@@ -288,7 +288,7 @@ Outputs
 .......
 
 ``Slope`` [raster]
-  Slope raster layer
+  Slope raster layer.
 
 
 .. Substitutions definitions - AVOID EDITING PAST THIS LINE

--- a/source/docs/user_manual/processing_algs/qgis/rastertools.rst
+++ b/source/docs/user_manual/processing_algs/qgis/rastertools.rst
@@ -34,12 +34,12 @@ Parameters
   of the tile size.
 
 ``Tile size`` [number]
-  Size of the tile of the output raster layer
+  Size of the tile of the output raster layer.
 
   Default: *1024*
 
 ``Map units per pixel`` [number]
-  Pixel size (in map units)
+  Pixel size (in map units).
 
   Default: *100*
 
@@ -52,39 +52,39 @@ Parameters
 ``Single layer to render`` [enumeration]
   Optional
 
-  Choose a single layer for the output raster layer
+  Choose a single layer for the output raster layer.
 
 Outputs
 .......
 
 ``Output layer`` [raster]
-  Output raster layer
+  Output raster layer.
 
 .. _qgiscreateconstantrasterlayer:
 
 Create constant raster layer
 ----------------------------
 Given an extent and a value, generates a raster layer with all the pixels having
-the same value choosen.
+the same value chosen.
 
 Parameters
 ..........
 
 ``Desired extent (xmin, xmax, ymin, ymax)`` [extent]
-  Extent for the raster layer
+  Extent for the raster layer.
 
 ``Target CRS`` [crs]
-  CRS for the output raster layer
+  CRS for the output raster layer.
 
   Default: *project CRS*
 
 ``Pixel size`` [number]
-  Pixel size (X=Y) in map units
+  Pixel size (X=Y) in map units.
 
   Default: *0.1*
 
 ``Constant value`` [number]
-  Constant pixel value for the raster layer
+  Constant pixel value for the raster layer.
 
   Default: *1*
 
@@ -92,7 +92,7 @@ Outputs
 .......
 
 ``Constant`` [raster]
-  Raster covering the desired extent with pixel size and value chosen
+  Raster covering the desired extent with pixel size and value chosen.
 
 
 .. _qgissetstyleforrasterlayer:
@@ -107,7 +107,7 @@ Parameters
 ..........
 
 ``Raster layer`` [raster]
-  Raster layer
+  Raster layer.
 
 ``Style file`` [file]
   Path of the ``QML`` style file.

--- a/source/docs/user_manual/processing_algs/qgis/vectoranalysis.rst
+++ b/source/docs/user_manual/processing_algs/qgis/vectoranalysis.rst
@@ -23,7 +23,7 @@ Numeric, date, time and string fields are supported.
 The statistics returned will depend on the field type.
 
 Statistics are generated as an HTML file and are available in the
-:menuselection:`Processing --> Results viewer`
+:menuselection:`Processing --> Results viewer`.
 
 ``Default menu``: :menuselection:`Vector --> Analysis Tools`
 
@@ -31,15 +31,15 @@ Parameters
 ..........
 
 ``Input vector`` [vector: any]
-  Vector layer to calculate the statistic on
+  Vector layer to calculate the statistic on.
 
 ``Field to calculate statistics on`` [tablefield: any]
-  Any supported table field to calculate the statistics
+  Any supported table field to calculate the statistics.
 
 Outputs
 .......
 ``Statistics`` [html]
-  HTML file with calculated statistics
+  HTML file with calculated statistics.
 
 
 .. _qgiscountpointsinpolygon:
@@ -67,10 +67,10 @@ will take precedence and the unique class field will be ignored.
 Parameters
 ..........
 ``Polygons`` [vector: polygon]
-  Polygons layer
+  Polygons layer.
 
 ``Points`` [vector: point]
-  Points layer
+  Points layer.
 
 ``Weight field`` [tablefield: any]
   Optional
@@ -87,7 +87,7 @@ Parameters
   classes that are found in it.
 
 ``Count field name`` [string]
-  The name of the field to store the count of points
+  The name of the field to store the count of points.
 
   Default: *NUMPOINTS*
 
@@ -112,14 +112,14 @@ Parameters
 ..........
 
 ``Input point layer`` [vector: point]
-  Input point vector layer
+  Input point vector layer.
 
 ``Input unique ID field`` [tablefield: any]
   Define the field of the input layer with unique ID that will be copied in the
   output attribute table.
 
 ``Target point layer`` [vector: point]
-  Destination point vector layer
+  Destination point vector layer.
 
 ``Target unique ID field`` [tablefield: any]
   Define the field of the target layer with unique ID that will be copied in the
@@ -170,14 +170,14 @@ Parameters
 ..........
 
 ``Source points layer`` [vector: any]
-  Input vector layer
+  Input vector layer.
 
 ``Destination hubs layer`` [vector: any]
-  Destination layer to calculate the nearest point
+  Destination layer to calculate the nearest point.
 
 ``Hub layer name attribute`` [tablefield: any]
   Attribute of the destination layer that will be copied into the
-  output
+  output.
 
 ``Measurement unit`` [enumeration]
   The distance field in the output attribute table will be calculated according
@@ -194,7 +194,7 @@ Parameters
 Outputs
 .......
 ``Hub distance`` [vector: line]
-  Line vector layer with distance values
+  Line vector layer with distance values.
 
 
 .. _qgisdistancetonearesthubpoints:
@@ -208,14 +208,14 @@ Parameters
 ..........
 
 ``Source points layer`` [vector: any]
-  Input vector layer
+  Input vector layer.
 
 ``Destination hubs layer`` [vector: any]
-  Destination layer to calculate the nearest point
+  Destination layer to calculate the nearest point.
 
 ``Hub layer name attribute`` [tablefield: any]
   Attribute of the destination layer that will be copied into the
-  output
+  output.
 
 ``Measurement unit`` [enumeration]
   The distance field in the output attribute table will be calculated according
@@ -232,7 +232,7 @@ Parameters
 Outputs
 .......
 ``Hub distance`` [vector: point]
-  Point vector layer with distance values
+  Point vector layer with distance values.
 
 
 .. _qgishublines:
@@ -256,10 +256,10 @@ Parameters
 ..........
 
 ``Hub point layer`` [vector: any]
-  Input layer
+  Input layer.
 
 ``Hub ID field`` [tablefield: any]
-  Field of the hub layer with ID to join
+  Field of the hub layer with ID to join.
 
 ``Hub layer fields to copy``
   Optional
@@ -268,10 +268,10 @@ Parameters
   all fields are taken.
 
 ``Spoke point layer`` [vector: any]
-  Additional spoke point layer
+  Additional spoke point layer.
 
 ``Spoke ID field`` [tablefield: any]
-  Field of the spoke layer with ID to join
+  Field of the spoke layer with ID to join.
 
 ``Spoke layer fields to copy``
   Optional
@@ -282,7 +282,7 @@ Parameters
 Outputs
 .......
 ``Hub lines`` [vector: lines]
-  The resulting line layer
+  The resulting line layer.
 
 
 .. _qgislistuniquevalues:
@@ -306,10 +306,10 @@ Outputs
 .......
 
 ``Unique values`` [table]
-  Summary table layer with unique values
+  Summary table layer with unique values.
 
 ``HTML report`` [html]
-  HTML report of unique values in the :menuselection:`Processing --> Results viewer`
+  HTML report of unique values in the :menuselection:`Processing --> Results viewer`.
 
 
 .. _qgismeancoordinates:
@@ -332,7 +332,7 @@ Parameters
 ..........
 
 ``Input layer`` [vector: any]
-  Input vector layer
+  Input vector layer.
 
 ``Weight field`` [tablefield: numeric]
   Optional
@@ -370,12 +370,12 @@ Parameters
 ..........
 
 ``Points`` [vector: point]
-  Point vector layer to calculate the statistics on
+  Point vector layer to calculate the statistics on.
 
 Outputs
 .......
 ``Nearest neighbour`` [html]
-  HTML file in output with the computed statistics
+  HTML file in output with the computed statistics.
 
 
 .. _qgisstatisticsbycategories:
@@ -405,20 +405,20 @@ Parameters
 ..........
 
 ``Input vector layer`` [vector: any]
-  Input vector layer with unique classes and values
+  Input vector layer with unique classes and values.
 
 ``Field to calculate the statistics on`` [tablefield: any]
   Optional
 
-  If empty only the count will be calculated
+  If empty only the count will be calculated.
 
 ``Field(s) with categories`` [tablefield: any] [list]
-  Field(s) of the categories
+  Field(s) of the categories.
 
 Outputs
 .......
 ``N unique values`` [table]
-  Table with statistics field
+  Table with statistics field.
 
 
 .. _qgissumlinelengths:
@@ -440,25 +440,25 @@ Parameters
 ..........
 
 ``Lines`` [vector: line]
-  Input vector line layer
+  Input vector line layer.
 
 ``Polygons`` [vector: polygon]
-  Polygon vector layer
+  Polygon vector layer.
 
 ``Lines length field name`` [string]
-  Name of the field of the lines length
+  Name of the field of the lines length.
 
   Default: *LENGTH*
 
 ``Lines count field name`` [string]
-  Name of the field of the lines count
+  Name of the field of the lines count.
 
   Default: *COUNT*
 
 Outputs
 .......
 ``Line length`` [vector: polygon]
-  Polygon output layer with fields of lines length and line count
+  Polygon output layer with fields of lines length and line count.
 
 
 .. Substitutions definitions - AVOID EDITING PAST THIS LINE

--- a/source/docs/user_manual/processing_algs/qgis/vectoranalysis.rst
+++ b/source/docs/user_manual/processing_algs/qgis/vectoranalysis.rst
@@ -335,12 +335,12 @@ Parameters
   Input vector layer
 
 ``Weight field`` [tablefield: numeric]
-  Optional.
+  Optional
 
   Field to use if you want to perform a weighted mean.
 
 ``Unique ID field`` [tablefield: numeric]
-  Optional.
+  Optional
 
   Unique field on which the calculation of the mean will be made.
 

--- a/source/docs/user_manual/processing_algs/qgis/vectorcreation.rst
+++ b/source/docs/user_manual/processing_algs/qgis/vectorcreation.rst
@@ -47,7 +47,7 @@ Parameters
   * Hexagon (polygon)
 
 ``Grid extent`` [extent]
-  Extent of the grid
+  Extent of the grid.
 
 ``Horizontal spacing`` [number]
   X-axis spacing between the lines.
@@ -60,17 +60,17 @@ Parameters
   Default: *0.000100*
 
 ``Horizontal overlay`` [number]
-  X-axis overlay
+  X-axis overlay.
 
   Default: *0.0*
 
 ``Vertical overlay`` [number]
-  Y-axis overlay
+  Y-axis overlay.
 
   Default: *0.0*
 
 ``Grid CRS`` [crs]
-  Coordinate reference system for grid
+  Coordinate reference system for grid.
 
   Default: *Project CRS*
 
@@ -78,7 +78,7 @@ Outputs
 .......
 
 ``Grid`` [vector: any]
-  Resulting grid layer
+  Resulting grid layer.
 
 
 .. _qgiscreatepointslayerfromtable:
@@ -94,7 +94,7 @@ Parameters
 ..........
 
 ``Input layer`` [table]
-  Input table
+  Input table.
 
 ``X field`` [tablefield: any]
   Table field containing the X coordinate.
@@ -129,7 +129,7 @@ Generate points (pixel centroids) along line
 --------------------------------------------
 Generates a point vector layer from an input raster and line layer.
 
-The points correspond to the pixel centroids that intersect the line layer
+The points correspond to the pixel centroids that intersect the line layer.
 
 
 .. figure:: img/points_centroids.png
@@ -141,16 +141,16 @@ Parameters
 ..........
 
 ``Raster layer`` [raster]
-  Raster layer in input
+  Raster layer in input.
 
 ``Vector layer`` [vector: line]
-  Line vector layer
+  Line vector layer.
 
 Outputs
 .......
 
 ``Points from polygons`` [vector: points]
-  Resulting point layer of pixel centroid
+  Resulting point layer of pixel centroid.
 
 
 
@@ -160,7 +160,7 @@ Generate points (pixel centroids) inside polygon
 ------------------------------------------------
 Generates a point vector layer from an input raster and polygon layer.
 
-The points correspond to the pixel centroids that intersect the polygon layer
+The points correspond to the pixel centroids that intersect the polygon layer.
 
 
 .. figure:: img/points_centroids_polygon.png
@@ -172,16 +172,16 @@ Parameters
 ..........
 
 ``Raster layer`` [raster]
-  Raster layer in input
+  Raster layer in input.
 
 ``Vector layer`` [vector: polygon]
-  Polygon vector layer
+  Polygon vector layer.
 
 Outputs
 .......
 
 ``Points from polygons`` [vector: points]
-  Resulting point layer of pixel centroid
+  Resulting point layer of pixel centroid.
 
 
 .. _qgisimportphotos:
@@ -202,22 +202,22 @@ Parameters
 ..........
 
 ``Input folder`` [folder]
-  Path to the source folder containing the geotagged photos
+  Path to the source folder containing the geotagged photos.
 
 ``Scan recursively`` [boolean]
-  If checked, the folder and its subfolders will be scanned
+  If checked, the folder and its subfolders will be scanned.
 
 Outputs
 .......
 
 ``Photos`` [vector: point]
   Point vector layer with geotagged photos. The form of the layer is automatically
-  filled with paths and photo previews settings
+  filled with paths and photo previews settings.
 
 ``Invalid photos table`` [table]
   Optional
 
-  Table of unreadable or non-geotagged photos can also be created
+  Table of unreadable or non-geotagged photos can also be created.
 
 
 .. _qgispointstopath:
@@ -232,20 +232,20 @@ Parameters
 ..........
 
 ``Input point layer`` [vector: point]
-  point vector layer to be converted
+  point vector layer to be converted.
 
 ``Order field`` [tablefield: any]
-  Table field containing the order of the points
+  Table field containing the order of the points.
 
 ``Group field`` [tablefield: any]
   Optional
 
-  Table field containing the group field of the points
+  Table field containing the group field of the points.
 
 ``Date format (if order field is DateTime)`` [string]
   Optional
 
-  Choose this option if the points are ordered in a DateTime field
+  Choose this option if the points are ordered in a DateTime field.
 
   Default: *(not set)*
 
@@ -253,10 +253,10 @@ Outputs
 .......
 
 ``Paths`` [vector: line]
-  Line vector layer of the path
+  Line vector layer of the path.
 
 ``Directory for text output`` [directory]
-  Directory containing description files of points and paths
+  Directory containing description files of points and paths.
 
 
 .. _qgisrandompointsalongline:
@@ -274,15 +274,15 @@ Parameters
 ..........
 
 ``Input layer`` [vector: line]
-  Line vector layer in input
+  Line vector layer in input.
 
 ``Number of points`` [number]
-  Number of point to create
+  Number of point to create.
 
   Default: *1*
 
 ``Minimum distance`` [number]
-  A minimum distance that points must respect
+  A minimum distance that points must respect.
 
   Default: *0.0*
 
@@ -290,7 +290,7 @@ Outputs
 .......
 
 ``Random points`` [vector: point]
-  Final random point layer along line
+  Final random point layer along line.
 
 
 .. _qgisrandompointsinextent:
@@ -308,26 +308,26 @@ Parameters
 ..........
 
 ``Input extent`` [extent]
-  Map extent for the random points
+  Map extent for the random points.
 
 ``Points number`` [number]
-  Number of point to create
+  Number of point to create.
 
   Default: *1*
 
 ``Minimum distance`` [number]
-  A minimum distance that points must respect
+  A minimum distance that points must respect.
 
   Default: *0.0*
 
 ``Target CRS`` [crs]
-  CRS of the random points layer
+  CRS of the random points layer.
 
 Outputs
 .......
 
 ``Random points`` [vector: point]
-  Final random point layer in extent
+  Final random point layer in extent.
 
 
 .. _qgisrandompointsinlayerbounds:
@@ -345,15 +345,15 @@ Parameters
 ..........
 
 ``Input layer`` [vector: polygon]
-  Input polygon layer for the extent
+  Input polygon layer for the extent.
 
 ``Points number`` [number]
-  Number of point to create
+  Number of point to create.
 
   Default: *1*
 
 ``Minimum distance`` [number]
-  A minimum distance that points must respect
+  A minimum distance that points must respect.
 
   default: *0.0*
 
@@ -362,7 +362,7 @@ Outputs
 .......
 
 ``Random points`` [vector: point]
-  Final random point layer in layer bounds
+  Final random point layer in layer bounds.
 
 
 .. _qgisrandompointsinsidepolygons:
@@ -399,12 +399,12 @@ Parameters
   Default: *0*
 
 ``Number or density of points`` [expression]
-  You can choose the points number also with an expression
+  You can choose the points number also with an expression.
 
   Default: *1.0*
 
 ``Minimum distance`` [number]
-  A minimum distance that points must respect
+  A minimum distance that points must respect.
 
   default: *0.0*
 
@@ -412,7 +412,7 @@ Outputs
 .......
 
 ``Random points`` [vector: point]
-  Final random point layer inside polygon
+  Final random point layer inside polygon.
 
 
 .. _qgisregularpoints:
@@ -432,25 +432,25 @@ Parameters
 ..........
 
 ``Input extent`` [extent]
-  Map extent for the random points
+  Map extent for the random points.
 
 ``Point spacing/count`` [number]
-  Spacing between the points
+  Spacing between the points.
 
   Default: *100*
 
 ``Initial inset from corner (LH side)`` [number]
-  Choose to move the initial points coordinate from the left upper corner
+  Choose to move the initial points coordinate from the left upper corner.
 
   Default: *0.0*
 
 ``Apply random offset to point spacing`` [boolean]
-  If checked the points will have a random spacing
+  If checked the points will have a random spacing.
 
   Default: *False*
 
 ``Use point spacing`` [boolean]
-  In unchecked the point spacing is not taken inot account
+  If unchecked the point spacing is not taken into account.
 
   Default: *True*
 
@@ -458,7 +458,7 @@ Outputs
 .......
 
 ``Regular points`` [vector: point]
-  Regular point layer in output
+  Regular point layer in output.
 
 
 .. Substitutions definitions - AVOID EDITING PAST THIS LINE

--- a/source/docs/user_manual/processing_algs/qgis/vectorcreation.rst
+++ b/source/docs/user_manual/processing_algs/qgis/vectorcreation.rst
@@ -243,7 +243,7 @@ Parameters
   Table field containing the group field of the points
 
 ``Date format (if order field is DateTime)`` [string]
-  Optional.
+  Optional
 
   Choose this option if the points are ordered in a DateTime field
 

--- a/source/docs/user_manual/processing_algs/qgis/vectorgeneral.rst
+++ b/source/docs/user_manual/processing_algs/qgis/vectorgeneral.rst
@@ -483,7 +483,7 @@ Parameters
 ``Destination CRS`` [projection]
   Optional
 
-  Optional parameter to choose the CRS of the output layer. If not specified the
+  Choose the CRS of the output layer. If not specified the
   CRS of the first input layer is taken.
 
 Outputs

--- a/source/docs/user_manual/processing_algs/qgis/vectorgeneral.rst
+++ b/source/docs/user_manual/processing_algs/qgis/vectorgeneral.rst
@@ -30,10 +30,10 @@ Attributes are not modified by this algorithm.
 Parameters
 ..........
 ``Input layer`` [vector: any]
-  Vector layer with wrong or missing CRS
+  Vector layer with wrong or missing CRS.
 
 ``Assigned CRS`` [projection]
-  Select the new CRS to assign to the vector layer
+  Select the new CRS to assign to the vector layer.
 
   Default: *EPSG:4326 - WGS84*
 
@@ -60,7 +60,7 @@ layers but accept only one ``vrt`` in which the layers are specified.
 Parameters
 ..........
 ``Input datasources`` [vector: any] [list]
-  Select the vector layers you want to use to build the virtual vector
+  Select the vector layers you want to use to build the virtual vector.
 
 ``Create "unioned" VRT`` [boolean]
   Check if you want to unite all the vectors in a single ``vrt`` file.
@@ -70,7 +70,7 @@ Parameters
 Outputs
 .......
 ``Virtual vector`` [vector: any]
-  The final virtual vector made by all the source vector chosen
+  The final virtual vector made by all the source vector chosen.
 
 
 .. _qgiscreateattributeindex:
@@ -87,10 +87,10 @@ Parameters
 ..........
 
 ``Input layer`` [vector: any]
-  Vector layer
+  Vector layer.
 
 ``Attribute to index`` [tablefield: any]
-  Field of the vector layer
+  Field of the vector layer.
 
 
 .. _qgiscreatespatialindex:
@@ -108,7 +108,7 @@ No new output layers are created.
 Parameters
 ..........
 ``Input layer`` [vector: any]
-  Vector layer in input
+  Vector layer in input.
 
 
 .. _qgisdefinecurrentprojection:
@@ -126,7 +126,7 @@ the same directory of the input layer.
 Parameters
 ..........
 ``Input layer`` [vector: any]
-  Vector layer with missing projection information
+  Vector layer with missing projection information.
 
 ``Output CRS`` [projection]
   Output CRS associated with the source vector layer. The CRS information are
@@ -149,13 +149,13 @@ but different attributes, only one of them will be added to the result layer.
 Parameters
 ..........
 ``Input layer`` [vector: any]
-  The layer with duplicate geometries you want to clean
+  The layer with duplicate geometries you want to clean.
 
 
 Outputs
 .......
 ``Cleaned`` [vector: any]
-  The final layer without any duplicated geometries
+  The final layer without any duplicated geometries.
 
 
 .. _qgisdropgeometries:
@@ -170,7 +170,7 @@ If the file is saved in a local folder, you can choose between many file formats
 Parameters
 ..........
 ``Input layer`` [vector: any]
-  Vector layer
+  Vector layer.
 
 Outputs
 .......
@@ -195,36 +195,36 @@ Parameters
   on how many layers have been chosen.
 
 ``SQL query`` [string]
-  Type here the string of your SQL query, e.g. ``SELECT * FROM input1``
+  Type here the string of your SQL query, e.g. ``SELECT * FROM input1``.
 
 ``Unique identifier field`` [string]
   Optional
   
-  Specify the column with unique ID
+  Specify the column with unique ID.
 
 ``Geometry field`` [string]
   Optional
 
-  Specify the geometry field
+  Specify the geometry field.
 
 ``Geometry type`` [enumeration]
   Optional
 
   Choose the final geometry of the result. By default the algorithm will autodetect
-  it
+  it.
 
   Default: *Autodetect*
 
 ``CRS`` [projection]
   Optional
 
-  The CRS to assign to the output layer
+  The CRS to assign to the output layer.
 
 
 Outputs
 .......
 ``SQL Output`` [vector: any]
-  Vector layer created by the query
+  Vector layer created by the query.
 
 
 .. _qgisfindprojection:
@@ -245,19 +245,19 @@ layer was in this projection.
 Parameters
 ..........
 ``Input layer`` [vector: any]
-  Layer with unknown projection
+  Layer with unknown projection.
 
 ``Target area for layer`` [extent]
-  This is the area in which the layer is expected to be
+  This is the area in which the layer is expected to be.
 
 ``Target area CRS`` [projection]
-  Choose the target CRS of the target area selected
+  Choose the target CRS of the target area selected.
 
 Outputs
 .......
 ``CRS candidates`` [table]
   The algorithm writes a table with all the CRS (EPSG codes) of the matching
-  criteria
+  criteria.
 
 See also
 ........
@@ -278,21 +278,21 @@ Parameters
 ..........
 ``Input layer`` [vector: any]
   Source input vector layer. The final attribute table will be added to **this**
-  vector layer
+  vector layer.
 
 ``Table field`` [tablefield]
-  Field of the source layer with the unique identifier
+  Field of the source layer with the unique identifier.
 
 ``Input layer 2`` [vector: any]
-  Layer with the attribute table to join
+  Layer with the attribute table to join.
 
 ``Table field 2`` [tablefield]
-  Table of the joining layer with the common unique field identifier
+  Table of the joining layer with the common unique field identifier.
 
 ``Layer 2 fields to copy`` [tablefield]
   Optional
 
-  Select the specific fields you want to add. By default all the fields are added
+  Select the specific fields you want to add. By default all the fields are added.
 
 ``Join type`` [enumeration] |32|
   Choose the type of the final joined layer between:
@@ -301,7 +301,7 @@ Parameters
   * Take attributes of the first matching feature only (one-to-one)
 
 ``Discard records which could not be joined`` [boolean] |32|
-  Check if you don't want to add the features that cannot be joined
+  Check if you don't want to add the features that cannot be joined.
 
 ``Joined field prefix`` [string] |32|
   Optional
@@ -312,7 +312,7 @@ Parameters
 Outputs
 .......
 ``Joined layer`` [vector: any]
-  Final vector layer with the attribute table as result of the joining
+  Final vector layer with the attribute table as result of the joining.
 
 
 .. _qgisjoinattributesbylocation:
@@ -331,11 +331,11 @@ added to each feature from the first layer.
 Parameters
 ..........
 ``Input layer`` [vector: any]
-  Source vector layer
+  Source vector layer.
 
 ``Join layer`` [vector: any]
-  the attributes of this vector layer will be **added** to the source layer
-  attribute table
+  The attributes of this vector layer will be **added** to the source layer
+  attribute table.
 
 ``Geometric predicate`` [enumeration] [list]
   Check the geometric criteria.
@@ -353,7 +353,7 @@ Parameters
 ``Fields to add`` [tablefield]
   Optional
 
-  Select the specific fields you want to add. By default all the fields are added
+  Select the specific fields you want to add. By default all the fields are added.
 
 ``Join type`` [enumeration]
   Choose the type of the final joined layer between:
@@ -362,7 +362,7 @@ Parameters
   * Take attributes of the first located feature only (one-to-one)
 
 ``Discard records which could not be joined`` [boolean]
-  Check if you don't want to add the features that cannot be joined
+  Check if you don't want to add the features that cannot be joined.
 
 ``Joined field prefix`` [string] |32|
   Optional
@@ -392,11 +392,11 @@ features in the second layer (e.g. maximum value, mean value, etc).
 Parameters
 ..........
 ``Input layer`` [vector: any]
-  Source vector layer
+  Source vector layer.
 
 ``Join layer`` [vector: any]
   The attributes of this vector layer will be **added** to the source layer
-  attribute table
+  attribute table.
 
 ``Geometric predicate`` [enumeration] [list]
   Check the geometric criteria.
@@ -414,7 +414,7 @@ Parameters
 ``Fields to summarize`` [tablefield] [list]
   Optional
 
-  Select the specific fields you want to add. By default all the fields are added
+  Select the specific fields you want to add. By default all the fields are added.
 
 ``Summaries to calculate`` [enumeration] [list]
   Optional
@@ -442,7 +442,7 @@ Parameters
   * mean_length
 
 ``Discard records which could not be joined`` [boolean]
-  Check if you don't want to add the features that cannot be joined
+  Check if you don't want to add the features that cannot be joined.
 
 Outputs
 .......
@@ -490,7 +490,7 @@ Outputs
 .......
 
 ``Merged`` [vector: any]
-  Merged vector layer containing all the features and attributes from input layers
+  Merged vector layer containing all the features and attributes from input layers.
 
 See also
 ........
@@ -511,10 +511,10 @@ Parameters
 ..........
 
 ``Input layer`` [vector: any]
-  Vector layer to sort
+  Vector layer to sort.
 
 ``Expression`` [expression]
-  Expression to use for the vector sorting
+  Expression to use for the vector sorting.
 
 ``Ascending`` [boolean]
   If checked the sorted vector layer will be sorted from the smallest to the
@@ -531,7 +531,7 @@ Outputs
 .......
 
 ``Output layer`` [vector: any]
-  Sorted vector layer
+  Sorted vector layer.
 
 
 .. _qgisreprojectlayer:
@@ -594,10 +594,10 @@ No new output are created: the style is immediately assigned to the vector layer
 Parameters
 ..........
 ``Vector layer`` [vector: any]
-  The layer you want to change the style
+  The layer you want to change the style.
 
 ``Style file`` [file]
-  ``qml`` file of the style
+  ``qml`` file of the style.
 
 
 .. _qgissplitvectorlayer:
@@ -619,7 +619,7 @@ Parameters
 ..........
 
 ``Input layer`` [vector: any]
-  Vector layer
+  Vector layer.
 
 ``Unique ID field`` [tablefield: any]
   Field of the attribute table on which the layer will be split.
@@ -647,7 +647,7 @@ Truncates a layer, by deleting all features from within the layer.
 Parameters
 ..........
 ``Input layer`` [vector: any]
-  Vector layer in input
+  Vector layer in input.
 
 
 .. Substitutions definitions - AVOID EDITING PAST THIS LINE

--- a/source/docs/user_manual/processing_algs/qgis/vectorgeometry.rst
+++ b/source/docs/user_manual/processing_algs/qgis/vectorgeometry.rst
@@ -24,17 +24,17 @@ additional attributes, containing geometric measurements based on a selected CRS
 Depending on the geometry type of the vector layer, the attributes added to the
 table will be different:
 
-* for **point** layers: X and Y coordinates called ``xcoord`` and ``ycoord``
+* for **point** layers: X and Y coordinates called ``xcoord`` and ``ycoord``;
 * for **line** layers: ``length`` and, |32| particularly for LineString and CompoundCurve
-  geometry type also adds feature's ``sinuosity`` and straight distance (``straightdis``)
-* for **polygon** layers: ``perimeter`` and ``area``
+  geometry type also adds feature's ``sinuosity`` and straight distance (``straightdis``);
+* for **polygon** layers: ``perimeter`` and ``area``.
 
 ``Default menu``: :menuselection:`Vector --> Geometry Tools`
 
 Parameters
 ..........
 ``Input layer`` [vector: any]
-  Vector layer in input
+  Vector layer in input.
 
 ``Calculate using`` [enumeration]
   Choose different calculation type for the geometric properties:
@@ -47,7 +47,7 @@ Output
 ......
 
 ``Added geom info`` [vector: any]
-  Copy of the input vector layer with the addition of the geometry fields
+  Copy of the input vector layer with the addition of the geometry fields.
 
 
 .. _qgisaggregate:
@@ -75,10 +75,10 @@ Parameters
 ..........
 
 ``Input layer`` [vector: any]
-  Vector layer in input to aggregate the features from
+  Vector layer in input to aggregate the features from.
 
 ``Group by expression`` [tablefield: any]
-  Choose the grouping field. If *NULL* all features will be grouped
+  Choose the grouping field. If *NULL* all features will be grouped.
 
   Default: *NULL*
 
@@ -88,10 +88,10 @@ Parameters
   By default, the embedded table lists all the fields of the source
   layer and allows you to edit them:
 
-  * click the |newAttribute| button to create a new field
-  * click the |deleteAttribute| to remove a field
-  * use |arrowUp| and |arrowDown| to change the selected field order
-  * click |clearText| to reset to the default view
+  * click the |newAttribute| button to create a new field;
+  * click the |deleteAttribute| to remove a field;
+  * use |arrowUp| and |arrowDown| to change the selected field order;
+  * click |clearText| to reset to the default view.
 
   For each of the fields you'd like to retrieve information from, you need to
   fill the following options:
@@ -131,7 +131,7 @@ Output
 ......
 
 ``Aggregated`` [vector: any]
-  Multigeometry vector layer with the aggregated values
+  Multigeometry vector layer with the aggregated values.
 
 See also
 ........
@@ -161,14 +161,14 @@ For **lines geometries**, the boundaries are the vertices between each features.
 .. figure:: img/boundary_lines.png
    :align: center
 
-   Boundary layer for lines. In yellow a selected features
+   Boundary layer for lines. In yellow a selected features.
 
 
 Parameters
 ..........
 
 ``Input layer`` [vector: line, polygon]
-  Input vector layer
+  Input vector layer.
 
 Output
 ......
@@ -194,7 +194,7 @@ Parameters
 ..........
 
 ``Input layer`` [vector: polygon, line]
-  Input vector layer
+  Input vector layer.
 
 Outputs
 .......
@@ -227,7 +227,7 @@ Parameters
 ..........
 
 ``Input layer`` [vector: any]
-  Input vector layer
+  Input vector layer.
 
 ``Distance`` [number]
   Distance radius of the buffer calculated from the boundary of each feature.
@@ -256,7 +256,7 @@ Parameters
   corners in a line.
 
 ``Miter limit`` [number]
-  Only applicable for miter join styles
+  Only applicable for miter join styles.
 
   Default: *2.0*
 
@@ -276,7 +276,7 @@ Outputs
 .......
 
 ``Buffer`` [vector: polygon]
-  Buffer polygon vector layer
+  Buffer polygon vector layer.
 
 See also
 ........
@@ -335,9 +335,9 @@ Performs a validity check on the geometries of a vector layer.
 The geometries are classified in three groups (valid, invalid and error) and a
 vector layer is generated with the features in each of these categories:
 
-* the **valid** layer contains only the valid features (without topological errors)
-* the **invalid** layer contains all the invalid features found by the algorithm
-* the **error** layer is the point layer where the invalid features have been found
+* the **valid** layer contains only the valid features (without topological errors);
+* the **invalid** layer contains all the invalid features found by the algorithm;
+* the **error** layer is the point layer where the invalid features have been found.
 
 The attribute table of each generated vector layer will contain some additional
 information (numbers of error found and type of error):
@@ -403,12 +403,12 @@ Parameters
 ..........
 
 ``Input layer`` [vector: any]
-  Vector layer to be transformed
+  Vector layer to be transformed.
 
 ``Unique ID fields`` [tablefield: any] [list]
   Optional
 
-  Choose one or more attributes to collect the geometries
+  Choose one or more attributes to collect the geometries.
 
 Output
 ......
@@ -431,10 +431,10 @@ Computes the concave hull of the features in an input point layer.
 Parameters
 ..........
 ``Input point layer`` [vector: point]
-  Point vector layer to calculate the concave hull
+  Point vector layer to calculate the concave hull.
 
 ``Threshold`` [number]
-  Number from 0 (maximum concave hull) to 1 (convex hull)
+  Number from 0 (maximum concave hull) to 1 (convex hull).
 
   Default: *0.3*
 
@@ -446,19 +446,19 @@ Parameters
 
 
 ``Allow holes`` [boolean]
-  Choose whether to allow holes in the final concave hull
+  Choose whether to allow holes in the final concave hull.
 
   Default: *True*
 
 ``Split multipart geometry into singlepart geometries`` [boolean]
-  Check if you want to have singlepart geometries instead of multipart ones
+  Check if you want to have singlepart geometries instead of multipart ones.
 
   Default: *False*
 
 Output
 ......
 ``Concave hull`` [vector: polygon]
-  Output concave hull
+  Output concave hull.
 
 See also
 ........
@@ -477,7 +477,7 @@ a point layer, but a point layer cannot be converted to a line layer.
 Parameters
 ..........
 ``Input layer`` [vector: any]
-  Input vector layer to transform
+  Input vector layer to transform.
 
 ``New geometry type`` [enumeration]
   List of all the conversions supported:
@@ -489,13 +489,13 @@ Parameters
   * Polygons
 
   .. note:: Conversion types availability depends on the input layer and the conversion
-    chosen: e.g. it is not possible to convert a point to a line
+    chosen: e.g. it is not possible to convert a point to a line.
 
 Output
 ......
 
 ``Converted`` [vector: any]
-  Converted vector layer depending on the parameters chosen
+  Converted vector layer depending on the parameters chosen.
 
 See also
 ........
@@ -521,12 +521,12 @@ covers the whole layer or grouped subsets of features.
 Parameters
 ..........
 ``Input point layer`` [vector: any]
-  Point vector layer to calculate the convex hull
+  Point vector layer to calculate the convex hull.
 
 Output
 ......
 ``Convex hull`` [vector: polygon]
-  Output convex hull
+  Output convex hull.
 
 See also
 ........
@@ -575,10 +575,10 @@ Parameters
 ..........
 
 ``Input layer`` [vector: point]
-  Input point vector layer
+  Input point vector layer.
 
 ``Azimuth (degrees from North)`` [number |dataDefined|]
-  Angle (in degrees) as the middle value of the wedge
+  Angle (in degrees) as the middle value of the wedge.
 
 ``Wedge width (in degrees)`` [number |dataDefined|]
   Width (in degrees) of the buffer. The wedge will extend to half of the angular
@@ -604,7 +604,7 @@ Output
 ......
 
 ``Buffers`` [vector: polygon]
-  Wedge buffer polygon vector layer
+  Wedge buffer polygon vector layer.
 
 See also
 ........
@@ -629,12 +629,12 @@ Parameters
 ..........
 
 ``Input layer`` [vector: point]
-  Point vector layer to compute the triangulation on
+  Point vector layer to compute the triangulation on.
 
 Output
 ......
 ``Delaunay triangulation`` [vector: polygon]
-  Resulting polygon layer of delaunay triangulation
+  Resulting polygon layer of delaunay triangulation.
 
 
 .. _qgisdeleteholes:
@@ -671,7 +671,7 @@ Outputs
 .......
 
 ``Cleaned`` [vector: polygon]
-  Vector layer without holes or holes larger than specified area
+  Vector layer without holes or holes larger than specified area.
 
 
 .. _qgisdensifygeometries:
@@ -762,7 +762,7 @@ Outputs
 .......
 
 ``Densified`` [vector: plygon, line]
-  Densified layer with vertices added at specified intervals
+  Densified layer with vertices added at specified intervals.
 
 
 See also
@@ -816,7 +816,7 @@ Outputs
 .......
 
 ``Dissolved`` [vector: polygon, line]
-  Output layer, either (multi) line or (multi) polygon
+  Output layer, either (multi) line or (multi) polygon.
 
 
 .. _qgisdropmzvalues:
@@ -828,22 +828,22 @@ Removes any M (measure) or Z (altitude) values from input geometries.
 Parameters
 ..........
 ``Input layer`` [vector: any]
-  Input vector layer to clean
+  Input vector layer to clean.
 
 ``Drop M Values`` [boolean]
-  Check to remove the M values
+  Check to remove the M values.
 
   Default: *False*
 
 ``Drop Z Values`` [boolean]
-  Check to remove the Z values
+  Check to remove the Z values.
 
   Default: *False*
 
 Output
 ......
 ``Z/M Dropped`` [vector: any]
-  Cleaned vector layer without M and/or Z values
+  Cleaned vector layer without M and/or Z values.
 
 
 .. _qgiseliminateselectedpolygons:
@@ -864,7 +864,7 @@ similar but not identical.
 Parameters
 ..........
 ``Input layer`` [vector: polygon]
-  Input polygon vector layer to clean
+  Input polygon vector layer to clean.
 
 ``Merge selection with the neighboring polygon with the`` [enumeration]
   Choose the parameter to use in order to get rid of the selected polygons:
@@ -876,8 +876,7 @@ Parameters
 Output
 ......
 ``Eliminated`` [vector: polygon]
-  Cleaned vector layer as result of the parameters chosen
-
+  Cleaned vector layer as result of the parameters chosen.
 
 
 .. _qgisexplodelines:
@@ -899,7 +898,7 @@ intermediate vertices between them.
 Parameters
 ..........
 ``Input layer`` [vector: line]
-  Line vector layer in input to explode
+  Line vector layer in input to explode.
 
 Output
 ......
@@ -925,19 +924,19 @@ Parameters
 ..........
 
 ``Input layer`` [vector: line]
-  Line vector layer to extend
+  Line vector layer to extend.
 
 ``Start distance`` [number]
-  Starting distance to extend the line by (starting point)
+  Starting distance to extend the line by (starting point).
 
 ``End distance`` [number]
-  Ending distance of the extension
+  Ending distance of the extension.
 
 Output
 ......
 
 ``Extended`` [vector: line]
-  Extended vector line layer
+  Extended vector line layer.
 
 
 .. _qgisextractspecificvertices:
@@ -965,11 +964,11 @@ and bisector angle of vertex for the original geometry.
 Parameters
 ..........
 ``Input layer`` [vector: line, polygon]
-  Vector layer in input to extract the vertices from
+  Vector layer in input to extract the vertices from.
 
 ``Vertex indices`` [number]
   Type the indices of the vertices to extract. The algorithm accepts comma separated
-  values for many vertices to extract (e.g. ``-2, 3, 5, 7``)
+  values for many vertices to extract (e.g. ``-2, 3, 5, 7``).
 
   Default: *0*
 
@@ -1005,7 +1004,7 @@ Parameters
 ..........
 
 ``Input layer`` [vector: any]
-  Vector layer in input to extract the vertices from
+  Vector layer in input to extract the vertices from.
 
 Output
 ......
@@ -1054,12 +1053,12 @@ which is available in the :ref:`expression builder <vector_expressions>`.
 Parameters
 ..........
 ``Input layer`` [vector: any]
-  Vector input layer
+  Vector input layer.
 
 ``Output geometry type`` [enumeration]
   The output geometry strongly depends on the expression you will choose: for
   instance, if you want to create a buffer then the geometry type has to be
-  a polygon
+  a polygon.
 
   Available options are:
 
@@ -1068,24 +1067,24 @@ Parameters
   * Point
 
 ``Output geometry has z dimension`` [boolean]
-  Choose if the output geometry should have the z dimension
+  Choose if the output geometry should have the z dimension.
 
   Default: *False*
 
 ``Output geometry has m dimension`` [boolean]
-  Choose if the output geometry should have the m dimension
+  Choose if the output geometry should have the m dimension.
 
   Default: *False*
 
 ``Geometry expression`` [expression]
   Add the geometry expression you want to use. You can use the button to open
   the Expression Dialog: the dialog has a lists of all the usable expression
-  together with their help and guide
+  together with their help and guide.
 
   Default: *$geometry*
 
 ``Modified geometry`` [vector: any]
-  Vector layer resulting from the expression added
+  Vector layer resulting from the expression added.
 
 
 .. _qgiskeepnbiggestparts:
@@ -1136,13 +1135,13 @@ Parameters
 ..........
 
 ``Input layer`` [vector: line]
-  Line vector layer to convert
+  Line vector layer to convert.
 
 Output
 ......
 
 ``Polygons`` [vector: polygon]
-  Polygon vector layer from the line input vector layer
+  Polygon vector layer from the line input vector layer.
 
 
 .. _qgismergelines:
@@ -1160,13 +1159,13 @@ Parameters
 ..........
 
 ``Input layer`` [vector: line]
-  MultiLineString vector layer
+  MultiLineString vector layer.
 
 Output
 ......
 
 ``Merged`` [vector: lines]
-  Single Linestring vector layer
+  Single LineString vector layer.
 
 
 .. _qgisminimumboundinggeometry:
@@ -1179,14 +1178,14 @@ Parameters
 ..........
 
 ``Input layer`` [vector: any]
-  Input vector layer
+  Input vector layer.
 
 ``Field`` [tablefield: any]
   Optional
 
   Features can be grouped by a field. If set, this causes the output
   layer to contain one feature per grouped value with a minimal geometry covering
-  just the features with matching values
+  only the features with matching values.
 
 ``Geometry type`` [enumeration]
   Numerous enclosing geometry types are supported:
@@ -1205,7 +1204,7 @@ Output
 ......
 
 ``Bounding geometry`` [vector: polygon]
-  Bounding polygon layer
+  Bounding polygon layer.
 
 
 .. _qgisminimumenclosingcircle:
@@ -1223,10 +1222,10 @@ Parameters
 ..........
 
 ``Input layer`` [vector: any]
-  Input vector layer
+  Input vector layer.
 
 ``Number of segment in circles`` [number]
-  Choose the number of segment for each circle
+  Choose the number of segment for each circle.
 
   Default: *72*
 
@@ -1234,7 +1233,7 @@ Output
 ......
 
 ``Minimum enclosing circles`` [vector: polygon]
-  Enclosing circles for each polygon feature
+  Enclosing circles for each polygon feature.
 
 See also
 ........
@@ -1273,7 +1272,7 @@ Output
 ......
 
 ``Multi-ring buffer (constant distance)``
-  Multi ring buffer polygon vector layer
+  Multi ring buffer polygon vector layer.
 
 See also
 ........
@@ -1330,29 +1329,29 @@ Parameters
 ..........
 
 ``Input layer`` [vector: line]
-  Line vector layer in input to elaborate the offset on
+  Line vector layer in input to elaborate the offset on.
 
 ``Distance`` [number]
   Distance of the offset. Negative distances are also supported: for instance a
-  negative distance will create the offset to the other part of the layer
+  negative distance will create the offset to the other part of the layer.
 
   Default: *10.0*
 
 ``Segment`` [number]
   Number of line segments to use to approximate a quarter circle when creating
-  rounded offsets
+  rounded offsets.
 
   Default: *8*
 
 ``Join style`` [enumeration]
   Specify whether round, miter or beveled joins should be used when offsetting
-  corners in a line
+  corners in a line.
 
   Default: *Round*
 
 ``Miter limit`` [number]
   Only applicable for mitered join styles, and controls the maximum distance from
-  the offset curve to use when creating a mitered join
+  the offset curve to use when creating a mitered join.
 
   Default: *2.0*
 
@@ -1360,7 +1359,7 @@ Output
 ......
 
 ``Offset`` [vector: line]
-  Offset line layer
+  Offset line layer.
 
 
 .. _qgisorientedminimumboundingbox:
@@ -1378,13 +1377,13 @@ Parameters
 ..........
 
 ``Input layer`` [vector: any]
-  Input vector layer
+  Input vector layer.
 
 Output
 ......
 
 ``Bounding boxes`` [vector: polygon]
-  Oriented minimum bounding boxes for each polygon feature
+  Oriented minimum bounding boxes for each polygon feature.
 
 See also
 ........
@@ -1409,7 +1408,7 @@ Parameters
 ..........
 
 ``Input layer`` [vector: polygon, line]
-  Input vector layer
+  Input vector layer.
 
 ``Maximum angle tolerance (degrees)`` [number]
   Specify the maximum deviation from a right angle or straight line a vertex can
@@ -1419,13 +1418,13 @@ Parameters
 
 ``Maximum algorithm iterations`` [number]
   Setting a larger number for the maximum iterations will result in a more
-  orthogonal geometry at the cost of extra processing time
+  orthogonal geometry at the cost of extra processing time.
 
 Output
 ......
 
 ``Orthogonalized`` [vector: polygon, line]
-  Final layer with angles adjusted depending on the parameters chosen
+  Final layer with angles adjusted depending on the parameters chosen.
 
 
 .. _qgispointonsurface:
@@ -1438,7 +1437,7 @@ Parameters
 ..........
 
 ``Input layer`` [vector: any]
-  Input vector layer
+  Input vector layer.
 
 ``Create point on surface for each part`` [boolean] |32|
   If checked a point for each different part of the geometry will be created.
@@ -1449,7 +1448,7 @@ Output
 ......
 
 ``Point`` [vector: point]
-  Point vector layer
+  Point vector layer.
 
 See also
 ........
@@ -1476,20 +1475,20 @@ Parameters
 ..........
 
 ``Input layer`` [vector: line, polygon]
-  Input vector layer
+  Input vector layer.
 
 ``Distance`` [number]
-  Set the distance between each point
+  Set the distance between each point.
 
   Default: *100*
 
 ``Start offset`` [number]
-  Specify an eventual offset where the first point should start
+  Specify an eventual offset where the first point should start.
 
   Default: *0*
 
 ``End offset`` [number]
-  Specify an eventual offset where the last point should end
+  Specify an eventual offset where the last point should end.
 
   Default: *0*
 
@@ -1497,7 +1496,7 @@ Output
 ......
 
 ``Points`` [vector: point]
-  Point vector layer
+  Point vector layer.
 
 
 .. _qgispointsdisplacement:
@@ -1512,20 +1511,20 @@ Parameters
 ..........
 
 ``Input layer`` [vector: point]
-  Input point vector layer
+  Input point vector layer.
 
 ``Minimum distance to other points`` [number]
-  Set the distance between each point
+  Set the distance between each point.
 
   Default: *0,000150*
 
 ``Displacement distance`` [number]
-  Specify an eventual offset where the first point should start
+  Specify an eventual offset where the first point should start.
 
   Default: *0,000150*
 
 ``Horizontal distribution for two point case`` [boolean]
-  Specify an eventual offset where the last point should end
+  Specify an eventual offset where the last point should end.
 
   Default: *False*
 
@@ -1560,10 +1559,10 @@ Parameters
 ..........
 
 ``Input layer`` [vector: polygon]
-  Input polygon vector layer
+  Input polygon vector layer.
 
 ``Tolerance (layer units)`` [number]
-  Set the tolerance for the calculation
+  Set the tolerance for the calculation.
 
   Default: *1.0*
 
@@ -1571,7 +1570,7 @@ Output
 ......
 
 ``Point`` [vector: point]
-  Point as pole of inaccessibility for the source polygon vector layer
+  Point as pole of inaccessibility for the source polygon vector layer.
 
 
 .. _qgispolygonize:
@@ -1582,7 +1581,7 @@ Creates a polygon layer whose features boundaries are generated from a **closed*
 line layer features.
 
 .. note:: the line layer must have closed shapes in order to be transformed into
-  a polygon
+  a polygon.
 
 .. figure:: img/polygonize.png
    :align: center
@@ -1593,12 +1592,12 @@ Parameters
 ..........
 
 ``Input layer`` [vector: line]
-  Input line vector layer
+  Input line vector layer.
 
 ``Keep table structure of line layer`` [boolean]
   Optional
 
-  Check to copy the original attribute of the line layer
+  Check to copy the original attribute of the line layer.
 
   Default: *False*
 
@@ -1606,7 +1605,7 @@ Output
 ......
 
 ``Polygons from lines`` [vector: polygon]
-  Vector layer with polygonized features
+  Vector layer with polygonized features.
 
 
 .. _qgispolygonstolines:
@@ -1627,13 +1626,13 @@ Parameters
 ..........
 
 ``Input layer`` [vector: polygon]
-  Input polygon vector layer
+  Input polygon vector layer.
 
 Output
 ......
 
 ``Lines`` [vector: line]
-  Lines from the polygon layer
+  Lines from the polygon layer.
 
 
 .. _qgisprojectpointcartesian:
@@ -1647,19 +1646,19 @@ Parameters
 ..........
 
 ``Input layer`` [vector: point]
-  Point vector layer to project
+  Point vector layer to project.
 
 ``Bearing (degrees from North)`` [number]
-  Clockwise angle starting from North, in degree (°) unit
+  Clockwise angle starting from North, in degree (°) unit.
 
 ``Distance`` [number]
-  Distance to offset geometries, in layer units
+  Distance to offset geometries, in layer units.
 
 Output
 ......
 
 ``Projected`` [vector: point]
-  Projected layer at given degrees and distance
+  Projected layer at given degrees and distance.
 
 
 .. _qgispromotetomulti:
@@ -1678,13 +1677,13 @@ Parameters
 ..........
 
 ``Input layer`` [vector: any]
-  Input vector layer
+  Input vector layer.
 
 Output
 ......
 
 ``Multiparts`` [vector: any]
-  Multiparts vector layer
+  Multiparts vector layer.
 
 See also
 ........
@@ -1709,7 +1708,7 @@ Parameters
 ..........
 
 ``Input layer`` [vector: point]
-  Input point vector layer
+  Input point vector layer.
 
 ``Buffer shape`` [enumeration]
   Different shape available:
@@ -1721,24 +1720,24 @@ Parameters
   Default: *Rectangles*
 
 ``Width`` [number]
-  Width of the buffer shape
+  Width of the buffer shape.
 
   Default: *1.0*
 
 ``Height`` [number]
-  Height of the buffer shape
+  Height of the buffer shape.
 
   Default: *1.0*
 
 ``Rotation`` [number]
   Optional
 
-  Rotation of the buffer shape
+  Rotation of the buffer shape.
 
   Default: *0.0*
 
 ``Number of segment`` [number]
-  How many segment should have the buffer shape
+  How many segment should have the buffer shape.
 
   Default: *36*
 
@@ -1746,7 +1745,7 @@ Outputs
 .......
 
 ``Output`` [vector: polygon]
-  Buffer shape in output
+  Buffer shape in output.
 
 See also
 ........
@@ -1771,7 +1770,7 @@ Parameters
 ..........
 
 ``Input layer`` [vector: point]
-  Input point vector layer
+  Input point vector layer.
 
 ``Buffer shape`` [enumeration]
   Different shape available:
@@ -1783,24 +1782,24 @@ Parameters
   Default: *Rectangles*
 
 ``Width`` [tablefield: numeric]
-  Width of the buffer shape
+  Width of the buffer shape.
 
   Default: *1.0*
 
 ``Height`` [tablefield: numeric]
-  Height of the buffer shape
+  Height of the buffer shape.
 
   Default: *1.0*
 
 ``Rotation`` [tablefield: numeric]
   Optional
 
-  Rotation of the buffer shape
+  Rotation of the buffer shape.
 
   Default: *0.0*
 
 ``Number of segment`` [number]
-  How many segment should have the buffer shape
+  How many segment should have the buffer shape.
 
   Default: *36*
 
@@ -1808,7 +1807,7 @@ Outputs
 .......
 
 ``Output`` [vector: polygon]
-  Buffer shape in output
+  Buffer shape in output.
 
 See also
 ........
@@ -1828,16 +1827,16 @@ The features with null geometries can be saved to a separate layer.
 Parameters
 ..........
 ``Input layer`` [vector: any]
-  Input vector layer with NULL geometries
+  Input vector layer with NULL geometries.
 
 Outputs
 .......
 
 ``Non null geometries`` [vector: any]
-  Vector layer without NULL geometries
+  Vector layer without NULL geometries.
 
 ``Null geometries`` [vector: any]
-  Vector layer with only NULL geometries
+  Vector layer with only NULL geometries.
 
 
 .. _qgisreverselinedirection:
@@ -1855,13 +1854,13 @@ Parameters
 ..........
 
 ``Input layer`` [vector: line]
-  Input line vector layer to invert the direction
+  Input line vector layer to invert the direction.
 
 Output
 ......
 
 ``Reversed`` [vector: line]
-  Inverted line vector layer
+  Inverted line vector layer.
 
 
 .. _qgisrotatefeatures:
@@ -1876,10 +1875,10 @@ Parameters
 ..........
 
 ``Input layer`` [vector: any]
-  Vector layer in input
+  Vector layer in input.
 
 ``Rotation (degrees clockwise)`` [number]
-  Angle of the rotation in degrees
+  Angle of the rotation in degrees.
 
   Default: *0.0*
 
@@ -1893,7 +1892,7 @@ Outputs
 .......
 
 ``Rotated`` [vector: any]
-  Vector layer with rotated geometries
+  Vector layer with rotated geometries.
 
 
 .. _qgissegmentizebymaxangle:
@@ -1912,10 +1911,10 @@ Parameters
 ..........
 
 ``Input layer`` [vector: line, polygon]
-  Vector layer in input
+  Vector layer in input.
 
 ``Maximum angle between vertices (degrees)`` [number]
-  Maximum allowed radius angle between vertices on the straightened geometry
+  Maximum allowed radius angle between vertices on the straightened geometry.
 
   Default: *5.0*
 
@@ -1923,7 +1922,7 @@ Outputs
 .......
 
 ``Segmentized`` [vector: line, polygon]
-  Vector layer with segmentized geometries
+  Vector layer with segmentized geometries.
 
 See also
 ........
@@ -1944,11 +1943,11 @@ Parameters
 ..........
 
 ``Input layer`` [vector: line, polygon]
-  Vector layer in input
+  Vector layer in input.
 
 ``Maximum offset distance`` [number]
   Maximum allowed offset distance between the original curve and the segmentized
-  representation, in the layer units
+  representation, in the layer units.
 
   Default: *1.0*
 
@@ -1956,7 +1955,7 @@ Outputs
 .......
 
 ``Segmentized`` [vector: line, polygon]
-  Vector layer with segmentized geometries
+  Vector layer with segmentized geometries.
 
 See also
 ........
@@ -1981,13 +1980,13 @@ Parameters
 ..........
 
 ``Input layer`` [vector: any]
-  Input vector layer
+  Input vector layer.
 
 Output
 ......
 
 ``M Added`` [vector: any]
-  Vector layer in output with M value
+  Vector layer in output with M value.
 
 
 .. _qgissetzvalue:
@@ -2008,13 +2007,13 @@ Parameters
 ..........
 
 ``Input layer`` [vector: any]
-  Input vector layer
+  Input vector layer.
 
 Output
 ......
 
 ``Z Added`` [vector: any]
-  Vector layer in output with Z value
+  Vector layer in output with Z value.
 
 
 .. _qgissimplifygeometries:
@@ -2084,10 +2083,10 @@ Parameters
 ..........
 
 ``Input layer`` [vector: line]
-  Input line vector layer
+  Input line vector layer.
 
 ``Distance`` [number]
-  Distance radius of the buffer
+  Distance radius of the buffer.
 
   Default: *10.0*
 
@@ -2101,7 +2100,7 @@ Parameters
 
 ``Segments`` [number]
   Controls the number of line segments to use to approximate a quarter circle when
-  creating rounded offsets
+  creating rounded offsets.
 
   Default: *5*
 
@@ -2117,7 +2116,7 @@ Parameters
 
 ``Miter limit`` [number]
   Only applicable for mitered join styles, and controls the maximum distance from
-  the offset curve to use when creating a mitered join
+  the offset curve to use when creating a mitered join.
 
   Default: *2.0*
 
@@ -2125,7 +2124,7 @@ Outputs
 .......
 
 ``Buffer`` [vector: polygon]
-  One side buffer polygon vector layer
+  One side buffer polygon vector layer.
 
 
 .. _qgissmoothgeometry:
@@ -2204,10 +2203,10 @@ Parameters
 ..........
 
 ``Input layer`` [vector: any]
-  Vector layer to align
+  Vector layer to align.
 
 ``Reference layer`` [vector: any]
-  Vector layer to snap to
+  Vector layer to snap to.
 
 ``Tolerance`` [number]
   Control how close input vertices need to be to the reference layer geometries
@@ -2233,7 +2232,7 @@ Outputs
 .......
 
 ``Snapped geometry`` [vector: any]
-  Vector layer with snapped geometries
+  Vector layer with snapped geometries.
 
 
 .. _qgissnappointstogrid:
@@ -2255,25 +2254,25 @@ Parameters
 ..........
 
 ``Input layer`` [vector: any]
-  Input vector layer to snap
+  Input vector layer to snap.
 
 ``X Grid Spacing`` [number]
-  X snapping parameter
+  X snapping parameter.
 
   Default: *1.0*
 
 ``Y Grid Spacing`` [number]
-  Y snapping parameter
+  Y snapping parameter.
 
   Default: *1.0*
 
 ``Z Grid Spacing`` [number]
-  Z snapping parameter
+  Z snapping parameter.
 
   Default: *0.0*
 
 ``M Grid Spacing`` [number]
-  M snapping parameter
+  M snapping parameter.
 
   Default: *0.0*
 
@@ -2281,7 +2280,7 @@ Outputs
 .......
 
 ``Snapped`` [vector: any]
-  Vector layer with snapped geometries
+  Vector layer with snapped geometries.
 
 
 .. _qgissubdivide:
@@ -2311,7 +2310,7 @@ Parameters
 ``Input layer`` [vector: any]
 
 ``Maximum nodes in parts`` [number]
-  Less *sub-parts* for higher values
+  Less *sub-parts* for higher values.
 
   Default: *256*
 
@@ -2335,13 +2334,13 @@ Parameters
 ..........
 
 ``Input layer`` [vector: any]
-  Input vector layer to swap
+  Input vector layer to swap.
 
 Outputs
 .......
 
 ``Swapped`` [vector: any]
-  Output swapped vector layer
+  Output swapped vector layer.
 
 
 .. _qgistaperedbuffer:
@@ -2369,13 +2368,13 @@ Parameters
   Represents the radius of the buffer applied at the end point of the line feature.
 
 ``Segments`` [number |dataDefined|]
-  Number of the buffer segments
+  Number of the buffer segments.
 
 Output
 ......
 
 ``Buffered`` [vector: polygon]
-  Variable buffer polygon layer
+  Variable buffer polygon layer.
 
 See also
 ........
@@ -2409,15 +2408,15 @@ Parameters
 ..........
 
 ``Input layer`` [vector: line]
-  Input line vector layer
+  Input line vector layer.
 
 ``Length of the transect`` [number]
-  Length in map unit of the transect
+  Length in map unit of the transect.
 
   Default: *5.0*
 
 ``Angle in degrees from the original line at the vertices`` [number]
-  Change the angle of the transect
+  Change the angle of the transect.
 
   Default: *90.0*
 
@@ -2434,7 +2433,7 @@ Outputs
 .......
 
 ``Transect`` [vector: line]
-  Transect of the source line vector layer
+  Transect of the source line vector layer.
 
 
 .. _qgistranslategeometry:
@@ -2452,15 +2451,15 @@ Parameters
 ..........
 
 ``Input layer`` [vector: any]
-  Vector layer in input
+  Vector layer in input.
 
 ``Offset distance (x-axis)`` [number]
-  X axis offset distance
+  X axis offset distance.
 
   Default: *0.0*
 
 ``Offset distance (y-axis)`` [number]
-  Y axis offset distance
+  Y axis offset distance.
 
   Default: *0.0*
 
@@ -2468,7 +2467,7 @@ Outputs
 .......
 
 ``Translated`` [vector: any]
-  Translated (offset) vector layer
+  Translated (offset) vector layer.
 
 
 .. _qgisbufferbym:
@@ -2487,7 +2486,7 @@ Parameters
 ..........
 
 ``Input layer`` [vector: line]
-  Line vector layer in input
+  Line vector layer in input.
 
 ``Segments`` [number]
   Number of the buffer segments. It can be a unique value (same value for all the
@@ -2498,7 +2497,7 @@ Output
 ......
 
 ``Buffered`` [vector: polygon]
-  Variable buffer polygon layer
+  Variable buffer polygon layer.
 
 See also
 ........
@@ -2526,10 +2525,10 @@ Parameters
 ..........
 
 ``Input layer`` [vector: point]
-  Input point vector layer
+  Input point vector layer.
 
 ``Buffer region`` [number]
-  Area of the Voronoi polygons or of the input layer
+  Area of the Voronoi polygons or of the input layer.
 
   Default: *0.0*
 
@@ -2537,7 +2536,7 @@ Outputs
 .......
 
 ``Voronoi polygons`` [vector: polygon]
-  Voronoi polygons of the input point vector layer
+  Voronoi polygons of the input point vector layer.
 
 
 .. Substitutions definitions - AVOID EDITING PAST THIS LINE

--- a/source/docs/user_manual/processing_algs/qgis/vectorgeometry.rst
+++ b/source/docs/user_manual/processing_algs/qgis/vectorgeometry.rst
@@ -660,7 +660,7 @@ Parameters
   Polygon layer with holes.
 
 ``Remove holes with area less than`` [number]
-  Optional.
+  Optional
 
   Only holes with an area less than this threshold will be deleted. If ``0.0`` is
   added, **all** the holes will be deleted.
@@ -802,7 +802,7 @@ Parameters
   Line or polygon layer to be dissolved.
 
 ``Unique ID fields`` [tablefield: any]
-  Optional.
+  Optional
 
   If features share a common value in all selected field(s) their geometries will
   be combined.

--- a/source/docs/user_manual/processing_algs/qgis/vectoroverlay.rst
+++ b/source/docs/user_manual/processing_algs/qgis/vectoroverlay.rst
@@ -85,10 +85,10 @@ Parameters
 ..........
 
 ``Input layer`` [vector: any]
-  Layer to extract features from
+  Layer to extract features from.
 
 ``Difference layer`` [vector: any]
-  Subtracting layer
+  Subtracting layer.
 
 Output
 ......
@@ -117,7 +117,7 @@ Parameters
   Input layer to be clipped.
 
 ``Extent (xmin, xmax, ymin, ymax)`` [extent]
-  Extent of the clipping
+  Extent of the clipping.
 
 ``Clip features to the extent`` [boolean]
   If checked, output geometries will be automatically converted to multi geometries
@@ -138,7 +138,7 @@ Intersection
 Extracts the portions of features from the input layer that overlap features in the intersection layer.
 
 Features in the intersection layer are assigned the attributes of the overlapping
-features from both the input and intersection layers
+features from both the input and intersection layers.
 
 Attributes are not modified (see :ref:`warning <warning_difference>`).
 
@@ -153,7 +153,7 @@ Parameters
 ..........
 
 ``Input layer`` [vector: any]
-  Input layer
+  Input layer.
 
 ``Intersection layer`` [vector: any]
   Layer containing the intersecting features.
@@ -200,7 +200,7 @@ Parameters
 ..........
 
 ``Input layer`` [vector: line]
-  Input layer
+  Input layer.
 
 ``Intersection layer`` [vector: line]
   Layer to use in the intersection operation.
@@ -221,7 +221,7 @@ Output
 ......
 
 ``Intersection`` [vector: point]
-  Point vector layer of the intersection
+  Point vector layer of the intersection.
 
 
 .. _qgissplitwithlines:
@@ -281,7 +281,7 @@ Parameters
   One layer containing feature(s) to be compared.
 
 ``Difference layer`` [vector: any]
-  Subtracting layer
+  Subtracting layer.
 
 Output
 ......
@@ -320,7 +320,7 @@ Parameters
 ..........
 
 ``Input layer`` [vector: any]
-  Input vector layer
+  Input vector layer.
 
 ``Union layer`` [vector: any]
   Layer that will be combined to the first one.
@@ -329,7 +329,7 @@ Output
 ......
 
 ``Union`` [vector: any]
-  Layer containing the union of the layers
+  Layer containing the union of the layers.
 
 
 .. Substitutions definitions - AVOID EDITING PAST THIS LINE

--- a/source/docs/user_manual/processing_algs/qgis/vectorselection.rst
+++ b/source/docs/user_manual/processing_algs/qgis/vectorselection.rst
@@ -26,10 +26,10 @@ Parameters
 ..........
 
 ``Input Layer`` [vector: any]
-  Vector layer to extract features from
+  Vector layer to extract features from.
 
 ``Selection attribute`` [tablefield: any]
-  Filtering field of the layer
+  Filtering field of the layer.
 
 ``Operator`` [enumeration]
   Many different operators are available:
@@ -51,16 +51,16 @@ Parameters
 ``Value`` [string]
   Optional
 
-  Value to be evaluated
+  Value to be evaluated.
 
 Outputs
 .......
 
 ``Extracted (attribute)`` [vector: any]
-  Vector layer with matching features
+  Vector layer with matching features.
 
 ``Extracted (non-matching)`` [vector: any]
-  Vector layer with not matching features
+  Vector layer with not matching features.
 
 
 .. _qgisextractbyexpression:
@@ -72,25 +72,25 @@ features while the second will contain all the non-matching features.
 
 The criteria for adding features to the resulting layer is based on a QGIS expression.
 
-For more information about expressions see the :ref:`vector_expressions`
+For more information about expressions see the :ref:`vector_expressions`.
 
 Parameters
 ..........
 
 ``Input Layer`` [vector: any]
-  Input vector layer
+  Input vector layer.
 
 ``Expression`` [expression]
-  Expression to filter the vector layer
+  Expression to filter the vector layer.
 
 Outputs
 .......
 
 ``Matching features`` [vector: any]
-  Vector layer with matching features
+  Vector layer with matching features.
 
 ``Non-matching`` [vector: any]
-  Vector layer with not matching features
+  Vector layer with not matching features.
 
 
 .. _qgisextractbylocation:
@@ -106,7 +106,7 @@ Parameters
 ..........
 
 ``Extract features from`` [vector: any]
-  Input vector layer
+  Input vector layer.
 
 ``Where the features (geometric predicate)`` [enumeration] [list]
   Spatial condition for the selection:
@@ -121,14 +121,14 @@ Parameters
   * cross
 
 ``By comparing to the features from`` [vector: any]
-  Intersection vector layer
+  Intersection vector layer.
 
 
 Output
 ......
 
 ``Extracted (location)`` [vector: any]
-  Vector layer of the spatial intersection
+  Vector layer of the spatial intersection.
 
 
 .. _qgisrandomextract:
@@ -145,7 +145,7 @@ Parameters
 ..........
 
 ``Input layer`` [vector: any]
-  Source vector layer to select the features from
+  Source vector layer to select the features from.
 
 ``Method`` [enumeration]
   Method of the random selection:
@@ -156,7 +156,7 @@ Parameters
   Default: *Number of selected features*
 
 ``Number/percentage of selected features`` [number]
-  Number or the percentage of the features to select
+  Number or the percentage of the features to select.
 
   Default: *10*
 
@@ -164,7 +164,7 @@ Output
 ......
 
 ``Extracted (random)`` [vector: any]
-  Vector layer containing random selected features
+  Vector layer containing random selected features.
 
 
 .. _qgisrandomextractwithinsubsets:
@@ -183,10 +183,10 @@ Parameters
 ..........
 
 ``Input layer`` [vector: any]
-  Source vector layer to select the features from
+  Source vector layer to select the features from.
 
 ``ID field`` [tablefield: any]
-  Category of the source vector layer to select the features from
+  Category of the source vector layer to select the features from.
 
 ``Method`` [enumeration]
   Method of the random selection:
@@ -197,7 +197,7 @@ Parameters
   Default: *Number of selected features*
 
 ``Number/percentage of selected features`` [number]
-  Number or the percentage of the feature to select
+  Number or the percentage of the feature to select.
 
   Default: *10*
 
@@ -205,7 +205,7 @@ Output
 ......
 
 ``Extracted (random stratified)`` [vector: any]
-  Random vector layer
+  Random vector layer.
 
 
 .. _qgisrandomselection:
@@ -224,7 +224,7 @@ Parameters
 ..........
 
 ``Input layer`` [vector: any]
-  Source vector layer to select the features from
+  Source vector layer to select the features from.
 
 ``Method`` [enumeration]
   Method of the random selection:
@@ -264,10 +264,10 @@ Parameters
 ..........
 
 ``Input layer`` [vector: any]
-  Source vector layer to select the features from
+  Source vector layer to select the features from.
 
 ``ID field`` [tablefield: any]
-  Category of the source vector layer
+  Category of the source vector layer.
 
 ``Method`` [enumeration]
   Method of the random selection:
@@ -298,10 +298,10 @@ Parameters
 ..........
 
 ``Input Layer`` [vector: any]
-  Input vector layer
+  Input vector layer.
 
 ``Selection attribute`` [tablefield: any]
-  Filtering field of the layer
+  Filtering field of the layer.
 
 ``Operator`` [enumeration]
   Many different operators are available:
@@ -339,7 +339,7 @@ Select by expression
 --------------------
 Creates a selection in a vector layer. The criteria for selecting
 features is based on a QGIS expression. For more information about expressions
-see the :ref:`vector_expressions`
+see the :ref:`vector_expressions`.
 
 No new outputs are created.
 
@@ -347,10 +347,10 @@ Parameters
 ..........
 
 ``Input Layer`` [vector: any]
-  Input vector layer
+  Input vector layer.
 
 ``Expression`` [expression]
-  Expression to filter the vector layer
+  Expression to filter the vector layer.
 
 ``Modify current selection by`` [enumeration]
   How the selection of the algorithm should be managed. You have many options:
@@ -379,7 +379,7 @@ Parameters
 ..........
 
 ``Select features from`` [vector: any]
-  Source vector layer
+  Source vector layer.
 
 ``Where the features (geometric predicate)`` [enumeration] [list]
   Spatial condition for the selection:
@@ -394,7 +394,7 @@ Parameters
   * cross
 
 ``By comparing to the features from`` [vector: any]
-  Intersection vector layer
+  Intersection vector layer.
 
 ``Modify current selection by`` [enumeration]
   How the selection of the algorithm should be managed. You have many options:

--- a/source/docs/user_manual/processing_algs/qgis/vectortable.rst
+++ b/source/docs/user_manual/processing_algs/qgis/vectortable.rst
@@ -29,17 +29,17 @@ Parameters
 ..........
 
 ``Input layer`` [vector: any]
-  Input vector layer
+  Input vector layer.
 
 ``Field name`` [string]
-  Name of the field with autoincremental values
+  Name of the field with autoincremental values.
 
   Default: *AUTO*
 
 ``Start values at`` [number]
   Optional
 
-  Choose the initial number of the incremental count
+  Choose the initial number of the incremental count.
 
   Default: *0*
   
@@ -76,7 +76,7 @@ Output
 ......
 
 ``Incremented`` [vector: any]
-  Vector layer with auto incremental field
+  Vector layer with auto incremental field.
 
 
 .. _qgisaddfieldtoattributestable:
@@ -94,10 +94,10 @@ Parameters
 ..........
 
 ``Input layer`` [vector: any]
-  Input vector layer
+  Input vector layer.
 
 ``Field name`` [string]
-  Name of the new field
+  Name of the new field.
 
   Default: *(not set)*
 
@@ -111,12 +111,12 @@ Parameters
   Default: *Integer*
 
 ``Field length`` [number]
-  Length of the field
+  Length of the field.
 
   Default: *10*
 
 ``Field precision`` [number]
-  Precision of the field. Useful with Float field type
+  Precision of the field. Useful with Float field type.
 
   Default: *0*
 
@@ -124,7 +124,7 @@ Output
 ......
 
 ``Added`` [vector: any]
-  Vector layer with new field added
+  Vector layer with new field added.
 
 
 .. _qgisadduniquevalueindexfield:
@@ -147,7 +147,7 @@ Parameters
 ..........
 
 ``Input layer`` [vector: any]
-  Input vector layer
+  Input vector layer.
 
 ``Class field`` [tablefield: any]
   Features of the same value are given the same index.
@@ -161,10 +161,10 @@ Output
 ......
 
 ``Layer with index field`` [vector: any]
-  Vector layer with the numeric field containing indexes
+  Vector layer with the numeric field containing indexes.
 
 ``Class summary`` [table]
-  Table with summary of the class field mapped to the corresponding unique value
+  Table with summary of the class field mapped to the corresponding unique value.
   
   Default: *Skip Output*
 
@@ -181,10 +181,10 @@ Parameters
 ..........
 
 ``Input layer`` [vector: any]
-  <put parameter description here>
+  Input vector layer.
 
 ``Result field name`` [string]
-  name of the new field
+  Name of the new field.
 
   Default: *NewField*
 
@@ -198,12 +198,12 @@ Parameters
   Default: *Integer*
 
 ``Field length`` [number]
-  Length of the field
+  Length of the field.
 
   Default: *10*
 
 ``Field precision`` [number]
-  Precision of the field. Useful with Float field type
+  Precision of the field. Useful with Float field type.
 
   Default: *3*
 
@@ -226,7 +226,7 @@ Output
 ......
 
 ``Calculated`` [vector: any]
-  Vector layer with the new calculated field
+  Vector layer with the new calculated field.
 
 
 .. _qgisdeletecolumn:
@@ -240,16 +240,16 @@ Parameters
 ..........
 
 ``Input layer`` [vector: any]
-  Input vector layer to drop field(s) from
+  Input vector layer to drop field(s) from.
 
 ``Fields to drop`` [tablefield: any] [list]
-  Select the field(s) to drop
+  Select the field(s) to drop.
 
 Output
 ......
 
 ``Fields dropped`` [vector: any]
-  Vector layer without the field(s) chosen
+  Vector layer without the field(s) chosen.
 
 
 .. _qgisfieldcalculator:
@@ -292,7 +292,7 @@ Parameters
 ..........
 
 ``Input layer`` [vector: any]
-  Layer to edit the attribute table structure
+  Layer to edit the attribute table structure.
 
 ``Fields mapping`` [list]
   List of output fields with their definitions.
@@ -300,10 +300,10 @@ Parameters
   The embedded table lists all the fields of the source
   layer and allows you to edit them:
 
-  * click the |newAttribute| button to create a new field
-  * click the |deleteAttribute| to remove a field
-  * use |arrowUp| and |arrowDown| to change the selected field order
-  * click |clearText| to reset to the default view
+  * click the |newAttribute| button to create a new field;
+  * click the |deleteAttribute| to remove a field;
+  * use |arrowUp| and |arrowDown| to change the selected field order;
+  * click |clearText| to reset to the default view.
 
   For each of the fields you'd like to reuse, you need to
   fill the following options:
@@ -331,7 +331,7 @@ Output
 ......
 
 ``Refactored`` [vector: any]
-  Output layer with refactored fields
+  Output layer with refactored fields.
 
 
 .. _qgistexttofloat:
@@ -339,7 +339,7 @@ Output
 Text to float
 -------------
 Modifies the type of a given attribute in a vector layer, converting a text attribute
-containing numeric strings into a numeric attribute (e.g. '1' to ``1.0``)
+containing numeric strings into a numeric attribute (e.g. '1' to ``1.0``).
 
 The algorithm creates a new vector layer so the source one is not modified.
 
@@ -349,16 +349,16 @@ Parameters
 ..........
 
 ``Input Layer`` [vector: any]
-  Input vector layer
+  Input vector layer.
 
 ``Text attribute to convert to float`` [tablefield: string]
-  String field to convert in a floating field type
+  String field to convert in a floating field type.
 
 Output
 ......
 
 ``Float from text`` [vector: any]
-  Output vector layer with string field converted into float
+  Output vector layer with string field converted into float.
 
 
 .. Substitutions definitions - AVOID EDITING PAST THIS LINE

--- a/source/docs/user_manual/processing_algs/qgis/vectortable.rst
+++ b/source/docs/user_manual/processing_algs/qgis/vectortable.rst
@@ -208,7 +208,7 @@ Parameters
   Default: *3*
 
 ``Global expression`` [string]
-  Optional.
+  Optional
 
   The code in the global expression section will be executed only once before the
   calculator starts iterating through all the features of the input layer.

--- a/source/docs/user_manual/processing_algs/r/home_range_analysis.rst
+++ b/source/docs/user_manual/processing_algs/r/home_range_analysis.rst
@@ -72,7 +72,7 @@ Parameters
   Default: *10.0*
 
 ``Folder`` [directory]
-  Optional.
+  Optional
 
   <put parameter description here>
 

--- a/source/docs/user_manual/processing_algs/saga/geostatistics.rst
+++ b/source/docs/user_manual/processing_algs/saga/geostatistics.rst
@@ -26,7 +26,7 @@ Parameters
   <put parameter description here>
 
 ``Points`` [vector: any]
-  Optional.
+  Optional
 
   <put parameter description here>
 
@@ -1623,17 +1623,17 @@ Parameters
   <put parameter description here>
 
 ``Categorial Grids`` [raster] [list]
-  Optional.
+  Optional
 
   <put parameter description here>
 
 ``Grids to analyse`` [raster] [list]
-  Optional.
+  Optional
 
   <put parameter description here>
 
 ``Aspect`` [raster]
-  Optional.
+  Optional
 
   <put parameter description here>
 

--- a/source/docs/user_manual/processing_algs/saga/grid_analysis.rst
+++ b/source/docs/user_manual/processing_algs/saga/grid_analysis.rst
@@ -511,7 +511,7 @@ Parameters
   <put parameter description here>
 
 ``Values`` [raster] [list]
-  Optional.
+  Optional
 
   <put parameter description here>
 
@@ -640,17 +640,17 @@ Parameters
 ..........
 
 ``Sand`` [raster]
-  Optional.
+  Optional
 
   <put parameter description here>
 
 ``Silt`` [raster]
-  Optional.
+  Optional
 
   <put parameter description here>
 
 ``Clay`` [raster]
-  Optional.
+  Optional
 
   <put parameter description here>
 

--- a/source/docs/user_manual/processing_algs/saga/grid_calculus.rst
+++ b/source/docs/user_manual/processing_algs/saga/grid_calculus.rst
@@ -712,7 +712,7 @@ Parameters
   <put parameter description here>
 
 ``Independent Variable (per Grid and Cell)`` [raster] [list]
-  Optional.
+  Optional
 
   <put parameter description here>
 
@@ -909,7 +909,7 @@ Parameters
   <put parameter description here>
 
 ``Additional layers`` [raster] [list]
-  Optional.
+  Optional
 
   <put parameter description here>
 

--- a/source/docs/user_manual/processing_algs/saga/grid_filter.rst
+++ b/source/docs/user_manual/processing_algs/saga/grid_filter.rst
@@ -496,7 +496,7 @@ Parameters
   <put parameter description here>
 
 ``Filter Matrix`` [table]
-  Optional.
+  Optional
 
   <put parameter description here>
 

--- a/source/docs/user_manual/processing_algs/saga/grid_tools.rst
+++ b/source/docs/user_manual/processing_algs/saga/grid_tools.rst
@@ -113,7 +113,7 @@ Parameters
   <put parameter description here>
 
 ``Mask`` [raster]
-  Optional.
+  Optional
 
   <put parameter description here>
 
@@ -153,7 +153,7 @@ Parameters
   <put parameter description here>
 
 ``Mask`` [raster]
-  Optional.
+  Optional
 
   <put parameter description here>
 
@@ -1033,7 +1033,7 @@ Parameters
   <put parameter description here>
 
 ``Threshold Grid`` [raster]
-  Optional.
+  Optional
 
   <put parameter description here>
 

--- a/source/docs/user_manual/processing_algs/saga/imagery_classification.rst
+++ b/source/docs/user_manual/processing_algs/saga/imagery_classification.rst
@@ -26,7 +26,7 @@ Parameters
   <put parameter description here>
 
 ``Look-up Table`` [table]
-  Optional.
+  Optional
 
   <put parameter description here>
 
@@ -43,7 +43,7 @@ Parameters
   <put parameter description here>
 
 ``Look-up Table`` [table]
-  Optional.
+  Optional
 
   <put parameter description here>
 

--- a/source/docs/user_manual/processing_algs/saga/imagery_rga.rst
+++ b/source/docs/user_manual/processing_algs/saga/imagery_rga.rst
@@ -29,7 +29,7 @@ Parameters
   <put parameter description here>
 
 ``Smooth Rep`` [raster]
-  Optional.
+  Optional
 
   <put parameter description here>
 

--- a/source/docs/user_manual/processing_algs/saga/shapes_grid.rst
+++ b/source/docs/user_manual/processing_algs/saga/shapes_grid.rst
@@ -516,7 +516,7 @@ Parameters
   <put parameter description here>
 
 ``Polygons`` [vector: any]
-  Optional.
+  Optional
 
   <put parameter description here>
 

--- a/source/docs/user_manual/processing_algs/saga/shapes_polygons.rst
+++ b/source/docs/user_manual/processing_algs/saga/shapes_polygons.rst
@@ -122,17 +122,17 @@ Parameters
   <put parameter description here>
 
 ``1. Attribute`` [tablefield: any]
-  Optional.
+  Optional
 
   <put parameter description here>
 
 ``2. Attribute`` [tablefield: any]
-  Optional.
+  Optional
 
   <put parameter description here>
 
 ``3. Attribute`` [tablefield: any]
-  Optional.
+  Optional
 
   <put parameter description here>
 

--- a/source/docs/user_manual/processing_algs/saga/shapes_tools.rst
+++ b/source/docs/user_manual/processing_algs/saga/shapes_tools.rst
@@ -23,7 +23,7 @@ Parameters
 ..........
 
 ``Extent`` [vector: any]
-  Optional.
+  Optional
 
   Grid will be created according to the selected layer.
 
@@ -173,7 +173,7 @@ Parameters
   Initial layer.
 
 ``Additional Layers`` [vector: any] [list]
-  Optional.
+  Optional
 
   Layer(s) to merge with.
 

--- a/source/docs/user_manual/processing_algs/saga/simulation_fire_spreading.rst
+++ b/source/docs/user_manual/processing_algs/saga/simulation_fire_spreading.rst
@@ -50,12 +50,12 @@ Parameters
   <put parameter description here>
 
 ``Value`` [raster]
-  Optional.
+  Optional
 
   <put parameter description here>
 
 ``Base Probability`` [raster]
-  Optional.
+  Optional
 
   <put parameter description here>
 

--- a/source/docs/user_manual/processing_algs/saga/simulation_hydrology.rst
+++ b/source/docs/user_manual/processing_algs/saga/simulation_hydrology.rst
@@ -26,7 +26,7 @@ Parameters
   <put parameter description here>
 
 ``Gauges`` [vector: any]
-  Optional.
+  Optional
 
   <put parameter description here>
 

--- a/source/docs/user_manual/processing_algs/saga/terrain_analysis_channels.rst
+++ b/source/docs/user_manual/processing_algs/saga/terrain_analysis_channels.rst
@@ -79,7 +79,7 @@ Parameters
   <put parameter description here>
 
 ``Flow Direction`` [raster]
-  Optional.
+  Optional
 
   <put parameter description here>
 
@@ -103,7 +103,7 @@ Parameters
   Default: *0.0*
 
 ``Divergence`` [raster]
-  Optional.
+  Optional
 
   <put parameter description here>
 
@@ -113,7 +113,7 @@ Parameters
   Default: *10*
 
 ``Tracing: Weight`` [raster]
-  Optional.
+  Optional
 
   <put parameter description here>
 
@@ -287,7 +287,7 @@ Parameters
   <put parameter description here>
 
 ``Sink Route`` [raster]
-  Optional.
+  Optional
 
   <put parameter description here>
 

--- a/source/docs/user_manual/processing_algs/saga/terrain_analysis_hydrology.rst
+++ b/source/docs/user_manual/processing_algs/saga/terrain_analysis_hydrology.rst
@@ -74,22 +74,22 @@ Parameters
   <put parameter description here>
 
 ``Sink Routes`` [raster]
-  Optional.
+  Optional
 
   <put parameter description here>
 
 ``Weight`` [raster]
-  Optional.
+  Optional
 
   <put parameter description here>
 
 ``Material`` [raster]
-  Optional.
+  Optional
 
   <put parameter description here>
 
 ``Target`` [raster]
-  Optional.
+  Optional
 
   <put parameter description here>
 
@@ -165,22 +165,22 @@ Parameters
   <put parameter description here>
 
 ``Sink Routes`` [raster]
-  Optional.
+  Optional
 
   <put parameter description here>
 
 ``Weight`` [raster]
-  Optional.
+  Optional
 
   <put parameter description here>
 
 ``Material`` [raster]
-  Optional.
+  Optional
 
   <put parameter description here>
 
 ``Target`` [raster]
-  Optional.
+  Optional
 
   <put parameter description here>
 
@@ -190,7 +190,7 @@ Parameters
   Default: *1*
 
 ``Target Areas`` [raster]
-  Optional.
+  Optional
 
   <put parameter description here>
 
@@ -304,7 +304,7 @@ Parameters
   <put parameter description here>
 
 ``Parameter`` [raster]
-  Optional.
+  Optional
 
   <put parameter description here>
 
@@ -538,7 +538,7 @@ Parameters
   <put parameter description here>
 
 ``Seeds`` [raster]
-  Optional.
+  Optional
 
   <put parameter description here>
 
@@ -593,7 +593,7 @@ Parameters
   <put parameter description here>
 
 ``Total Catchment Area (TCA)`` [raster]
-  Optional.
+  Optional
 
   <put parameter description here>
 
@@ -837,7 +837,7 @@ Parameters
   <put parameter description here>
 
 ``Sink Route`` [raster]
-  Optional.
+  Optional
 
   <put parameter description here>
 
@@ -968,7 +968,7 @@ Parameters
   <put parameter description here>
 
 ``Transmissivity`` [raster]
-  Optional.
+  Optional
 
   <put parameter description here>
 
@@ -1020,7 +1020,7 @@ Parameters
 ..........
 
 ``Target Area`` [raster]
-  Optional.
+  Optional
 
   <put parameter description here>
 
@@ -1038,7 +1038,7 @@ Parameters
   <put parameter description here>
 
 ``Sink Routes`` [raster]
-  Optional.
+  Optional
 
   <put parameter description here>
 

--- a/source/docs/user_manual/processing_algs/saga/terrain_analysis_morphometry.rst
+++ b/source/docs/user_manual/processing_algs/saga/terrain_analysis_morphometry.rst
@@ -285,12 +285,12 @@ Parameters
   <put parameter description here>
 
 ``Wind Direction`` [raster]
-  Optional.
+  Optional
 
   <put parameter description here>
 
 ``Wind Speed`` [raster]
-  Optional.
+  Optional
 
   <put parameter description here>
 
@@ -501,7 +501,7 @@ Parameters
   <put parameter description here>
 
 ``Vertical Distance to Channel Network`` [raster]
-  Optional.
+  Optional
 
   <put parameter description here>
 
@@ -1124,12 +1124,12 @@ Parameters
   <put parameter description here>
 
 ``Wind Direction`` [raster]
-  Optional.
+  Optional
 
   <put parameter description here>
 
 ``Wind Speed`` [raster]
-  Optional.
+  Optional
 
   <put parameter description here>
 

--- a/source/docs/user_manual/processing_algs/saga/terrain_analysis_profiles.rst
+++ b/source/docs/user_manual/processing_algs/saga/terrain_analysis_profiles.rst
@@ -113,7 +113,7 @@ Parameters
   <put parameter description here>
 
 ``Values`` [raster] [list]
-  Optional.
+  Optional
 
   <put parameter description here>
 

--- a/source/docs/user_manual/processing_algs/taudem/basic_grid_analysis_tools.rst
+++ b/source/docs/user_manual/processing_algs/taudem/basic_grid_analysis_tools.rst
@@ -49,14 +49,14 @@ Parameters
   **"D8 Flow Directions"** tool.
 
 ``Outlets Shapefile`` [vector: point]
-  Optional.
+  Optional
 
   A point shapefile defining the outlets of interest. If this input file is
   used, only the cells upslope of these outlet cells are considered to be
   within the domain being evaluated.
 
 ``Weight Grid`` [raster]
-  Optional.
+  Optional
 
   A grid giving contribution to flow for each cell. These contributions (also
   sometimes referred to as weights or loadings) are used in the contributing
@@ -240,14 +240,14 @@ Parameters
   facet with the steepest downward slope.
 
 ``Outlets Shapefile`` [vector: point]
-  Optional.
+  Optional
 
   A point shapefile defining the outlets of interest. If this input file is
   used, only the cells upslope of these outlet cells are considered to be
   within the domain being evaluated.
 
 ``Weight Grid`` [raster]
-  Optional.
+  Optional
 
   A grid giving contribution to flow for each cell. These contributions (also
   sometimes referred to as weights or loadings) are used in the contributing
@@ -424,14 +424,14 @@ Parameters
   **"D8 Flow Directions"** tool.
 
 ``Outlets Shapefile`` [vector: point]
-  Optional.
+  Optional
 
   A point shapefile defining the outlets of interest. If this input file is
   used, only the cells upslope of these outlet cells are considered to be within
   the domain being evaluated.
 
 ``Mask Grid`` [raster]
-  Optional.
+  Optional
 
   A grid that is used to determine the domain do be analyzed. If the mask grid
   value >= mask threshold (see below), then the cell will be included in the

--- a/source/docs/user_manual/processing_algs/taudem/specialized_grid_analysis_tools.rst
+++ b/source/docs/user_manual/processing_algs/taudem/specialized_grid_analysis_tools.rst
@@ -289,7 +289,7 @@ Parameters
   evaluation of Overland Flow Specific Discharge.
 
 ``Outlets shapefile`` [vector: point]
-  Optional.
+  Optional
 
   This optional input is a point shapefile defining outlets of interest. If this
   file is used, the tool will only evaluate the area upslope of these outlets.
@@ -377,14 +377,14 @@ Parameters
   movement of an attenuating substance.
 
 ``Weight Grid`` [raster]
-  Optional.
+  Optional
 
   A grid giving weights (loadings) to be used in the accumulation. If this
   optional grid is not specified, weights are taken as the linear grid cell
   size to give a per unit width accumulation.
 
 ``Outlets Shapefile`` [vector: point]
-  Optional.
+  Optional
 
   This optional input is a point shapefile defining outlets of interest. If
   this file is used, the tool will only evaluate the area upslope of these
@@ -455,7 +455,7 @@ Parameters
   **"Stream Network Analysis"** toolset.
 
 ``Weight Path Grid`` [raster]
-  Optional.
+  Optional
 
   A grid giving weights (loadings) to be used in the distance calculation. This
   might be used for example where only flow distance through a buffer is to be
@@ -783,7 +783,7 @@ Parameters
   eroded sediment.
 
 ``Outlets Shapefile`` [vector: point]
-  Optional.
+  Optional
 
   This optional input is a point shapefile defining outlets of interest. If
   this file is used, the tool will only evaluate the area upslope of these
@@ -908,7 +908,7 @@ Parameters
   give the transport capacity of the carrying flow.
 
 ``Outlets Shapefile`` [vector: point]
-  Optional.
+  Optional
 
   This optional input is a point shapefile defining outlets of interest. If
   this file is used, the tool will only evaluate the area upslope of these

--- a/source/docs/user_manual/processing_algs/taudem/stream_network_analysis_tools.rst
+++ b/source/docs/user_manual/processing_algs/taudem/stream_network_analysis_tools.rst
@@ -52,7 +52,7 @@ Parameters
   needed when generating stream rasters according to drop analysis.
 
 ``Outlets Shapefile`` [vector: point]
-  Optional.
+  Optional
 
   A point shape file defining outlets of interest. If this input file is used,
   only the area upslope of these outlets will be evaluated by the tool.
@@ -388,7 +388,7 @@ Parameters
   Default: *100*
 
 ``Mask Grid`` [raster]
-  Optional.
+  Optional
 
   This optional input is a grid that is used to mask the domain of interest and
   output is only provided where this grid is >= 0. A common use of this input
@@ -625,7 +625,7 @@ Parameters
   the stream network.
 
 ``Outlets Shapefile as Network Nodes`` [vector: point]
-  Optional.
+  Optional
 
   A point shape file defining points of interest. If this file is used, the
   tool will only deliiniate the stream network upstream of these outlets.


### PR DESCRIPTION
Follow-up https://github.com/qgis/QGIS-Documentation/pull/2769#discussion_r199426509
Adds full stop at the end of any descriptive sentence and replace `Optional.` with `Optional`.
Changes are done in all our native algorithms and in some GDAL ones.
Now we need to stick to these rules.