### PR TITLE
symbology and styles clarifications

### DIFF
--- a/source/docs/user_manual/introduction/general_tools.rst
+++ b/source/docs/user_manual/introduction/general_tools.rst
@@ -1530,13 +1530,13 @@ applied to each newly added layer according to its geometry type.
 
 But, most of the time, you'd prefer to have a custom and more complex style
 that can be applied automatically or manually (with less efforts) to the layers.
-You can achieve this goal using the :menuselection:`Style` combobox at the bottom
-of the Layer Properties dialog. This combobox provides you with functions to
+You can achieve this goal using the :menuselection:`Style` menu at the bottom
+of the Layer Properties dialog. This menu provides you with functions to
 create, load and manage styles.
 
 A style stores any information set in the layer properties dialog to render
-or interact with the features (including symbology, labeling, action, diagram...
-settings) for vector layer, or the pixels (band or color rendering, transparency,
+or interact with the layer (including symbology, labeling, fields and form definition, 
+actions, diagrams...) for vector layers, or the pixels (band or color rendering, transparency,
 pyramids, histogram ...) for raster.
 
 

--- a/source/docs/user_manual/working_with_vector/vector_properties.rst
+++ b/source/docs/user_manual/working_with_vector/vector_properties.rst
@@ -33,11 +33,11 @@ from the pop-up menu.
    you can use to speed up the configuration of the layer styles and
    automatically view your changes in the map canvas.
 
-.. tip:: **Styles**
+.. tip:: **Share full or partial properties of the layer styles**
 
-   The :menuselection:`Style` menu at the bottom of the page allows you to import or export
-   these or part of these properties from several destination (file, clipboard, databse).
-   See :ref:`managing-custom-styles`.
+   The :menuselection:`Style` menu at the bottom of the dialog allows you to import or export
+   these or part of these properties from/to several destination (file, clipboard, database).
+   See :ref:`manage-custom-style`.
 
 .. note::
 

--- a/source/docs/user_manual/working_with_vector/vector_properties.rst
+++ b/source/docs/user_manual/working_with_vector/vector_properties.rst
@@ -37,7 +37,7 @@ from the pop-up menu.
 
    The :menuselection:`Style` menu at the bottom of the dialog allows you to import or export
    these or part of these properties from/to several destination (file, clipboard, database).
-   See :ref:`manage-custom-style`.
+   See :ref:`manage_custom_style`.
 
 .. note::
 

--- a/source/docs/user_manual/working_with_vector/vector_properties.rst
+++ b/source/docs/user_manual/working_with_vector/vector_properties.rst
@@ -35,7 +35,7 @@ from the pop-up menu.
 
 .. tip:: **Styles**
 
-   The :ref:`Style` menu at the bottom of the page allows you to import or export
+   The :menuselection:`Style` menu at the bottom of the page allows you to import or export
    these or part of these properties from several destination (file, clipboard, databse).
    See :ref:`managing-custom-styles`.
 

--- a/source/docs/user_manual/working_with_vector/vector_properties.rst
+++ b/source/docs/user_manual/working_with_vector/vector_properties.rst
@@ -33,6 +33,12 @@ from the pop-up menu.
    you can use to speed up the configuration of the layer styles and
    automatically view your changes in the map canvas.
 
+.. tip:: **Styles**
+
+   The :ref:`Style` menu at the bottom of the page allows you to import or export
+   these or part of these properties from several destination (file, clipboard, databse).
+   See :ref:`managing-custom-styles`.
+
 .. note::
 
    Because properties (symbology, label, actions, default values, forms...) of

--- a/source/docs/user_manual/working_with_vector/vector_properties.rst
+++ b/source/docs/user_manual/working_with_vector/vector_properties.rst
@@ -181,12 +181,12 @@ the bottom the :ref:`layer_rendering` widget.
 
 .. tip:: **Switch quickly between different layer representations**
 
-   Using the :menuselection:`Styles --> Add` combobox at the bottom of the
-   :guilabel:`Layer Properties` dialog, you can save as many combinations of
-   layer properties settings (symbology, labeling, diagram, fields form,
-   actions...) as you want. Then, simply switch between styles from the context
-   menu of the layer in :guilabel:`Layers Panel` to automatically get different
-   representations of your data.
+   Using the :menuselection:`Styles --> Add` menu at the bottom of the
+   :guilabel:`Layer Properties` dialog, you can save as many styles as needed.
+   A style is the combination of all properties of a layer (such as symbology,
+   labeling, diagram, fields form, actions...) as you want. Then, simply 
+   switch between styles from the context menu of the layer in :guilabel:`Layers Panel`
+   to automatically get different representations of your data.
 
 
 .. tip:: **Export vector symbology**
@@ -246,7 +246,7 @@ See :ref:`symbol-selector` for further information about symbol representation.
 .. tip:: **Edit symbol directly from layer panel**
 
    If in your **Layers Panel** you have layers with categories defined through
-   categorized, graduated or rule-based style mode, you can quickly change the
+   categorized, graduated or rule-based symbology mode, you can quickly change the
    fill color of the symbol of the categories by right-clicking on a category
    and choose the color you prefer from a |colorWheel| :sup:`color wheel` menu.
    Right-clicking on a category will also give you access to the options **Hide
@@ -448,7 +448,7 @@ Proportional Symbol and Multivariate Analysis
 .............................................
 
 Proportional Symbol and Multivariate Analysis are not
-rendering types available from the Style rendering drop-down list.
+rendering types available from the Symbology rendering drop-down list.
 However with the :ref:`data-defined override <data_defined>` options applied
 over any of the previous
 rendering options, QGIS allows you to display your point and line data with
@@ -770,7 +770,7 @@ units).
 Layer rendering
 ---------------
 
-From the Style tab, you can also set some options that invariabily act on all
+From the Symbology tab, you can also set some options that invariabily act on all
 features of the layer:
 
 * :guilabel:`Layer transparency` |slider|: You can make the underlying layer in
@@ -913,7 +913,7 @@ the resort to other software for final rendering of maps, QGIS provides another
 powerful functionality: the |paintEffects| :guilabel:`Draw Effects` options,
 which adds paint effects for customizing the visualization of vector layers.
 
-The option is available in the :guilabel:`Layer Properties --> Style` dialog,
+The option is available in the :guilabel:`Layer Properties --> Symbology` dialog,
 under the :ref:`Layer rendering <layer_rendering>` group (applying to the whole
 layer) or in :ref:`symbol layer properties <symbol-selector>` (applying
 to corresponding features). You can combine both usage.


### PR DESCRIPTION
screenshots not up to date:
* in `user_manual/working_with_vector/vector_properties.html#symbology-properties` the screenshot (https://docs.qgis.org/testing/en/_images/style_combobox.png) should be updated with the new menu (with style categories)
* https://docs.qgis.org/testing/en/_images/categorysymbol_ng_line.png 

actually, it seems that all screen shots present the old "style" tab instead of "symbology".


see https://github.com/qgis/QGIS/pull/7863
