### PR TITLE
Add documentation for WFS and RESULTTYPE=hits

### DIFF
--- a/source/docs/user_manual/working_with_ogc/server/services.rst
+++ b/source/docs/user_manual/working_with_ogc/server/services.rst
@@ -798,7 +798,7 @@ Standard requests provided by QGIS Server:
 +--------------------+-----------------------------------------------------------+
 | DescribeFeatureType| Returns a description of feature types and properties     |
 +--------------------+-----------------------------------------------------------+
-| Transaction        | Allows features to be insertde, updated or deleted        |
+| Transaction        | Allows features to be inserted, updated or deleted        |
 +--------------------+-----------------------------------------------------------+
 
 
@@ -913,7 +913,7 @@ URL example:
 RESULTTYPE
 ^^^^^^^^^^
 
-This parameter may be used to specify the kind of result to return. Availables
+This parameter may be used to specify the kind of result to return. Available
 values are:
 
 - ``results``: the default behavior
@@ -957,11 +957,10 @@ URL example:
 STARTINDEX
 ^^^^^^^^^^
 
-This parameter is standard in WFS 2.0, but it's an extension for WFS 1.0.
-0 which is the only version implemented in QGIS Server. Actually, it can be
-used to skip some features in the result set and in combination with
-``MAXFEATURES`` will provide for the ability to use WFS **GetFeature** to page
-through results.
+This parameter is standard in WFS 2.0, but it's an extension for WFS 1.0.0.
+Actually, it can be used to skip some features in the result set and in
+combination with ``MAXFEATURES``, it provides the ability to page through
+results.
 
 URL example:
 

--- a/source/docs/user_manual/working_with_ogc/server/services.rst
+++ b/source/docs/user_manual/working_with_ogc/server/services.rst
@@ -777,21 +777,202 @@ not available in the GetCapabilities output:
 Web Feature Service (WFS)
 =========================
 
+
+The **1.0.0** and **1.1.0** WFS standards implemented in QGIS Server provide
+a HTTP interface to query geographic features from a QGIS project. A typical
+WFS request defines the QGIS project to use and the layer to query.
+
+Specifications document according to the version number of the service:
+
+- `WFS 1.0.0 <http://portal.opengeospatial.org/files/?artifact_id=7176>`_
+- `WFS 1.1.0 <http://portal.opengeospatial.org/files/?artifact_id=8339>`_
+
+Standard requests provided by QGIS Server:
+
++--------------------+-----------------------------------------------------------+
+| Request            |  Description                                              |
++====================+===========================================================+
+| GetCapabilities    | Returns XML metadata with information about the server    |
++--------------------+-----------------------------------------------------------+
+| GetFeature         | Returns a selection of features                           |
++--------------------+-----------------------------------------------------------+
+| DescribeFeatureType| Returns a description of feature types and properties     |
++--------------------+-----------------------------------------------------------+
+| Transaction        | Allows features to be insertde, updated or deleted        |
++--------------------+-----------------------------------------------------------+
+
+
+.. _`qgisserver-wfs-getfeature`:
+
 GetFeature
 ----------
 
-In the WFS GetFeature request, QGIS Server accepts two extra parameters in
-addition to the standard parameters according to the OGC WFS 1.0.0 and 1.1.0
-specification:
+Standard parameters for the **GetFeature** request according to the OGC WFS 1.0.0
+and 1.1.0 specifications:
 
