### PR TITLE
Fix typo and inconsistencies in TOC

### DIFF
--- a/source/docs/index.rst
+++ b/source/docs/index.rst
@@ -10,10 +10,10 @@ Please have a look into one of the documents below.
 .. toctree::
    :maxdepth: 2
 
-   User guide/Manual (QGIS Testing) <user_manual/index>
-   User guide/Manual PDF's <http://docs.qgis.org/testing/pdf/>
-   PyQGIS cookbook (QGIS Testing) <pyqgis_developer_cookbook/index>
-   QGIS Developers Guide <developers_guide/index>
+   User Guide/Manual (QGIS Testing) <user_manual/index>
+   User Guide/Manual PDF's <http://docs.qgis.org/testing/pdf/>
+   PyQGIS Cookbook (QGIS Testing) <pyqgis_developer_cookbook/index>
+   Developers Guide <developers_guide/index>
    Documentation Guidelines <documentation_guidelines/index>
-   A gentle introduction in GIS <gentle_gis_introduction/index>
-   Trainings manual <training_manual/index>
+   A Gentle Introduction to GIS <gentle_gis_introduction/index>
+   Training Manual <training_manual/index>


### PR DESCRIPTION
Typo: "Trainings"

QGIS in "QGIS Developers Guide" when others do not have that.

Use uppercase as per titles.
