### PR TITLE
Simplify description of removeMapLayer() in PyQGIS Cookbook

### DIFF
--- a/source/docs/pyqgis_developer_cookbook/loadlayer.rst
+++ b/source/docs/pyqgis_developer_cookbook/loadlayer.rst
@@ -270,6 +270,17 @@ Adding a layer to the registry:
 
     QgsProject.instance().addMapLayer(layer)
 
+To add a layer at an absolute position:
+
+.. code-block:: python
+
+    # first add the layer without showing it
+    QgsProject.instance().addMapLayer(layer, False)
+    # obtain the layer tree of the top-level group in the project
+    layerTree = iface.layerTreeCanvasBridge().rootGroup()
+    # the position is a number starting from 0, with -1 an alias for the end
+    layerTree.insertChildNode(-1, QgsLayerTreeLayer(layer))
+
 If you want to delete the layer use:
 
 .. code-block:: python

--- a/source/docs/pyqgis_developer_cookbook/loadlayer.rst
+++ b/source/docs/pyqgis_developer_cookbook/loadlayer.rst
@@ -270,8 +270,7 @@ Adding a layer to the registry:
 
     QgsProject.instance().addMapLayer(layer)
 
-Layers are destroyed automatically on exit, however if you want to delete the
-layer explicitly, use:
+If you want to delete the layer use:
 
 .. code-block:: python
 


### PR DESCRIPTION
All unsaved changes to the project will be lost on exit. Remove text
that made map layers appear to be a special case.

---

Please check, maybe I missed the point here.