### PR TITLE
|toolbox| substitution added

### DIFF
--- a/source/substitutions.txt
+++ b/source/substitutions.txt
@@ -918,3 +918,4 @@
    :width: 2em
 .. |linguist_previous_todo| image:: img/linguist_previous_todo.png
    :width: 2em
+.. |toolbox| replace:: :menuselection:`Processing --> Toolbox`


### PR DESCRIPTION
Another harmless feature. 

Sick of writing :menuselection:`Processing --> Toolbox` I added the replacement tag |toolbox| in the file. 

This should become handy in any resource (manual, training, ...)