### PR TITLE
[tm] adding an anchor to Processing index

### DIFF
--- a/source/docs/training_manual/processing/index.rst
+++ b/source/docs/training_manual/processing/index.rst
@@ -7,6 +7,8 @@
    You can adapt this file completely to your liking, but it should at least
    contain the root `toctree` directive.
 
+.. _processing_tm:
+
 The QGIS processing guide
 ==========================================
 


### PR DESCRIPTION
It just add an harmless anchor to the Processing TM index page. Useful in some upcoming chapters.

I'm going to merge after Travis is happy, we can revert/change it easily