-* **GeometryName** parameter: this parameter can be used to get the *extent*
-  or the *centroid* as the geometry or no geometry if *none* if used (ie
-  attribute only). Allowed values are *extent*, *centroid* or *none*.
-* **StartIndex** parameter: STARTINDEX is standard in WFS 2.0, but it's an
-  extension for WFS 1.0.0 which is the only version implemented in QGIS Server.
-  STARTINDEX can be used to skip some features in the result set and in
-  combination with MAXFEATURES will provide for the ability to use WFS
-  GetFeature to page through results. Note that STARTINDEX=0 means start with
++---------------+----------+-------------------------------------+
+| Parameter     | Required | Description                         |
++===============+==========+=====================================+
+| SERVICE       | Yes      | Name of the service                 |
++---------------+----------+-------------------------------------+
+| VERSION       | No       | Version of the service              |
++---------------+----------+-------------------------------------+
+| REQUEST       | Yes      | Name of the request                 |
++---------------+----------+-------------------------------------+
+| TYPENAME      | No       | Name of layers                      |
++---------------+----------+-------------------------------------+
+| OUTPUTFORMAT  | No       | Output Format                       |
++---------------+----------+-------------------------------------+
+| RESULTTYPE    | No       | Type of the result                  |
++---------------+----------+-------------------------------------+
+| PROPERTYNAME  | No       | Name of properties to return        |
++---------------+----------+-------------------------------------+
+| MAXFEATURES   | No       | Maximum number of features to return|
++---------------+----------+-------------------------------------+
+| SRSNAME       | No       | Coordinate reference system         |
++---------------+----------+-------------------------------------+
+| FEATUREID     | No       | Filter the features by ids          |
++---------------+----------+-------------------------------------+
+| FILTER        | No       | OGC Filter Encoding                 |
++---------------+----------+-------------------------------------+
+| BBOX          | No       | Map Extent                          |
++---------------+----------+-------------------------------------+
+| SORTBY        | No       | Sort the results                    |
++---------------+----------+-------------------------------------+
+
+|
+
+In addition to the standard ones, QGIS Server supports the following extra
+parameters:
+
+
++---------------+----------+----------------------------------+
+| Parameter     | Required | Description                      |
++===============+==========+==================================+
+| MAP           | Yes      | Specify the QGIS project file    |
++---------------+----------+----------------------------------+
+| STARTINDEX    | No       | Paging                           |
++---------------+----------+----------------------------------+
+| GEOMETRYNAME  | No       | Type of geometry to return       |
++---------------+----------+----------------------------------+
+| EXP_FILTER    | No       | Expression filtering             |
++---------------+----------+----------------------------------+
+
+
+SERVICE
+^^^^^^^
+
+This parameter has to be ``WFS`` in case of the **GetFeature** request.
+
+For example:
+
+.. code-block:: none
+
+  http://localhost/qgis_server?
+  SERVICE=WFS
+  &...
+
+
+VERSION
+^^^^^^^
+
+This parameter allows to specify the version of the service to use. Available
+values for the ``VERSION`` parameter are:
+
+- ``1.0.0``
+- ``1.1.0``
+
+If no version is indicated in the request, then ``1.1.0`` is used by default.
+
+URL example:
+
+.. code-block:: none
+
+  http://localhost/qgis_server?
+  SERVICE=WFS
+  &VERSION=1.1.0
+  &...
+
+
+REQUEST
+^^^^^^^
+
+This parameter is ``GetFeature`` in case of the **GetFeature** request.
+
+URL example:
+
+.. code-block:: none
+
+  http://localhost/qgis_server?
+  SERVICE=WFS
+  &VERSION=1.1.0
+  &REQUEST=GetFeature
+  &...
+
+
+RESULTTYPE
+^^^^^^^^^^
+
+This parameter may be used to specify the kind of result to return. Availables
+values are:
+
+- ``results``: the default behavior
+- ``hits``: returns only a feature count
+
+URL example:
+
+.. code-block:: none
+
+  http://localhost/qgis_server?
+  SERVICE=WFS
+  &VERSION=1.1.0
+  &REQUEST=GetFeature
+  &RESULTTYPE=hits
+  &...
+
+
+GEOMETRYNAME
+^^^^^^^^^^^^
+
+This parameter can be used to specify the kind of geometry to return for
+features. Available values are:
+
+- ``extent``
+- ``centroid``
+- ``none``
+
+URL example:
+
+.. code-block:: none
+
+  http://localhost/qgis_server?
+  SERVICE=WFS
+  &VERSION=1.1.0
+  &REQUEST=GetFeature
+  &GEOMETRYNAME=centroid
+  &...
+
+
+
+STARTINDEX
+^^^^^^^^^^
+
+This parameter is standard in WFS 2.0, but it's an extension for WFS 1.0.
+0 which is the only version implemented in QGIS Server. Actually, it can be
+used to skip some features in the result set and in combination with
+``MAXFEATURES`` will provide for the ability to use WFS **GetFeature** to page
+through results.
+
+URL example:
+
+.. code-block:: none
+
+  http://localhost/qgis_server?
+  SERVICE=WFS
+  &VERSION=1.1.0
+  &REQUEST=GetFeature
+  &STARTINDEX=2
+  &...
 
 
 .. _`extra-getmap-parameters`:


### PR DESCRIPTION
This PR updates the WFS service documentation in a similar way than the WMS service.

Moreover, it adds some words on RESULTTYPE parameter to fix https://github.com/qgis/QGIS-Documentation/issues/2171.