### PR TITLE
remove server relative svg warning as it's fixed

### DIFF
--- a/source/docs/user_manual/working_with_ogc/server/getting_started.rst
+++ b/source/docs/user_manual/working_with_ogc/server/getting_started.rst
@@ -489,18 +489,6 @@ If you don't check |checkbox| :guilabel:`Service capabilities`,
 QGIS Server will use the information given in the :file:`wms_metadata.xml` file
 located in the :file:`cgi-bin` folder.
 
-.. warning::
-
- If you're using the QGIS project with styling based on SVG files using
- relative paths then you should know that the server considers the path
- relative to its :file:`qgis_mapserv.fcgi` file (not to the :file:`qgs` file).
- So, if you deploy a project on the server and the SVG files are not placed
- accordingly, the output images may not respect the Desktop styling.
- To ensure this doesn't happen, you can simply copy the SVG files relative
- to the :file:`qgis_mapserv.fcgi`. You can also create a symbolic link in the
- directory where the fcgi file resides that points to the directory containing
- the SVG files (on Linux/Unix).
-
 WMS capabilities
 ----------------
 


### PR DESCRIPTION
I just build the master and tested this issue and it now works correctly.
I don't know when this was fixed, I suppose @pblottiere or @elpaso worked on it (thank you guys).
Will also close the relevant https://issues.qgis.org/issues/13703