### PR TITLE
Simplify creation of QgsRasterLayer() example in PyQGIS Cookbook

### DIFF
--- a/source/docs/pyqgis_developer_cookbook/loadlayer.rst
+++ b/source/docs/pyqgis_developer_cookbook/loadlayer.rst
@@ -203,14 +203,11 @@ Raster Layers
 For accessing raster files, GDAL library is used. It supports a wide range of
 file formats. In case you have troubles with opening some files, check whether
 your GDAL has support for the particular format (not all formats are available
-by default). To load a raster from a file, specify its file name and base name:
+by default). To load a raster from a file, specify its filename and display name:
 
 .. code-block:: python
 
-    fileName = "/path/to/raster/file.tif"
-    fileInfo = QFileInfo(fileName)
-    baseName = fileInfo.baseName()
-    rlayer = QgsRasterLayer(fileName, baseName)
+    rlayer = QgsRasterLayer("/path/to/raster/file.tif", "my layer")
     if not rlayer.isValid():
       print("Layer failed to load!")
 


### PR DESCRIPTION
Using QFileInfo.baseName() is potentially confusing, this is just the
display name.

--

C++ documentation changed here: https://github.com/qgis/QGIS/commit/2a72eda5142b54dde60244b5dab3ec5db8441680