### PR TITLE
Indicate updated sections to avoid losing time on testing

### DIFF
--- a/source/docs/pyqgis_developer_cookbook/vector.rst
+++ b/source/docs/pyqgis_developer_cookbook/vector.rst
@@ -677,6 +677,8 @@ Finally, let's check whether everything went well
 Appearance (Symbology) of Vector Layers
 =======================================
 
+.. **FOR WRITERS**: This section has been updated to QGIS3, down to...
+
 When a vector layer is being rendered, the appearance of the data is given by
 **renderer** and **symbols** associated with the layer.  Symbols are classes
 which take care of drawing of visual representation of features, while
@@ -907,6 +909,8 @@ arrangement)
   myVectorLayer.setRenderer(myRenderer)
   QgsProject.instance().addMapLayer(myVectorLayer)
 
+
+.. **FOR WRITERS**: ...End of updated section to QGIS3
 
 .. index:: Symbols; Working with
 


### PR DESCRIPTION
Because I don't know how long we'll remember the sections that got updated nor when the earlier sections in the chapter will be updated (so that we move the warning message), this PR places a note so that writers do not lose time on testing what does not need.