### PR TITLE
Fix link to data training repository

### DIFF
--- a/source/docs/training_manual/foreword/foreword.rst
+++ b/source/docs/training_manual/foreword/foreword.rst
@@ -114,7 +114,7 @@ Data
 ----
 
 .. note:: The sample data used throughout the manual can be downloaded here:
-   https://github.com/qgis/QGIS-Training-Data/archive/QGIS-Training-Data-v1.0.zip.
+   https://github.com/qgis/QGIS-Training-Data/archive/QGIS-Training-Data-v2.0.zip.
    You can save the files in a folder named **exercise_data**.
 
 The sample data that accompanies this resource is freely available and comes

--- a/source/docs/training_manual/foreword/preparing_data.rst
+++ b/source/docs/training_manual/foreword/preparing_data.rst
@@ -21,7 +21,7 @@ more complex data sources which may or may not be available for your region.
   these instructions if you wish to replace the default data sets.
 
 .. note:: The sample data used throughout the manual can be downloaded here:
-   https://github.com/qgis/QGIS-Training-Data/archive/QGIS-Training-Data-v1.0.zip.
+   https://github.com/qgis/QGIS-Training-Data/archive/QGIS-Training-Data-v2.0.zip.
    You can save the files in a folder named **exercise_data**.
 
 

--- a/source/docs/training_manual/introduction/preparation.rst
+++ b/source/docs/training_manual/introduction/preparation.rst
@@ -12,7 +12,7 @@ exercises.
 
 .. note::  Before starting this exercise, QGIS must be installed on your
    computer. Also, download the ``training_manual_exercise_data.zip`` file
-   from the `QGIS data downloads area <https://github.com/qgis/QGIS-Training-Data/archive/QGIS-Training-Data-v1.0.zip>`_.
+   from the `QGIS data downloads area <https://github.com/qgis/QGIS-Training-Data/archive/QGIS-Training-Data-v2.0.zip>`_.
 
 Launch QGIS from its desktop shortcut, menu item, etc., depending on how you
 configured its installation.
@@ -72,7 +72,7 @@ GeoPackage is a single file format that can contain different types of data: vec
 and raster files but also tables without spatial information in them (like CSV
 file).
 
-Within the `Training data <https://github.com/qgis/QGIS-Training-Data/archive/QGIS-Training-Data-v1.0.zip>`_
+Within the `Training data <https://github.com/qgis/QGIS-Training-Data/archive/QGIS-Training-Data-v2.0.zip>`_
 archive you will find the :file:`training_data.gpkg` file. We will now see how
 to load layers from a GeoPackage file.
 

--- a/source/docs/training_manual/qgis_server/wms.rst
+++ b/source/docs/training_manual/qgis_server/wms.rst
@@ -5,7 +5,7 @@
 |LS| Serving WMS
 ===============================================================================
 
-Let's download the `demo data <https://github.com/qgis/QGIS-Training-Data/archive/master.zip>`_
+Let's download the `demo data <https://github.com/qgis/QGIS-Training-Data/archive/QGIS-Training-Data-v2.0.zip>`_
 and unzip the files in the :file:`qgis-server-tutorial-data` subdirectory to
 any directory. We recommend that you simply create a :file:`/home/qgis/projects`
 directory and put your files there in order to avoid possible permissions problems.

--- a/source/docs/user_manual/working_with_ogc/server/getting_started.rst
+++ b/source/docs/user_manual/working_with_ogc/server/getting_started.rst
@@ -412,9 +412,9 @@ retrieve the project:
 .. code-block:: bash
 
  cd /home/user/
- wget https://github.com/qgis/QGIS-Training-Data/archive/master.zip -O qgis-server-tutorial.zip
+ wget https://github.com/qgis/QGIS-Training-Data/archive/QGIS-Training-Data-v2.0.zip -O qgis-server-tutorial.zip
  unzip qgis-server-tutorial.zip
- mv QGIS-Training-Data-master/training_manual_data/qgis-server-tutorial-data ~
+ mv QGIS-Training-Data-QGIS-Training-Data-v2.0/training_manual_data/qgis-server-tutorial-data ~
 
 The project file is ``qgis-server-tutorial-data-master/world.qgs``. Of course,
 you can use your favorite GIS software to open this file and take a look on the


### PR DESCRIPTION
Because 3.4 data training aims to give a particular place to gpkg
Because 3.4 exercises may not be compatible with 2.18
Because 2.18 users should still be able to train themselves with "working" data
We cannot keep the same branch for the two docs. A new branch is created and linked to.