### PR TITLE
Update coordinate_reference_systems.rst

### DIFF
--- a/source/docs/gentle_gis_introduction/coordinate_reference_systems.rst
+++ b/source/docs/gentle_gis_introduction/coordinate_reference_systems.rst
@@ -183,7 +183,7 @@ in your town to find out whether it is large enough for a new shopping mall,
 equal area projections are the best choice. On the one hand, the larger the area
 you are analysing, the more precise your area measures will be, if you use an
 equal area projection rather than another type. On the other hand, an equal area
-projection results in** distortions of angular conformity** when dealing with
+projection results in **distortions of angular conformity** when dealing with
 large areas. Small areas will be far less prone to having their angles distorted
 when you use an equal area projection. **Alber's equal area**, **Lambert's equal
 area** and **Mollweide Equal Area Cylindrical projections** (shown in


### PR DESCRIPTION
There was a typo in `coordinate_reference_systems.rst` on line 186. 

>On the other hand, an equal area projection results in** distortions of angular conformity** when dealing with large areas.

Replaced this with:

"On the other hand, an equal area projection results in **distortions of angular conformity** when dealing with large areas."

Fixes issue #3066 