### PR TITLE
Exploring the use of "shapefile"

### DIFF
--- a/source/docs/pyqgis_developer_cookbook/loadlayer.rst
+++ b/source/docs/pyqgis_developer_cookbook/loadlayer.rst
@@ -56,10 +56,10 @@ providers:
 .. index::
   pair: Loading; OGR layers
 
-* OGR library (shapefiles and many other file formats) --- data source is the
+* OGR library (Shapefile and many other file formats) --- data source is the
   path to the file:
 
-  * for shapefile:
+  * for Shapefile:
 
   .. code-block:: python
 

--- a/source/docs/pyqgis_developer_cookbook/vector.rst
+++ b/source/docs/pyqgis_developer_cookbook/vector.rst
@@ -541,7 +541,7 @@ Writing Vector Layers
 =====================
 
 You can write vector layer files using :class:`QgsVectorFileWriter` class. It
-supports any other kind of vector file that OGR supports (shapefiles, GeoJSON,
+supports any other kind of vector file that OGR supports (Shapefile, GeoJSON,
 KML and others).
 
 There are two possibilities how to export a vector layer:
@@ -560,7 +560,7 @@ There are two possibilities how to export a vector layer:
         print("success again!")
 
   The third parameter specifies output text encoding. Only some drivers need this
-  for correct operation - shapefiles are one of those --- however in case you
+  for correct operation - Shapefile is one of those --- however in case you
   are not using international characters you do not have to care much about
   the encoding. The fourth parameter that we left as ``None`` may specify
   destination CRS --- if a valid instance of :class:`QgsCoordinateReferenceSystem`

--- a/source/docs/training_manual/complete_analysis/analysis_combination.rst
+++ b/source/docs/training_manual/complete_analysis/analysis_combination.rst
@@ -40,9 +40,9 @@ example:
 .. note:: If you find that the :guilabel:`Intersect` tool does not produce any
   results, check the CRS settings of each of your layers. The CRS must be the
   same for both the layers you are comparing. You may need to reproject one
-  layer by saving the layer as a new shapefile with the required CRS. In our
-  example, the :kbd:`suitable_terrain` layer was reprojected to
-  |localCRS| and named :kbd:`suitable_terrain_34S`.
+  layer by saving the layer as a new file with the required CRS. In our
+  example, the :file:`suitable_terrain` layer was reprojected to
+  |localCRS| and named :file:`suitable_terrain_34S.shp`.
 
 
 .. _backlink-complete-analysis-2:

--- a/source/docs/training_manual/complete_analysis/raster_to_vector.rst
+++ b/source/docs/training_manual/complete_analysis/raster_to_vector.rst
@@ -33,13 +33,13 @@ exercises.
      :align: center
 
 * Change the field name (describing the values of the raster) to
-  :kbd:`suitable`.
-* Save the shapefile under :kbd:`exercise_data/residential_development`
-  as :kbd:`all_terrain.shp`.
+  :guilabel:`suitable`.
+* Save the layer under :file:`exercise_data/residential_development`
+  as :file:`all_terrain.shp`.
 
 Now you have a vector file which contains all the values of the raster, but
 the only areas you're interested in are those that are suitable; i.e., those
-polygons where the value of :kbd:`suitable` is :kbd:`1`. You can change the
+polygons where the value of :guilabel:`suitable` is ``1``. You can change the
 style of this layer if you want to have a clearer visualization of it.
 
 .. _backlink-complete-analysis-1:

--- a/source/docs/training_manual/introduction/overview.rst
+++ b/source/docs/training_manual/introduction/overview.rst
@@ -58,7 +58,7 @@ will be using some of them before long, so take a look around!
 ...............................................................................
 
 The QGIS Browser is a panel in QGIS that lets you easily navigate in your
-database. You can have access to common vector files (e.g. ESRI shapefile
+database. You can have access to common vector files (e.g. ESRI Shapefile
 or MapInfo files), databases (e.g. PostGIS, Oracle, SpatiaLite, GeoPackage or
 MSSQL Spatial) and WMS/WFS connections. You can also view your GRASS data.
 
@@ -166,7 +166,7 @@ Try to find each of these tools on your screen. What is their purpose?
 |basic| |TY| 3
 -------------------------------------------------------------------------------
 
-Try to load some layer, both ESRI shapefile and Geopackage, from the Browser
+Try to load some layer, both ESRI Shapefile and Geopackage, from the Browser
 panel.
 
 :ref:`Check your results <interface-overview-3>`

--- a/source/docs/training_manual/introduction/preparation.rst
+++ b/source/docs/training_manual/introduction/preparation.rst
@@ -66,7 +66,7 @@ your work.
 
 `GeoPackage <http://www.geopackage.org/>`_ is an open format for storing
 geospatial data. QGIS adds a lot of support to this new format that is slowly
-replacing the ESRI shapefile format.
+replacing the ESRI Shapefile format.
 
 GeoPackage is a single file format that can contain different types of data: vector
 and raster layers but also tables without spatial information in them (like CSV

--- a/source/docs/training_manual/spatial_databases/import_export.rst
+++ b/source/docs/training_manual/spatial_databases/import_export.rst
@@ -12,7 +12,7 @@ of tools that will let you easily move data into and out of PostGIS.
 shp2pgsql
 -------------------------------------------------------------------------------
 
-shp2pgsql is a commandline tool to import ESRI shapefiles to the database.
+shp2pgsql is a commandline tool to import ESRI Shapefile to the database.
 Under Unix, you can use the following command for importing a new PostGIS
 table:
 

--- a/source/docs/training_manual/spatial_databases/index.rst
+++ b/source/docs/training_manual/spatial_databases/index.rst
@@ -10,8 +10,7 @@ Spatial Databases allow the storage of the geometries of records inside a
 Database as well as providing functionality for querying and retrieving the
 records  using these Geometries. In this module we will use PostGIS, an
 extension to PostgreSQL, to learn how to setup a spatial database, import data
-from files into the database and make use of the geographic functions that
-PostGIS offers.
+into the database and make use of the geographic functions that PostGIS offers.
 
 While working through this section, you may want to keep a copy of the **PostGIS
 cheat sheet**  available

--- a/source/docs/training_manual/spatial_databases/index.rst
+++ b/source/docs/training_manual/spatial_databases/index.rst
@@ -10,7 +10,7 @@ Spatial Databases allow the storage of the geometries of records inside a
 Database as well as providing functionality for querying and retrieving the
 records  using these Geometries. In this module we will use PostGIS, an
 extension to PostgreSQL, to learn how to setup a spatial database, import data
-from shapefiles into the database and make use of the geographic functions that
+from files into the database and make use of the geographic functions that
 PostGIS offers.
 
 While working through this section, you may want to keep a copy of the **PostGIS

--- a/source/docs/training_manual/vector_analysis/spatial_statistics.rst
+++ b/source/docs/training_manual/vector_analysis/spatial_statistics.rst
@@ -446,8 +446,8 @@ possible rectangle which will still enclose all the points.
 |moderate| |FA| Minimum Distance Analysis
 -------------------------------------------------------------------------------
 
-Often, the output of an algorithm will not be a shapefile, but rather a table
-summarizing the statistical properties of a dataset. One of these is the
+Often, the output of an algorithm will not be a spatial layer, but rather a
+table summarizing the statistical properties of a dataset. One of these is the
 :guilabel:`Minimum Distance Analysis` tool.
 
 * Find this tool in the :guilabel:`Processing Toolbox` as :guilabel:`Minimum

--- a/source/docs/user_manual/grass_integration/grass_integration.rst
+++ b/source/docs/user_manual/grass_integration/grass_integration.rst
@@ -832,7 +832,7 @@ The next example shows how a GRASS module can aggregate raster data and add colu
 of statistics for each polygon in a vector map.
 
 * Again using the Alaska data, refer to :ref:`sec_import_loc_data` to import the
-  trees shapefile from the ``shapefiles`` directory into GRASS.
+  :file:`shapefiles/trees.shp` file into GRASS.
 * Now an intermediate step is required: centroids must be added to the imported
   trees map to make it a complete GRASS area vector (including both boundaries
   and centroids).

--- a/source/docs/user_manual/introduction/getting_started.rst
+++ b/source/docs/user_manual/introduction/getting_started.rst
@@ -193,7 +193,7 @@ This returns::
     vectors, and QGIS project files (.qgs):
      1. Rasters - supported formats include GeoTiff, DEM
         and others supported by GDAL
-     2. Vectors - supported formats include ESRI Shapefiles
+     2. Vectors - supported formats include ESRI Shapefile
         and others supported by OGR and PostgreSQL layers using
         the PostGIS extension
 

--- a/source/docs/user_manual/managing_data_source/create_layers.rst
+++ b/source/docs/user_manual/managing_data_source/create_layers.rst
@@ -270,7 +270,7 @@ Vector specific parameters
 Depending on the format of export, some of these options are available or not:
 
 * :guilabel:`Format`: exports to any vector format GDAL can write to, such as
-  GeoPackage, ESRI shapefile, AutoCAD DXF, ESRI FileGDB, Mapinfo TAB or MIF,
+  GeoPackage, ESRI Shapefile, AutoCAD DXF, ESRI FileGDB, Mapinfo TAB or MIF,
   SpatiaLite, CSV, KML, ODS...
 * :guilabel:`Layer name` depending on the selected format;
 * :guilabel:`Encoding`

--- a/source/docs/user_manual/managing_data_source/opening_data.rst
+++ b/source/docs/user_manual/managing_data_source/opening_data.rst
@@ -21,7 +21,7 @@ As part of an Open Source Software ecosystem, QGIS is built upon different
 libraries that, combined with its own providers, offer capabilities to read
 and often write a lot of formats:
 
-* Vector data formats include ESRI formats (shapefiles, geodatabases...),
+* Vector data formats include ESRI formats (Shapefile, Geodatabase...),
   MapInfo and MicroStation file formats, AutoCAD DWG/DXF, GeoPackage, GeoJSON,
   GRASS, GPX, KML, Comma Separated Values, and many more...
   Read the complete list of `OGR vector supported formats

--- a/source/docs/user_manual/managing_data_source/supported_data.rst
+++ b/source/docs/user_manual/managing_data_source/supported_data.rst
@@ -69,7 +69,7 @@ This section describes how to work with these specificities.
 ESRI Shapefile
 --------------
 
-The ESRI Shapefile is still one of the most used vector file format in QGIS.
+ESRI Shapefile is still one of the most used vector file format in QGIS.
 However, this file format has some limitation that some other file format have
 not (like GeoPackage, SpatiaLite). Support is provided by the
 `OGR Simple Feature Library <http://www.gdal.org/ogr/>`_.
@@ -81,7 +81,8 @@ required:
 #. :file:`.dbf` file containing the attributes in dBase format
 #. :file:`.shx` index file
 
-Shapefile also can include a file with a :file:`.prj` suffix, which contains
+An ESRI Shapefile format dataset can also include a file with a :file:`.prj`
+suffix, which contains
 the projection information. While it is very useful to have a projection file,
 it is not mandatory. A shapefile dataset can contain additional files. For
 further details, see the ESRI technical specification at

--- a/source/docs/user_manual/managing_data_source/supported_data.rst
+++ b/source/docs/user_manual/managing_data_source/supported_data.rst
@@ -47,7 +47,7 @@ Vector Data
 
 Many of the features available in QGIS work the same, regardless the vector
 data source. However, because of the differences in formats specifications
-(ESRI shapefiles, MapInfo and MicroStation file formats, AutoCAD DXF, PostGIS,
+(ESRI Shapefile, MapInfo and MicroStation file formats, AutoCAD DXF, PostGIS,
 SpatiaLite, DB2, Oracle Spatial and MSSQL Spatial databases, and many more),
 QGIS may handle differently some of their properties.
 This section describes how to work with these specificities.
@@ -66,10 +66,10 @@ This section describes how to work with these specificities.
 .. index:: ESRI, Shapefile, OGR
 .. _vector_shapefiles:
 
-ESRI Shapefiles
----------------
+ESRI Shapefile
+--------------
 
-The ESRI shapefile is still one of the most used vector file format in QGIS.
+The ESRI Shapefile is still one of the most used vector file format in QGIS.
 However, this file format has some limitation that some other file format have
 not (like GeoPackage, SpatiaLite). Support is provided by the
 `OGR Simple Feature Library <http://www.gdal.org/ogr/>`_.
@@ -81,7 +81,7 @@ required:
 #. :file:`.dbf` file containing the attributes in dBase format
 #. :file:`.shx` index file
 
-Shapefiles also can include a file with a :file:`.prj` suffix, which contains
+Shapefile also can include a file with a :file:`.prj` suffix, which contains
 the projection information. While it is very useful to have a projection file,
 it is not mandatory. A shapefile dataset can contain additional files. For
 further details, see the ESRI technical specification at
@@ -360,7 +360,7 @@ reference systems and projections.
 .. tip:: **Exporting datasets from PostGIS**
 
    Like the import tool **shp2pgsql**, there is also a tool to export
-   PostGIS datasets as shapefiles: **pgsql2shp**. This is shipped within
+   PostGIS datasets as Shapefile: **pgsql2shp**. This is shipped within
    your PostGIS distribution.
 
 .. index:: ogr2ogr

--- a/source/docs/user_manual/preamble/features.rst
+++ b/source/docs/user_manual/preamble/features.rst
@@ -27,7 +27,7 @@ format. Supported formats include:
 
 *  Spatially-enabled tables and views using PostGIS, SpatiaLite and MS SQL
    Spatial, Oracle Spatial, vector formats supported by the installed OGR
-   library, including ESRI shapefiles, MapInfo, SDTS, GML and many more.
+   library, including ESRI Shapefile, MapInfo, SDTS, GML and many more.
    See section :ref:`label_workingvector`.
 *  Raster and imagery formats supported by the installed GDAL (Geospatial
    Data Abstraction Library) library, such as GeoTIFF, ERDAS IMG, ArcInfo
@@ -53,7 +53,7 @@ friendly GUI. The many helpful tools available in the GUI include:
 *  Annotation tools
 *  Identify/select features
 *  Edit/view/search attributes
-*  Data-defined feature labelling
+*  Data-defined feature labeling
 *  Data-defined vector and raster symbology tools
 *  Atlas map composition with graticule layers
 *  North arrow scale bar and copyright label for maps
@@ -66,14 +66,13 @@ You can create, edit, manage and export vector and raster layers in
 several formats. QGIS offers the following:
 
 *  Digitizing tools for OGR-supported formats and GRASS vector layers
-*  Ability to create and edit shapefiles and GRASS vector layers
+*  Ability to create and edit multiple file formats and GRASS vector layers
 *  Georeferencer plugin to geocode images
 *  GPS tools to import and export GPX format, and convert other GPS
    formats to GPX or down/upload directly to a GPS unit (On Linux,
    usb: has been added to list of GPS devices.)
 *  Support for visualizing and editing OpenStreetMap data
-*  Ability to create spatial database tables from shapefiles with
-   DB Manager plugin
+*  Ability to create spatial database tables from files with DB Manager plugin
 *  Improved handling of spatial database tables
 *  Tools for managing vector attribute tables
 *  Option to save screenshots as georeferenced images

--- a/source/docs/user_manual/preamble/features.rst
+++ b/source/docs/user_manual/preamble/features.rst
@@ -72,7 +72,7 @@ several formats. QGIS offers the following:
    formats to GPX or down/upload directly to a GPS unit (On Linux,
    usb: has been added to list of GPS devices.)
 *  Support for visualizing and editing OpenStreetMap data
-*  Ability to create spatial database tables from files with DB Manager plugin
+*  Ability to create spatial database tables from files with the DB Manager plugin
 *  Improved handling of spatial database tables
 *  Tools for managing vector attribute tables
 *  Option to save screenshots as georeferenced images

--- a/source/docs/user_manual/processing/3rdParty.rst
+++ b/source/docs/user_manual/processing/3rdParty.rst
@@ -66,7 +66,7 @@ automatically converts from the original file format to one accepted by the
 external application before passing the layer to it. This adds extra processing
 time, which might be significant if the layer has a large size, so do not be
 surprised if it takes more time to process a layer from a DB connection than it
-does to process one of a similar size stored in a Shapefile.
+process a layer from a Shapefile format dataset of similar size.
 
 Providers not using external applications can process any layer that you can
 open in QGIS, since they open it for analysis through QGIS.

--- a/source/docs/user_manual/processing/3rdParty.rst
+++ b/source/docs/user_manual/processing/3rdParty.rst
@@ -66,7 +66,7 @@ automatically converts from the original file format to one accepted by the
 external application before passing the layer to it. This adds extra processing
 time, which might be significant if the layer has a large size, so do not be
 surprised if it takes more time to process a layer from a DB connection than it
-does to process one of a similar size stored in a shapefile.
+does to process one of a similar size stored in a Shapefile.
 
 Providers not using external applications can process any layer that you can
 open in QGIS, since they open it for analysis through QGIS.

--- a/source/docs/user_manual/processing_algs/qgis/vectorgeneral.rst
+++ b/source/docs/user_manual/processing_algs/qgis/vectorgeneral.rst
@@ -121,7 +121,7 @@ a layer is missing the ``proj`` file and you know the correct projection.
 Contrary to the :ref:`qgisassignprojection` algorithm, it modifies the current
 layer and will not output a new layer.
   
-.. note:: For shapefile datasets, the ``.prj`` and ``.qpj`` files will
+.. note:: For Shapefile datasets, the ``.prj`` and ``.qpj`` files will
    be overwritten - or created if missing - to match the provided CRS.
     
 ``Default menu``: :menuselection:`Vector --> Data Management Tools`

--- a/source/docs/user_manual/working_with_projections/working_with_projections.rst
+++ b/source/docs/user_manual/working_with_projections/working_with_projections.rst
@@ -44,9 +44,9 @@ coordinate reference system or you will need to define a global, layer or
 project-wide CRS. For PostGIS layers, QGIS uses the spatial reference identifier
 that was specified when the layer was created. For data supported by OGR, QGIS
 relies on the presence of a recognized means of specifying the CRS. In the case
-of shapefiles, this means a file containing the well-known text (:index:`WKT`)
+of Shapefile, this means a file containing the well-known text (:index:`WKT`)
 specification of the CRS. This projection file has the same base name as the
-shapefile and a :file:`.prj` extension. For example, a shapefile named
+:file:`.shp` file and a :file:`.prj` extension. For example, a shapefile named
 :file:`alaska.shp` would have a corresponding projection file named
 :file:`alaska.prj`.
 

--- a/source/docs/user_manual/working_with_vector/editing_geometry_attributes.rst
+++ b/source/docs/user_manual/working_with_vector/editing_geometry_attributes.rst
@@ -265,7 +265,7 @@ supports it (see :ref:`supported_format`), and the underlying data source is wri
    From the :menuselection:`Project --> Properties... --> Data Sources --> Layers Capabilities` table,
    You can choose to set any layer read-only regardless the provider permission.
    This can be a handy way, in a multi-users environment to avoid unauthorized users
-   to mistakenly edit layers (e.g., shapefile), hence potentially corrupt data.
+   to mistakenly edit layers (e.g., Shapefile), hence potentially corrupt data.
    Note that this setting only applies inside the current project.
 
 

--- a/source/docs/user_manual/working_with_vector/expression.rst
+++ b/source/docs/user_manual/working_with_vector/expression.rst
@@ -443,7 +443,7 @@ Adding or subtracting an interval to dates, datetimes or times, using the
    * *date*, *Datetime* and *time* can be stored in text type fields after
      using the ``to_format()`` function.
 
-   * Intervals* can be stored in integer or decimal type fields after using
+   * *Intervals* can be stored in integer or decimal type fields after using
      one of the date extraction functions (e.g., ``day()`` to get the interval
      expressed in days)
 

--- a/source/docs/user_manual/working_with_vector/expression.rst
+++ b/source/docs/user_manual/working_with_vector/expression.rst
@@ -436,16 +436,16 @@ Adding or subtracting an interval to dates, datetimes or times, using the
 .. note:: **Storing date and datetime and intervals on fields**
 
    The ability to store *date*, *time* and *datetime* values directly on
-   fields may depend on the data source's provider (e.g., shapefiles accept
+   fields may depend on the data source's provider (e.g., Shapefile accepts
    *date* format, but not *datetime* or *time* format). The following are some
-   suggestions to overcame this limitation.
+   suggestions to overcome this limitation:
 
-   *date*, *Datetime* and *time* can be stored in text type fields after
-   using the ``to_format()`` function.
+   * *date*, *Datetime* and *time* can be stored in text type fields after
+     using the ``to_format()`` function.
 
-   *Intervals* can be stored in integer or decimal type fields after using
-   one of the date extraction functions (e.g., ``day()`` to get the interval
-   expressed in days)
+   * Intervals* can be stored in integer or decimal type fields after using
+     one of the date extraction functions (e.g., ``day()`` to get the interval
+     expressed in days)
 
 .. _fields_values:
 

--- a/source/docs/user_manual/working_with_vector/vector_properties.rst
+++ b/source/docs/user_manual/working_with_vector/vector_properties.rst
@@ -2944,7 +2944,7 @@ Usually, when we create an action to open a file with an external application,
 we can use absolute paths, or eventually relative paths. In the second case,
 the path is relative to the location of the external program executable file.
 But what about if we need to use relative paths, relative to the selected layer
-(a file-based one, like a Shapefile or SpatiaLite)? The following code will
+(a file-based one, like Shapefile or SpatiaLite)? The following code will
 do the trick:
 
 .. code-block:: python

--- a/source/docs/user_manual/working_with_vector/vector_properties.rst
+++ b/source/docs/user_manual/working_with_vector/vector_properties.rst
@@ -2944,7 +2944,7 @@ Usually, when we create an action to open a file with an external application,
 we can use absolute paths, or eventually relative paths. In the second case,
 the path is relative to the location of the external program executable file.
 But what about if we need to use relative paths, relative to the selected layer
-(a file-based one, like a shapefile or SpatiaLite)? The following code will
+(a file-based one, like a Shapefile or SpatiaLite)? The following code will
 do the trick:
 
 .. code-block:: python


### PR DESCRIPTION
More than renaming the training manual shapefiles folder into shapefile, this is a review of the use of this term:
* use **S**hapefile when it's about the format itself
* avoid the use of shapefile as synonym of vector layer: shapefile must die, right?
* fix some formatting (:kbd: instead of :file: or ``) and typo

Hoping that i've been constant in my rules...