### PR TITLE
[TM] Structuring reference to training data download page

### DIFF
--- a/source/docs/training_manual/foreword/foreword.rst
+++ b/source/docs/training_manual/foreword/foreword.rst
@@ -110,12 +110,10 @@ Sponsors
 
 * Cape Peninsula University of Technology
 
+.. _data_downloadlink:
+
 Data
 ----
-
-.. note:: The sample data used throughout the manual can be downloaded here:
-   https://github.com/qgis/QGIS-Training-Data/archive/QGIS-Training-Data-v2.0.zip.
-   You can save the files in a folder named **exercise_data**.
 
 The sample data that accompanies this resource is freely available and comes
 from the following sources:
@@ -123,6 +121,13 @@ from the following sources:
 * Streets and Places datasets from OpenStreetMap (http://www.openstreetmap.org/)
 * Property boundaries (urban and rural), water bodies from NGI (http://www.ngi.gov.za/)
 * SRTM DEM from the CGIAR-CGI (http://srtm.csi.cgiar.org/)
+
+Download the prepared dataset from the `Training data repository <training_data_>`_
+and unzip the file. All the necessary data are provided in the :file:`exercise_data`
+folder.
+
+.. _training_data: https://github.com/qgis/QGIS-Training-Data/archive/v2.0.zip
+
 
 Source files and Issue reports
 -------------------------------

--- a/source/docs/training_manual/foreword/preparing_data.rst
+++ b/source/docs/training_manual/foreword/preparing_data.rst
@@ -5,31 +5,26 @@
 Preparing Exercise Data
 =======================
 
-The sample data provided with the Training Manual refers to the town of
-|majorUrbanName| and its surroundings. |majorUrbanName| is located about 2 hours' east of
-Cape Town in the Western Cape of South Africa. The dataset contains feature
-names in both English and Afrikaans.
+.. note:: This process is intended for course conveners, or more experienced
+  QGIS users who wish to create localised sample data sets for their course.
+  Default data sets are provided with the Training Manual, but you may follow
+  these instructions if you wish to replace the default data sets.
+
+The :ref:`sample data provided <data_downloadlink>` with the Training Manual
+refers to the town of |majorUrbanName| and its surroundings. |majorUrbanName| is
+located about 2 hours' east of Cape Town in the Western Cape of South Africa.
+The dataset contains feature names in both English and Afrikaans.
 
 Anyone can use this dataset without difficulty, but you may prefer to use data
 from your own country or home town. If you choose to do so, your localised
 data will be used in all lessons from Module 3 to Module 7.2. Later modules use
 more complex data sources which may or may not be available for your region.
 
-.. note:: This process is intended for course conveners, or more experienced
-  QGIS users who wish to create localised sample data sets for their course.
-  Default data sets are provided with the Training Manual, but you may follow
-  these instructions if you wish to replace the default data sets.
-
-.. note:: The sample data used throughout the manual can be downloaded here:
-   https://github.com/qgis/QGIS-Training-Data/archive/QGIS-Training-Data-v2.0.zip.
-   You can save the files in a folder named **exercise_data**.
-
-
-|hard| |TY|
---------------------------------------------------------------------------------
-
 .. note:: These instructions assume you have a good knowledge of QGIS and are
   not intended to be used as teaching material.
+  
+|hard| |TY|  Create OSM based vector Files
+--------------------------------------------------------------------------------
 
 If you wish to replace the default data set with localised data for your course,
 this can easily be done with tools built into QGIS. The region you choose to use

--- a/source/docs/training_manual/introduction/preparation.rst
+++ b/source/docs/training_manual/introduction/preparation.rst
@@ -11,8 +11,8 @@ exercises.
 **The goal for this lesson:** To get started with an example map.
 
 .. note::  Before starting this exercise, QGIS must be installed on your
-   computer. Also, download the ``training_manual_exercise_data.zip`` file
-   from the `QGIS data downloads area <https://github.com/qgis/QGIS-Training-Data/archive/QGIS-Training-Data-v2.0.zip>`_.
+   computer. Also, you should have downloaded the :ref:`sample data 
+   <data_downloadlink>` to use.
 
 Launch QGIS from its desktop shortcut, menu item, etc., depending on how you
 configured its installation.
@@ -69,12 +69,8 @@ geospatial data. QGIS adds a lot of support to this new format that is slowly
 replacing the ESRI shapefile format.
 
 GeoPackage is a single file format that can contain different types of data: vector
-and raster files but also tables without spatial information in them (like CSV
+and raster layers but also tables without spatial information in them (like CSV
 file).
-
-Within the `Training data <https://github.com/qgis/QGIS-Training-Data/archive/QGIS-Training-Data-v2.0.zip>`_
-archive you will find the :file:`training_data.gpkg` file. We will now see how
-to load layers from a GeoPackage file.
 
 In order to load a layer from a GeoPackage:
 


### PR DESCRIPTION
1. Currently, there are four places where the link to the training manual data is provided. fortunately, they are all the same. With this PR, only a single place remains for the link and the other places are removed or point to it. Easier to maintain.
1. Also, instead of adding a clear link in the text that would be translated, a reference is used, allowing us to freely manage the branches of the data training repo without breaking future translations and still keep the good reference.
1. Downloading the TM data currently creates a `QGIS-Training-Data-QGIS-Training-Data-v2.0.zip` file. Rather ugly name imho. Fixing this by a new `v2.0` branch created in the training data repo and the export file will now be named `QGIS-Training-Data-v2.0.zip`
1. The zip file stores the file under a `training_manual_data` folder we further ask to rename `exercise_data`. This PR skips this process by using the `exercise_data` naming directly.

TODO:

- [x] Rename the `training_manual_data` folder into `exercise_data` in the v2.0 branch to have a functional URL