### PR TITLE
Add concave hull knn and update the name of original concave hull

### DIFF
--- a/source/docs/user_manual/processing_algs/qgis/vectorgeometry.rst
+++ b/source/docs/user_manual/processing_algs/qgis/vectorgeometry.rst
@@ -518,7 +518,9 @@ Parameters
 
   Default (and minimum): *3*
 
-``Field`` [tablefield: any] Optional
+``Field`` [tablefield: any]
+  Optional
+
   If specified, one concave hull polygon is generated for each unique
   value of the field (by selecting features using this value).
 

--- a/source/docs/user_manual/processing_algs/qgis/vectorgeometry.rst
+++ b/source/docs/user_manual/processing_algs/qgis/vectorgeometry.rst
@@ -444,8 +444,8 @@ See also
 
 .. _qgisconcavehull:
 
-Concave hull
-------------
+Concave hull (alpha shapes)
+---------------------------
 Computes the concave hull of the features in an input point layer.
 
 Parameters
@@ -481,6 +481,38 @@ Outputs
 See also
 ........
 :ref:`qgisconvexhull`
+
+
+.. _qgisconcavehullknn:
+
+Concave hull (k-nearest neighbor)
+---------------------------------
+Computes the concave hull of the features in an input point layer
+using nearest neighbors.
+
+Parameters
+..........
+``Input point layer`` [vector: point]
+  Point vector layer to calculate the concave hull.
+
+``Number of neighboring points to consider`` [number]
+  Number (integer) from 3 (maximum concave hull) to 999999999 (convex hull).
+
+  Default: *3*
+
+``Field`` [tablefield: any]
+  To create concave hulls by class (one concave hull per class).
+
+  Default: *None*
+
+Outputs
+.......
+``Concave hull`` [vector: polygon]
+  Output concave hull.
+
+See also
+........
+:ref:`qgisconcavehull`
 
 
 .. _qgisconvertgeometrytype:

--- a/source/docs/user_manual/processing_algs/qgis/vectorgeometry.rst
+++ b/source/docs/user_manual/processing_algs/qgis/vectorgeometry.rst
@@ -491,7 +491,7 @@ This algorithm generates a concave hull polygon from a set of points.
 If the input layer is a line or polygon layer, it will use the
 vertices.
 
-The number of neighbours to consider determines the concaveness of the
+The number of neighbors to consider determines the concaveness of the
 output polygon.
 A lower number will result in a concave hull that follows the points very
 closely, while a higher number will have a smoother shape.

--- a/source/docs/user_manual/processing_algs/qgis/vectorgeometry.rst
+++ b/source/docs/user_manual/processing_algs/qgis/vectorgeometry.rst
@@ -495,7 +495,7 @@ The number of neighbors to consider determines the concaveness of the
 output polygon.
 A lower number will result in a concave hull that follows the points very
 closely, while a higher number will have a smoother shape.
-The minimum number of neighbour points to consider is 3.
+The minimum number of neighbor points to consider is 3.
 A value equal to or greater than the number of points will result in a
 convex hull.
 

--- a/source/docs/user_manual/processing_algs/qgis/vectorgeometry.rst
+++ b/source/docs/user_manual/processing_algs/qgis/vectorgeometry.rst
@@ -489,7 +489,7 @@ Concave hull (k-nearest neighbor) |34|
 --------------------------------------
 This algorithm generates a concave hull polygon from a set of points.
 If the input layer is a line or polygon layer, it will use the
-vertices / nodes.
+vertices.
 
 The number of neighbours to consider determines the concaveness of the
 output polygon.

--- a/source/docs/user_manual/processing_algs/qgis/vectorgeometry.rst
+++ b/source/docs/user_manual/processing_algs/qgis/vectorgeometry.rst
@@ -509,17 +509,18 @@ Parameters
   Vector layer to calculate the concave hull.
 
 ``Number of neighboring points to consider`` [number]
-  Number (integer) from 3 (maximum concave hull) to 999999999 (convex
-  hull).
   Determines the concaveness of the output polygon.
-  A lower number will result in a concave hull that follows the points
-  very closely, while a higher number will tend to a convex hull.
+  A small number will result in a concave hull that follows
+  the points very closely, while a high number will make
+  the polygon look more like the convex hull (if the number
+  is equal to or larger than the number of features, the
+  result will be the convex hull).
 
-  Default: *3*
+  Default (and minimum): *3*
 
 ``Field`` [tablefield: any] Optional
   If specified, one concave hull polygon is generated for each unique
-  value of the field (by selecting points using this value).
+  value of the field (by selecting features using this value).
 
   Default: *None*
 

--- a/source/docs/user_manual/processing_algs/qgis/vectorgeometry.rst
+++ b/source/docs/user_manual/processing_algs/qgis/vectorgeometry.rst
@@ -480,28 +480,46 @@ Outputs
 
 See also
 ........
-:ref:`qgisconvexhull`
+:ref:`qgisconvexhull`, :ref:`qgisknearestconcavehull`
 
 
-.. _qgisconcavehullknn:
+.. _qgisknearestconcavehull:
 
-Concave hull (k-nearest neighbor)
----------------------------------
-Computes the concave hull of the features in an input point layer
-using nearest neighbors.
+Concave hull (k-nearest neighbor) |34| 
+--------------------------------------
+This algorithm generates a concave hull polygon from a set of points.
+If the input layer is a line or polygon layer, it will use the
+vertices / nodes.
+
+The number of neighbours to consider determines the concaveness of the
+output polygon.
+A lower number will result in a concave hull that follows the points very
+closely, while a higher number will have a smoother shape.
+The minimum number of neighbour points to consider is 3.
+A value equal to or greater than the number of points will result in a
+convex hull.
+
+If a field is selected, the algorithm will group the features in the
+input layer using unique values in that field and generate individual
+polygons in the output layer for each group. 
 
 Parameters
 ..........
-``Input point layer`` [vector: point]
-  Point vector layer to calculate the concave hull.
+``Input layer`` [vector: any]
+  Vector layer to calculate the concave hull.
 
 ``Number of neighboring points to consider`` [number]
-  Number (integer) from 3 (maximum concave hull) to 999999999 (convex hull).
+  Number (integer) from 3 (maximum concave hull) to 999999999 (convex
+  hull).
+  Determines the concaveness of the output polygon.
+  A lower number will result in a concave hull that follows the points
+  very closely, while a higher number will tend to a convex hull.
 
   Default: *3*
 
-``Field`` [tablefield: any]
-  To create concave hulls by class (one concave hull per class).
+``Field`` [tablefield: any] Optional
+  If specified, one concave hull polygon is generated for each unique
+  value of the field (by selecting points using this value).
 
   Default: *None*
 


### PR DESCRIPTION
A new concave hull algorithm has been added.  It is now documented, and the title of the original concave hull algorithm is changed (Fixes #3018).