### PR TITLE
Add examples of expression in the layout label item

### DIFF
--- a/source/docs/user_manual/print_composer/composer_items/composer_label.rst
+++ b/source/docs/user_manual/print_composer/composer_items/composer_label.rst
@@ -79,6 +79,52 @@ Appearance
   * and :guilabel:`Top`, :guilabel:`Middle`, :guilabel:`Bottom` for
     :guilabel:`Vertical alignment`.
 
+.. _layout_label_expressions:
+
+Exploring expressions in label item
+------------------------------------
+
+Below some examples of expressions you can use to populate the label item with
+interesting information - remember that the code, or at least the calculated part,
+should be surrounded by ``[%`` and ``%]`` in the :guilabel:`Main properties` frame):
+
+* Display a title with the current atlas feature value in "field1":
+
+  .. code-block::
+
+    concat( 'This is the map for ', "field1" ) )
+
+  or, written in the :guilabel:`Main properties` section:
+
+  .. code-block::
+
+    This is the map for [% "field1" %]
+
+* Add a pagination for processed atlas features (eg, ``Page 1/10``):
+
+  .. code-block::
+
+    concat( 'Page ', @atlas_featurenumber, '/', @atlas_totalfeatures )
+
+* Return the x coordinate of the bottom left corner of a map canvas:
+
+  .. code-block::
+
+    x_min( map_get( item_variables( 'Map 1' ), 'map_extent' ) )
+
+* Retrieve the name of the layers in the current layout 'Map 1' item,
+  and formats in one name by line :
+
+  .. code-block::
+
+    array_to_string(
+      array_foreach(
+        map_get( item_variables( 'Map 1' ), 'map_layers' ), -- retrieve the layers list
+        layer_property( @element, 'name' ) -- retrieve each layer name
+      ),
+      '\n' -- converts the list to string separated by breaklines
+    )
+
 
 .. Substitutions definitions - AVOID EDITING PAST THIS LINE
    This will be automatically updated by the find_set_subst.py script.

--- a/source/docs/user_manual/print_composer/composer_items/composer_label.rst
+++ b/source/docs/user_manual/print_composer/composer_items/composer_label.rst
@@ -81,8 +81,8 @@ Appearance
 
 .. _layout_label_expressions:
 
-Exploring expressions in label item
-------------------------------------
+Exploring expressions in a label item
+-------------------------------------
 
 Below some examples of expressions you can use to populate the label item with
 interesting information - remember that the code, or at least the calculated part,
@@ -92,7 +92,7 @@ should be surrounded by ``[%`` and ``%]`` in the :guilabel:`Main properties` fra
 
   ::
 
-    concat( 'This is the map for ', "field1" )
+    'This is the map for ' || "field1"
 
   or, written in the :guilabel:`Main properties` section:
 

--- a/source/docs/user_manual/print_composer/composer_items/composer_label.rst
+++ b/source/docs/user_manual/print_composer/composer_items/composer_label.rst
@@ -86,36 +86,36 @@ Exploring expressions in label item
 
 Below some examples of expressions you can use to populate the label item with
 interesting information - remember that the code, or at least the calculated part,
-should be surrounded by ``[%`` and ``%]`` in the :guilabel:`Main properties` frame):
+should be surrounded by ``[%`` and ``%]`` in the :guilabel:`Main properties` frame:
 
 * Display a title with the current atlas feature value in "field1":
 
-  .. code-block::
+  ::
 
-    concat( 'This is the map for ', "field1" ) )
+    concat( 'This is the map for ', "field1" )
 
   or, written in the :guilabel:`Main properties` section:
 
-  .. code-block::
+  ::
 
     This is the map for [% "field1" %]
 
 * Add a pagination for processed atlas features (eg, ``Page 1/10``):
 
-  .. code-block::
+  ::
 
     concat( 'Page ', @atlas_featurenumber, '/', @atlas_totalfeatures )
 
 * Return the x coordinate of the bottom left corner of a map canvas:
 
-  .. code-block::
+  ::
 
     x_min( map_get( item_variables( 'Map 1' ), 'map_extent' ) )
 
 * Retrieve the name of the layers in the current layout 'Map 1' item,
-  and formats in one name by line :
+  and formats in one name by line:
 
-  .. code-block::
+  ::
 
     array_to_string(
       array_foreach(


### PR DESCRIPTION
QGIS has a lot of functions and variables plus a lot of places where these functions can be combined to endless possibilities. In the user manual, other than stating that an option is data-definable, i think there's a lack of showcase. What can I do? Or how can I write an expression?
This PR would like to introduce a section now in the print layout label item (the easiest) but the idea is to add more section in different chapters with things people can do with variables and expressions (map/legend/scalebar/... item size/placement modification, playing with map theme, playing with symbology....) .

(_Yes, there are some code samples in the Expression chapter but I think while those are desirable, putting the code sample near the feature in which I'd use it is also nice_)