### PR TITLE
Update of external web links

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -223,7 +223,7 @@ latex_elements = {
 rst_prolog = """
 .. role:: disclaimer
 """
-#.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+#.. |updatedisclaimer| replace:: :disclaimer:`Docs for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
 #"""
 
 # Substitutions below are sorted and should be in lowerCamelCase

--- a/source/docs/developers_guide/codingstandards.rst
+++ b/source/docs/developers_guide/codingstandards.rst
@@ -355,7 +355,7 @@ Braces should start on the line following the expression:
 API Compatibility
 ==================
 
-There is `API documentation <http://qgis.org/api/>`_ for C++.
+There is `API documentation <https://qgis.org/api/>`_ for C++.
 
 We try to keep the API stable and backwards compatible. Cleanups to the API
 should be done in a manner similar to the Qt sourcecode e.g.
@@ -569,10 +569,10 @@ Book recommendations
 ---------------------
 
 
-- `Effective Modern C++ <http://shop.oreilly.com/product/0636920033707.do>`_, Scott Meyers
-- `More Effective C++ <http://www.informit.com/store/more-effective-c-plus-plus-35-new-ways-to-improve-your-9780201633719>`_, Scott Meyers
-- `Effective STL <http://www.informit.com/store/effective-stl-50-specific-ways-to-improve-your-use-9780201749625>`_, Scott Meyers
-- `Design Patterns <http://www.amazon.com/Design-Patterns-Elements-Reusable-Object-Oriented/dp/0201633612>`_, GoF
+- `Effective Modern C++ <https://shop.oreilly.com/product/0636920033707.do>`_, Scott Meyers
+- `More Effective C++ <https://www.informit.com/store/more-effective-c-plus-plus-35-new-ways-to-improve-your-9780201633719>`_, Scott Meyers
+- `Effective STL <https://www.informit.com/store/effective-stl-50-specific-ways-to-improve-your-use-9780201749625>`_, Scott Meyers
+- `Design Patterns <https://www.amazon.com/Design-Patterns-Elements-Reusable-Object-Oriented/dp/0201633612>`_, GoF
 
 You should also really read this article from Qt Quarterly on
 `designing Qt style (APIs) <https://doc.qt.io/archives/qq/qq13-apis.html>`_
@@ -587,11 +587,11 @@ contribution by:
 * adding a note to the changelog for the first version where 
   the code has been incorporated, of the type::
 
-    This feature was funded by: Olmiomland http://olmiomland.ol
-    This feature was developed by: Chuck Norris http://chucknorris.kr
+    This feature was funded by: Olmiomland https://olmiomland.ol
+    This feature was developed by: Chuck Norris https://chucknorris.kr
 
 * writing an article about the new feature on a blog, 
-  and add it to the QGIS planet http://plugins.qgis.org/planet/
+  and add it to the QGIS planet https://plugins.qgis.org/planet/
 * adding their name to:
 
   * https://github.com/qgis/QGIS/blob/master/doc/CONTRIBUTORS

--- a/source/docs/developers_guide/git.rst
+++ b/source/docs/developers_guide/git.rst
@@ -26,13 +26,13 @@ Debian based distro users can do:
 Install git for Windows
 ------------------------
 
-Windows users can obtain `msys git <http://code.google.com/p/msysgit/>`_ or use git distributed with `cygwin <http://cygwin.com>`_.
+Windows users can obtain `msys git <https://gitforwindows.org/>`_ or use git distributed with `cygwin <https://cygwin.com>`_.
 
 
 Install git for OSX
 -------------------
 
-The `git project <http://git-scm.com/>`_ has a downloadable build of git.
+The `git project <https://git-scm.com/>`_ has a downloadable build of git.
 Make sure to get the package matching your processor (x86_64 most likely, only the first Intel Macs need the i386 package).
 
 Once downloaded open the disk image and run the installer.
@@ -42,7 +42,7 @@ PPC/source note
 The git site does not offer PPC builds. If you need a PPC build, or you just want
 a little more control over the installation, you need to compile it yourself.
 
-Download the source from http://git-scm.com/. Unzip it, and in a Terminal cd to the source folder, then:
+Download the source from https://git-scm.com/. Unzip it, and in a Terminal cd to the source folder, then:
 
 .. code-block:: bash
 
@@ -127,8 +127,8 @@ GIT Documentation
 
 See the following sites for information on becoming a GIT master.
 
-* http://gitref.org
-* http://progit.org
+* https://services.github.com/
+* https://progit.org
 * http://gitready.com
 
 
@@ -221,7 +221,7 @@ branch.
 
 If you are a developer and wish to evaluate the pull request queue, there is a
 very nice `tool that lets you do this from the command line
-<http://thechangelog.com/git-pulls-command-line-tool-for-github-pull-requests/>`_
+<https://changelog.com/posts/git-pulls-command-line-tool-for-github-pull-requests>`_
 
 Please see the section below on 'getting your patch noticed'. In general when
 you submit a PR you should take the responsibility to follow it through to
@@ -295,10 +295,10 @@ Patch file naming
 
 If the patch is a fix for a specific bug, please name the file with the bug
 number in it e.g. bug777fix.patch, and attach it to the `original bug report in trac 
-<http://hub.qgis.org/projects/quantum-gis>`_.
+<https://issues.qgis.org/projects/qgis>`_.
 
 If the bug is an enhancement or new feature, its usually a good idea to create
-a `ticket in trac <http://hub.qgis.org/projects/quantum-gis>`_ 
+a `ticket in trac <https://issues.qgis.org/projects/qgis>`_
 first and then attach your patch.
 
 
@@ -330,8 +330,8 @@ Getting your patch noticed
 
 QGIS developers are busy folk. We do scan the incoming patches on bug reports
 but sometimes we miss things. Don't be offended or alarmed. Try to identify a
-developer to help you - using the `Technical Resources 
-<http://qgis.org/en/site/getinvolved/governance/organisation/governance.html#community-resources>`_ 
+developer to help you - using the `Technical Resources
+<https://qgis.org/en/site/getinvolved/governance/governance.html#technical-resources>`_
 and contact them
 asking them if they can look at your patch. If you don't get any response, you
 can escalate your query to one of the Project Steering Committee members

--- a/source/docs/developers_guide/ogcconformancetesting.rst
+++ b/source/docs/developers_guide/ogcconformancetesting.rst
@@ -11,7 +11,7 @@
 The Open Geospatial Consortium (OGC) provides tests which can be run free of
 charge to make sure a server is compliant with a certain specification.
 This chapter provides a quick tutorial to setup the WMS tests on an Ubuntu system.
-A detailed documentation can be found at the `OGC website <http://www.opengeospatial.org/compliance>`_.
+A detailed documentation can be found at the `OGC website <https://www.opengeospatial.org/compliance>`_.
 
 Setup of WMS 1.3 and WMS 1.1.1 conformance tests
 =================================================
@@ -55,13 +55,13 @@ For the WMS tests, data can be downloaded and loaded into a QGIS project:
 
 .. code-block:: bash
 
-  wget http://cite.opengeospatial.org/teamengine/about/wms/1.3.0/site/data-wms-1.3.0.zip
+  wget https://cite.opengeospatial.org/teamengine/about/wms/1.3.0/site/data-wms-1.3.0.zip
   unzip data-wms-1.3.0.zip
 
 Then create a `QGIS project
 <https://github.com/qgis/QGIS/blob/master/tests/testdata/qgis_server/ets-wms12/project.qgs>`_
 according to the description in
-http://cite.opengeospatial.org/teamengine/about/wms/1.3.0/site/.
+https://cite.opengeospatial.org/teamengine/about/wms/1.3.0/site/.
 To run the tests, we need to provide the GetCapabilities URL of the service later.
 
 

--- a/source/docs/documentation_guidelines/do_translations.rst
+++ b/source/docs/documentation_guidelines/do_translations.rst
@@ -114,7 +114,7 @@ Translation in Transifex
 ........................
 
 In order to translate QGIS with Transifex, you first need to `join the project
-<http://qgis.org/en/site/getinvolved/translate.html#join-a-project>`_. Once
+<https://qgis.org/en/site/getinvolved/translate.html#join-a-project>`_. Once
 you got a team, click on the corresponding project and your language.
 You get a list of all translatable ``.po`` files. Click on the
 ``docs_user-manual_plugins_plugins-heatmap`` to select the heatmap plugin file
@@ -125,7 +125,7 @@ The next page lists all the sentences in the file. All you need to do is select
 the text and translate following the :ref:`guidelines <translate_manual>`.
 
 For further information on the use of Transifex Web Editor, see
-http://docs.transifex.com/tutorials/txeditor/.
+https://docs.transifex.com/translation/translating-with-the-web-editor.
 
 
 .. _translation_linguist:
@@ -287,13 +287,13 @@ does not need translation.
     For the following example, we will use the ``airports`` vector point
     layer from the QGIS sample dataset (see :ref:`label_sampledata`).
     Another excellent QGIS tutorial on making heatmaps can be found on
-    `http://qgis.spatialthoughts.com
-    <http://qgis.spatialthoughts.com/2012/07/tutorial-making-heatmaps-using-qgis-and.html>`_.
+    `https://www.qgistutorials.com
+    <https://www.qgistutorials.com/en/docs/creating_heatmaps.html>`_.
 
 
 This item also includes a hyperlink with an url and an external presentation.
 The url should of course be left intact, you are allowed to change the external
-text ``http://qgis.spatialthoughts.com`` which is visible by the reader. Never
+text ``https://www.qgistutorials.com`` which is visible by the reader. Never
 remove the underscore at the end of the hyperlink which forms an essential
 part of it!!
 
@@ -354,4 +354,4 @@ For any question, please contact the `QGIS Community Team
    :width: 2em
 .. |selectString| image:: /static/common/selectstring.png
    :width: 2.5em
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/documentation_guidelines/writing.rst
+++ b/source/docs/documentation_guidelines/writing.rst
@@ -12,22 +12,22 @@ Introduction
 
 QGIS Documentation will
 be built automatically on the server at 0, 8am, 4pm US/Pacific (Pacific Time).
-The current status is available at http://docs.qgis.org.
+The current status is available at https://docs.qgis.org.
 
 QGIS Documentation is mainly written using the reStructuredText (reST) format syntax,
 coupled with some scripts from the Sphinx toolset to post-process the HTML output.
 See http://docutils.sourceforge.net/docs/ref/rst/restructuredtext.html
-or http://sphinx.pocoo.org/markup/inline.html.
+or https://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html.
 
 In general, when creating rst documentation for the QGIS project, please follow
 the `Python documentation style guidelines
-<http://docs.python.org/devguide/documenting.html>`_.
+<https://devguide.python.org/documenting/>`_.
 Below are exposed some general guidelines to follow when
 using reST for the QGIS documentation writing.
 
 If you are looking for general rules on contributing to QGIS project or managing
 repositories, you may find help at
-`Get Involved in the QGIS Community <http://qgis.org/en/site/getinvolved/index.html>`_.
+`Get Involved in the QGIS Community <https://qgis.org/en/site/getinvolved/index.html>`_.
 
 
 Writing Documentation
@@ -343,7 +343,7 @@ useful (coherent, consistent and really connected to each other):
 * Always capitalize only the first letter of the index unless the word has a
   particular spelling, in which case keep using its spelling e.g., ``Loading layers``,
   ``Atlas generation``, ``WMS``, ``pgsql2shp``
-* Keep an eye on the existing `Index list <http://docs.qgis.org/testing/en/genindex.html>`_
+* Keep an eye on the existing `Index list <https://docs.qgis.org/testing/en/genindex.html>`_
   in order to reuse the most convenient expression with the right spelling
   and avoid wrong duplicates.
 
@@ -364,7 +364,7 @@ advised to use this latter tag as it's easier to fulfill them.
 
 It's also recommanded to use index parameters such as ``single``, ``pair``,
 ``see``... in order to build a more structured and interconnected table of index.
-See http://www.sphinx-doc.org/en/stable/markup/misc.html#index-generating-markup
+See `Index generating <https://www.sphinx-doc.org/en/master/usage/restructuredtext/directives.html#index-generating-markup>`_
 for more information on index creation.
 
 Special Comments
@@ -373,9 +373,9 @@ Special Comments
 Sometimes, you may want to emphasize some points of the description, either to
 warn, remind or give some hints to the user. In QGIS Documentation, we use reST
 special directives such as ``.. warning::``, ``.. note::`` and ``.. tip::``
-generating particular frames that highlight your comments. See
-http://www.sphinx-doc.org/en/stable/markup/para.html#paragraph-level-markup for
-more information.
+generating particular frames that highlight your comments. See `Paragraph Level markup
+<https://www.sphinx-doc.org/en/master/usage/restructuredtext/directives.html#paragraph-level-markup>`_
+for more information.
 A clear and appropriate title is required for both warnings and tips.
 
 .. code-block:: rst
@@ -393,8 +393,7 @@ You may also want to give examples and insert a code snippet. In this case,
 write the comment below a line with the ``::`` directive inserted. However, for
 a better rendering, especially to apply color highlighting to code according
 to its language, use the code-block directive, e.g. ``.. code-block:: xml``.
-By default, Python code snippets do not need this reST directive. More details
-at http://www.sphinx-doc.org/en/stable/markup/code.html.
+More details at `Showing code <https://www.sphinx-doc.org/en/master/usage/restructuredtext/directives.html#showing-code-examples>`_.
 
 .. note::
 
@@ -456,7 +455,7 @@ rst file.
 * you can find some prepared QGIS-projects that were used before to create
   screenshots in :file:`./qgis-projects`.
   This makes it easier to reproduce screenshots for the next version of QGIS.
-  These projects use the QGIS `Sample Data <http://qgis.org/downloads/data/>`_
+  These projects use the QGIS `Sample Data <https://qgis.org/downloads/data/>`_
   (aka Alaska Dataset), which should be placed in the same folder
   as the QGIS-Documentation Repository.
 * Use the following command to remove the global menu function in Ubuntu
@@ -479,7 +478,7 @@ the same folder as the rst file.
 * use the QGIS -projects included in QGIS-Documentation repository (in
   :file:`./qgis_projects` ).
   These were used to produce the 'original' screenshots in the manual.
-  The QGIS `Sample Data <http://qgis.org/downloads/data/>`_ (aka Alaska Dataset)
+  The QGIS `Sample Data <https://qgis.org/downloads/data/>`_ (aka Alaska Dataset)
   should be placed in the same folder as the QGIS-Documentation Repository.
 * same size as the english 'original' screenshots, otherwise they will be stretched
   and look ugly. If you need to have a different size due to longer ui strings,

--- a/source/docs/gentle_gis_introduction/authors_and_contributors.rst
+++ b/source/docs/gentle_gis_introduction/authors_and_contributors.rst
@@ -10,19 +10,19 @@ About the authors & contributors
 |                | is also a founding member of Linfiniti Consulting CC. --- a small    |
 |                | business set up with the goal of helping people to learn and use     |
 |                | opensource GIS software.                                             |
-|                | **Web**: http://linfiniti.com, **Email**: tim@linfiniti.com          |
+|                | **Web**: https://www.kartoza.com **Email**: tim@kartoza.com          |
 +----------------+----------------------------------------------------------------------+
 | |otto|         | Otto Dassau --- Assistant Author. Otto Dassau is the documentation   |
 |                | maintainer and project steering committee member of the QGIS         |
 |                | project. Otto has considerable experience in using and training      |
 |                | people to use Free and Open Source GIS software.                     |
-|                | **Web**: http://www.nature-consult.de, **Email**: otto.dassau@gmx.de |
+|                | **Web**: http://www.nature-consult.de **Email**: otto.dassau@gmx.de  |
 +----------------+----------------------------------------------------------------------+
 | |marcelle|     | Marcelle Sutton --- Project Manager. Marcelle Sutton studied English |
 |                | and drama and is a qualified teacher. Marcelle is also a founding    |
 |                | member of Linfiniti Consulting CC. --- a small business set up with  |
 |                | the goal of helping people to learn and use opensource GIS software. |
-|                | **Web**: http://linfiniti.com, **Email**: marcelle@linfiniti.com     |
+|                | **Web**: https://kartoza.com **Email**: marcelle@kartoza.com         |
 +----------------+----------------------------------------------------------------------+
 | |lerato|       | Lerato Nsibande –-- Video Presenter. Lerato is a grade 12 scholar    |
 |                | living in Pretoria. Lerato learns Geography at school and has        |

--- a/source/docs/gentle_gis_introduction/coordinate_reference_systems.rst
+++ b/source/docs/gentle_gis_introduction/coordinate_reference_systems.rst
@@ -475,8 +475,8 @@ Further reading
 
 **Websites**:
 
-* http://www.colorado.edu/geography/gcraft/notes/mapproj/mapproj_f.html
-* http://geology.isu.edu/geostac/Field_Exercise/topomaps/index.htm
+* https://www.colorado.edu/geography/gcraft/notes/mapproj/mapproj_f.html
+* https://geology.isu.edu/wapi/geostac/Field_Exercise/topomaps/index.htm
 
 The QGIS User Guide also has more detailed information on working with map
 projections in QGIS.

--- a/source/docs/gentle_gis_introduction/gnu_free_documentation_license.rst
+++ b/source/docs/gentle_gis_introduction/gnu_free_documentation_license.rst
@@ -7,7 +7,7 @@ GNU Free Documentation License
 Version 1.3, 3 November 2008
 
 Copyright  2000, 2001, 2002, 2007, 2008  Free Software Foundation, Inc
-http://fsf.org/
+https://www.fsf.org/
 
 Everyone is permitted to copy and distribute verbatim copies of this
 license document, but changing it is not allowed.
@@ -383,7 +383,7 @@ The Free Software Foundation may publish new, revised versions
 of the GNU Free Documentation License from time to time.  Such new
 versions will be similar in spirit to the present version, but may
 differ in detail to address new problems or concerns.  See
-http://www.gnu.org/copyleft/.
+https://www.gnu.org/copyleft/.
 
 Each version of the License is given a distinguishing version number.
 If the Document specifies that a particular numbered version of this

--- a/source/docs/gentle_gis_introduction/introducing_gis.rst
+++ b/source/docs/gentle_gis_introduction/introducing_gis.rst
@@ -212,8 +212,7 @@ a question of how much money you can afford and personal preference. For these
 tutorials, we will be using the QGIS Application. QGIS is completely free and you 
 can copy it and share it with your friends as much as you like. If you received 
 this tutorial in printed form, you should have received a copy of QGIS with it. 
-If not, you can always visit
-http://hub.qgis.org/projects/quantum-gis/wiki/Download to download your free copy
+If not, you can always visit https://www.qgis.org/ to download your free copy
 if you have access to the internet.
 
 GIS Data

--- a/source/docs/gentle_gis_introduction/map_production.rst
+++ b/source/docs/gentle_gis_introduction/map_production.rst
@@ -293,8 +293,8 @@ Further reading
 
 **Websites**:
 
-* http://en.wikipedia.org/wiki/Scale_(map)
-* http://www.colorado.edu/geography/gcraft/notes/mapproj/mapproj.html
+* https://en.wikipedia.org/wiki/Scale_(map)
+* https://www.colorado.edu/geography/gcraft/notes/mapproj/mapproj.html
 
 The QGIS User Guide also has more detailed information on map production provided
 in QGIS.

--- a/source/docs/gentle_gis_introduction/raster_data.rst
+++ b/source/docs/gentle_gis_introduction/raster_data.rst
@@ -347,7 +347,7 @@ Further reading
 * DeMers, Michael N. (2005). Fundamentals of Geographic Information Systems. 3rd
   Edition. Wiley. ISBN: 9814126195
 
-**Website:** http://en.wikipedia.org/wiki/GIS#Raster
+**Website:** https://en.wikipedia.org/wiki/GIS#Raster
 
 The QGIS User Guide also has more detailed information on working with raster
 data in QGIS.

--- a/source/docs/gentle_gis_introduction/spatial_analysis_interpolation.rst
+++ b/source/docs/gentle_gis_introduction/spatial_analysis_interpolation.rst
@@ -227,9 +227,9 @@ Further reading
 
 **Websites**:
 
-* http://en.wikipedia.org/wiki/Interpolation
-* http://en.wikipedia.org/wiki/Delaunay_triangulation
-* http://www.agt.bme.hu/public_e/funcint/funcint.html
+* https://en.wikipedia.org/wiki/Interpolation
+* https://en.wikipedia.org/wiki/Delaunay_triangulation
+* https://www.agt.bme.hu/public_e/funcint/funcint.html
 
 The QGIS User Guide also has more detailed information on interpolation tools
 provided in QGIS.

--- a/source/docs/gentle_gis_introduction/topology.rst
+++ b/source/docs/gentle_gis_introduction/topology.rst
@@ -210,8 +210,8 @@ Further reading
 
 **Websites**:
 
-* http://www.innovativegis.com/basis/primer/concepts.html
-* http://en.wikipedia.org/wiki/Geospatial_topology
+* http://www.innovativegis.com/basis/
+* https://en.wikipedia.org/wiki/Geospatial_topology
 
 The QGIS User Guide also has more detailed information on topological editing
 provided in QGIS.

--- a/source/docs/gentle_gis_introduction/vector_attribute_data.rst
+++ b/source/docs/gentle_gis_introduction/vector_attribute_data.rst
@@ -493,7 +493,7 @@ the same technique?
 Further reading
 ===============
 
-**Website:** http://en.wikipedia.org/wiki/Cartography#Map_symbology
+**Website:** https://en.wikipedia.org/wiki/Cartography#Map_symbology
 
 The QGIS User Guide also has more detailed information on working with attribute
 data and symbology in QGIS.

--- a/source/docs/index.rst
+++ b/source/docs/index.rst
@@ -11,7 +11,7 @@ Please have a look into one of the documents below.
    :maxdepth: 2
 
    User Guide/Manual (QGIS Testing) <user_manual/index>
-   User Guide/Manual PDF's <http://docs.qgis.org/testing/pdf/>
+   User Guide/Manual PDF's <https://docs.qgis.org/testing/pdf/>
    PyQGIS Cookbook (QGIS Testing) <pyqgis_developer_cookbook/index>
    Developers Guide <developers_guide/index>
    Documentation Guidelines <documentation_guidelines/index>

--- a/source/docs/pyqgis_developer_cookbook/authentication.rst
+++ b/source/docs/pyqgis_developer_cookbook/authentication.rst
@@ -156,7 +156,7 @@ credentials for an hypothetic alice user:
   p_config = QgsAuthMethodConfig()
   p_config.setName("alice")
   p_config.setMethod("PKI-Paths")
-  p_config.setUri("http://example.com")
+  p_config.setUri("https://example.com")
   p_config.setConfig("certpath", "path/to/alice-cert.pem" ))
   p_config.setConfig("keypath", "path/to/alice-key.pem" ))
   # check if method parameters are correctly set
@@ -412,7 +412,7 @@ an integrated example can be found in the related `test <https://github.com/qgis
 Authorities Editor GUI
 ----------------------
 
-A GUI used to manage only authorities is managed by the class `QgsAuthAuthoritiesEditor <http://www2.qgis.org/api/classQgsAuthAuthoritiesEditor.html>`_
+A GUI used to manage only authorities is managed by the class `QgsAuthAuthoritiesEditor <https://www.qgis.org/api/classQgsAuthAuthoritiesEditor.html>`_
 
 .. figure:: img/QgsAuthAuthoritiesEditor.png
    :align: center
@@ -434,4 +434,4 @@ and can be used as in the following snippet:
    source folder.
 
 .. |outofdate| replace:: `Despite our constant efforts, information beyond this line may not be updated for QGIS 3. Refer to https://qgis.org/pyqgis/master for the python API documentation or, give a hand to update the chapters you know about. Thanks.`
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/pyqgis_developer_cookbook/canvas.rst
+++ b/source/docs/pyqgis_developer_cookbook/canvas.rst
@@ -29,7 +29,7 @@ This framework generally provides a surface and a view where custom graphics
 items are placed and user can interact with them.  We will assume that you are
 familiar enough with Qt to understand the concepts of the graphics scene, view
 and items. If not, please make sure to read the `overview of the framework
-<http://qt-project.org/doc/qt-4.8/graphicsview.html>`_.
+<https://doc.qt.io/archives/qt-4.8/graphicsview.html>`_.
 
 Whenever the map has been panned, zoomed in/out (or some other action triggers
 a refresh), the map is rendered again within the current extent. The layers are
@@ -385,4 +385,4 @@ Writing Custom Map Canvas Items
    source folder.
 
 .. |outofdate| replace:: `Despite our constant efforts, information beyond this line may not be updated for QGIS 3. Refer to https://qgis.org/pyqgis/master for the python API documentation or, give a hand to update the chapters you know about. Thanks.`
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/pyqgis_developer_cookbook/communicating.rst
+++ b/source/docs/pyqgis_developer_cookbook/communicating.rst
@@ -186,4 +186,4 @@ save about the execution of your code.
    source folder.
 
 .. |outofdate| replace:: `Despite our constant efforts, information beyond this line may not be updated for QGIS 3. Refer to https://qgis.org/pyqgis/master for the python API documentation or, give a hand to update the chapters you know about. Thanks.`
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/pyqgis_developer_cookbook/composer.rst
+++ b/source/docs/pyqgis_developer_cookbook/composer.rst
@@ -105,7 +105,7 @@ then exported to PDF, raster images or directly printed on a printer.
 The layout consists of a bunch of classes. They all belong to the core
 library. QGIS application has a convenient GUI for placement of the elements,
 though it is not available in the GUI library. If you are not familiar with
-`Qt Graphics View framework <http://doc.qt.io/qt-4.8/qgraphicsview.html>`_,
+`Qt Graphics View framework <https://doc.qt.io/archives/qt-4.8/graphicsview.html>`_,
 then you are encouraged to check the documentation now, because the layout
 is based on it. Also check the `Python documentation of the implementation of QGraphicView
 <http://pyqt.sourceforge.net/Docs/PyQt4/qgraphicsview.html>`_.
@@ -290,4 +290,4 @@ The following code fragment renders a composition to a PDF file
    source folder.
 
 .. |outofdate| replace:: `Despite our constant efforts, information beyond this line may not be updated for QGIS 3. Refer to https://qgis.org/pyqgis/master for the python API documentation or, give a hand to update the chapters you know about. Thanks.`
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/pyqgis_developer_cookbook/crs.rst
+++ b/source/docs/pyqgis_developer_cookbook/crs.rst
@@ -115,4 +115,4 @@ transformation, but it is capable to do also inverse transformation.
    source folder.
 
 .. |outofdate| replace:: `Despite our constant efforts, information beyond this line may not be updated for QGIS 3. Refer to https://qgis.org/pyqgis/master for the python API documentation or, give a hand to update the chapters you know about. Thanks.`
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/pyqgis_developer_cookbook/expressions.rst
+++ b/source/docs/pyqgis_developer_cookbook/expressions.rst
@@ -164,4 +164,4 @@ matches a predicate.
    source folder.
 
 .. |outofdate| replace:: `Despite our constant efforts, information beyond this line may not be updated for QGIS 3. Refer to https://qgis.org/pyqgis/master for the python API documentation or, give a hand to update the chapters you know about. Thanks.`
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/pyqgis_developer_cookbook/geometry.rst
+++ b/source/docs/pyqgis_developer_cookbook/geometry.rst
@@ -31,7 +31,7 @@ coordinates in CRS of the layer.
 
 Description and specifications of all possible geometries construction and
 relationships are available in the `OGC Simple Feature Access Standards
-<http://www.opengeospatial.org/standards/sfa>`_ for advanced details.
+<https://www.opengeospatial.org/standards/sfa>`_ for advanced details.
 
 .. index:: Geometry; Construction
 
@@ -175,4 +175,4 @@ Additional information can be found in following sources:
    source folder.
 
 .. |outofdate| replace:: `Despite our constant efforts, information beyond this line may not be updated for QGIS 3. Refer to https://qgis.org/pyqgis/master for the python API documentation or, give a hand to update the chapters you know about. Thanks.`
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/pyqgis_developer_cookbook/index.rst
+++ b/source/docs/pyqgis_developer_cookbook/index.rst
@@ -37,4 +37,4 @@ PyQGIS Developer Cookbook
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/pyqgis_developer_cookbook/intro.rst
+++ b/source/docs/pyqgis_developer_cookbook/intro.rst
@@ -31,7 +31,7 @@ Python application.
 
 .. index:: API
 
-There is a `complete QGIS API <http://qgis.org/api/>`_ reference that
+There is a `complete QGIS API <https://qgis.org/api/>`_ reference that
 documents the classes from the QGIS libraries. `The Pythonic QGIS API
 (pyqgis) <https://qgis.org/pyqgis/>`_ is nearly identical to the C++ API.
 
@@ -93,7 +93,7 @@ development.
 Many plugins covering various functionality have been written since
 the introduction of Python support. The plugin installer allows users
 to easily fetch, upgrade and remove Python plugins.
-See the `Python Plugin <http://plugins.qgis.org/>`_ page for more
+See the `Python Plugin <https://plugins.qgis.org/>`_ page for more
 information about plugins and plugin development.
 
 Creating plugins in Python is simple, see :ref:`developing_plugins`
@@ -349,4 +349,4 @@ PyQt.
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/pyqgis_developer_cookbook/loadlayer.rst
+++ b/source/docs/pyqgis_developer_cookbook/loadlayer.rst
@@ -298,4 +298,4 @@ For a list of loaded layers and layer ids, use:
    source folder.
 
 .. |outofdate| replace:: `Despite our constant efforts, information beyond this line may not be updated for QGIS 3. Refer to https://qgis.org/pyqgis/master for the python API documentation or, give a hand to update the chapters you know about. Thanks.`
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/pyqgis_developer_cookbook/loadproject.rst
+++ b/source/docs/pyqgis_developer_cookbook/loadproject.rst
@@ -62,4 +62,4 @@ use to check if the operation was successful.
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/pyqgis_developer_cookbook/network_analysis.rst
+++ b/source/docs/pyqgis_developer_cookbook/network_analysis.rst
@@ -54,19 +54,19 @@ In the latter case the edge will be split and a new vertex added.
 Vector layer attributes and length of an edge can be used as the properties
 of an edge.
 
-Converting from a vector layer to the graph is done using the `Builder <http://en.wikipedia.org/wiki/Builder_pattern>`_
+Converting from a vector layer to the graph is done using the `Builder <https://en.wikipedia.org/wiki/Builder_pattern>`_
 programming pattern. A graph is constructed using a so-called Director.
-There is only one Director for now: `QgsLineVectorLayerDirector <http://qgis.org/api/classQgsLineVectorLayerDirector.html>`_.
+There is only one Director for now: `QgsLineVectorLayerDirector <https://qgis.org/api/classQgsLineVectorLayerDirector.html>`_.
 The director sets the basic settings that will be used to construct a graph
 from a line vector layer, used by the builder to create the graph. Currently, as
-in the case with the director, only one builder exists: `QgsGraphBuilder <http://qgis.org/api/classQgsGraphBuilder.html>`_,
-that creates `QgsGraph <http://qgis.org/api/classQgsGraph.html>`_ objects.
+in the case with the director, only one builder exists: `QgsGraphBuilder <https://qgis.org/api/classQgsGraphBuilder.html>`_,
+that creates `QgsGraph <https://qgis.org/api/classQgsGraph.html>`_ objects.
 You may want to implement your own builders that will build a graphs compatible
-with such libraries as `BGL <http://www.boost.org/doc/libs/1_48_0/libs/graph/doc/index.html>`_
-or `NetworkX <http://networkx.lanl.gov/>`_.
+with such libraries as `BGL <https://www.boost.org/doc/libs/1_48_0/libs/graph/doc/index.html>`_
+or `NetworkX <https://networkx.lanl.gov/>`_.
 
-To calculate edge properties the programming pattern `strategy <http://en.wikipedia.org/wiki/Strategy_pattern>`_
-is used. For now only `QgsDistanceArcProperter <http://qgis.org/api/classQgsDistanceArcProperter.html>`_
+To calculate edge properties the programming pattern `strategy <https://en.wikipedia.org/wiki/Strategy_pattern>`_
+is used. For now only `QgsDistanceArcProperter <https://qgis.org/api/classQgsDistanceArcProperter.html>`_
 strategy is available, that takes into account the length of the route. You
 can implement your own strategy that will use all necessary parameters.
 For example, RoadGraph plugin uses a strategy that computes travel time
@@ -203,7 +203,7 @@ with the following properties:
   single available path and it is optimal (shortest) on this graph
 
 To get the shortest path tree use the methods :func:`shortestTree` and
-:func:`dijkstra` of `QgsGraphAnalyzer <http://qgis.org/api/classQgsGraphAnalyzer.html>`_
+:func:`dijkstra` of `QgsGraphAnalyzer <https://qgis.org/api/classQgsGraphAnalyzer.html>`_
 class. It is recommended to use method :func:`dijkstra` because it works
 faster and uses memory more efficiently.
 
@@ -232,7 +232,7 @@ from the root.
 Here is some very simple code to display the shortest path tree using the graph
 created with the :func:`shortestTree` method (select linestring layer in TOC
 and replace coordinates with your own). **Warning**: use this code only as an
-example, it creates a lots of `QgsRubberBand <http://qgis.org/api/classQgsRubberBand.html>`_
+example, it creates a lots of `QgsRubberBand <https://qgis.org/api/classQgsRubberBand.html>`_
 objects and may be slow on large data-sets.
 
 ::
@@ -515,4 +515,4 @@ Here is an example
    source folder.
 
 .. |outofdate| replace:: `Despite our constant efforts, information beyond this line may not be updated for QGIS 3. Refer to https://qgis.org/pyqgis/master for the python API documentation or, give a hand to update the chapters you know about. Thanks.`
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/pyqgis_developer_cookbook/plugins/ide_debugging.rst
+++ b/source/docs/pyqgis_developer_cookbook/plugins/ide_debugging.rst
@@ -30,7 +30,7 @@ If you used the OSGeo4W Installer, you can find this under the ``bin`` folder
 of your OSGeo4W install. Look for something like
 :file:`C:\\OSGeo4W\\bin\\qgis-unstable.bat`.
 
-For using `Pyscripter IDE <http://code.google.com/p/pyscripter>`_, here's what
+For using `Pyscripter IDE <https://github.com/pyscripter/pyscripter>`_, here's what
 you have to do:
 
 * Make a copy of :file:`qgis-unstable.bat` and rename it ``pyscripter.bat``.
@@ -84,7 +84,7 @@ Installation
 To use Eclipse, make sure you have installed the following
 
 * `Eclipse <https://eclipse.org>`_
-* `Aptana Eclipse Plugin <http://www.aptana.com/products/studio3/success_plugin.html>`_ or `PyDev <http://www.pydev.org>`_
+* `Aptana Studio 3 Plugin <www.aptana.com/>`_ or `PyDev <https://www.pydev.org>`_
 * QGIS 2.x
 
 Preparing QGIS
@@ -264,4 +264,4 @@ And when the application hits your breakpoint you can type in the console!
    source folder.
 
 .. |outofdate| replace:: `Despite our constant efforts, information beyond this line may not be updated for QGIS 3. Refer to https://qgis.org/pyqgis/master for the python API documentation or, give a hand to update the chapters you know about. Thanks.`
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/pyqgis_developer_cookbook/plugins/index.rst
+++ b/source/docs/pyqgis_developer_cookbook/plugins/index.rst
@@ -44,4 +44,4 @@ For definitions of ``~`` and ``(UserProfile)`` see :ref:`core_and_external_plugi
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/pyqgis_developer_cookbook/plugins/pluginlayer.rst
+++ b/source/docs/pyqgis_developer_cookbook/plugins/pluginlayer.rst
@@ -24,7 +24,7 @@ Subclassing QgsPluginLayer
 ==========================
 
 Below is an example of a minimal QgsPluginLayer implementation. It is an
-excerpt of the `Watermark example plugin <http://github.com/sourcepole/qgis-watermark-plugin>`_
+excerpt of the `Watermark example plugin <https://github.com/sourcepole/qgis-watermark-plugin>`_
 
 ::
 
@@ -83,4 +83,4 @@ You can also add code for displaying custom information in the layer properties
    source folder.
 
 .. |outofdate| replace:: `Despite our constant efforts, information beyond this line may not be updated for QGIS 3. Refer to https://qgis.org/pyqgis/master for the python API documentation or, give a hand to update the chapters you know about. Thanks.`
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/pyqgis_developer_cookbook/plugins/plugins.rst
+++ b/source/docs/pyqgis_developer_cookbook/plugins/plugins.rst
@@ -75,7 +75,7 @@ What is the meaning of the files:
 * :file:`metadata.txt` = Contains general info, version, name and some other
   metadata used by plugins website and plugin infrastructure.
 
-`Here <http://www.dimitrisk.gr/qgis/creator/>`_
+`Here <https://www.dimitrisk.gr/qgis/creator/>`_
 is an online automated way of creating the basic files (skeleton) of a typical
 QGIS Python plugin.
 
@@ -197,7 +197,7 @@ An example for this metadata.txt
   tags=wkt,raster,hello world
 
   ; these metadata can be empty, they will eventually become mandatory.
-  homepage=http://www.itopen.it
+  homepage=https://www.itopen.it
   icon=icon.png
 
   ; experimental flag (applies to the single version)
@@ -579,4 +579,4 @@ Information and requirements are here: `plugins.qgis.org <https://plugins.qgis.o
    source folder.
 
 .. |outofdate| replace:: `Despite our constant efforts, information beyond this line may not be updated for QGIS 3. Refer to https://qgis.org/pyqgis/master for the python API documentation or, give a hand to update the chapters you know about. Thanks.`
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/pyqgis_developer_cookbook/plugins/releasing.rst
+++ b/source/docs/pyqgis_developer_cookbook/plugins/releasing.rst
@@ -50,7 +50,7 @@ You can find the *official* Python plugin repository at
 `<https://plugins.qgis.org/>`_.
 
 In order to use the official repository you must obtain an OSGEO ID from the
-`OSGEO web portal <http://www.osgeo.org/osgeo_userid/>`_.
+`OSGEO web portal <https://www.osgeo.org/community/getting-started-osgeo/osgeo_userid/>`_.
 
 Once you have uploaded your plugin it will be approved by a staff member and
 you will be notified.
@@ -146,4 +146,4 @@ look like.
    source folder.
 
 .. |outofdate| replace:: `Despite our constant efforts, information beyond this line may not be updated for QGIS 3. Refer to https://qgis.org/pyqgis/master for the python API documentation or, give a hand to update the chapters you know about. Thanks.`
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/pyqgis_developer_cookbook/plugins/snippets.rst
+++ b/source/docs/pyqgis_developer_cookbook/plugins/snippets.rst
@@ -99,4 +99,4 @@ field of the selected feature(s)) and can be called by
    source folder.
 
 .. |outofdate| replace:: `Despite our constant efforts, information beyond this line may not be updated for QGIS 3. Refer to https://qgis.org/pyqgis/master for the python API documentation or, give a hand to update the chapters you know about. Thanks.`
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/pyqgis_developer_cookbook/processing.rst
+++ b/source/docs/pyqgis_developer_cookbook/processing.rst
@@ -66,4 +66,4 @@ To create a set of processing scripts, follow these steps:
    source folder.
 
 .. |outofdate| replace:: `Despite our constant efforts, information beyond this line may not be updated for QGIS 3. Refer to https://qgis.org/pyqgis/master for the python API documentation or, give a hand to update the chapters you know about. Thanks.`
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/pyqgis_developer_cookbook/raster.rst
+++ b/source/docs/pyqgis_developer_cookbook/raster.rst
@@ -228,4 +228,4 @@ keys, and band values as values.
    source folder.
 
 .. |outofdate| replace:: `Despite our constant efforts, information beyond this line may not be updated for QGIS 3. Refer to https://qgis.org/pyqgis/master for the python API documentation or, give a hand to update the chapters you know about. Thanks.`
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/pyqgis_developer_cookbook/server.rst
+++ b/source/docs/pyqgis_developer_cookbook/server.rst
@@ -522,4 +522,4 @@ to completely disable the cache.
    source folder.
 
 .. |outofdate| replace:: `Despite our constant efforts, information beyond this line may not be updated for QGIS 3. Refer to https://qgis.org/pyqgis/master for the python API documentation or, give a hand to update the chapters you know about. Thanks.`
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/pyqgis_developer_cookbook/settings.rst
+++ b/source/docs/pyqgis_developer_cookbook/settings.rst
@@ -30,7 +30,7 @@ We can make difference between several types of settings:
   framework by the means of :class:`QSettings` class. By default, this class stores
   settings in system's "native" way of storing settings, that is --- registry
   (on Windows), .plist file (on macOS) or .ini file (on Unix). The
-  `QSettings documentation <http://doc.qt.io/qt-4.8/qsettings.html>`_
+  `QSettings documentation <https://doc.qt.io/archives/qt-4.8/qsettings.html>`_
   is comprehensive, so we will provide just a simple example
 
   ::
@@ -104,4 +104,4 @@ We can make difference between several types of settings:
    source folder.
 
 .. |outofdate| replace:: `Despite our constant efforts, information beyond this line may not be updated for QGIS 3. Refer to https://qgis.org/pyqgis/master for the python API documentation or, give a hand to update the chapters you know about. Thanks.`
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/pyqgis_developer_cookbook/tasks.rst
+++ b/source/docs/pyqgis_developer_cookbook/tasks.rst
@@ -342,4 +342,4 @@ added to the project in a safe way.
   task.executed.connect(partial(task_finished, context))
   QgsApplication.taskManager().addTask(task)
 
-See also: http://www.opengis.ch/2018/06/22/threads-in-pyqgis3/.
+See also: https://www.opengis.ch/2018/06/22/threads-in-pyqgis3/.

--- a/source/docs/pyqgis_developer_cookbook/vector.rst
+++ b/source/docs/pyqgis_developer_cookbook/vector.rst
@@ -1287,7 +1287,7 @@ Further Topics
 * exploring symbol layer and renderer registries
 
 
-.. _supported formats by OGR: http://www.gdal.org/ogr_formats.html
+.. _supported formats by OGR: https://www.gdal.org/ogr_formats.html
 
 
 .. Substitutions definitions - AVOID EDITING PAST THIS LINE
@@ -1297,4 +1297,4 @@ Further Topics
    source folder.
 
 .. |outofdate| replace:: `Despite our constant efforts, information beyond this line may not be updated for QGIS 3. Refer to https://qgis.org/pyqgis/master for the python API documentation or, give a hand to update the chapters you know about. Thanks.`
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/answers/answers.rst
+++ b/source/docs/training_manual/answers/answers.rst
@@ -750,7 +750,7 @@ Marble data is more suitable at global or national scales.
 You may notice that many WMS servers are not always available. Sometimes this
 is temporary, sometimes it is permanent. An example of a WMS server that worked
 at the time of writing is the :guilabel:`World Mineral Deposits` WMS at
-:kbd:`http://apps1.gdr.nrcan.gc.ca/cgi-bin/worldmin_en-ca_ows`. It does not
+http://apps1.gdr.nrcan.gc.ca/cgi-bin/worldmin_en-ca_ows. It does not
 require fees or have access constraints, and it is global. Therefore, it does
 satisfy the requirements. Keep in mind, however, that this is merely an
 example. There are many other WMS servers to choose from.
@@ -1198,4 +1198,4 @@ As you can see, our constraint allows nulls to be added into the database.
    :width: 1.5em
 .. |symbology| image:: /static/common/symbology.png
    :width: 2em
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/appendix/contribute.rst
+++ b/source/docs/training_manual/appendix/contribute.rst
@@ -22,8 +22,8 @@ system.
 Manual Format
 ===============================================================================
 
-This manual is written using `Sphinx <http://sphinx.pocoo.org/>`_, a Python
-document generator using the `reStructuredText
+This manual is written using `Sphinx <https://www.sphinx-doc.org/en/master/>`_,
+a Python document generator using the `reStructuredText
 <http://docutils.sourceforge.net/rst.html>`_ markup language. Instructions on
 how to use these tools are available on their respective sites.
 
@@ -387,4 +387,4 @@ more accessible to users and adding value to the QGIS project as a whole.
 .. |basic| image:: /static/global/basic.png
 .. |hard| image:: /static/global/hard.png
 .. |moderate| image:: /static/global/moderate.png
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/assessment/index.rst
+++ b/source/docs/training_manual/assessment/index.rst
@@ -13,7 +13,7 @@ Use your own data for this section. You will need:
 - a line vector dataset of roads
 - a polygon vector dataset of land use (using property boundaries)
 - a visual-spectrum image (such as an aerial photograph)
-- a DEM (downloadable from `this URL <http://srtm.csi.cgiar.org/>`_ if you
+- a DEM (downloadable from `the CGIAR-CSI <http://srtm.csi.cgiar.org/>`_ if you
   don't have your own)
 
 Create a base map
@@ -169,4 +169,4 @@ Final Map
 .. |basic| image:: /static/global/basic.png
 .. |hard| image:: /static/global/hard.png
 .. |moderate| image:: /static/global/moderate.png
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/basic_map/index.rst
+++ b/source/docs/training_manual/basic_map/index.rst
@@ -23,4 +23,4 @@ for further demonstrations of QGIS functionality.
    source folder.
 
 .. |MOD| replace:: Module:
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/basic_map/symbology.rst
+++ b/source/docs/training_manual/basic_map/symbology.rst
@@ -564,7 +564,7 @@ even nice to look at!
 |FR|
 -------------------------------------------------------------------------------
 
-`Examples of Beautiful Maps <http://gis.stackexchange.com/questions/3083/examples-of-beautiful-maps>`_
+`Examples of Beautiful Maps <https://gis.stackexchange.com/questions/3083/examples-of-beautiful-maps>`_
 
 |WN|
 -------------------------------------------------------------------------------
@@ -599,7 +599,7 @@ map.
 .. |moderate| image:: /static/global/moderate.png
 .. |symbology| image:: /static/common/symbology.png
    :width: 2em
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
 .. |zoomIn| image:: /static/common/mActionZoomIn.png
    :width: 1.5em
 .. |zoomOut| image:: /static/common/mActionZoomOut.png

--- a/source/docs/training_manual/basic_map/vector_data.rst
+++ b/source/docs/training_manual/basic_map/vector_data.rst
@@ -180,4 +180,4 @@ lesson.
    :width: 1.5em
 .. |openTable| image:: /static/common/mActionOpenTable.png
    :width: 1.5em
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/complete_analysis/analysis_combination.rst
+++ b/source/docs/training_manual/complete_analysis/analysis_combination.rst
@@ -100,4 +100,4 @@ Next you will present these results as part of your second assignment.
 .. |WN| replace:: What's Next?
 .. |localCRS| replace:: ``WGS 84 / UTM 34S``
 .. |moderate| image:: /static/global/moderate.png
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/complete_analysis/analysis_exercise.rst
+++ b/source/docs/training_manual/complete_analysis/analysis_exercise.rst
@@ -748,4 +748,4 @@ cartography in creating your output map.
    source folder.
 
 .. |LS| replace:: Lesson:
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/complete_analysis/assignment.rst
+++ b/source/docs/training_manual/complete_analysis/assignment.rst
@@ -26,4 +26,4 @@ are suitable.
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/complete_analysis/index.rst
+++ b/source/docs/training_manual/complete_analysis/index.rst
@@ -26,4 +26,4 @@ present the final results.
    source folder.
 
 .. |MOD| replace:: Module:
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/complete_analysis/raster_to_vector.rst
+++ b/source/docs/training_manual/complete_analysis/raster_to_vector.rst
@@ -110,4 +110,4 @@ for the residential development.
 .. |TY| replace:: Try Yourself
 .. |WN| replace:: What's Next?
 .. |moderate| image:: /static/global/moderate.png
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/create_vector_data/actions.rst
+++ b/source/docs/training_manual/create_vector_data/actions.rst
@@ -192,13 +192,13 @@ Usually when you use Google, you enter your search phrase into the Google
 Search bar. But in this case, you want your computer to do this for you. The
 way you tell Google to search for something (if you don't want to use its
 search bar directly) is by giving your Internet browser the address
-:kbd:`http://www.google.com/search?q=SEARCH_PHRASE`, where
-:kbd:`SEARCH_PHRASE` is what you want to search for. Since we don't know what
+``https://www.google.com/search?q=SEARCH_PHRASE``, where
+``SEARCH_PHRASE`` is what you want to search for. Since we don't know what
 phrase to search for yet, we'll just enter the first part (without the search
 phrase).
 
 * In the :guilabel:`Action` field, write
-  :kbd:`http://www.google.com/search?q=`. Remember to add a space after your
+  ``https://www.google.com/search?q=``. Remember to add a space after your
   initial command before writing this in!
 
 Now you want QGIS to tell the browser to tell Google to search for the value of
@@ -216,13 +216,13 @@ This will tell QGIS to add the phrase next:
    :align: center
 
 What this means is that QGIS is going to open the browser and send it to the
-address :kbd:`http://www.google.com/search?q=[% "name" %]`. But :kbd:`[%
+address ``https://www.google.com/search?q=[% "name" %]``. But :kbd:`[%
 "name" %]` tells QGIS to use the contents of the :kbd:`name` field as the
 phrase to search for.
 
 So if, for example, the landuse area you click on is named
-:kbd:`Marloth Nature Reserve`, then QGIS is going to send the browser to
-:kbd:`http://www.google.com/search?q=Marloth%20Nature%20Reserve`, which will
+``Marloth Nature Reserve``, then QGIS is going to send the browser to
+``https://www.google.com/search?q=Marloth%20Nature%20Reserve``, which will
 cause your browser to visit Google, which will in turn search for
 "Marloth Nature Reserve".
 
@@ -265,7 +265,7 @@ webkit based html widget) to display the content in a pop up window.
 Instead of Google, let's use Wikipedia this time. So the URL you request will
 look like this:
 
-:kbd:`http://wikipedia.org/wiki/SEARCH_PHRASE`
+``https://wikipedia.org/wiki/SEARCH_PHRASE``
 
 To create the layer action:
 
@@ -275,8 +275,9 @@ To create the layer action:
 
   * :guilabel:`Type`: :kbd:`Python`
   * :guilabel:`Name`: :kbd:`Wikipedia`
-  * :guilabel:`Action` (all on one line):
-    :kbd:`from PyQt4.QtCore import QUrl; from PyQt4.QtWebKit import QWebView;  myWV = QWebView(None); myWV.load(QUrl('http://wikipedia.org/wiki/[% "name" %]')); myWV.show()`
+  * :guilabel:`Action` (all on one line)::
+
+     from PyQt4.QtCore import QUrl; from PyQt4.QtWebKit import QWebView;  myWV = QWebView(None); myWV.load(QUrl('https://wikipedia.org/wiki/[% "name" %]')); myWV.show()
 
 .. image:: img/python_action_example.png
    :align: center
@@ -333,4 +334,4 @@ analyze this data to solve problems. That's the topic of the next module.
 .. |basic| image:: /static/global/basic.png
 .. |hard| image:: /static/global/hard.png
 .. |moderate| image:: /static/global/moderate.png
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/create_vector_data/create_new_vector.rst
+++ b/source/docs/training_manual/create_vector_data/create_new_vector.rst
@@ -310,6 +310,6 @@ be useful.
 .. |saveEdits| image:: /static/common/mActionSaveEdits.png
    :width: 1.5em
 .. |schoolAreaType1| replace:: athletics field
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
 .. |vertexToolActiveLayer| image:: /static/common/mActionVertexToolActiveLayer.png
    :width: 1.5em

--- a/source/docs/training_manual/create_vector_data/forms.rst
+++ b/source/docs/training_manual/create_vector_data/forms.rst
@@ -247,4 +247,4 @@ that you define. This is the subject of the next lesson.
    :width: 1.5em
 .. |majorUrbanName| replace:: Swellendam
 .. |moderate| image:: /static/global/moderate.png
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/create_vector_data/index.rst
+++ b/source/docs/training_manual/create_vector_data/index.rst
@@ -27,4 +27,4 @@ learn how to modify existing vector data and create new datasets entirely.
    source folder.
 
 .. |MOD| replace:: Module:
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/create_vector_data/topo_editing.rst
+++ b/source/docs/training_manual/create_vector_data/topo_editing.rst
@@ -316,4 +316,4 @@ so that attribute editing is simpler and more effective.
    :width: 1.5em
 .. |undo| image:: /static/common/mActionUndo.png
    :width: 1.5em
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/database_concepts/adding_data.rst
+++ b/source/docs/training_manual/database_concepts/adding_data.rst
@@ -204,4 +204,4 @@ data in various ways.
 .. |basic| image:: /static/global/basic.png
 .. |hard| image:: /static/global/hard.png
 .. |moderate| image:: /static/global/moderate.png
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/database_concepts/data_model.rst
+++ b/source/docs/training_manual/database_concepts/data_model.rst
@@ -19,7 +19,7 @@ Install PostgreSQL
   PostgreSQL using
   `Homebrew <http://russbrooks.com/2010/11/25/install-postgresql-9-on-os-x>`_.
   Windows users can use the
-  graphical installer located here: `<http://www.postgresql.org/download/windows/>`_.
+  `graphical installer <https://www.postgresql.org/download/windows/>`_.
   Please note that the documentation will assume users are running QGIS under
   Ubuntu.
 
@@ -55,7 +55,7 @@ Help
 -------------------------------------------------------------------------------
 
 PostgreSQL has very good `online
-<http://www.postgresql.org/docs/9.1/static/index.html>`_ documentation.
+<https://www.postgresql.org/docs/9.1/index.html>`_ documentation.
 
 Create a database user
 -------------------------------------------------------------------------------
@@ -174,9 +174,7 @@ To get help on a specific command, type (for example)::
 
   \help create table
 
-See also the `Psql cheat sheet <http://www.postgresonline.com/downloads/special_feature/postgresql90_cheatsheet_A4.pdf>`_ -
-available online `here
-<http://www.postgresonline.com/downloads/special_feature/postgresql90_cheatsheet_A4.pdf>`_.
+See also the `Psql cheat sheet <http://www.postgresonline.com/downloads/special_feature/postgresql90_cheatsheet_A4.pdf>`_.
 
 Make Tables in SQL
 -------------------------------------------------------------------------------
@@ -422,4 +420,4 @@ Next you'll learn how to use the DBMS to add new data.
 .. |TY| replace:: Try Yourself
 .. |WN| replace:: What's Next?
 .. |moderate| image:: /static/global/moderate.png
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/database_concepts/db_intro.rst
+++ b/source/docs/training_manual/database_concepts/db_intro.rst
@@ -114,7 +114,7 @@ Result:
     (3 rows)
 
 There are many more datatypes you can use - `check the PostgreSQL manual!
-<http://www.postgresql.org/docs/current/static/datatype.html>`_
+<https://www.postgresql.org/docs/current/datatype.html>`_
 
 Modelling an Address Database
 -------------------------------------------------------------------------------
@@ -195,7 +195,7 @@ Redesign the theoretical `people` table above to reduce duplication and to
 normalise the data structure.
 
 You can read more about database normalisation `here
-<http://en.wikipedia.org/wiki/Database_normalization>`_
+<https://en.wikipedia.org/wiki/Database_normalization>`_
 
 :ref:`Check your results <database-concepts-2>`
 
@@ -395,4 +395,4 @@ database to implement the theory we've covered.
 .. |WN| replace:: What's Next?
 .. |basic| image:: /static/global/basic.png
 .. |moderate| image:: /static/global/moderate.png
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/database_concepts/index.rst
+++ b/source/docs/training_manual/database_concepts/index.rst
@@ -29,4 +29,4 @@ learning about other typical RDBMS functions.
    source folder.
 
 .. |MOD| replace:: Module:
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/database_concepts/queries.rst
+++ b/source/docs/training_manual/database_concepts/queries.rst
@@ -307,4 +307,4 @@ Next you'll see how to create views from the queries that you've written.
 .. |TY| replace:: Try Yourself
 .. |WN| replace:: What's Next?
 .. |moderate| image:: /static/global/moderate.png
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/database_concepts/rules.rst
+++ b/source/docs/training_manual/database_concepts/rules.rst
@@ -84,4 +84,4 @@ which takes these database concepts and applies them to GIS data.
 .. |IC| replace:: In Conclusion
 .. |LS| replace:: Lesson:
 .. |WN| replace:: What's Next?
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/database_concepts/views.rst
+++ b/source/docs/training_manual/database_concepts/views.rst
@@ -103,4 +103,4 @@ in the database. The next lesson will show you how to do this.
 .. |IC| replace:: In Conclusion
 .. |LS| replace:: Lesson:
 .. |WN| replace:: What's Next?
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/databases/db_browser.rst
+++ b/source/docs/training_manual/databases/db_browser.rst
@@ -103,4 +103,4 @@ complete set of database management tasks.
 .. |LS| replace:: Lesson:
 .. |WN| replace:: What's Next?
 .. |basic| image:: /static/global/basic.png
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/databases/db_manager.rst
+++ b/source/docs/training_manual/databases/db_manager.rst
@@ -36,7 +36,7 @@ Schemas are a way of grouping data tables and other objects in a PostgreSQL
 database and a container for permissions and other constraints. Managing 
 PostgreSQL schemas is beyond the scope of this manual, but you can find 
 more information about them in the `PostgreSQL documentation on Schemas
-<http://www.postgresql.org/docs/9.1/static/ddl-schemas.html>`_.
+<https://www.postgresql.org/docs/9.1/ddl-schemas.html>`_.
 You can use the DB Manager to create new Schemas, but will need to use a tool
 like pgAdmin III or the command line interface to manage them effectively.
 
@@ -156,7 +156,7 @@ table is, this may take some time to complete.
 
 You can find more information about the VACUUM ANALYZE process in the
 `PostgreSQL Documentation on VACUUM ANALYZE
-<http://www.postgresql.org/docs/9.1/static/sql-vacuum.html>`_ 
+<https://www.postgresql.org/docs/9.1/sql-vacuum.html>`_.
 
 |basic| |FA| Executing SQL Queries with DB Manager
 -------------------------------------------------------------------------------
@@ -286,4 +286,4 @@ Next, we will look at how to use many of these same techniques with
 .. |basic| image:: /static/global/basic.png
 .. |dbManager| image:: /static/common/dbmanager.png
    :width: 1.5em
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/databases/index.rst
+++ b/source/docs/training_manual/databases/index.rst
@@ -27,4 +27,4 @@ spatial database implementations including spatialite.
    source folder.
 
 .. |MOD| replace:: Module:
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/databases/spatialite.rst
+++ b/source/docs/training_manual/databases/spatialite.rst
@@ -83,4 +83,4 @@ use these tables as layers in QGIS.
 .. |basic| image:: /static/global/basic.png
 .. |newSpatiaLiteLayer| image:: /static/common/mActionNewSpatiaLiteLayer.png
    :width: 1.5em
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/forestry/basic_lidar.rst
+++ b/source/docs/training_manual/forestry/basic_lidar.rst
@@ -20,7 +20,7 @@ data and a hillshade raster.
 -------------------------------------------------------------------------------
 
 Managing LiDAR data within QGIS is possible using the Processing framework and
-the algorithms provided by `LAStools <http://rapidlasso.com/2013/09/29//how-to-install-lastools-toolbox-in-qgis>`_.
+the algorithms provided by `LAStools <https://rapidlasso.com/2013/09/29//how-to-install-lastools-toolbox-in-qgis>`_.
 
 You can obtain a digital elevation model (DEM) from a LiDAR point cloud and then
 create a hillshade raster that is visually more intuitive for presentation purposes.
@@ -36,16 +36,16 @@ properly work with LAStools:
 .. image:: img/remove_lidar_folder.png
    :align: center
 
-* Go to the :kbd:`exercise_data\\forestry\\lidar\\` folder, there you can find
-  the file :kbd:`QGIS_2_2_toolbox.zip`. Open it and extract the :kbd:`lidar`
+* Go to the :file:`exercise_data\\forestry\\lidar\\` folder, there you can find
+  the file :file:`QGIS_2_2_toolbox.zip`. Open it and extract the :kbd:`lidar`
   folder to replace the one you just deleted.
 * If you are using a different QGIS version, you can see more installation
-  instructions in `this tutorial <http://rapidlasso.com/2013/09/29/how-to-install-lastools-toolbox-in-qgis/>`_.
+  instructions in `this tutorial <https://rapidlasso.com/2013/09/29/how-to-install-lastools-toolbox-in-qgis/>`_.
 
 Now you need to install the LAStools to your computer. Get the newest
-:kbd:`lastools` version `here <http://lastools.org/download/lastools.zip>`_
-and extract the content of the :kbd:`lastools.zip` file into a folder in your
-system, for example, :file:`C:\\lastools\\`. The path to the :kbd:`lastools`
+*lastools* version `here <http://lastools.org/download/lastools.zip>`_
+and extract the content of the :file:`lastools.zip` file into a folder in your
+system, for example, :file:`C:\\lastools\\`. The path to the :file:`lastools`
 folder cannot have spaces or special characters.
 
 .. note:: Read the :kbd:`LICENSE.txt` file inside the :kbd:`lastools` folder.
@@ -106,7 +106,7 @@ click and drag on the viewer to pan the LiDAR point cloud to see what it looks l
 
 .. note:: If you want to know further details on how the LAStools work, you can
   read the :file:`README` text files about each of the tools, in the :file:`C:\\lastools\\bin\\`
-  folder. Tutorials and other materials are available at the `Rapidlasso webpage <http://rapidlasso.com/>`_.
+  folder. Tutorials and other materials are available at the `Rapidlasso webpage <https://rapidlasso.com/>`_.
 
 * Close the viewer when you are ready.
 
@@ -133,7 +133,7 @@ The brown points are the points classified as ground and the gray ones are the r
 you can click the letter :kbd:`g` to visualize only the ground points or the
 letter :kbd:`u` to see only the unclassified points. Click the letter :kbd:`a`
 to see all the points again. Check the :file:`lasview_README.txt` file for more
-commands. If you are interested, also this `tutorial <http://www.rapidlasso.com/2014/03/02/tutorial-manual-lidar-editing/>`_
+commands. If you are interested, also this `tutorial <https://www.rapidlasso.com/2014/03/02/tutorial-manual-lidar-editing/>`_
 about editing LiDAR points manually will show you different operations within
 the viewer.
 
@@ -179,7 +179,7 @@ soil drains that have been dug in the forests.
 
 Using LiDAR data to get a DEM, specially in forested areas, gives good results
 with not much effort. You could also use ready LiDAR derived DEMs or other
-sources like the `SRTM 9m resolution DEMs <http://www.cgiar-csi.org/data/srtm-90m-digital-elevation-database-v4-1>`_.
+sources like the `SRTM 9m resolution DEMs <http://srtm.csi.cgiar.org/SELECTION/inputCoord.asp>`_.
 Either way, you can use them to create a hillshade raster to use in your map
 presentations.
 
@@ -201,4 +201,4 @@ raster and the forest inventory results to create a map presentation of the resu
 .. |LS| replace:: Lesson:
 .. |WN| replace:: What's Next?
 .. |basic| image:: /static/global/basic.png
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/forestry/forest_maps.rst
+++ b/source/docs/training_manual/forestry/forest_maps.rst
@@ -484,4 +484,4 @@ then use it to your enhance your data and maps visibility.
    :width: 1.5em
 .. |select| image:: /static/common/mActionSelect.png
    :width: 1.5em
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/forestry/forestry_intro.rst
+++ b/source/docs/training_manual/forestry/forestry_intro.rst
@@ -21,18 +21,18 @@ Forestry Sample Data
 -------------------------------------------------------------------------------
 
 .. note:: The sample data used in this module is part of the training manual
- data set and can be `downloaded here  <http://qgis.org/downloads/data/training_manual_exercise_data.zip>`_.
+ data set and can be `downloaded here  <https://qgis.org/downloads/data/training_manual_exercise_data.zip>`_.
  Download the zip file and extract the :file:`forestry\\` folder into your
  :file:`exercise_data\\` folder.
 
 The forestry related sample data (forestry map, forest data), has been provided
-by the `EVO-HAMK forestry school <http://www.hamk.fi/tietoa-hamkista/kartat-ja-toimipaikat/Sivut/evo.aspx>`_.
+by the `EVO-HAMK forestry school <https://www.hamk.fi/tietoa-hamkista/kartat-ja-toimipaikat/Sivut/evo.aspx>`_.
 The datasets have been modified to adapt to the lessons needs.
 
 The general sample data (aerial images, LiDAR data, basic maps) has been
 obtained from the National Land Survey of Finland open data service, and adapted
 for the purposes of the exercises. The open data file download service can be
-accessed in English `here <http://www.maanmittauslaitos.fi/en/file_download_service>`_.
+accessed in English `here <https://tiedostopalvelu.maanmittauslaitos.fi/tp/kartta?lang=en>`_.
 
 
 .. warning::
@@ -50,4 +50,4 @@ accessed in English `here <http://www.maanmittauslaitos.fi/en/file_download_serv
    source folder.
 
 .. |LS| replace:: Lesson:
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/forestry/index.rst
+++ b/source/docs/training_manual/forestry/index.rst
@@ -38,4 +38,4 @@ The development of this module has been sponsored by the European Union.
    source folder.
 
 .. |MOD| replace:: Module:
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/forestry/map_georeferencing.rst
+++ b/source/docs/training_manual/forestry/map_georeferencing.rst
@@ -161,4 +161,4 @@ and add the inventory data to them.
 .. |LS| replace:: Lesson:
 .. |WN| replace:: What's Next?
 .. |basic| image:: /static/global/basic.png
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/forestry/parameters_calculation.rst
+++ b/source/docs/training_manual/forestry/parameters_calculation.rst
@@ -202,4 +202,4 @@ results you just calculated.
 .. |LS| replace:: Lesson:
 .. |WN| replace:: What's Next?
 .. |basic| image:: /static/global/basic.png
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/forestry/results_map.rst
+++ b/source/docs/training_manual/forestry/results_map.rst
@@ -115,4 +115,4 @@ starting point to explore how you could achieve the specific results you need.
 .. |LS| replace:: Lesson:
 .. |TY| replace:: Try Yourself
 .. |basic| image:: /static/global/basic.png
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/forestry/stands_digitazing.rst
+++ b/source/docs/training_manual/forestry/stands_digitazing.rst
@@ -28,7 +28,7 @@ photograph.
 If what you are using to digitize is a good map, as it is in our case, it is
 likely that the information is clearly displayed as lines with different colors
 for each type of element. Those colors can be relatively easy extracted as
-individual images using an image processing software like `GIMP <http://www.gimp.org/>`_.
+individual images using an image processing software like `GIMP <https://www.gimp.org/>`_.
 Such separate images can be used to assist the digitizing, as you will see below.
 
 The first step will be to use GIMP to obtain an image that contains only the
@@ -373,4 +373,4 @@ aerial photos and the addition of some relevant information to your dataset.
 .. |TY| replace:: Try Yourself
 .. |WN| replace:: What's Next?
 .. |basic| image:: /static/global/basic.png
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/forestry/systematic_sampling.rst
+++ b/source/docs/training_manual/forestry/systematic_sampling.rst
@@ -38,7 +38,7 @@ rectangular, variable size), and can be located in the forest in different ways
 (for ex. randomly, systematically, along lines). The size, form and location of
 the sample plots are usually decided following statistical, economical and
 practical considerations. If you have no forestry knowledge, you might be
-interested in reading `this Wikipedia article <http://en.wikipedia.org/wiki/Forest_inventory>`_.
+interested in reading `this Wikipedia article <https://en.wikipedia.org/wiki/Forest_inventory>`_.
 
 |basic| |FA| Implementing a Systematic Sampling Plot Design
 -------------------------------------------------------------------------------
@@ -146,7 +146,7 @@ new :kbd:`Plot_id` field.
 The field teams will be probably using a GPS device to locate the sample plots
 you planned. The next step is to export the points you created to a format that
 your GPS can read. QGIS allows you to save your point and line vector data in
-`GPS eXchange Format (GPX)<http://en.wikipedia.org/wiki/GPS_Exchange_Format>`,
+`GPS eXchange Format (GPX)<https://en.wikipedia.org/wiki/GPS_Exchange_Format>`,
 which is an standard GPS data format that can be read by most of the
 specialized software. You need to be careful with selecting the CRS when you
 save your data:
@@ -205,4 +205,4 @@ navigate to the sample plots assigned to them.
 .. |LS| replace:: Lesson:
 .. |WN| replace:: What's Next?
 .. |basic| image:: /static/global/basic.png
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/forestry/updating_stands.rst
+++ b/source/docs/training_manual/forestry/updating_stands.rst
@@ -28,16 +28,16 @@ CIR aerial photographs and add information from other data-sets.
 The National Land Survey of Finland has an open data policy that allows you
 downloading a variety of geographical data like aerial imagery, traditional
 topographic maps, DEM, LiDAR data, etc. The service can be accessed also in
-English `here <http://www.maanmittauslaitos.fi/en/file_download_service>`_.
+English `here <https://tiedostopalvelu.maanmittauslaitos.fi/tp/kartta?lang=en>`_.
 The aerial image used in this exercise has been created from two orthorectified
 CIR images downloaded from that service (M4134F_21062012 and M4143E_21062012). 
 
-* Open QGIS and set the project's CRS to :kbd:`ETRS89 / ETRS-TM35FIN` in
+* Open QGIS and set the project's CRS to :guilabel:`ETRS89 / ETRS-TM35FIN` in
   :menuselection:`Project --> Properties... --> CRS`.
 * Make sure that :guilabel:`Enable 'on the fly' CRS transformation` is checked.
-* From the :kbd:`exercise_data\\forestry\\` folder, add the CIR image
-  :kbd:`rautjarvi_aerial.tif` that is containing the digitized lakes.
-* Then save the QGIS project as :kbd:`digitizing_2012.qgs`.
+* From the :file:`exercise_data\\forestry\\` folder, add the CIR image
+  :file:`rautjarvi_aerial.tif` that is containing the digitized lakes.
+* Then save the QGIS project as :file:`digitizing_2012.qgs`.
 
 The CIR images are from 2012. You can compare the stands that were created
 in 1994 with the situation almost 20 years later.
@@ -289,4 +289,4 @@ of forest parameters.
 .. |TY| replace:: Try Yourself
 .. |WN| replace:: What's Next?
 .. |basic| image:: /static/global/basic.png
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/foreword/foreword.rst
+++ b/source/docs/training_manual/foreword/foreword.rst
@@ -36,7 +36,7 @@ License
 
 The Free Quantum GIS Training Manual by Linfiniti Consulting CC. is based on
 an earlier version from Linfiniti and is licensed under a
-`Creative Commons Attribution 4.0 International <http://creativecommons.org/licenses/by/4.0/>`_.
+`Creative Commons Attribution 4.0 International <https://creativecommons.org/licenses/by/4.0/>`_.
 Permissions beyond the scope of this license may be available at below.
 
 
@@ -65,7 +65,7 @@ guidelines are as follows:
   at office@linfiniti.com and we will advise you if what you intend doing is
   acceptable.
 * If you publish this work under a self publishing site such as
-  http://lulu.com we request that you donate the profits to the QGIS project.
+  https://www.lulu.com we request that you donate the profits to the QGIS project.
 * You may not commercialise this work, except with the expressed permission of
   the authors. To be clear, by commercialisation we mean that you may not sell
   for profit, create commercial derivative works (e.g. selling content for use
@@ -118,7 +118,7 @@ Data
 The sample data that accompanies this resource is freely available and comes
 from the following sources:
 
-* Streets and Places datasets from OpenStreetMap (http://www.openstreetmap.org/)
+* Streets and Places datasets from OpenStreetMap (https://www.openstreetmap.org/)
 * Property boundaries (urban and rural), water bodies from NGI (http://www.ngi.gov.za/)
 * SRTM DEM from the CGIAR-CGI (http://srtm.csi.cgiar.org/)
 
@@ -144,7 +144,7 @@ Latest Version
 --------------
 
 You can always obtain the latest version of this document by visiting the online
-version which is part of the QGIS documentation website (http://docs.qgis.org).
+version which is part of the QGIS documentation website (https://docs.qgis.org).
 
 .. note:: There are links to online and PDF versions of the Documentation and Training manuals.
 
@@ -159,4 +159,4 @@ Tim Sutton, May 2012
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/foreword/index.rst
+++ b/source/docs/training_manual/foreword/index.rst
@@ -19,4 +19,4 @@ Course Introduction
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/foreword/preparing_data.rst
+++ b/source/docs/training_manual/foreword/preparing_data.rst
@@ -229,7 +229,7 @@ The tokens you need to replace are as follows:
    :width: 1.5em
 .. |majorUrbanName| replace:: Swellendam
 .. |radioButtonOn| image:: /static/common/radiobuttonon.png
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
 .. |zoomFullExtent| image:: /static/common/mActionZoomFullExtent.png
    :width: 1.5em
 .. |zoomToLayer| image:: /static/common/mActionZoomToLayer.png

--- a/source/docs/training_manual/grass/grass_setup.rst
+++ b/source/docs/training_manual/grass/grass_setup.rst
@@ -336,4 +336,4 @@ operations that GRASS offers.
    :width: 1.5em
 .. |hard| image:: /static/global/hard.png
 .. |srtmFileName| replace:: :file:`srtm_41_19_4326.tif`
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/grass/grass_tools.rst
+++ b/source/docs/training_manual/grass/grass_tools.rst
@@ -189,4 +189,4 @@ organizes tools by type.
 .. |TY| replace:: Try Yourself
 .. |basic| image:: /static/global/basic.png
 .. |moderate| image:: /static/global/moderate.png
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/grass/index.rst
+++ b/source/docs/training_manual/grass/index.rst
@@ -25,4 +25,4 @@ QGIS allows you to make use of GRASS' powerful GIS tools directly.
    source folder.
 
 .. |MOD| replace:: Module:
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/index.rst
+++ b/source/docs/training_manual/index.rst
@@ -50,4 +50,4 @@ Indices and tables
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/introduction/index.rst
+++ b/source/docs/training_manual/introduction/index.rst
@@ -22,4 +22,4 @@
    source folder.
 
 .. |MOD| replace:: Module:
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/introduction/intro.rst
+++ b/source/docs/training_manual/introduction/intro.rst
@@ -130,4 +130,4 @@ lesson will guide you in creating your first QGIS map.
 .. |basic| image:: /static/global/basic.png
 .. |hard| image:: /static/global/hard.png
 .. |moderate| image:: /static/global/moderate.png
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/introduction/overview.rst
+++ b/source/docs/training_manual/introduction/overview.rst
@@ -198,6 +198,6 @@ to you and start improving on your map! This is the topic of the next lesson.
    :width: 1.5em
 .. |measure| image:: /static/common/mActionMeasure.png
    :width: 1.5em
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
 .. |zoomToLayer| image:: /static/common/mActionZoomToLayer.png
    :width: 1.5em

--- a/source/docs/training_manual/introduction/preparation.rst
+++ b/source/docs/training_manual/introduction/preparation.rst
@@ -64,7 +64,7 @@ your work.
 |moderate| |FA| Load a layer from GeoPackage
 -------------------------------------------------------------------------------
 
-`GeoPackage <http://www.geopackage.org/>`_ is an open format for storing
+`GeoPackage <https://www.geopackage.org/>`_ is an open format for storing
 geospatial data. QGIS adds a lot of support to this new format that is slowly
 replacing the ESRI Shapefile format.
 
@@ -125,4 +125,4 @@ layout of the QGIS interface. This is the topic of the next lesson.
 .. |newGeoPackageLayer| image:: /static/common/mActionNewGeoPackageLayer.png
    :width: 1.5em
 .. |radioButtonOn| image:: /static/common/radiobuttonon.png
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/linfiniti-sphinx-theme/README.txt
+++ b/source/docs/training_manual/linfiniti-sphinx-theme/README.txt
@@ -14,9 +14,9 @@ License:
 --------
 
 This is a theme for the `sphinx documentation system
-<http://sphinx.pocoo.org/>`_ based on the `bootstrap css framework
-<http://twitter.github.com/bootstrap/>`_. It also uses a few icons from the
-free `34aL volume 3.2 SE <http://www.icojoy.com/articles/26/>`_ icon set.
+<http://www.sphinx-doc.org/en/master/>`_ based on the `bootstrap css framework
+<https://twitter.github.com/bootstrap/>`_. It also uses a few icons from the
+free `34aL volume 3.2 SE <www.icojam.com>`_ icon set.
 
 The base layout.html is taken from the default sphinx theme and modified.
 
@@ -25,7 +25,7 @@ of which is included under static/bootstrap/LICENSE.txt
 
 This theme is the original work of Tim Sutton, Linfiniti Consulting CC and made
 available under the Creative Commons Share-Alike license. More about this
-license can be found `here <http://creativecommons.org/licenses/by-sa/3.0/>`_.
+license can be found `here <https://creativecommons.org/licenses/by-sa/3.0/>`_.
 
 Please do not remove our name / license logo from the theme without our
 permission.
@@ -127,7 +127,7 @@ History:
 
 We developed this theme for some in-house projects we were working on, but
 decided to 'put it out there' since we started using the theme in some of our
-contributions to the `Quantum GIS (QGIS) <http://qgis.org>`_ project too.
+contributions to the `Quantum GIS (QGIS) <https://qgis.org>`_ project too.
 
 Contact:
 --------

--- a/source/docs/training_manual/linfiniti-sphinx-theme/static/bootstrap/LICENSE.txt
+++ b/source/docs/training_manual/linfiniti-sphinx-theme/static/bootstrap/LICENSE.txt
@@ -1,6 +1,6 @@
                                  Apache License
                            Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+                        https://www.apache.org/licenses/
 
    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 

--- a/source/docs/training_manual/linfiniti-sphinx-theme/static/img/readme.txt
+++ b/source/docs/training_manual/linfiniti-sphinx-theme/static/img/readme.txt
@@ -21,4 +21,4 @@ File Types:
 
 Note: These icons are free for use.
 
-http://www.icojoy.com/articles/26/
+http://www.icojam.com/

--- a/source/docs/training_manual/map_composer/day_1_assignment.rst
+++ b/source/docs/training_manual/map_composer/day_1_assignment.rst
@@ -47,4 +47,4 @@ start to finish, using both raster and vector data sources.
 .. |IC| replace:: In Conclusion
 .. |basic| image:: /static/global/basic.png
 .. |moderate| image:: /static/global/moderate.png
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/map_composer/index.rst
+++ b/source/docs/training_manual/map_composer/index.rst
@@ -23,4 +23,4 @@ quality maps with all the requisite map components.
    source folder.
 
 .. |MOD| replace:: Module:
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/map_composer/map_composer.rst
+++ b/source/docs/training_manual/map_composer/map_composer.rst
@@ -332,7 +332,7 @@ you to practice the techniques you have learned so far.
    :width: 1.5em
 .. |signMinus| image:: /static/common/symbologyRemove.png
    :width: 1.5em
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
 .. |zoomFullExtent| image:: /static/common/mActionZoomFullExtent.png
    :width: 1.5em
 .. |zoomIn| image:: /static/common/mActionZoomIn.png

--- a/source/docs/training_manual/online_resources/index.rst
+++ b/source/docs/training_manual/online_resources/index.rst
@@ -28,4 +28,4 @@ Services (WMS) and Web Feature Services (WFS).
    source folder.
 
 .. |MOD| replace:: Module:
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/online_resources/wfs.rst
+++ b/source/docs/training_manual/online_resources/wfs.rst
@@ -22,9 +22,9 @@ WMS.
   |wfs|
 
 * Click the :guilabel:`New` button.
-* In the dialog that appears, enter the :guilabel:`Name` as :kbd:`nsidc.org`
+* In the dialog that appears, enter the :guilabel:`Name` as ``nsidc.org``
   and the :guilabel:`URL` as
-  :kbd:`http://nsidc.org/cgi-bin/atlas_south?version=1.1.0`.
+  ``https://nsidc.org/cgi-bin/atlas_south?version=1.1.0``.
 
   .. image:: img/new_wfs_connection.png
      :align: center
@@ -170,6 +170,6 @@ Next, you'll see how to use QGIS Server to provide OGC services.
 .. |WN| replace:: What's Next?
 .. |basic| image:: /static/global/basic.png
 .. |moderate| image:: /static/global/moderate.png
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
 .. |wfs| image:: /static/common/mActionAddWfsLayer.png
    :width: 1.5em

--- a/source/docs/training_manual/online_resources/wms.rst
+++ b/source/docs/training_manual/online_resources/wms.rst
@@ -50,17 +50,17 @@ layers are on a remote server.
 
 You'll need a WMS address to continue. There are several free WMS servers
 available on the Internet. One of these is `terrestris
-<http://ows.terrestris.de/osm/service>`_, which makes use of the `OpenStreetMap
-<http://wiki.openstreetmap.org/wiki/Main_Page>`_ dataset.
+<https://ows.terrestris.de/osm/service>`_, which makes use of the `OpenStreetMap
+<https://wiki.openstreetmap.org/wiki/Main_Page>`_ dataset.
 
 * To make use of this WMS, set it up in your current dialog, like this:
 
   .. image:: img/new_wms_connection.png
      :align: center
 
-* The value of the :guilabel:`Name` field should be :kbd:`terrestris`.
+* The value of the :guilabel:`Name` field should be ``terrestris``.
 * The value of the :guilabel:`URL` field should be
-  :kbd:`http://ows.terrestris.de/osm/service`.
+  ``https://ows.terrestris.de/osm/service``.
 * Click :guilabel:`OK`. You should see the new WMS server listed:
 
   .. image:: img/new_connection_listed.png
@@ -154,7 +154,7 @@ layer from the :guilabel:`terrestris` WMS server.
 
 * Hide the :guilabel:`OSM-WSM` layer in the :guilabel:`Layers` panel.
 * Add the "ZAF CGS 1M Bedrock Lithostratigraphy" WMS server at this URL:
-  :kbd:`http://196.33.85.22/cgi-bin/ZAF_CGS_Bedrock_Geology/wms`
+  ``http://196.33.85.22/cgi-bin/ZAF_CGS_Bedrock_Geology/wms``
 * Load the :guilabel:`BEDROCKGEOLOGY` layer into the map (use the :guilabel:`Add WMS
   Layer` button as before). Remember to check that it's in the same
   :guilabel:`WGS 84 / World Mercator` projection as the rest of your map!
@@ -176,7 +176,7 @@ layer from the :guilabel:`terrestris` WMS server.
 * Hide all other WMS layers to prevent them rendering unnecessarily in the
   background.
 * Add the "OGC" WMS server at this URL:
-  :kbd:`http://ogc.gbif.org:80/wms`
+  ``http://ogc.gbif.org:80/wms``
 * Add the :guilabel:`bluemarble` layer.
 
 :ref:`Check your results <wms-2>`
@@ -189,7 +189,7 @@ layer from the :guilabel:`terrestris` WMS server.
 
 Part of the difficulty of using WMS is finding a good (free) server.
 
-* Find a new WMS at `directory.spatineo.com <http://directory.spatineo.com/>`_ (or
+* Find a new WMS at `directory.spatineo.com <https://directory.spatineo.com/>`_ (or
   elsewhere online). It must not have associated fees or restrictions, and must
   have coverage over the |majorUrbanName| study area.
 
@@ -207,10 +207,10 @@ Using a WMS, you can add inactive maps as backdrops for your existing map data.
 |FR|
 -------------------------------------------------------------------------------
 
-- `Spatineo Directory <http://directory.spatineo.com/>`_
-- `Geopole.org <http://geopole.org/>`_
+- `Spatineo Directory <https://directory.spatineo.com/>`_
+- `Geopole.org <https://geopole.org/>`_
 - `OpenStreetMap.org list of WMS servers
-  <http://wiki.openstreetmap.org/wiki/WMS>`_
+  <https://wiki.openstreetmap.org/wiki/WMS>`_
 
 |WN|
 -------------------------------------------------------------------------------
@@ -237,6 +237,6 @@ Feature Service (WFS). That's the topic of the next lesson.
 .. |hard| image:: /static/global/hard.png
 .. |majorUrbanName| replace:: Swellendam
 .. |moderate| image:: /static/global/moderate.png
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
 .. |wms| image:: /static/common/mActionAddWmsLayer.png
    :width: 1.5em

--- a/source/docs/training_manual/processing/batch_conversion.rst
+++ b/source/docs/training_manual/processing/batch_conversion.rst
@@ -99,4 +99,4 @@ all your layers will have been processed, and 3 new layers would have been creat
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/processing/batch_modeler.rst
+++ b/source/docs/training_manual/processing/batch_modeler.rst
@@ -37,4 +37,4 @@ Click on *OK* and you should get 5 new layers with watersheds corresponding to t
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/processing/crs.rst
+++ b/source/docs/training_manual/processing/crs.rst
@@ -118,4 +118,4 @@ two layers that we had computed before.
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/processing/cutting_merging.rst
+++ b/source/docs/training_manual/processing/cutting_merging.rst
@@ -124,4 +124,4 @@ This can be solved by clipping it again, as we did to obtain the base DEM.
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/processing/extents.rst
+++ b/source/docs/training_manual/processing/extents.rst
@@ -103,4 +103,4 @@ selection, and then use it as input.
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/processing/first_alg.rst
+++ b/source/docs/training_manual/processing/first_alg.rst
@@ -96,4 +96,4 @@ that is found below the output path box.
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/processing/first_saga_alg.rst
+++ b/source/docs/training_manual/processing/first_saga_alg.rst
@@ -119,4 +119,4 @@ when issues like this appear.
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/processing/generalize.rst
+++ b/source/docs/training_manual/processing/generalize.rst
@@ -5,7 +5,7 @@
 Vector simplification and smoothing
 ====================================
 
-Module contributed by Paolo Cavallini - `Faunalia <http://www.faunalia.eu>`_ 
+Module contributed by Paolo Cavallini - `Faunalia <https://www.faunalia.eu>`_
 
 .. note:: This chapter shows how simplify vectors, and smooth out sharp corners.
 
@@ -36,4 +36,4 @@ raster, to GPS tracks with sparse vertices, etc.
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/processing/geomorpho.rst
+++ b/source/docs/training_manual/processing/geomorpho.rst
@@ -5,7 +5,7 @@
 Predicting landslides
 ==========================================
 
-Module contributed by Paolo Cavallini - `Faunalia <http://www.faunalia.eu>`_ 
+Module contributed by Paolo Cavallini - `Faunalia <https://www.faunalia.eu>`_
 
 .. note:: This chapter shows how to create an oversimplified model to predict
   the probability of landslides.
@@ -39,4 +39,4 @@ let's say ``(rainfall * slope )/100``:
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/processing/hooks.rst
+++ b/source/docs/training_manual/processing/hooks.rst
@@ -13,7 +13,7 @@ actual data processing is performed. This can be used to automate tasks that
 should be performed whenever an algorithm is executed.
 
 The syntax of the hooks is identical to the syntax of Processing scripts, see the
-corresponding `chapter <http://docs.qgis.org/testing/en/docs/user_manual/processing/console.html>`_
+corresponding `chapter <https://docs.qgis.org/testing/en/docs/user_manual/processing/console.html>`_
 in the QGIS User Guide for more details.
 
 In addition to all scripts features, in hooks you can use a special global
@@ -88,4 +88,4 @@ The hook will be executed before running any Processing algorithm.
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/processing/html.rst
+++ b/source/docs/training_manual/processing/html.rst
@@ -59,4 +59,4 @@ other algorithms.
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/processing/hydro.rst
+++ b/source/docs/training_manual/processing/hydro.rst
@@ -123,4 +123,4 @@ automate both of them and work more effectively.
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/processing/index.rst
+++ b/source/docs/training_manual/processing/index.rst
@@ -63,4 +63,4 @@ Contents:
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/processing/interp_contour.rst
+++ b/source/docs/training_manual/processing/interp_contour.rst
@@ -5,7 +5,7 @@
 Interpolation and contouring
 =============================
 
-Module contributed by Paolo Cavallini - `Faunalia <http://www.faunalia.eu>`_
+Module contributed by Paolo Cavallini - `Faunalia <https://www.faunalia.eu>`_
 
 .. note:: This chapter shows how to use different backends to calculate different interpolations.
 
@@ -28,7 +28,8 @@ Then measure variation among methods and correlate it with distance to points:
 - :menuselection:`GRASS --> r.series` [Unselect Propagate NULLs, Aggregate operation: stddev]
 - :menuselection:`GRASS --> v.to.rast.value` on ``points.shp``
 - :menuselection:`GDAL --> Proximity`
-- :menuselection:`GRASS --> r.covar` to show the correlation matrix; check the significance of the correlation e.g. with http://vassarstats.net/rsig.html.
+- :menuselection:`GRASS --> r.covar` to show the correlation matrix; check the
+  significance of the correlation e.g. with http://vassarstats.net/rsig.html.
  
 Thus, areas far from points will have less accurate interpolation.
 
@@ -48,4 +49,4 @@ Various methods to draw contour lines [always step= 10] on the *stddev* raster:
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/processing/interpolation.rst
+++ b/source/docs/training_manual/processing/interpolation.rst
@@ -90,4 +90,4 @@ With the above parameters you will get the following result
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/processing/interpolation_cross.rst
+++ b/source/docs/training_manual/processing/interpolation_cross.rst
@@ -66,4 +66,4 @@ Your results might differ from these ones, since there is a random component int
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/processing/intro.rst
+++ b/source/docs/training_manual/processing/intro.rst
@@ -15,7 +15,7 @@ This guide is comprised of a set of small exercises of progressive complexity. I
 
 For a more systematic description of all the framework components and their usage, it is recommended to check the corresponding chapter in the QGIS manual. Use it as a support text along with this guide.
 
-All the exercises in this guide use free data set that can be downloaded from the `QGIS website <http://qgis.org/downloads/data/>`_. The zip file to download contains several folders corresponding to each one of the lessons in this guide. In each of them you will find a QGIS project file. Just open it and you will be ready to start the lesson.
+All the exercises in this guide use free data set that can be downloaded from the `QGIS website <https://qgis.org/downloads/data/>`_. The zip file to download contains several folders corresponding to each one of the lessons in this guide. In each of them you will find a QGIS project file. Just open it and you will be ready to start the lesson.
 
 Enjoy!
 
@@ -26,4 +26,4 @@ Enjoy!
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/processing/iterative.rst
+++ b/source/docs/training_manual/processing/iterative.rst
@@ -58,4 +58,4 @@ If you enter an output filename, resulting files will be named using that filena
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/processing/iterative_model.rst
+++ b/source/docs/training_manual/processing/iterative_model.rst
@@ -44,4 +44,4 @@ If you now run the model, apart from the tables you will get a set of pages with
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/processing/john_snow.rst
+++ b/source/docs/training_manual/processing/john_snow.rst
@@ -10,7 +10,7 @@ First analysis example
 
 Now that everything is configured and we can use external algorithms, we have a very powerful tool to perform spatial analysis. It is time to work out a larger exercise with some real--world data. 
 
-We will be using the well-known dataset that John Snow used in 1854, in his groundbreaking work (http://en.wikipedia.org/wiki/John_Snow_%28physician%29), and we will get some interesting results. The analysis of this dataset is pretty obvious and there is no need for sofisticated GIS techniques to end up with good results and conclusions, but it is a good way of showing how these spatial problems can be analyzed and solved by using different processing tools.
+We will be using the well-known dataset that John Snow used in 1854, in his groundbreaking work (https://en.wikipedia.org/wiki/John_Snow_%28physician%29), and we will get some interesting results. The analysis of this dataset is pretty obvious and there is no need for sofisticated GIS techniques to end up with good results and conclusions, but it is a good way of showing how these spatial problems can be analyzed and solved by using different processing tools.
 
 The dataset contains shapefiles with cholera deaths and pump locations, and an OSM rendered map in TIFF format. Open the corresponding QGIS project for this lesson.
 
@@ -64,4 +64,4 @@ Combining with the pumps layer, we see that there is one pump clearly in the hot
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/processing/log.rst
+++ b/source/docs/training_manual/processing/log.rst
@@ -39,4 +39,4 @@ You can also modify the algorithm. Just copy it, open the :menuselection:`Plugin
    source folder.
 
 .. |hard| image:: /static/global/hard.png
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/processing/modeler_hydro.rst
+++ b/source/docs/training_manual/processing/modeler_hydro.rst
@@ -56,4 +56,4 @@ Threshold = 1,0000,000
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/processing/modeler_hydro_calculator.rst
+++ b/source/docs/training_manual/processing/modeler_hydro_calculator.rst
@@ -58,4 +58,4 @@ Our new model is now finished.
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/processing/modeler_hydro_twi.rst
+++ b/source/docs/training_manual/processing/modeler_hydro_twi.rst
@@ -48,4 +48,4 @@ As you see, using a model in another model is nothing special, and you can add i
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/processing/modeler_only.rst
+++ b/source/docs/training_manual/processing/modeler_only.rst
@@ -60,4 +60,4 @@ The final algorithm should look like this:
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/processing/modeler_twi.rst
+++ b/source/docs/training_manual/processing/modeler_twi.rst
@@ -118,4 +118,4 @@ Run it using the DEM as input and you will get the TWI layer in just one single 
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/processing/more_backends.rst
+++ b/source/docs/training_manual/processing/more_backends.rst
@@ -5,7 +5,7 @@
 Other programs
 ===================
 
-Module contributed by Paolo Cavallini - `Faunalia <http://www.faunalia.eu>`_ 
+Module contributed by Paolo Cavallini - `Faunalia <https://www.faunalia.eu>`_
 
 .. note:: This chapter shows how to use additional programs from inside Processing. To complete it, you must have installed, with the tools of your operating system, the relevant packages.
 
@@ -78,12 +78,12 @@ Dissolve features based on a common attribute:
 
 **Exercise for the reader**: find the differences (geometry and attributes) between different methods.
 
-.. _GRASS: http://grass.osgeo.org/
-.. _R: http://www.r-project.org/
-.. _LASTools: http://rapidlasso.com/lastools/
-.. _LecoS: http://conservationecology.wordpress.com/qgis-plugins-and-scripts/lecos-land-cover-statistics/
+.. _GRASS: https://grass.osgeo.org/
+.. _R: https://www.r-project.org/
+.. _LASTools: https://rapidlasso.com/lastools/
+.. _LecoS: https://conservationecology.wordpress.com/qgis-plugins-and-scripts/lecos-land-cover-statistics/
 .. _lwgeom: https://plugins.qgis.org/plugins/processinglwgeomprovider/
-.. _Animove: http://www.faunalia.eu/en/animove.html
+.. _Animove: https://www.faunalia.eu/en/animove.html
 
 
 .. Substitutions definitions - AVOID EDITING PAST THIS LINE
@@ -92,4 +92,4 @@ Dissolve features based on a common attribute:
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/processing/no_data.rst
+++ b/source/docs/training_manual/processing/no_data.rst
@@ -103,4 +103,4 @@ All that can be done in a single operation with the calculator. We leave that as
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/processing/r_intro.rst
+++ b/source/docs/training_manual/processing/r_intro.rst
@@ -9,7 +9,7 @@ Use R scripts in Processing
 ****************************
 
 Module contributed by Matteo Ghetta - funded by `Scuola Superiore Sant'Anna
-<http://www.santannapisa.it/it/istituto/scienze-della-vita/agricultural-water-management>`_
+<https://www.santannapisa.it/it/istituto/scienze-della-vita/agricultural-water-management>`_
 
 Processing allows to write and run R scripts inside QGIS.
 
@@ -229,4 +229,4 @@ Beware that Processing uses some special syntax to get the results out of R:
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/processing/r_syntax-table.rst
+++ b/source/docs/training_manual/processing/r_syntax-table.rst
@@ -8,7 +8,7 @@
 R Syntax Summary table for Processing
 **************************************
 
-Module contributed by Matteo Ghetta - funded by `Scuola Superiore Sant'Anna <http://www.santannapisa.it/it/istituto/scienze-della-vita/agricultural-water-management>`_
+Module contributed by Matteo Ghetta - funded by `Scuola Superiore Sant'Anna <https://www.santannapisa.it/it/istituto/scienze-della-vita/agricultural-water-management>`_
 
 Processing allows a lot of different input and output parameter that can be used
 in the script body.
@@ -105,4 +105,4 @@ look at the :ref:`R Syntax chapter <r-syntax>`.
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/processing/r_syntax.rst
+++ b/source/docs/training_manual/processing/r_syntax.rst
@@ -8,7 +8,7 @@
 R Syntax in Processing scripts
 *******************************
 
-Module contributed by Matteo Ghetta - funded by `Scuola Superiore Sant'Anna <http://www.santannapisa.it/it/istituto/scienze-della-vita/agricultural-water-management>`_
+Module contributed by Matteo Ghetta - funded by `Scuola Superiore Sant'Anna <https://www.santannapisa.it/it/istituto/scienze-della-vita/agricultural-water-management>`_
 
 Writing R scripts in Processing could be quite tricky because of the syntax that
 has to be adopted.
@@ -212,4 +212,4 @@ The plot is automatically added to the *Result Viewer* of Processing.
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/processing/second_alg.rst
+++ b/source/docs/training_manual/processing/second_alg.rst
@@ -81,4 +81,4 @@ Try yourself the *Create grid* algorithm with different grid sizes, and also wit
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/processing/selection.rst
+++ b/source/docs/training_manual/processing/selection.rst
@@ -43,4 +43,4 @@ By now, just remember that selections can be made using processing geoalgorithms
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/processing/set_up.rst
+++ b/source/docs/training_manual/processing/set_up.rst
@@ -55,4 +55,4 @@ which we will do in the next lesson.
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/processing/solar.rst
+++ b/source/docs/training_manual/processing/solar.rst
@@ -5,7 +5,7 @@
 Planning a solar farm
 ======================
 
-Module contributed by Paolo Cavallini - `Faunalia <http://www.faunalia.eu>`_ 
+Module contributed by Paolo Cavallini - `Faunalia <https://www.faunalia.eu>`_
 
 .. note:: This chapter shows how to use several criteria to locate the areas suitable for installing a photovoltaic power station
 
@@ -41,4 +41,4 @@ Finally, we convert to a vector:
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/processing/vector_calculator.rst
+++ b/source/docs/training_manual/processing/vector_calculator.rst
@@ -62,4 +62,4 @@ A python field calculator is available in the *Advanced Python field calculator*
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/processing/warning.rst
+++ b/source/docs/training_manual/processing/warning.rst
@@ -55,7 +55,7 @@ Here is a good reference that you can read to learn more about spatial data anal
 *Geospatial Analysis (3rd Edition)*: A Comprehensive Guide to Principles, Techniques and Software Tools
 Michael John De Smith, Michael F. Goodchild, Paul A. Longley
 
-It is available online `here <http://www.spatialanalysisonline.com/>`_
+It is available online `here <https://www.spatialanalysisonline.com/>`_
 
 
 .. Substitutions definitions - AVOID EDITING PAST THIS LINE
@@ -64,4 +64,4 @@ It is available online `here <http://www.spatialanalysisonline.com/>`_
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/qgis_plugins/fetching_plugins.rst
+++ b/source/docs/training_manual/qgis_plugins/fetching_plugins.rst
@@ -127,4 +127,4 @@ Next we'll introduce you to some useful plugins as examples.
 .. |LS| replace:: Lesson:
 .. |WN| replace:: What's Next?
 .. |basic| image:: /static/global/basic.png
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/qgis_plugins/index.rst
+++ b/source/docs/training_manual/qgis_plugins/index.rst
@@ -23,4 +23,4 @@ you'll be shown how to activate and use plugins.
    source folder.
 
 .. |MOD| replace:: Module:
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/qgis_plugins/plugin_examples.rst
+++ b/source/docs/training_manual/qgis_plugins/plugin_examples.rst
@@ -264,4 +264,4 @@ time.
    :width: 1.5em
 .. |symbology| image:: /static/common/symbology.png
    :width: 2em
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/qgis_server/index.rst
+++ b/source/docs/training_manual/qgis_server/index.rst
@@ -28,4 +28,4 @@ For an introduction to what QGIS Server is (see the :ref:`label_qgisserver` sect
    source folder.
 
 .. |MOD| replace:: Module:
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/qgis_server/install.rst
+++ b/source/docs/training_manual/qgis_server/install.rst
@@ -21,7 +21,7 @@ any Debian based distribution like Ubuntu and its derivatives.
 -------------------------------------------------------------------------------
 
 In this lesson we're going to do only the install from packages as shown
-`here <http://qgis.org/en/site/forusers/alldownloads.html#linux>`_ .
+`here <https://qgis.org/en/site/forusers/alldownloads.html#linux>`_ .
 
 First add the QGIS repository by creating the
 :file:`/etc/apt/sources.list.d/debian-qgis.list` file with the following
@@ -30,8 +30,8 @@ content:
 .. code-block:: sourceslist
 
  # latest stable
- deb http://qgis.org/debian stretch main
- deb-src http://qgis.org/debian stretch main
+ deb https://qgis.org/debian stretch main
+ deb-src https://qgis.org/debian stretch main
 
 After you add the ``gis.org`` repository public key to your apt keyring (follow
 the above link on how to do it) you can run the ``apt-get update`` command
@@ -79,7 +79,7 @@ like:
  Content-Length: 206
  Content-Type: text/xml; charset=utf-8
 
- <ServiceExceptionReport version="1.3.0" xmlns="http://www.opengis.net/ogc">
+ <ServiceExceptionReport version="1.3.0" xmlns="https://www.opengis.net/ogc">
   <ServiceException code="Service configuration error">Service unknown or unsupported</ServiceException>
  </ServiceExceptionReport>
 
@@ -94,7 +94,7 @@ In order to access on the installed QGIS server from an Internet Browser we
 need to use an HTTP server.
 
 In this lesson we're going to use the
-`Apache HTTP server <http://httpd.apache.org>`_, colloquially called Apache.
+`Apache HTTP server <https://httpd.apache.org>`_, colloquially called Apache.
 
 First we need to install Apache by running the following command in a terminal:
 ``apt-get install apache2 libapache2-mod-fcgid``.
@@ -121,7 +121,7 @@ called :file:`qgis.demo.conf`, with this content:
    FcgidInitialEnv PYTHONIOENCODING UTF-8
    FcgidInitialEnv LANG "en_US.UTF-8"
 
-   # QGIS log (different from apache logs) see http://docs.qgis.org/testing/en/docs/user_manual/working_with_ogc/ogc_server_support.html#qgis-server-logging
+   # QGIS log (different from apache logs) see https://docs.qgis.org/testing/en/docs/user_manual/working_with_ogc/ogc_server_support.html#qgis-server-logging
    FcgidInitialEnv QGIS_SERVER_LOG_FILE /var/log/qgis/qgisserver.log
    FcgidInitialEnv QGIS_SERVER_LOG_LEVEL 0
 
@@ -134,7 +134,7 @@ called :file:`qgis.demo.conf`, with this content:
    FcgidInitialEnv QGIS_AUTH_DB_DIR_PATH "/home/qgis/qgisserverdb/"
    FcgidInitialEnv QGIS_AUTH_PASSWORD_FILE "/home/qgis/qgisserverdb/qgis-auth.db"
 
-   # See http://docs.qgis.org/testing/en/docs/user_manual/working_with_vector/supported_data.html#pg-service-file
+   # See https://docs.qgis.org/testing/en/docs/user_manual/working_with_vector/supported_data.html#pg-service-file
    SetEnv PGSERVICEFILE /home/qgis/.pg_service.conf
    FcgidInitialEnv PGPASSFILE "/home/qgis/.pgpass"
 
@@ -234,7 +234,7 @@ In the above configuration file there's a ``FcgidInitialEnv DISPLAY ":99"``
 that tells QGIS Server instances to use display no. 99. If you're running the
 Server in Desktop then there's no need to install xvfb and you should simply
 comment with ``#`` this specific setting in the configuration file.
-More info at http://www.itopen.it/qgis-server-setup-notes/.
+More info at https://www.itopen.it/qgis-server-setup-notes/.
 
 Now that Apache knows that he should answer requests to http://qgis.demo
 we also need to setup the client system so that it knows who ``qgis.demo``
@@ -263,7 +263,7 @@ should output:
 
 .. code-block:: xml
 
-  <ServiceExceptionReport version="1.3.0" xmlns="http://www.opengis.net/ogc">
+  <ServiceExceptionReport version="1.3.0" xmlns="https://www.opengis.net/ogc">
   <ServiceException code="Service configuration error">Service unknown or unsupported</ServiceException>
   </ServiceExceptionReport>
 
@@ -351,4 +351,4 @@ The topic of the next lesson is to learn how to access QGIS Server WMS services.
 .. |LS| replace:: Lesson:
 .. |WN| replace:: What's Next?
 .. |moderate| image:: /static/global/moderate.png
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/qgis_server/wms.rst
+++ b/source/docs/training_manual/qgis_server/wms.rst
@@ -323,4 +323,4 @@ Next, you'll see how to use QGIS as a frontend for the famous GRASS GIS.
 .. |TY| replace:: Try Yourself
 .. |WN| replace:: What's Next?
 .. |moderate| image:: /static/global/moderate.png
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/rasters/changing_symbology.rst
+++ b/source/docs/training_manual/rasters/changing_symbology.rst
@@ -175,4 +175,4 @@ analyze it further.
 .. |WN| replace:: What's Next?
 .. |basic| image:: /static/global/basic.png
 .. |srtmFileName| replace:: :kbd:`srtm_41_19.tif`
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/rasters/data_manipulation.rst
+++ b/source/docs/training_manual/rasters/data_manipulation.rst
@@ -169,4 +169,4 @@ symbolization is useful in the case of rasters as well.
    :width: 1.5em
 .. |basic| image:: /static/global/basic.png
 .. |hard| image:: /static/global/hard.png
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/rasters/index.rst
+++ b/source/docs/training_manual/rasters/index.rst
@@ -27,4 +27,4 @@ directly. In this module, you'll see how it's done in QGIS.
    source folder.
 
 .. |MOD| replace:: Module:
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/rasters/terrain_analysis.rst
+++ b/source/docs/training_manual/rasters/terrain_analysis.rst
@@ -323,4 +323,4 @@ problem? That's the topic for the next lesson, starting in the next module.
 .. |WN| replace:: What's Next?
 .. |basic| image:: /static/global/basic.png
 .. |moderate| image:: /static/global/moderate.png
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/spatial_databases/geometry.rst
+++ b/source/docs/training_manual/spatial_databases/geometry.rst
@@ -228,7 +228,7 @@ Geometry Cleaning
 -------------------------------------------------------------------------------
 
 You can get more information for this topic in `this blog entry
-<http://linfiniti.com/?s=cleangeometry>`_.
+<https://linfiniti.com/?s=cleangeometry>`_.
 
 Differences between tables
 -------------------------------------------------------------------------------
@@ -281,4 +281,4 @@ that would otherwise seem cryptic.
 .. |TY| replace:: Try Yourself
 .. |hard| image:: /static/global/hard.png
 .. |moderate| image:: /static/global/moderate.png
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/spatial_databases/import_export.rst
+++ b/source/docs/training_manual/spatial_databases/import_export.rst
@@ -104,4 +104,4 @@ Next we'll look at how to query the data we've created before.
 .. |IC| replace:: In Conclusion
 .. |LS| replace:: Lesson:
 .. |WN| replace:: What's Next?
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/spatial_databases/index.rst
+++ b/source/docs/training_manual/spatial_databases/index.rst
@@ -14,8 +14,8 @@ into the database and make use of the geographic functions that PostGIS offers.
 
 While working through this section, you may want to keep a copy of the **PostGIS
 cheat sheet**  available
-from `Boston GIS user group <http://www.bostongis.com/postgis_quickguide.bqg>`_.
-Another useful resource is the `online <http://postgis.net/docs/>`_ PostGIS
+from `Boston GIS user group <https://www.bostongis.com/postgis_quickguide.bqg>`_.
+Another useful resource is the `online <https://postgis.net/docs/>`_ PostGIS
 documentation.
 
 There are also some more extensive tutorials on PostGIS and Spatial Databases
@@ -44,4 +44,4 @@ See also `PostGIS online <http://postgisonline.org/>`_.
    source folder.
 
 .. |MOD| replace:: Module:
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/spatial_databases/simple_feature_model.rst
+++ b/source/docs/training_manual/spatial_databases/simple_feature_model.rst
@@ -35,7 +35,7 @@ The model defines geospatial data from Point, Linestring, and Polygon types
 (and aggregations of them to Multi objects).
 
 For further information, have a look at the `OGC Simple Feature for SQL
-<http://www.opengeospatial.org/standards/sfs>`_ standard.
+<https://www.opengeospatial.org/standards/sfs>`_ standard.
 
 Add a geometry field to table
 -------------------------------------------------------------------------------
@@ -215,4 +215,4 @@ Next you'll see how to import data into, and export data from, your database.
 .. |basic| image:: /static/global/basic.png
 .. |hard| image:: /static/global/hard.png
 .. |moderate| image:: /static/global/moderate.png
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/spatial_databases/spatial_functions.rst
+++ b/source/docs/training_manual/spatial_databases/spatial_functions.rst
@@ -51,18 +51,18 @@ Installing under Windows
 Installing on Windows is a little more complicated, but still not hard. Note
 that you need to be online to install the postgis stack.
 
-First Visit `the download page <http://www.postgresql.org/download/>`_.
+First Visit `the download page <https://www.postgresql.org/download/>`_.
 
 Then follow `this guide
-<http://www.bostongis.com/PrinterFriendly.aspx?content_name=postgis_tut01>`_.
+<https://www.bostongis.com/PrinterFriendly.aspx?content_name=postgis_tut01>`_.
 
 More information about installing on Windows can be found on the `PostGIS
-website <http://postgis.net/windows_downloads>`_.
+website <https://postgis.net/windows_downloads>`_.
 
 Installing on Other Platforms
 -------------------------------------------------------------------------------
 
-The `PostGIS website download <http://postgis.net/install/>`_ has information about
+The `PostGIS website download <https://postgis.net/install/>`_ has information about
 installing on other platforms including macOS and on other linux distributions
 
 Configuring Databases to use PostGIS
@@ -80,7 +80,7 @@ previous exercise.
 .. note:: If you are using PostGIS 1.5 and a version of PostgreSQL lower than
    9.1, you will need to follow a different set of steps in order to install
    the postgis extensions for your database. Please consult the
-   `PostGIS Documentation <http://postgis.net/docs/postgis_installation.html#create_new_db>`_
+   `PostGIS Documentation <https://postgis.net/docs/postgis_installation.html#create_new_db>`_
    for instructions on how to do this. There are also some instructions in the
    `previous version <http://manual.linfiniti.com/en/postgis/spatial_functions.html#install-plpgsql>`_
    of this manual.
@@ -251,4 +251,4 @@ Next you'll learn how spatial features are represented in a database.
 .. |IC| replace:: In Conclusion
 .. |LS| replace:: Lesson:
 .. |WN| replace:: What's Next?
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/spatial_databases/spatial_queries.rst
+++ b/source/docs/training_manual/spatial_databases/spatial_queries.rst
@@ -384,4 +384,4 @@ how to create them using PostGIS.
 .. |TY| replace:: Try Yourself
 .. |WN| replace:: What's Next?
 .. |moderate| image:: /static/global/moderate.png
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/vector_analysis/basic_analysis.rst
+++ b/source/docs/training_manual/vector_analysis/basic_analysis.rst
@@ -435,4 +435,4 @@ the road from one point to another.
 .. |basic| image:: /static/global/basic.png
 .. |majorUrbanName| replace:: Swellendam
 .. |moderate| image:: /static/global/moderate.png
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/vector_analysis/index.rst
+++ b/source/docs/training_manual/vector_analysis/index.rst
@@ -44,4 +44,4 @@ locate suitable farm properties for this new residential development.
 
 .. |MOD| replace:: Module:
 .. |majorUrbanName| replace:: Swellendam
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/vector_analysis/network_analysis.rst
+++ b/source/docs/training_manual/vector_analysis/network_analysis.rst
@@ -221,4 +221,4 @@ Next you'll see how to run spatial statistics algorithms on vector datasets.
 .. |moderate| image:: /static/global/moderate.png
 .. |splitFeatures| image:: /static/common/mActionSplitFeatures.png
    :width: 1.5em
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/vector_analysis/reproject_transform.rst
+++ b/source/docs/training_manual/vector_analysis/reproject_transform.rst
@@ -264,10 +264,10 @@ represented accurately.
 -------------------------------------------------------------------------------
 
 Materials for the *Advanced* section of this lesson were taken from `this
-article <http://tinyurl.com/75b92np>`_.
+article <https://anitagraser.com/2012/03/18/beautiful-global-projections-adding-custom-projections-to-qgis/>`_.
 
 Further information on Coordinate Reference Systems is available `here
-<http://linfiniti.com/dla/worksheets/7_CRS.pdf>`_.
+<https://linfiniti.com/dla/worksheets/7_CRS.pdf>`_.
 
 |WN|
 -------------------------------------------------------------------------------
@@ -291,4 +291,4 @@ vector analysis tools.
 .. |hard| image:: /static/global/hard.png
 .. |majorUrbanName| replace:: Swellendam
 .. |moderate| image:: /static/global/moderate.png
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/vector_analysis/spatial_statistics.rst
+++ b/source/docs/training_manual/vector_analysis/spatial_statistics.rst
@@ -145,8 +145,8 @@ N
   The amount of samples/values.
 
 CV
-  The `spatial <http://en.wikipedia.org/wiki/Spatial_covariance>`_ `covariance
-  <http://en.wikipedia.org/wiki/Covariance>`_ of the dataset.
+  The `spatial <https://en.wikipedia.org/wiki/Spatial_covariance>`_ `covariance
+  <https://en.wikipedia.org/wiki/Covariance>`_ of the dataset.
 
 Number of unique values
   The number of values that are unique across this dataset. If there are 90
@@ -414,7 +414,7 @@ Homebrew users can install SAGA with this command:
 
 If you do not use Homebrew, please follow the instructions here:
 
-http://sourceforge.net/apps/trac/saga-gis/wiki/Compiling%20SAGA%20on%20Mac%20OS%20X
+https://sourceforge.net/p/saga-gis/wiki/Compiling%20SAGA%20on%20Mac%20OS%20X/
 
 After installing
 ................................................................................
@@ -493,4 +493,4 @@ rasters? That's what we'll do in the next module!
 .. |localCRS| replace:: ``WGS 84 / UTM 34S``
 .. |moderate| image:: /static/global/moderate.png
 .. |srtmFileName| replace:: :kbd:`srtm_41_19.tif`
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/vector_classification/attribute_data.rst
+++ b/source/docs/training_manual/vector_classification/attribute_data.rst
@@ -58,4 +58,4 @@ this in the next lesson.
 .. |LS| replace:: Lesson:
 .. |WN| replace:: What's Next?
 .. |basic| image:: /static/global/basic.png
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/vector_classification/classification.rst
+++ b/source/docs/training_manual/vector_classification/classification.rst
@@ -329,4 +329,4 @@ of the next lesson!
 .. |moderate| image:: /static/global/moderate.png
 .. |signPlus| image:: /static/common/symbologyAdd.png
    :width: 1.5em
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/vector_classification/index.rst
+++ b/source/docs/training_manual/vector_classification/index.rst
@@ -26,4 +26,4 @@ features.
    source folder.
 
 .. |MOD| replace:: Module:
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/training_manual/vector_classification/label_tool.rst
+++ b/source/docs/training_manual/vector_classification/label_tool.rst
@@ -367,4 +367,4 @@ topic for the next lesson!
    :width: 1.5em
 .. |toggleEditing| image:: /static/common/mActionToggleEditing.png
    :width: 1.5em
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/appendices/appendices.rst
+++ b/source/docs/user_manual/appendices/appendices.rst
@@ -297,7 +297,7 @@ Version 1.3, 3 November 2008
 
 Copyright  2000, 2001, 2002, 2007, 2008  Free Software Foundation, Inc
 
-http://fsf.org/
+https://fsf.org/
 
 
 Everyone is permitted to copy and distribute verbatim copies of this
@@ -701,7 +701,7 @@ The Free Software Foundation may publish new, revised versions
 of the GNU Free Documentation License from time to time.  Such new
 versions will be similar in spirit to the present version, but may
 differ in detail to address new problems or concerns.  See
-http://www.gnu.org/copyleft/.
+https://www.gnu.org/copyleft/.
 
 Each version of the License is given a distinguishing version number.
 If the Document specifies that a particular numbered version of this
@@ -791,4 +791,4 @@ to permit their use in free software.
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/auth_system/auth_considerations.rst
+++ b/source/docs/user_manual/auth_system/auth_considerations.rst
@@ -76,7 +76,7 @@ plugin. Maybe.  I don't really know. I'm not a lawyer.
 The authentication system safely disables itself when ``qca-ossl`` is not found
 at run-time.
 
-.. _licensing and exporting: http://www.opensslfoundation.com/export/README.blurb
+.. _licensing and exporting: https://www.openssl.org/docs/faq.html
 
 
 .. Substitutions definitions - AVOID EDITING PAST THIS LINE
@@ -85,4 +85,4 @@ at run-time.
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/auth_system/auth_overview.rst
+++ b/source/docs/user_manual/auth_system/auth_overview.rst
@@ -299,4 +299,4 @@ See :ref:`authentication_security_considerations` concerning Python access.
    :width: 1.5em
 .. |symbologyEdit| image:: /static/common/symbologyEdit.png
    :width: 1.5em
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/auth_system/auth_workflows.rst
+++ b/source/docs/user_manual/auth_system/auth_workflows.rst
@@ -422,4 +422,4 @@ save the configuration to the database.
    :width: 1.5em
 .. |transformSettings| image:: /static/common/mActionTransformSettings.png
    :width: 1.5em
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/auth_system/index.rst
+++ b/source/docs/user_manual/auth_system/index.rst
@@ -22,4 +22,4 @@ Authentication System
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/grass_integration/grass_integration.rst
+++ b/source/docs/user_manual/grass_integration/grass_integration.rst
@@ -35,10 +35,10 @@ As an example, we will use the QGIS Alaska dataset (see section :ref:`label_samp
 It includes a small sample GRASS :file:`LOCATION` with three vector layers and one
 raster elevation map. Create a new folder called :file:`grassdata`, download
 the QGIS 'Alaska' dataset :file:`qgis\_sample\_data.zip` from
-http://qgis.org/downloads/data/ and unzip the file into :file:`grassdata`.
+https://qgis.org/downloads/data/ and unzip the file into :file:`grassdata`.
 
 More sample GRASS :file:`LOCATIONs` are available at the GRASS website at
-http://grass.osgeo.org/download/sample-data/.
+https://grass.osgeo.org/download/sample-data/.
 
 .. _sec_load_grassdata:
 
@@ -352,7 +352,7 @@ used as the link to one key column in the database table.
 
    The best way to learn the GRASS vector model and its capabilities is to
    download one of the many GRASS tutorials where the vector model is described
-   more deeply. See http://grass.osgeo.org/documentation/manuals/ for more information,
+   more deeply. See https://grass.osgeo.org/documentation/manuals/ for more information,
    books and tutorials in several languages.
 
 .. index::
@@ -599,7 +599,7 @@ working environment, about 200 of the available GRASS modules and functionalitie
 are also provided by graphical dialogs within the GRASS plugin Toolbox.
 
 A complete list of GRASS modules available in the graphical Toolbox in QGIS
-version |CURRENT| is available in the GRASS wiki at http://grass.osgeo.org/wiki/GRASS-QGIS_relevant_module_list.
+version |CURRENT| is available in the GRASS wiki at https://grass.osgeo.org/wiki/GRASS-QGIS_relevant_module_list.
 
 It is also possible to customize the GRASS Toolbox content. This procedure is
 described in section :ref:`sec_toolbox-customizing`.
@@ -939,4 +939,4 @@ https://qgis.org/en/site/getinvolved/development/addinggrasstools.html.
    :width: 2.5em
 .. |showPluginManager| image:: /static/common/mActionShowPluginManager.png
    :width: 1.5em
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/index.rst
+++ b/source/docs/user_manual/index.rst
@@ -45,4 +45,4 @@ QGIS User Guide
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/introduction/general_tools.rst
+++ b/source/docs/user_manual/introduction/general_tools.rst
@@ -1144,7 +1144,7 @@ The :guilabel:`Info` section in the dialog explains how calculations are made
 according to CRS settings available.
 
 .. %FixMe: currently, validating the Settings --> Options dialog revert any change
-   made on units in the measurement dialog (see http://hub.qgis.org/issues/15436
+   made on units in the measurement dialog (see https://issues.qgis.org/issues/15436
    bug or not? should it be documented?)
 
 .. _figure_measure_length:
@@ -1716,9 +1716,9 @@ variables overwritten by lower level ones are strike through.
 
 .. note:: You can read more about variables and find some examples
    in Nyall Dawson's `Exploring variables in QGIS 2.12, part 1
-   <http://nyalldawson.net/2015/12/exploring-variables-in-qgis-2-12-part-1/>`_,
-   `part 2 <http://nyalldawson.net/2015/12/exploring-variables-in-qgis-pt-2-project-management/>`_
-   and `part 3 <http://nyalldawson
+   <https://nyalldawson.net/2015/12/exploring-variables-in-qgis-2-12-part-1/>`_,
+   `part 2 <https://nyalldawson.net/2015/12/exploring-variables-in-qgis-pt-2-project-management/>`_
+   and `part 3 <https://nyalldawson
    .net/2015/12/exploring-variables-in-qgis-pt-3-layer-level-variables/>`_
    blog posts.
 
@@ -2211,7 +2211,7 @@ The values presented in the varying size assistant above will set the size
    :width: 1.5em
 .. |unchecked| image:: /static/common/checkbox_unchecked.png
    :width: 1.3em
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
 .. |zoomActual| image:: /static/common/mActionZoomActual.png
    :width: 1.5em
 .. |zoomIn| image:: /static/common/mActionZoomIn.png

--- a/source/docs/user_manual/introduction/getting_started.rst
+++ b/source/docs/user_manual/introduction/getting_started.rst
@@ -16,7 +16,7 @@ Getting Started
    .. contents::
       :local:
 
-This chapter provides a quick overview of installing QGIS, downloading QGIS sample data, 
+This chapter provides a quick overview of installing QGIS, downloading QGIS sample data, +
 and running a first simple session visualizing raster and vector data.
 
 .. index:: Installation
@@ -30,7 +30,7 @@ for MS Windows |win| and MacOS |osx|. Binary packages (rpm and deb) or
 software repositories are provided for many flavors of GNU/Linux |nix|.
 
 For more information and instructions for your operating system check 
-http://download.qgis.org.
+https://download.qgis.org.
 
 Installing from source
 ----------------------
@@ -38,7 +38,7 @@ Installing from source
 If you need to build QGIS from source, please refer to the installation
 instructions. They are distributed with the QGIS source code in a file
 called :file:`INSTALL`. You can also find them online at
-http://htmlpreview.github.io/?https://raw.github.com/qgis/QGIS/master/doc/INSTALL.html.
+https://htmlpreview.github.io/?https://raw.github.com/qgis/QGIS/master/doc/INSTALL.html.
 
 If you want to build a particular release, you should replace ``master`` by the
 release branch (commonly in the ``release-X_Y`` form) in the above-mentioned
@@ -71,14 +71,14 @@ you may do one of the following:
 
 * Use GIS data that you already have
 * Download sample data from
-  http://qgis.org/downloads/data/qgis_sample_data.zip
+  https://qgis.org/downloads/data/qgis_sample_data.zip
 * Uninstall QGIS and reinstall with the data download option checked (only recommended if
   the above solutions are unsuccessful)
 
 |nix| |osx| For GNU/Linux and macOS, there are no dataset installation
 packages available as rpm, deb or dmg. To use the sample dataset, download the
 file :file:`qgis_sample_data` as a ZIP archive from
-http://qgis.org/downloads/data/ and unzip the archive
+https://qgis.org/downloads/data/ and unzip the archive
 on your system.
 
 The Alaska dataset includes all GIS data that are used for the examples and
@@ -111,7 +111,7 @@ units feet. The EPSG code is 2964.
 
 If you intend to use QGIS as a graphical front end for GRASS, you can find a
 selection of sample locations (e.g., Spearfish or South Dakota) at the
-official GRASS GIS website, http://grass.osgeo.org/download/sample-data/.
+official GRASS GIS website, https://grass.osgeo.org/download/sample-data/.
 
 .. index:: Start QGIS, Stop QGIS
 
@@ -515,6 +515,6 @@ Other ways to produce output files are:
    :width: 1em
 .. |saveMapAsImage| image:: /static/common/mActionSaveMapAsImage.png
    :width: 1.5em
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
 .. |win| image:: /static/common/win.png
    :width: 1em

--- a/source/docs/user_manual/introduction/qgis_configuration.rst
+++ b/source/docs/user_manual/introduction/qgis_configuration.rst
@@ -659,7 +659,7 @@ Figure_Network_Tab_).
 
 If you need more detailed information about the different proxy settings,
 please refer to the manual of the underlying QT library documentation at
-http://doc.qt.io/qt-5.9/qnetworkproxy.html#ProxyType-enum
+https://doc.qt.io/qt-5.9/qnetworkproxy.html#ProxyType-enum
 
 .. tip:: **Using Proxies**
 
@@ -1116,6 +1116,6 @@ and :guilabel:`Load` them into another QGIS installation.
    :width: 2em
 .. |unchecked| image:: /static/common/checkbox_unchecked.png
    :width: 1.3em
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
 .. |win| image:: /static/common/win.png
    :width: 1em

--- a/source/docs/user_manual/introduction/qgis_gui.rst
+++ b/source/docs/user_manual/introduction/qgis_gui.rst
@@ -905,7 +905,7 @@ open the Plugin Manager dialog.
    :width: 1.5em
 .. |undo| image:: /static/common/mActionUndo.png
    :width: 1.5em
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
 .. |vertexTool| image:: /static/common/mActionVertexTool.png
    :width: 1.5em
 .. |vertexToolActiveLayer| image:: /static/common/mActionVertexToolActiveLayer.png

--- a/source/docs/user_manual/literature_web/literature_and_web_references.rst
+++ b/source/docs/user_manual/literature_web/literature_and_web_references.rst
@@ -8,19 +8,19 @@
 Literature and Web References
 *******************************
 
-GDAL-SOFTWARE-SUITE. Geospatial data abstraction library. http://www.gdal.org, 2013.
+GDAL-SOFTWARE-SUITE. Geospatial data abstraction library. https://www.gdal.org, 2013.
 
-GRASS-PROJECT. Geographic resource analysis support system. http://grass.osgeo.org , 2013.
+GRASS-PROJECT. Geographic resource analysis support system. https://grass.osgeo.org, 2013.
 
 NETELER, M., AND MITASOVA, H. Open source gis: A grass gis approach, 2008.
 
-OGR-SOFTWARE-SUITE. Geospatial data abstraction library. http://www.gdal.org/ogr , 2013.
+OGR-SOFTWARE-SUITE. Geospatial data abstraction library. https://www.gdal.org/ogr, 2013.
 
-OPEN-GEOSPATIAL-CONSORTIUM. Web map service (1.1.1) implementation specification. http://portal.opengeospatial.org, 2002.
+OPEN-GEOSPATIAL-CONSORTIUM. Web map service (1.1.1) implementation specification. https://portal.opengeospatial.org, 2002.
 
-OPEN-GEOSPATIAL-CONSORTIUM. Web map service (1.3.0) implementation specification. http://portal.opengeospatial.org, 2004.
+OPEN-GEOSPATIAL-CONSORTIUM. Web map service (1.3.0) implementation specification. https://portal.opengeospatial.org, 2004.
 
-POSTGIS-PROJECT. Spatial support for postgresql. http://postgis.refractions.net/ , 2013.
+POSTGIS-PROJECT. Spatial support for postgresql. http://postgis.refractions.net/, 2013.
 
 
 .. Substitutions definitions - AVOID EDITING PAST THIS LINE
@@ -29,4 +29,4 @@ POSTGIS-PROJECT. Spatial support for postgresql. http://postgis.refractions.net/
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/managing_data_source/create_layers.rst
+++ b/source/docs/user_manual/managing_data_source/create_layers.rst
@@ -252,7 +252,7 @@ Raster specific parameters
 * :guilabel:`Resolution`
 * :guilabel:`Create Options`: advanced options (file compression, block sizes,
   colorimetry...) to fine tune the output file. See the `gdal-ogr
-  <http://gdal.org>`_ driver documentation.
+  <https://www.gdal.org>`_ driver documentation.
 * :guilabel:`Pyramids` creation
 * :guilabel:`VRT Tiles` in case you opted to |checkbox| :guilabel:`Create VRT`
 * :guilabel:`No data values`
@@ -297,7 +297,7 @@ Depending on the format of export, some of these options are available or not:
      the data as a hidden attribute. Only some formats can handle this kind of
      information. KML, DXF and TAB file formats are such formats. For advanced
      users, you can read the `OGR Feature Styles specification
-     <http://www.gdal.org/ogr_feature_style.html>`_ document.
+     <https://www.gdal.org/ogr_feature_style.html>`_ document.
 
 * :guilabel:`Geometry`: you can configure the geometry capabilities of the
   output layer
@@ -319,7 +319,7 @@ Depending on the format of export, some of these options are available or not:
 
 * :guilabel:`Datasources Options`, :guilabel:`Layer Options` or
   :guilabel:`Custom Options` which allow you to configure some advanced
-  parameters. See the `gdal-ogr <http://gdal.org>`_ driver documentation.
+  parameters. See the `gdal-ogr <https://www.gdal.org>`_ driver documentation.
 
 .. _figure_save_vector:
 
@@ -624,6 +624,6 @@ used in conjunction with this spatial index syntax.
    :width: 1.5em
 .. |unchecked| image:: /static/common/checkbox_unchecked.png
    :width: 1.3em
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
 .. |virtualLayer| image:: /static/common/mActionAddVirtualLayer.png
    :width: 1.5em

--- a/source/docs/user_manual/managing_data_source/index.rst
+++ b/source/docs/user_manual/managing_data_source/index.rst
@@ -22,4 +22,4 @@
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/managing_data_source/opening_data.rst
+++ b/source/docs/user_manual/managing_data_source/opening_data.rst
@@ -25,12 +25,12 @@ and often write a lot of formats:
   MapInfo and MicroStation file formats, AutoCAD DWG/DXF, GeoPackage, GeoJSON,
   GRASS, GPX, KML, Comma Separated Values, and many more...
   Read the complete list of `OGR vector supported formats
-  <http://www.gdal.org/ogr_formats.html>`_.
+  <https://www.gdal.org/ogr_formats.html>`_.
 * Raster data formats include ArcInfo Binary Grid, ArcInfo ASCII Grid, JPEG,
   GeoTIFF, ERDAS IMAGINE, MBTiles, R or Idrisi rasters, ASCII Gridded XYZ,
   GDAL Virtual, SRTM, Sentinel Data, and many more...
   Read the complete list of `raster supported formats
-  <http://www.gdal.org/formats_list.html>`_.
+  <https://www.gdal.org/formats_list.html>`_.
 * Database formats include PostgreSQL/PostGIS, SQLite/SpatiaLite, Oracle, DB2
   or MSSQL Spatial, MySQL...
 * Support of web data services (WM(T)S, WFS, WCS, CSW, ArcGIS Servers...) is
@@ -39,7 +39,7 @@ and often write a lot of formats:
   formats such as virtual and memory layers.
 
 As of the date of this document, more than 80 vector and 140 raster formats are
-supported by the `GDAL/OGR <http://www.gdal.org/>`_ and QGIS native providers.
+supported by the `GDAL/OGR <https://www.gdal.org/>`_ and QGIS native providers.
 
 .. note::
 
@@ -969,4 +969,4 @@ Description of these capabilities and how-to are provided in chapter
    :width: 2.5em
 .. |setProjection| image:: /static/common/mActionSetProjection.png
    :width: 1.5em
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/managing_data_source/supported_data.rst
+++ b/source/docs/user_manual/managing_data_source/supported_data.rst
@@ -72,7 +72,7 @@ ESRI Shapefile
 ESRI Shapefile is still one of the most used vector file format in QGIS.
 However, this file format has some limitation that some other file format have
 not (like GeoPackage, SpatiaLite). Support is provided by the
-`OGR Simple Feature Library <http://www.gdal.org/ogr/>`_.
+`OGR Simple Feature Library <https://www.gdal.org/ogr/>`_.
 
 A shapefile actually consists of several files. The following three are
 required:
@@ -86,7 +86,7 @@ suffix, which contains
 the projection information. While it is very useful to have a projection file,
 it is not mandatory. A shapefile dataset can contain additional files. For
 further details, see the ESRI technical specification at
-http://www.esri.com/library/whitepapers/pdfs/shapefile.pdf.
+https://www.esri.com/library/whitepapers/pdfs/shapefile.pdf.
 
 **Improving Performance for Shapefiles**
 
@@ -227,7 +227,7 @@ You can even specify width and precision of each column, e.g.::
 This file is saved in the same folder as the :file:`.csv` file, with the same
 name, but :file:`.csvt` as the extension.
 
-*You can find more information at* `GDAL CSV Driver <http://www.gdal.org/drv_csv.html>`_.
+*You can find more information at* `GDAL CSV Driver <https://www.gdal.org/drv_csv.html>`_.
 
 
 .. index:: PostGIS, PostgreSQL
@@ -414,7 +414,7 @@ over a network. You can improve the drawing performance of PostgreSQL layers by
 ensuring that a PostGIS spatial index exists on each layer in the
 database. PostGIS supports creation of a GiST (Generalized Search Tree)
 index to speed up spatial searches of the data (GiST index information is taken
-from the PostGIS documentation available at http://postgis.net).
+from the PostGIS documentation available at https://postgis.net).
 
 .. tip:: You can use the DBManager to create an index to your layer. You should
    first select the layer and click on :menuselection:`Table --> Edit table`, go
@@ -459,7 +459,7 @@ Vector layers crossing 180 |degrees| longitude
 
 Many GIS packages don't wrap vector maps with a geographic reference system
 (lat/lon) crossing the 180 degrees longitude line
-(http://postgis.refractions.net/documentation/manual-2.0/ST\_Shift\_Longitude.html).
+(http://postgis.refractions.net/documentation/manual-2.0/ST_Shift_Longitude.html).
 As result, if we open such a map in QGIS, we will see two far, distinct locations,
 that should appear near each other. In Figure_vector_crossing_, the tiny point on the far
 left of the map canvas (Chatham Islands) should be within the grid, to the right of the
@@ -510,7 +510,7 @@ right clicking the layer in the legend. Then, click on :menuselection:`Save as..
 define the name of the output file, and select 'SpatiaLite' as format and the CRS.
 Also, you can select 'SQLite' as format and then add ``SPATIALITE=YES`` in the
 OGR data source creation option field. This tells OGR to create a SpatiaLite
-database. See also http://www.gdal.org/ogr/drv_sqlite.html.
+database. See also https://www.gdal.org/ogr/drv_sqlite.html.
 
 QGIS also supports editable views in SpatiaLite.
 
@@ -541,7 +541,7 @@ The DB2 provider for QGIS supports the full range of visualization, analysis
 and manipulation of spatial data in these databases.
 
 .. _DB2 z/OS KnowledgeCenter: https://www.ibm.com/support/knowledgecenter/en/SSEPEK_11.0.0/spatl/src/tpc/spatl_db2sb03.html
-.. _DB2 LUW KnowledgeCenter: http://www.ibm.com/support/knowledgecenter/SSEPGG_11.1.0/com.ibm.db2.luw.spatial.topics.doc/doc/db2sb03.html
+.. _DB2 LUW KnowledgeCenter: https://www.ibm.com/support/knowledgecenter/SSEPGG_11.1.0/com.ibm.db2.luw.spatial.topics.doc/doc/db2sb03.html
 .. _DB2 DashDB KnowledgeCenter: https://www.ibm.com/support/knowledgecenter/SS6NHC/com.ibm.db2.luw.spatial.topics.doc/doc/csbp1001.html
 .. _DB2 Spatial Tutorial: https://www.ibm.com/developerworks/data/tutorials/dm-1202db2spatialdata1/
 
@@ -597,4 +597,4 @@ the name **db2.bat** and including it in the directory **%OSGEO4W_ROOT%/etc/ini*
    :width: 1em
 .. |setProjection| image:: /static/common/mActionSetProjection.png
    :width: 1.5em
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/plugins/core_plugins.rst
+++ b/source/docs/user_manual/plugins/core_plugins.rst
@@ -66,4 +66,4 @@ Icon                    Plugin                        Description               
    :width: 1.5em
 .. |topologyChecker| image:: /static/common/mActionTopologyChecker.png
    :width: 1.5em
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/plugins/index.rst
+++ b/source/docs/user_manual/plugins/index.rst
@@ -30,4 +30,4 @@ Plugins
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/plugins/plugins.rst
+++ b/source/docs/user_manual/plugins/plugins.rst
@@ -31,7 +31,7 @@ and are automatically part of every QGIS distribution. They are written in one
 of two languages: **C++** or **Python**.
 
 Most of External Plugins are currently written in Python. They are stored either
-in the 'Official' QGIS Repository at http://plugins.qgis.org/plugins/ or in
+in the 'Official' QGIS Repository at https://plugins.qgis.org/plugins/ or in
 external repositories and are maintained by the individual authors. Detailed
 documentation about the usage, minimum QGIS version, home page, authors,and
 other important information are provided for the plugins in the Official
@@ -258,6 +258,6 @@ directly from their repository.
    :width: 1.5em
 .. |transformSettings| image:: /static/common/mActionTransformSettings.png
    :width: 1.5em
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
 .. |win| image:: /static/common/win.png
    :width: 1em

--- a/source/docs/user_manual/plugins/plugins_coordinate_capture.rst
+++ b/source/docs/user_manual/plugins/plugins_coordinate_capture.rst
@@ -55,4 +55,4 @@ coordinates on the map canvas for two selected coordinate reference systems (CRS
 .. |geographic| image:: /static/common/geographic.png
 .. |tracking| image:: /static/common/tracking.png
    :width: 1.5em
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/plugins/plugins_db_manager.rst
+++ b/source/docs/user_manual/plugins/plugins_db_manager.rst
@@ -86,4 +86,4 @@ and only that portion will be executed when you press :kbd:`F5` or click the
 
 .. |dbManager| image:: /static/common/dbmanager.png
    :width: 1.5em
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/plugins/plugins_evis.rst
+++ b/source/docs/user_manual/plugins/plugins_evis.rst
@@ -16,7 +16,7 @@ eVis Plugin
 (This section is derived
 from Horning, N., K. Koy, P. Ersts. 2009. eVis (v1.1.0) User's Guide. American
 Museum of Natural History, Center for Biodiversity and Conservation. Available
-from http://biodiversityinformatics.amnh.org/, and released under the GNU FDL.)
+from https://biodiversityinformatics.amnh.org/, and released under the GNU FDL.)
 
 The Biodiversity Informatics Facility at the American Museum of Natural History's
 (AMNH) Center for Biodiversity and Conservation (CBC)
@@ -185,9 +185,9 @@ of the different approaches are listed in Table `evis_examples`_.
   X        Y        FILE                                                BEARING
   780596   1784017  C:\Workshop\eVis_Data\groundphotos\DSC_0168.JPG     275
   780596   1784017  /groundphotos/DSC_0169.JPG                          80
-  780819   1784015  http://biodiversityinformatics.amnh.org/\
+  780819   1784015  https://biodiversityinformatics.amnh.org/\
                     evis_testdata/DSC_0170.JPG                          10
-  780596   1784017  pdf:http://www.testsite.com/attachments.php?\
+  780596   1784017  pdf:https://www.testsite.com/attachments.php?\
                     attachment_id-12                                    76
 
 
@@ -359,7 +359,7 @@ SQL queries are used to extract information from a database or ODBC resource.
 In eVis, the output from these queries is a vector layer added to the QGIS map
 window. Click on the :guilabel:`SQL Query` tab to display the SQL query
 interface. SQL commands can be entered in this text window. A helpful tutorial
-on SQL commands is available at http://www.w3schools.com/sql. For example, to
+on SQL commands is available at https://www.w3schools.com/sql. For example, to
 extract all of the data from a worksheet in an Excel file, ``select * from [sheet1$]``
 where ``sheet1`` is the name of the worksheet.
 
@@ -561,4 +561,4 @@ A complete sample XML file with three queries is displayed below:
 .. |radioButtonOn| image:: /static/common/radiobuttonon.png
 .. |selectString| image:: /static/common/selectstring.png
    :width: 2.5em
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/plugins/plugins_geometry_checker.rst
+++ b/source/docs/user_manual/plugins/plugins_geometry_checker.rst
@@ -155,4 +155,4 @@ by attribute value`.
    :width: 2.5em
 .. |success| image:: /static/common/mIconSuccess.png
    :width: 1em
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/plugins/plugins_georeferencer.rst
+++ b/source/docs/user_manual/plugins/plugins_georeferencer.rst
@@ -82,7 +82,7 @@ Plugin dialog appears as shown in figure_georeferencer_dialog_.
 For this example, we are using a topo sheet of South Dakota from SDGS. It can
 later be visualized together with the data from the GRASS :file:`spearfish60`
 location. You can download the topo sheet here:
-http://grass.osgeo.org/sampledata/spearfish_toposheet.tar.gz.
+https://grass.osgeo.org/sampledata/spearfish_toposheet.tar.gz.
 
 .. _figure_georeferencer_dialog:
 
@@ -290,7 +290,7 @@ the new georeferenced raster.
    :width: 1.5em
 .. |transformSettings| image:: /static/common/mActionTransformSettings.png
    :width: 1.5em
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
 .. |zoomIn| image:: /static/common/mActionZoomIn.png
    :width: 1.5em
 .. |zoomLast| image:: /static/common/mActionZoomLast.png

--- a/source/docs/user_manual/plugins/plugins_metasearch.rst
+++ b/source/docs/user_manual/plugins/plugins_metasearch.rst
@@ -38,7 +38,7 @@ MetaSearch is included by default with QGIS 2.0 and higher. All dependencies
 are included within MetaSearch.
 
 Install MetaSearch from the QGIS plugin manager, or manually from
-http://plugins.qgis.org/plugins/MetaSearch.
+https://plugins.qgis.org/plugins/MetaSearch.
 
 Working with Metadata Catalogs in QGIS
 --------------------------------------
@@ -99,7 +99,7 @@ example of the XML file format.
   <?xml version="1.0" encoding="UTF-8"?>
   <qgsCSWConnections version="1.0">
       <csw name="Data.gov CSW" url="https://catalog.data.gov/csw-all"/>
-      <csw name="Geonorge - National CSW service for Norway" url="http://www.geonorge.no/geonetwork/srv/eng/csw"/>
+      <csw name="Geonorge - National CSW service for Norway" url="https://www.geonorge.no/geonetwork/srv/eng/csw"/>
       <csw name="Geoportale Nazionale - Servizio di ricerca Italiano" url="http://www.pcn.minambiente.it/geoportal/csw"/>
       <csw name="LINZ Data Service" url="http://data.linz.govt.nz/feeds/csw"/>
       <csw name="Nationaal Georegister (Nederland)" url="http://www.nationaalgeoregister.nl/geonetwork/srv/eng/csw"/>
@@ -188,8 +188,8 @@ You can fine tune MetaSearch with the following :guilabel:`settings`:
 * :guilabel:`Timeout`: when searching metadata catalogs, the number of
   seconds for blocking connection attempt. Default value is 10.
 
-.. _`CSW (Catalog Service for the Web)`: http://www.opengeospatial.org/standards/cat
-.. _`OGC (Open Geospatial Consortium)`: http://www.opengeospatial.org
+.. _`CSW (Catalog Service for the Web)`: https://www.opengeospatial.org/standards/cat
+.. _`OGC (Open Geospatial Consortium)`: https://www.opengeospatial.org
 
 
 .. Substitutions definitions - AVOID EDITING PAST THIS LINE
@@ -200,4 +200,4 @@ You can fine tune MetaSearch with the following :guilabel:`settings`:
 
 .. |metasearch| image:: /static/common/MetaSearch.png
    :width: 1.5em
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/plugins/plugins_offline_editing.rst
+++ b/source/docs/user_manual/plugins/plugins_offline_editing.rst
@@ -54,4 +54,4 @@ Using the plugin
    :width: 1.5em
 .. |offlineEditingSync| image:: /static/common/offline_editing_sync.png
    :width: 1.5em
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/plugins/plugins_topology_checker.rst
+++ b/source/docs/user_manual/plugins/plugins_topology_checker.rst
@@ -96,4 +96,4 @@ On **polygon layers**, the following rules are available:
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/plugins/python_console.rst
+++ b/source/docs/user_manual/plugins/python_console.rst
@@ -198,4 +198,4 @@ the Python console behavior:
    :width: 1em
 .. |start| image:: /static/common/mActionStart.png
    :width: 1.5em
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/preamble/contributors.rst
+++ b/source/docs/user_manual/preamble/contributors.rst
@@ -16,7 +16,7 @@
 QGIS is an open source project developed by a team of dedicated volunteers and
 organisations. We strive to be a welcoming community for people of all race, creed,
 gender and walks of life.
-At any moment, you can `get involved <http://qgis.org/en/site/getinvolved/index.html>`_.
+At any moment, you can `get involved <https://qgis.org/en/site/getinvolved/index.html>`_.
 
 .. index::
    single: Contributors; Authors
@@ -89,7 +89,7 @@ QGIS is a multi-language application and as is, also publishes a documentation
 translated into several languages. Many other languages are being translated
 and would be released as soon as they reach a reasonable percentage of
 translation. If you wish to help improving a language or request a new one,
-please see http://qgis.org/en/site/getinvolved/index.html.
+please see https://qgis.org/en/site/getinvolved/index.html.
 
 The current translations are made possible thanks to:
 
@@ -149,4 +149,4 @@ Ukrainian             Alexander Bruy
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/preamble/conventions.rst
+++ b/source/docs/user_manual/preamble/conventions.rst
@@ -54,7 +54,7 @@ any text or coding within QGIS.
 
 .. Use for all urls. Otherwise, it is not clickable in the document.
 
-* Hyperlinks: http://qgis.org
+* Hyperlinks: https://qgis.org
 * Keystroke Combinations: Press :kbd:`Ctrl+B`, meaning press and hold the Ctrl
   key and then press the B key.
 * Name of a File: :file:`lakes.shp`
@@ -127,6 +127,6 @@ platform-specific icon at the end of the figure caption.
 .. |selectString| image:: /static/common/selectstring.png
    :width: 2.5em
 .. |slider| image:: /static/common/slider.png
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
 .. |win| image:: /static/common/win.png
    :width: 1em

--- a/source/docs/user_manual/preamble/features.rst
+++ b/source/docs/user_manual/preamble/features.rst
@@ -197,8 +197,8 @@ need to log in again before any changes take effect.
 
 More info:
 
-http://www.cyberciti.biz/faq/linux-increase-the-maximum-number-of-open-files/
-http://linuxaria.com/article/open-files-in-linux?lang=en
+https://www.cyberciti.biz/faq/linux-increase-the-maximum-number-of-open-files/
+https://linuxaria.com/article/open-files-in-linux
 
 
 .. Substitutions definitions - AVOID EDITING PAST THIS LINE
@@ -207,4 +207,4 @@ http://linuxaria.com/article/open-files-in-linux?lang=en
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/preamble/foreword.rst
+++ b/source/docs/user_manual/preamble/foreword.rst
@@ -40,7 +40,7 @@ also can find it in Appendix :ref:`gpl_appendix`.
 
         The latest version of this document can always be found in the
         documentation area of the QGIS website at
-        http://www.qgis.org/en/docs/.
+        https://www.qgis.org/en/docs/.
 
 
 .. Substitutions definitions - AVOID EDITING PAST THIS LINE
@@ -49,4 +49,4 @@ also can find it in Appendix :ref:`gpl_appendix`.
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/preamble/help_and_support.rst
+++ b/source/docs/user_manual/preamble/help_and_support.rst
@@ -27,7 +27,7 @@ QGIS Users
 This mailing list is used for discussion of QGIS in general, as well
 as specific questions regarding its installation and use. You can
 subscribe to the qgis-users mailing list by visiting the following
-URL: http://lists.osgeo.org/mailman/listinfo/qgis-user
+URL: https://lists.osgeo.org/mailman/listinfo/qgis-user
 
 QGIS Developers
 ---------------
@@ -36,7 +36,7 @@ If you are a developer facing problems of a more technical nature, you
 may want to join the qgis-developer mailing list. This list is also a
 place where people can chime in and collect and discuss QGIS
 related UX (User Experience) / usability issues. It's here:
-http://lists.osgeo.org/mailman/listinfo/qgis-developer
+https://lists.osgeo.org/mailman/listinfo/qgis-developer
 
 QGIS Community Team
 -------------------
@@ -46,7 +46,7 @@ guide, web sites, blog, mailing lists, forums, and translation
 efforts. If you would like to work on the user guide as well, this
 list is a good starting point to ask your questions. You can subscribe
 to this list at:
-http://lists.osgeo.org/mailman/listinfo/qgis-community-team
+https://lists.osgeo.org/mailman/listinfo/qgis-community-team
 
 QGIS Translations
 -----------------
@@ -55,14 +55,14 @@ This list deals with the translation efforts. If you like to work on
 the translation of the website, manuals or the graphical user interface (GUI),
 this list is a good starting point to ask your questions. You can
 subscribe to this list at:
-http://lists.osgeo.org/mailman/listinfo/qgis-tr
+https://lists.osgeo.org/mailman/listinfo/qgis-tr
 
 QGIS Project Steering Committee (PSC)
 -------------------------------------
 
 This list is used to discuss Steering Committee issues related to
 overall management and direction of QGIS. You can subscribe to this
-list at: http://lists.osgeo.org/mailman/listinfo/qgis-psc
+list at: https://lists.osgeo.org/mailman/listinfo/qgis-psc
 
 QGIS User groups
 ----------------
@@ -71,7 +71,7 @@ In order to locally promote QGIS and contribute to its development, some QGIS
 communities are organized into QGIS User Groups. These groups are places to
 discuss local topics, organize regional or national user meetings, organize
 sponsoring of features... The list of current user groups is available at
-http://qgis.org/en/site/forusers/usergroups.html
+https://qgis.org/en/site/forusers/usergroups.html
 
 
 You are welcome to subscribe to any of the lists. Please remember to
@@ -86,11 +86,11 @@ channel on irc.freenode.net. Please wait for a response to your
 question, as many folks on the channel are doing other things and it
 may take a while for them to notice your question. If you missed a
 discussion on IRC, not a problem! We log all discussion, so you can
-easily catch up. Just go to http://qgis.org/irclogs and read the
+easily catch up. Just go to https://qgis.org/irclogs and read the
 IRC-logs.
 
 Commercial support for QGIS is also available. Check the website
-http://qgis.org/en/commercial-support.html for more information.
+https://qgis.org/en/commercial-support.html for more information.
 
 BugTracker
 ==========
@@ -98,7 +98,7 @@ BugTracker
 While the qgis-users mailing list is useful for general 'How do I do
 XYZ in QGIS?'-type questions, you may wish to notify us about bugs in
 QGIS. You can submit bug reports using the QGIS bug tracker at
-http://hub.qgis.org/projects/quantum-gis/issues. When creating a new
+https://issues.qgis.org/projects/qgis/issues. When creating a new
 ticket for a bug, please provide an email address where we can contact
 you for additional information.
 
@@ -113,7 +113,7 @@ as for bugs. Please make sure to select the type ``Feature``.
 If you have found a bug and fixed it yourself, you can submit either a
 Pull Request on the Github QGIS Project (prefered) or a patch also.
 The lovely redmine ticketsystem at
-http://hub.qgis.org/projects/quantum-gis/issues has this type as well.
+https://issues.qgis.org/projects/qgis/issues has this type as well.
 Check the ``Patch supplied`` checkbox and attach your patch before
 submitting your bug. One of the developers will review it and apply it
 to QGIS. Please don't be alarmed if your patch is not applied straight
@@ -126,14 +126,14 @@ Blog
 ====
 
 The QGIS community also runs a weblog at
-http://planet.qgis.org/planet/, which has some interesting articles
+https://planet.qgis.org/planet/, which has some interesting articles
 for users and developers as well provided by other blogs in the
 community. You are invited to contribute your own QGIS blog!
 
 Plugins
 =======
 
-The website http://plugins.qgis.org provides the official QGIS plugins
+The website https://plugins.qgis.org provides the official QGIS plugins
 web portal. Here, you find a list of all stable and experimental QGIS
 plugins available via the 'Official QGIS Plugin Repository'.
 
@@ -141,7 +141,7 @@ Wiki
 ====
 
 Lastly, we maintain a WIKI web site at
-http://hub.qgis.org/projects/quantum-gis/wiki where you can find a
+https://github.com/qgis/QGIS/wiki where you can find a
 variety of useful information relating to QGIS development, release
 plans, links to download sites, message-translation hints and
 more. Check it out, there are some goodies inside!
@@ -153,4 +153,4 @@ more. Check it out, there are some goodies inside!
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/preamble/preamble.rst
+++ b/source/docs/user_manual/preamble/preamble.rst
@@ -12,7 +12,7 @@ This document is the original user guide of the described software
 QGIS. The software and hardware described in this document are in most
 cases registered trademarks and are therefore subject to legal
 requirements. QGIS is subject to the GNU General Public License. Find
-more information on the QGIS homepage, http://www.qgis.org.
+more information on the QGIS homepage, https://www.qgis.org.
 
 The details, data, and results in this document have been written and
 verified to the best of the knowledge and responsibility of the
@@ -27,11 +27,11 @@ to report possible mistakes.
 This document has been typeset with reStructuredText. It is available
 as reST source code via `github
 <https://github.com/qgis/QGIS-Documentation>`_ and online as HTML and
-PDF via http://www.qgis.org/en/docs/. Translated versions of this
+PDF via https://www.qgis.org/en/docs/. Translated versions of this
 document can be downloaded in several formats via the documentation
 area of the QGIS project as well. For more information about
 contributing to this document and about translating it, please visit
-http://qgis.org/en/site/getinvolved/index.html.
+https://qgis.org/en/site/getinvolved/index.html.
 
 **Links in this Document**
 
@@ -48,7 +48,7 @@ the following documentation is available at :ref:`doc_contributors`.
 
 Copyright (c) 2004 - 2017 QGIS Development Team
 
-**Internet:** http://www.qgis.org
+**Internet:** https://www.qgis.org
 
 **License of this document**
 
@@ -65,4 +65,4 @@ copy of the license is included in Appendix :ref:`gfl_appendix`.
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/preamble/whats_new.rst
+++ b/source/docs/user_manual/preamble/whats_new.rst
@@ -14,11 +14,11 @@ previous releases.
 
 This release includes hundreds of bug fixes and many new features and
 enhancements over |QGIS_CURRENT|_ that will be described in this manual.
-You may also review the visual changelogs at http://qgis.org/en/site/forusers/visualchangelogs.html.
+You may also review the visual changelogs at https://qgis.org/en/site/forusers/visualchangelogs.html.
 
 
 .. |QGIS_CURRENT| replace:: QGIS 2.18
-.. _QGIS_CURRENT: http://docs.qgis.org/2.18/en/docs/
+.. _QGIS_CURRENT: https://docs.qgis.org/2.18/en/docs/
 
 
 .. Substitutions definitions - AVOID EDITING PAST THIS LINE
@@ -27,4 +27,4 @@ You may also review the visual changelogs at http://qgis.org/en/site/forusers/vi
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/print_composer/composer_items/composer_attribute_table.rst
+++ b/source/docs/user_manual/print_composer/composer_items/composer_attribute_table.rst
@@ -320,4 +320,4 @@ the following functionalities (see figure_layout_table_frames_):
    :width: 1.5em
 .. |signPlus| image:: /static/common/symbologyAdd.png
    :width: 1.5em
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/print_composer/composer_items/composer_html_frame.rst
+++ b/source/docs/user_manual/print_composer/composer_items/composer_html_frame.rst
@@ -155,4 +155,4 @@ following functionalities (see figure_layout_html_breaks_):
    :width: 1.3em
 .. |dataDefined| image:: /static/common/mIconDataDefine.png
    :width: 1.5em
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/print_composer/composer_items/composer_image.rst
+++ b/source/docs/user_manual/print_composer/composer_items/composer_image.rst
@@ -84,7 +84,7 @@ transparency:
 * `stroke-opacity="param(outline-opacity)"`
 
 You can read this `blog post
-<http://blog.sourcepole.ch/2011/06/30/svg-symbols-in-qgis-with-modifiable-colors/>`_
+<https://blog.sourcepole.ch/2011/06/30/svg-symbols-in-qgis-with-modifiable-colors/>`_
 to see an example.
 
 Images can be rotated with the :guilabel:`Image rotation` field.
@@ -127,4 +127,4 @@ You can also apply a declination :guilabel:`Offset` to the picture rotation.
    :width: 1.3em
 .. |dataDefined| image:: /static/common/mIconDataDefine.png
    :width: 1.5em
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/print_composer/composer_items/composer_items_options.rst
+++ b/source/docs/user_manual/print_composer/composer_items/composer_items_options.rst
@@ -336,4 +336,4 @@ More information on variables usage in the :ref:`general_tools_variables` sectio
 .. |signPlus| image:: /static/common/symbologyAdd.png
    :width: 1.5em
 .. |slider| image:: /static/common/slider.png
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/print_composer/composer_items/composer_items_shape.rst
+++ b/source/docs/user_manual/print_composer/composer_items/composer_items_shape.rst
@@ -178,4 +178,4 @@ hitting the :kbd:`Del` key.
    :ltrim:
 .. |editNodesShape| image:: /static/common/mActionEditNodesShape.png
    :width: 1.5em
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/print_composer/composer_items/composer_label.rst
+++ b/source/docs/user_manual/print_composer/composer_items/composer_label.rst
@@ -138,4 +138,4 @@ should be surrounded by ``[%`` and ``%]`` in the :guilabel:`Main properties` fra
    :width: 1.5em
 .. |logo| image:: /static/common/logo.png
    :width: 1.5em
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/print_composer/composer_items/composer_legend.rst
+++ b/source/docs/user_manual/print_composer/composer_items/composer_legend.rst
@@ -208,4 +208,4 @@ column or line can be customized through this dialog.
    :width: 1.5em
 .. |sum| image:: /static/common/mActionSum.png
    :width: 1.5em
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/print_composer/composer_items/composer_map.rst
+++ b/source/docs/user_manual/print_composer/composer_items/composer_map.rst
@@ -350,4 +350,4 @@ drawing over the selected map frame. You can customize it with:
    :width: 1.5em
 .. |signPlus| image:: /static/common/symbologyAdd.png
    :width: 1.5em
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/print_composer/composer_items/composer_scale_bar.rst
+++ b/source/docs/user_manual/print_composer/composer_items/composer_scale_bar.rst
@@ -146,4 +146,4 @@ Fill colors are only used for *Single Box* and *Double Box* styles.
 
 .. |scaleBar| image:: /static/common/mActionScaleBar.png
    :width: 1.5em
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/print_composer/composer_items/index.rst
+++ b/source/docs/user_manual/print_composer/composer_items/index.rst
@@ -30,4 +30,4 @@ Layout Items
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/print_composer/create_output.rst
+++ b/source/docs/user_manual/print_composer/create_output.rst
@@ -396,7 +396,7 @@ the image file format set in :guilabel:`Atlas` panel or to SVG file.
   to any supported file format).
 
 
-.. _Multiple_format_map_series_using_QGIS_2.6: http://sigsemgrilhetas.wordpress.com/2014/11/09/series-de-mapas-com-formatos-multiplos-em-qgis-2-6-parte-1-multiple-format-map-series-using-qgis-2-6-part-1
+.. _Multiple_format_map_series_using_QGIS_2.6: https://sigsemgrilhetas.wordpress.com/2014/11/09/series-de-mapas-com-formatos-multiplos-em-qgis-2-6-parte-1-multiple-format-map-series-using-qgis-2-6-part-1
 
 
 .. Substitutions definitions - AVOID EDITING PAST THIS LINE
@@ -432,4 +432,4 @@ the image file format set in :guilabel:`Atlas` panel or to SVG file.
    :width: 2.5em
 .. |unchecked| image:: /static/common/checkbox_unchecked.png
    :width: 1.3em
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/print_composer/index.rst
+++ b/source/docs/user_manual/print_composer/index.rst
@@ -28,4 +28,4 @@ geographical information produced with QGIS that can be included in reports or p
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/print_composer/overview_composer.rst
+++ b/source/docs/user_manual/print_composer/overview_composer.rst
@@ -891,7 +891,7 @@ the actions done after the selected one will be removed.
    :width: 1.5em
 .. |unlocked| image:: /static/common/unlocked.png
    :width: 1.5em
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
 .. |vectorGrid| image:: /static/common/vector_grid.png
    :width: 1.5em
 .. |zoomActual| image:: /static/common/mActionZoomActual.png

--- a/source/docs/user_manual/processing/3rdParty.rst
+++ b/source/docs/user_manual/processing/3rdParty.rst
@@ -391,4 +391,4 @@ GRASS configuration parameters.
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/processing/batch.rst
+++ b/source/docs/user_manual/processing/batch.rst
@@ -143,4 +143,4 @@ progress bar in the lower part of the dialog.
 
 .. |browseButton| image:: /static/common/browsebutton.png
    :width: 2.3em
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/processing/configuration.rst
+++ b/source/docs/user_manual/processing/configuration.rst
@@ -79,4 +79,4 @@ when covering particular algorithm providers.
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/processing/console.rst
+++ b/source/docs/user_manual/processing/console.rst
@@ -580,4 +580,4 @@ entered.
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/processing/history.rst
+++ b/source/docs/user_manual/processing/history.rst
@@ -71,4 +71,4 @@ Make sure you check those messages in the log if you are having unexpected resul
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/processing/index.rst
+++ b/source/docs/user_manual/processing/index.rst
@@ -28,4 +28,4 @@ QGIS processing framework
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/processing/intro.rst
+++ b/source/docs/user_manual/processing/intro.rst
@@ -77,4 +77,4 @@ In the following sections, we will review each one of these elements in detail.
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/processing/modeler.rst
+++ b/source/docs/user_manual/processing/modeler.rst
@@ -306,4 +306,4 @@ not appear in the list of algorithms that you can find in the modeler dialog.
    :width: 1.5em
 .. |qgsProjectFile| image:: /static/common/mIconQgsProjectFile.png
    :width: 1.5em
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/processing/scripts.rst
+++ b/source/docs/user_manual/processing/scripts.rst
@@ -257,4 +257,4 @@ entered.
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/processing/toolbox.rst
+++ b/source/docs/user_manual/processing/toolbox.rst
@@ -391,4 +391,4 @@ to a temporary file and deleted once you exit QGIS).
    :width: 1.5em
 .. |search| image:: /static/common/search.png
    :width: 1.5em
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/processing_algs/gdal/index.rst
+++ b/source/docs/user_manual/processing_algs/gdal/index.rst
@@ -6,10 +6,10 @@
 GDAL algorithm provider
 ***********************
 
-`GDAL <http://gdal.org>`_ (Geospatial Data Abstraction Library) is a translator
+`GDAL <https://www.gdal.org>`_ (Geospatial Data Abstraction Library) is a translator
 library for raster and vector geospatial data formats. Algorithms in the Processing
-Framework are derived from the `GDAL raster utilities <http://www.gdal.org/gdal_utilities.html>`_
-and `GDAL/OGR vector utilities <http://www.gdal.org/ogr_utilities.html>`_ .
+Framework are derived from the `GDAL raster utilities <https://www.gdal.org/gdal_utilities.html>`_
+and `GDAL/OGR vector utilities <https://www.gdal.org/ogr_utilities.html>`_ .
 
 .. toctree::
      :maxdepth: 2
@@ -30,4 +30,4 @@ and `GDAL/OGR vector utilities <http://www.gdal.org/ogr_utilities.html>`_ .
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/processing_algs/gdal/rasteranalysis.rst
+++ b/source/docs/user_manual/processing_algs/gdal/rasteranalysis.rst
@@ -21,7 +21,7 @@ Aspect is the compass direction that a slope faces. The pixels will
 have a value from 0-360° measured in degrees from north indicating the azimuth.
 On the northern hemisphere, the north side of slopes is often shaded (small azimuth from 0°-90°),
 while the southern side receives more solar radiation (higher azimuth from 180°-270°).
-The algorithm is derived from the `GDAL DEM utility <http://www.gdal.org/gdaldem.html>`_ .
+The algorithm is derived from the `GDAL DEM utility <https://www.gdal.org/gdaldem.html>`_ .
 
 ``Default menu``: :menuselection:`Raster --> Analysis`
 
@@ -72,7 +72,7 @@ Color reliefs can particularly be used to depict elevations.
 The Algorithm outputs a 4-band raster with values computed from the elevation
 and a text-based color configuration file. By default, the colors between the given
 elevation values are blended smoothly and the result is a nice colorized elevation raster.
-The algorithm is derived from the `GDAL DEM utility <http://www.gdal.org/gdaldem.html>`__ .
+The algorithm is derived from the `GDAL DEM utility <https://www.gdal.org/gdaldem.html>`__ .
 
 Parameters
 ..........
@@ -125,7 +125,7 @@ interpolating missing regions of fairly continuously varying rasters (such as el
 models for instance). It is also suitable for filling small holes and cracks in more irregularly
 varying images (like airphotos). It is generally not so great for interpolating a raster
 from sparse point data.
-The algorithm is derived from the `GDAL fillnodata utility <http://www.gdal.org/gdal_fillnodata.html>`__ .
+The algorithm is derived from the `GDAL fillnodata utility <https://www.gdal.org/gdal_fillnodata.html>`__ .
 
 ``Default menu``: :menuselection:`Raster --> Analysis`
 
@@ -246,7 +246,7 @@ Interpolated raster file.
 See also
 ........
 
-`GDAL grid tutorial <http://www.gdal.org/grid_tutorial.html>`_
+`GDAL grid tutorial <https://www.gdal.org/grid_tutorial.html>`_
 
 
 .. _gdalgriddatametrics:
@@ -340,7 +340,7 @@ Outputs
 
 See also
 ........
-`GDAL grid tutorial <http://www.gdal.org/grid_tutorial.html>`_
+`GDAL grid tutorial <https://www.gdal.org/grid_tutorial.html>`_
 
 
 .. _gdalgridinversedistance:
@@ -442,7 +442,7 @@ Outputs
 See also
 .........
 
-`GDAL grid tutorial <http://www.gdal.org/grid_tutorial.html>`_
+`GDAL grid tutorial <https://www.gdal.org/grid_tutorial.html>`_
 
 
 .. _gdalgridinversedistancenearestneighbor:
@@ -523,7 +523,7 @@ Outputs
 See also
 ........
 
-`GDAL grid <http://www.gdal.org/gdal_grid.html>`_
+`GDAL grid <https://www.gdal.org/gdal_grid.html>`_
 
 
 .. _gdalgridlinear:
@@ -589,7 +589,7 @@ Outputs
 See also
 ........
 
-`GDAL grid <http://www.gdal.org/gdal_grid.html>`_
+`GDAL grid <https://www.gdal.org/gdal_grid.html>`_
 
 
 .. _gdalgridnearestneighbor:
@@ -662,7 +662,7 @@ Outputs
 See also
 ........
 
-`GDAL grid tutorial <http://www.gdal.org/grid_tutorial.html>`_
+`GDAL grid tutorial <https://www.gdal.org/grid_tutorial.html>`_
 
 
 .. _gdalhillshade:
@@ -672,7 +672,7 @@ Hillshade
 Outputs a raster with a nice shaded relief effect. It’s very useful for visualizing
 the terrain. You can optionally specify the azimuth and altitude of the light source, a vertical
 exaggeration factor and a scaling factor to account for differences between vertical and horizontal units.
-The algorithm is derived from the `GDAL DEM utility <http://www.gdal.org/gdaldem.html>`__ .
+The algorithm is derived from the `GDAL DEM utility <https://www.gdal.org/gdaldem.html>`__ .
 
 ``Default menu``: :menuselection:`Raster --> Analysis`
 
@@ -765,7 +765,7 @@ Outputs
 See also
 ........
 
-`GDAL nearblack <http://www.gdal.org/nearblack.html>`_
+`GDAL nearblack <https://www.gdal.org/nearblack.html>`_
 
 
 .. _gdalproximity:
@@ -848,7 +848,7 @@ Outputs
 See also
 ........
 
-`GDAL proximity algorithm <http://www.gdal.org/gdal_proximity.html>`_
+`GDAL proximity algorithm <https://www.gdal.org/gdal_proximity.html>`_
 
 
 .. _gdalroughness:
@@ -861,7 +861,7 @@ difference of a central pixel and its surrounding cell.
 The determination of the roughness plays a role in the analysis of terrain elevation data,
 it's useful for calculations of the river morphology, in climatology and physical geography
 in general.
-The algorithm is derived from the `GDAL DEM utility <http://www.gdal.org/gdaldem.html>`__ .
+The algorithm is derived from the `GDAL DEM utility <https://www.gdal.org/gdaldem.html>`__ .
 
 ``Default menu``: :menuselection:`Raster --> Analysis`
 
@@ -895,7 +895,7 @@ Sieve
 Removes raster polygons smaller than a provided threshold size (in pixels) and
 replaces them with the pixel value of the largest neighbour polygon. It is
 useful if you have a large amount of small areas on your raster map.
-The algorithm is derived from the `GDAL sieve utility <http://www.gdal.org/gdal_sieve.html>`_ .
+The algorithm is derived from the `GDAL sieve utility <https://www.gdal.org/gdal_sieve.html>`_ .
 
 ``Default menu``: :menuselection:`Raster --> Analysis`
 
@@ -934,7 +934,7 @@ Slope
 Generate a slope map from any GDAL-supported elevation raster. Slope is the
 angle of inclination to the horizontal. You have the option of specifying the
 type of slope value you want: degrees or percent slope.
-The algorithm is derived from the `GDAL DEM utility <http://www.gdal.org/gdaldem.html>`__ .
+The algorithm is derived from the `GDAL DEM utility <https://www.gdal.org/gdaldem.html>`__ .
 
 ``Default menu``: :menuselection:`Raster --> Analysis`
 
@@ -1011,7 +1011,7 @@ Outputs
 See also
 ........
 
-`GDAL DEM utility <http://www.gdal.org/gdaldem.html#gdaldem_TPI>`__
+`GDAL DEM utility <https://www.gdal.org/gdaldem.html#gdaldem_TPI>`__
 
 
 .. _gdaltriterrainruggednessindex:
@@ -1048,7 +1048,7 @@ Outputs
 
 See also
 ........
-`GDAL DEM utility <http://www.gdal.org/gdaldem.html#gdaldem_TRI>`__
+`GDAL DEM utility <https://www.gdal.org/gdaldem.html#gdaldem_TRI>`__
 
 
 .. Substitutions definitions - AVOID EDITING PAST THIS LINE
@@ -1057,4 +1057,4 @@ See also
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/processing_algs/gdal/rasterconversion.rst
+++ b/source/docs/user_manual/processing_algs/gdal/rasterconversion.rst
@@ -103,7 +103,7 @@ Outputs
 
 See also
 ........
-`GDAL pct2rgb utility <http://www.gdal.org/pct2rgb.html>`_
+`GDAL pct2rgb utility <https://www.gdal.org/pct2rgb.html>`_
 
 
 .. _gdalpolygonize:
@@ -113,7 +113,7 @@ Polygonize (raster to vector)
 Creates vector polygons for all connected regions of pixels in the
 raster sharing a common pixel value. Each polygon is created with an
 attribute indicating the pixel value of that polygon.
-The algorithm is derived from the `GDAL polygonize utility <http://www.gdal.org/gdal_polygonize.html>`_ .
+The algorithm is derived from the `GDAL polygonize utility <https://www.gdal.org/gdal_polygonize.html>`_ .
 
 ``Default menu``: :menuselection:`Raster --> Conversion`
 
@@ -215,7 +215,7 @@ maximize output image visual quality.
 
 If you want to classify a raster map and want to reduce the number of classes it
 can be helpful to downsample your image with this algorithm before.
-The algorithm is derived from the `GDAL rgb2pct utility <http://www.gdal.org/rgb2pct.html>`_ .
+The algorithm is derived from the `GDAL rgb2pct utility <https://www.gdal.org/rgb2pct.html>`_ .
 
 ``Default menu``: :menuselection:`Raster --> Conversion`
 
@@ -305,4 +305,4 @@ Outputs
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/processing_algs/gdal/rasterextraction.rst
+++ b/source/docs/user_manual/processing_algs/gdal/rasterextraction.rst
@@ -17,7 +17,7 @@ Raster extraction
 Clip raster by extent
 ---------------------
 Clips any GDAL-supported raster file to a given extent.
-The algorithm is derived from the `GDAL grid utility <http://www.gdal.org/gdal_grid.html>`_ .
+The algorithm is derived from the `GDAL grid utility <https://www.gdal.org/gdal_grid.html>`_ .
 
 ``Default menu``: :menuselection:`Raster --> Extraction`
 
@@ -77,7 +77,7 @@ Outputs
 Clip raster by mask layer
 -------------------------
 Clips any GDAL-supported raster by a vector mask layer.
-The algorithm is derived from the `GDAL grid utility <http://www.gdal.org/gdal_grid.html>`_ .
+The algorithm is derived from the `GDAL grid utility <https://www.gdal.org/gdal_grid.html>`_ .
 
 ``Default menu``: :menuselection:`Raster --> Extraction`
 
@@ -150,7 +150,7 @@ Outputs
 Contour
 -------
 Extracts contour lines from any GDAL-supported elevation raster.
-The algorithm is derived from the `GDAL contour utility <http://www.gdal.org/gdal_contour.html>`_ .
+The algorithm is derived from the `GDAL contour utility <https://www.gdal.org/gdal_contour.html>`_ .
 
 ``Default menu``: :menuselection:`Raster --> Extraction`
 
@@ -214,4 +214,4 @@ Outputs
    source folder.
 
 .. |34| replace:: ``NEW in 3.4``
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/processing_algs/gdal/rastermiscellaneous.rst
+++ b/source/docs/user_manual/processing_algs/gdal/rastermiscellaneous.rst
@@ -17,7 +17,7 @@ Build Virtual Raster
 --------------------
 Builds a VRT (Virtual Dataset) that is a mosaic of the list of input GDAL-supported rasters.
 With a mosaic you can merge several raster files.
-The algorithm is derived from the `GDAL buildvrt utility <http://www.gdal.org/gdalbuildvrt.html>`_ .
+The algorithm is derived from the `GDAL buildvrt utility <https://www.gdal.org/gdalbuildvrt.html>`_ .
 
 ``Default menu``: :menuselection:`Raster --> Miscellaneous`
 
@@ -65,7 +65,7 @@ Merge
 Merges raster files in a simple way. Here you can use a pseudocolor
 table from an input raster and define the output raster type. All
 the images must be in the same coordinate system.
-The algorithm is derived from the `GDAL merge utility <http://www.gdal.org/gdal_merge.html>`_ .
+The algorithm is derived from the `GDAL merge utility <https://www.gdal.org/gdal_merge.html>`_ .
 
 ``Default menu``: :menuselection:`Raster --> Miscellaneous`
 
@@ -119,7 +119,7 @@ Build overviews (pyramids)
 To speed up rendering time of raster layers overviews (pyramids) can
 be created. Overviews are lower resolution copies of the data which
 QGIS uses depending of the level of zoom.
-The algorithm is derived from the `GDAL addo utility <http://www.gdal.org/gdaladdo.html>`_ .
+The algorithm is derived from the `GDAL addo utility <https://www.gdal.org/gdaladdo.html>`_ .
 
 ``Default menu``: :menuselection:`Raster --> Miscellaneous`
 
@@ -206,7 +206,7 @@ Outputs
 
 See also
 ........
-`GDAL info <http://www.gdal.org/gdalinfo.html>`_
+`GDAL info <https://www.gdal.org/gdalinfo.html>`_
 
 
 .. _gdaltileindex:
@@ -279,7 +279,7 @@ Outputs
 See also
 ........
 
-`GDAL Tile Index <http://www.gdal.org/gdaltindex.html>`_
+`GDAL Tile Index <https://www.gdal.org/gdaltindex.html>`_
 
 .. Substitutions definitions - AVOID EDITING PAST THIS LINE
    This will be automatically updated by the find_set_subst.py script.
@@ -287,4 +287,4 @@ See also
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/processing_algs/gdal/rasterprojections.rst
+++ b/source/docs/user_manual/processing_algs/gdal/rasterprojections.rst
@@ -153,4 +153,4 @@ Outputs
    source folder.
 
 .. |34| replace:: ``NEW in 3.4``
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/processing_algs/gdal/vectorconversion.rst
+++ b/source/docs/user_manual/processing_algs/gdal/vectorconversion.rst
@@ -18,7 +18,7 @@ Convert format
 --------------
 Converts any OGR-supported vector layer into another OGR-supported
 format.
-This algorithm is derived from the `ogr2ogr utility <http://www.gdal.org/ogr2ogr.html>`_ .
+This algorithm is derived from the `ogr2ogr utility <https://www.gdal.org/ogr2ogr.html>`_ .
 
 Parameters
 ..........
@@ -75,7 +75,7 @@ Outputs
 Rasterize (vector to raster)
 ----------------------------
 Converts vector geometries (points, lines and polygons) into a raster image.
-The algorithm is derived from the `GDAL rasterize utility <http://www.gdal.org/gdal_rasterize.html>`_ .
+The algorithm is derived from the `GDAL rasterize utility <https://www.gdal.org/gdal_rasterize.html>`_ .
 
 ``Default menu``: :menuselection:`Raster --> Conversion`
 
@@ -192,4 +192,4 @@ Outputs
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/processing_algs/gdal/vectorgeoprocessing.rst
+++ b/source/docs/user_manual/processing_algs/gdal/vectorgeoprocessing.rst
@@ -17,7 +17,7 @@ Vector geoprocessing
 Clip vector by extent
 ----------------------
 Clips any OGR-supported vector file to a given extent.
-The algorithm is derived from the `ogr2ogr utility <http://www.gdal.org/ogr2ogr.html>`_ .
+The algorithm is derived from the `ogr2ogr utility <https://www.gdal.org/ogr2ogr.html>`_ .
 
 Parameters
 ..........
@@ -48,7 +48,7 @@ Outputs
 Clip vector by polygon
 -----------------------
 Clips any OGR-supported vector layer by a polygon.
-The algorithm is derived from the `ogr2ogr utility <http://www.gdal.org/ogr2ogr.html>`_ .
+The algorithm is derived from the `ogr2ogr utility <https://www.gdal.org/ogr2ogr.html>`_ .
 
 Parameters
 ..........
@@ -79,4 +79,4 @@ Outputs
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/processing_algs/gdal/vectormiscellaneous.rst
+++ b/source/docs/user_manual/processing_algs/gdal/vectormiscellaneous.rst
@@ -58,7 +58,7 @@ Imports vector layers inside a PostgreSqL database on the basis of
 an available connection. The connection has to :ref:`be defined properly
 <vector_create_stored_connection>` beforehand. Be aware that the checkboxes 'Save Username'
 and 'Save Password' are activated. Then you can use the algorithm.
-The algorithm is derived from the `ogr2ogr utility <http://www.gdal.org/ogr2ogr.html>`_ .
+The algorithm is derived from the `ogr2ogr utility <https://www.gdal.org/ogr2ogr.html>`_ .
 
 Parameters
 ..........
@@ -247,7 +247,7 @@ Export to PostgreSQL (new connection)
 -------------------------------------
 Imports vector layers inside a PostGreSQL database. A new connection
 to the PostGIS database must be created.
-The algorithm is derived from the `ogr2ogr utility <http://www.gdal.org/ogr2ogr.html>`_ .
+The algorithm is derived from the `ogr2ogr utility <https://www.gdal.org/ogr2ogr.html>`_ .
 
 Parameters
 ..........
@@ -490,4 +490,4 @@ Outputs
    source folder.
 
 .. |34| replace:: ``NEW in 3.4``
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/processing_algs/index.rst
+++ b/source/docs/user_manual/processing_algs/index.rst
@@ -26,4 +26,4 @@ Processing providers and algorithms
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/processing_algs/lidartools/lastools.rst
+++ b/source/docs/user_manual/processing_algs/lidartools/lastools.rst
@@ -6,7 +6,7 @@
 LAStools algorithm provider
 *******************************
 
-`LAStools <http://rapidlasso.com/lastools/>`_ is a collection of highly
+`LAStools <https://rapidlasso.com/lastools/>`_ is a collection of highly
 efficient, multicore command line tools for LiDAR data processing.
 
 .. only:: html
@@ -23,7 +23,7 @@ Description
 
 This tool can turn billions of points with via seamless Delaunay triangulation
 implemented using streaming into large elevation, intensity, or RGB rasters.
-For more info see the `blast2dem <http://rapidlasso.com/blast2dem>`_ page and 
+For more info see the `blast2dem <https://rapidlasso.com/blast2dem>`_ page and 
 its online `README <http://lastools.org/download/blast2dem_README.txt>`__ file.
 
 Parameters
@@ -92,7 +92,7 @@ Console usage
 See also
 ........
 
-See also the `blast2dem <http://rapidlasso.com/blast2dem>`_ page and its online
+See also the `blast2dem <https://rapidlasso.com/blast2dem>`_ page and its online
 `README <http://lastools.org/download/blast2dem_README.txt>`__ file.
 
 blast2iso
@@ -103,7 +103,7 @@ Description
 
 This tool can turn billions of points with via seamless Delaunay triangulation
 implemented using streaming into large iso-contour lines (optionally tiled).
-For more info see the `blast2iso <http://rapidlasso.com/blast2iso>`_ page and
+For more info see the `blast2iso <https://rapidlasso.com/blast2iso>`_ page and
 its online `README <http://lastools.org/download/blast2iso_README.txt>`__ file.
 
 Parameters
@@ -173,7 +173,7 @@ Console usage
 See also
 .........
 
-See also the `blast2iso <http://rapidlasso.com/blast2iso>`_ page and its online
+See also the `blast2iso <https://rapidlasso.com/blast2iso>`_ page and its online
 `README <http://lastools.org/download/blast2iso_README.txt>`__ file.
 
 las2dem
@@ -184,7 +184,7 @@ Description
 
 This tool turns points (up to 20 million) via a temporary Delaunay triangulation
 that is rastered with a user-defined step size into an elevation, intensity, or
-RGB raster. For more info see the `las2dem <http://rapidlasso.com/las2dem>`_ page
+RGB raster. For more info see the `las2dem <https://rapidlasso.com/las2dem>`_ page
 and its online `README <http://lastools.org/download/las2dem_README.txt>`__ file.
 
 Parameters
@@ -253,7 +253,7 @@ Console usage
 See also
 ........
 
-See also the `las2dem <http://rapidlasso.com/las2dem>`_ page and its online
+See also the `las2dem <https://rapidlasso.com/las2dem>`_ page and its online
 `README <http://lastools.org/download/las2dem_README.txt>`__ file.
 
 las2iso
@@ -264,7 +264,7 @@ Description
 
 This tool turns point clouds (up to 20 million per file) into iso-contour lines
 by creating a temporary Delaunay triangulation on which the contours are then traced.
-For more info see the `las2iso <http://rapidlasso.com/las2iso>`_ page and its
+For more info see the `las2iso <https://rapidlasso.com/las2iso>`_ page and its
 online `README <http://lastools.org/download/las2iso_README.txt>`__ file.
 
 Parameters
@@ -334,7 +334,7 @@ Console usage
 See also
 ........
 
-See also the `las2iso <http://rapidlasso.com/las2iso>`_ page and its online
+See also the `las2iso <https://rapidlasso.com/las2iso>`_ page and its online
 `README <http://lastools.org/download/las2iso_README.txt>`__ file.
 
 las2las_filter
@@ -345,7 +345,7 @@ Description
 
 This tool uses las2las to filter LiDAR points based on different attributes and
 to write the surviving subset of points to a new LAZ or LAS file. For more info
-see the `las2las <http://rapidlasso.com/las2las>`_ page and its online
+see the `las2las <https://rapidlasso.com/las2las>`_ page and its online
 `README <http://lastools.org/download/las2las_README.txt>`__ file.
 
 Parameters
@@ -509,7 +509,7 @@ Console usage
 See also
 ........
 
-See also the `las2las <http://rapidlasso.com/las2las>`__ page and its online
+See also the `las2las <https://rapidlasso.com/las2las>`__ page and its online
 `README <http://lastools.org/download/las2las_README.txt>`__ file.
 
 las2las_project
@@ -1115,7 +1115,7 @@ Description
 
 This tool uses las2las to filter LiDAR points based on different attributes and
 to write the surviving subset of points to a new LAZ or LAS file. For more info
-see the `las2las <http://rapidlasso.com/las2las>`_ page and its online
+see the `las2las <https://rapidlasso.com/las2las>`_ page and its online
 `README <http://lastools.org/download/las2las_README.txt>`__ file.
 
 Parameters
@@ -1289,7 +1289,7 @@ Console usage
 See also
 ........
 
-See also the `las2las <http://rapidlasso.com/las2las>`_ page and its online
+See also the `las2las <https://rapidlasso.com/las2las>`_ page and its online
 `README <http://lastools.org/download/las2las_README.txt>`__ file.
 
 las2txt
@@ -1382,7 +1382,7 @@ Description
 This tool grids a selected attribute (e.g. elevation, intensity, classification,
 scan angle, ...) of a large point clouds with a user-defined step size onto raster
 using a particular method (e.g. min, max, average). For more info see the
-`lasgrid <http://rapidlasso.com/lasgrid>`_ page and its online
+`lasgrid <https://rapidlasso.com/lasgrid>`_ page and its online
 `README <http://lastools.org/download/lasgrid_README.txt>`__ file.
 
 Parameters
@@ -1459,7 +1459,7 @@ Console usage
 See also
 ........
 
-See also the `lasgrid <http://rapidlasso.com/lasgrid>`_ page and its online
+See also the `lasgrid <https://rapidlasso.com/lasgrid>`_ page and its online
 `README <http://lastools.org/download/lasgrid_README.txt>`__ file.
 
 lasinfo
@@ -1785,4 +1785,4 @@ See also
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/processing_algs/otb/calibration.rst
+++ b/source/docs/user_manual/processing_algs/otb/calibration.rst
@@ -77,4 +77,4 @@ See also
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/processing_algs/otb/feature_extraction.rst
+++ b/source/docs/user_manual/processing_algs/otb/feature_extraction.rst
@@ -974,4 +974,4 @@ See also
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/processing_algs/otb/geometry.rst
+++ b/source/docs/user_manual/processing_algs/otb/geometry.rst
@@ -862,4 +862,4 @@ See also
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/processing_algs/otb/image_filtering.rst
+++ b/source/docs/user_manual/processing_algs/otb/image_filtering.rst
@@ -470,4 +470,4 @@ See also
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/processing_algs/otb/image_manipulation.rst
+++ b/source/docs/user_manual/processing_algs/otb/image_manipulation.rst
@@ -612,4 +612,4 @@ See also
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/processing_algs/otb/index.rst
+++ b/source/docs/user_manual/processing_algs/otb/index.rst
@@ -6,7 +6,7 @@
 OrfeoToolbox algorithm provider
 *******************************
 
-`Orfeo ToolBox <http://www.orfeo-toolbox.org/otb/>`_ (OTB) is an open source
+`Orfeo ToolBox <https://www.orfeo-toolbox.org/otb/>`_ (OTB) is an open source
 library of image processing algorithms. OTB is based on the medical image
 processing library ITK and offers particular functionalities for remote sensing
 image processing in general and for high spatial resolution images in
@@ -39,4 +39,4 @@ or SAR (TerraSarX, ERS, Palsar) are available.
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/processing_algs/otb/learning.rst
+++ b/source/docs/user_manual/processing_algs/otb/learning.rst
@@ -1585,4 +1585,4 @@ See also
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/processing_algs/otb/miscellaneous.rst
+++ b/source/docs/user_manual/processing_algs/otb/miscellaneous.rst
@@ -265,4 +265,4 @@ See also
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/processing_algs/otb/segmentation.rst
+++ b/source/docs/user_manual/processing_algs/otb/segmentation.rst
@@ -944,4 +944,4 @@ See also
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/processing_algs/otb/stereo.rst
+++ b/source/docs/user_manual/processing_algs/otb/stereo.rst
@@ -232,4 +232,4 @@ See also
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/processing_algs/otb/vector_data_manipulation.rst
+++ b/source/docs/user_manual/processing_algs/otb/vector_data_manipulation.rst
@@ -48,4 +48,4 @@ See also
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/processing_algs/qgis/cartography.rst
+++ b/source/docs/user_manual/processing_algs/qgis/cartography.rst
@@ -143,4 +143,4 @@ Outputs
    source folder.
 
 .. |34| replace:: :kbd:`NEW in 3.4`
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/processing_algs/qgis/database.rst
+++ b/source/docs/user_manual/processing_algs/qgis/database.rst
@@ -320,4 +320,4 @@ For some SQL query examples see :ref:`PostGIS SQL Query Examples <qgis_postgis_e
    source folder.
 
 .. |34| replace:: ``NEW in 3.4``
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/processing_algs/qgis/filetools.rst
+++ b/source/docs/user_manual/processing_algs/qgis/filetools.rst
@@ -38,4 +38,4 @@ Outputs
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/processing_algs/qgis/graphics.rst
+++ b/source/docs/user_manual/processing_algs/qgis/graphics.rst
@@ -251,4 +251,4 @@ Outputs
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/processing_algs/qgis/index.rst
+++ b/source/docs/user_manual/processing_algs/qgis/index.rst
@@ -43,4 +43,4 @@ algorithms.
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/processing_algs/qgis/interpolation.rst
+++ b/source/docs/user_manual/processing_algs/qgis/interpolation.rst
@@ -173,7 +173,7 @@ The final result is shown in Figure_Heatmap_styled_processing_.
 
    Styled heatmap of airports of Alaska
 
-.. _Wikipedia: http://en.wikipedia.org/wiki/Kernel_(statistics)#Kernel_functions_in_common_use
+.. _Wikipedia: https://en.wikipedia.org/wiki/Kernel_(statistics)#Kernel_functions_in_common_use
 
 
 .. _qgisidwinterpolation:
@@ -309,4 +309,4 @@ Outputs
    :width: 1.5em
 .. |signPlus| image:: /static/common/symbologyAdd.png
    :width: 1.5em
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/processing_algs/qgis/layertools.rst
+++ b/source/docs/user_manual/processing_algs/qgis/layertools.rst
@@ -47,4 +47,4 @@ Outputs
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/processing_algs/qgis/modelertools.rst
+++ b/source/docs/user_manual/processing_algs/qgis/modelertools.rst
@@ -130,4 +130,4 @@ See also
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/processing_algs/qgis/rasteranalysis.rst
+++ b/source/docs/user_manual/processing_algs/qgis/rasteranalysis.rst
@@ -435,4 +435,4 @@ Parameters
 
 .. |32| replace:: ``NEW in 3.2``
 .. |34| replace:: ``NEW in 3.4``
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/processing_algs/qgis/rasterterrainanalysis.rst
+++ b/source/docs/user_manual/processing_algs/qgis/rasterterrainanalysis.rst
@@ -297,4 +297,4 @@ Outputs
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/processing_algs/qgis/rastertools.rst
+++ b/source/docs/user_manual/processing_algs/qgis/rastertools.rst
@@ -125,4 +125,4 @@ Parameters
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/processing_algs/qgis/vectoranalysis.rst
+++ b/source/docs/user_manual/processing_algs/qgis/vectoranalysis.rst
@@ -569,4 +569,4 @@ Outputs
    source folder.
 
 .. |34| replace:: ``NEW in 3.4``
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/processing_algs/qgis/vectorcreation.rst
+++ b/source/docs/user_manual/processing_algs/qgis/vectorcreation.rst
@@ -661,4 +661,4 @@ Outputs
    :width: 1.3em
 .. |dataDefined| image:: /static/common/mIconDataDefine.png
    :width: 1.5em
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/processing_algs/qgis/vectorgeneral.rst
+++ b/source/docs/user_manual/processing_algs/qgis/vectorgeneral.rst
@@ -695,4 +695,4 @@ Parameters
 .. |34| replace:: ``NEW in 3.4``
 .. |checkbox| image:: /static/common/checkbox.png
    :width: 1.3em
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/processing_algs/qgis/vectorgeometry.rst
+++ b/source/docs/user_manual/processing_algs/qgis/vectorgeometry.rst
@@ -3077,4 +3077,4 @@ Outputs
    :width: 1.5em
 .. |newAttribute| image:: /static/common/mActionNewAttribute.png
    :width: 1.5em
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/processing_algs/qgis/vectoroverlay.rst
+++ b/source/docs/user_manual/processing_algs/qgis/vectoroverlay.rst
@@ -369,4 +369,4 @@ Outputs
 
 .. |checkbox| image:: /static/common/checkbox.png
    :width: 1.3em
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/processing_algs/qgis/vectorselection.rst
+++ b/source/docs/user_manual/processing_algs/qgis/vectorselection.rst
@@ -424,4 +424,4 @@ Parameters
    source folder.
 
 .. |32| replace:: ``NEW in 3.2``
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/processing_algs/qgis/vectortable.rst
+++ b/source/docs/user_manual/processing_algs/qgis/vectortable.rst
@@ -372,4 +372,4 @@ Outputs
    :width: 1.5em
 .. |newAttribute| image:: /static/common/mActionNewAttribute.png
    :width: 1.5em
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/processing_algs/r/basic_statistics.rst
+++ b/source/docs/user_manual/processing_algs/r/basic_statistics.rst
@@ -117,4 +117,4 @@ See also
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/processing_algs/r/home_range_analysis.rst
+++ b/source/docs/user_manual/processing_algs/r/home_range_analysis.rst
@@ -178,4 +178,4 @@ See also
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/processing_algs/r/index.rst
+++ b/source/docs/user_manual/processing_algs/r/index.rst
@@ -6,7 +6,7 @@
 R algorithm provider
 ********************
 
-`R <http://www.r-project.org/>`_ also called GNU S, is a strongly functional
+`R <https://www.r-project.org/>`_ also called GNU S, is a strongly functional
 language and environment to statistically explore data sets, make many graphical
 displays of data from custom data sets
 
@@ -30,4 +30,4 @@ displays of data from custom data sets
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/processing_algs/r/point_pattern_analysis.rst
+++ b/source/docs/user_manual/processing_algs/r/point_pattern_analysis.rst
@@ -370,4 +370,4 @@ See also
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/processing_algs/r/raster_processing.rst
+++ b/source/docs/user_manual/processing_algs/r/raster_processing.rst
@@ -83,4 +83,4 @@ See also
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/processing_algs/r/vector_processing.rst
+++ b/source/docs/user_manual/processing_algs/r/vector_processing.rst
@@ -51,4 +51,4 @@ See also
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/processing_algs/saga/geostatistics.rst
+++ b/source/docs/user_manual/processing_algs/saga/geostatistics.rst
@@ -1665,4 +1665,4 @@ See also
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/processing_algs/saga/grid_analysis.rst
+++ b/source/docs/user_manual/processing_algs/saga/grid_analysis.rst
@@ -680,4 +680,4 @@ See also
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/processing_algs/saga/grid_calculus.rst
+++ b/source/docs/user_manual/processing_algs/saga/grid_calculus.rst
@@ -941,4 +941,4 @@ See also
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/processing_algs/saga/grid_filter.rst
+++ b/source/docs/user_manual/processing_algs/saga/grid_filter.rst
@@ -526,4 +526,4 @@ See also
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/processing_algs/saga/grid_gridding.rst
+++ b/source/docs/user_manual/processing_algs/saga/grid_gridding.rst
@@ -516,4 +516,4 @@ See also
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/processing_algs/saga/grid_spline.rst
+++ b/source/docs/user_manual/processing_algs/saga/grid_spline.rst
@@ -515,4 +515,4 @@ See also
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/processing_algs/saga/grid_tools.rst
+++ b/source/docs/user_manual/processing_algs/saga/grid_tools.rst
@@ -1075,4 +1075,4 @@ See also
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/processing_algs/saga/grid_visualization.rst
+++ b/source/docs/user_manual/processing_algs/saga/grid_visualization.rst
@@ -209,4 +209,4 @@ See also
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/processing_algs/saga/imagery_classification.rst
+++ b/source/docs/user_manual/processing_algs/saga/imagery_classification.rst
@@ -244,4 +244,4 @@ See also
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/processing_algs/saga/imagery_rga.rst
+++ b/source/docs/user_manual/processing_algs/saga/imagery_rga.rst
@@ -59,4 +59,4 @@ See also
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/processing_algs/saga/imagery_segmentation.rst
+++ b/source/docs/user_manual/processing_algs/saga/imagery_segmentation.rst
@@ -326,4 +326,4 @@ See also
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/processing_algs/saga/imagery_tools.rst
+++ b/source/docs/user_manual/processing_algs/saga/imagery_tools.rst
@@ -118,4 +118,4 @@ See also
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/processing_algs/saga/index.rst
+++ b/source/docs/user_manual/processing_algs/saga/index.rst
@@ -6,7 +6,7 @@
 SAGA algorithm provider
 ***********************
 
-`SAGA <http://www.saga-gis.org/en.html>`_ (System for Automated
+`SAGA <http://www.saga-gis.org/>`_ (System for Automated
 Geoscientific Analyses) is a free, hybrid, cross-platform GIS software. SAGA
 provides many geoscientific methods which are bundled in so-called module
 libraries.
@@ -54,4 +54,4 @@ libraries.
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/processing_algs/saga/kriging.rst
+++ b/source/docs/user_manual/processing_algs/saga/kriging.rst
@@ -596,4 +596,4 @@ See also
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/processing_algs/saga/shapes_grid.rst
+++ b/source/docs/user_manual/processing_algs/saga/shapes_grid.rst
@@ -646,4 +646,4 @@ See also
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/processing_algs/saga/shapes_lines.rst
+++ b/source/docs/user_manual/processing_algs/saga/shapes_lines.rst
@@ -256,4 +256,4 @@ See also
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/processing_algs/saga/shapes_points.rst
+++ b/source/docs/user_manual/processing_algs/saga/shapes_points.rst
@@ -589,4 +589,4 @@ See also
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/processing_algs/saga/shapes_polygons.rst
+++ b/source/docs/user_manual/processing_algs/saga/shapes_polygons.rst
@@ -361,4 +361,4 @@ See also
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/processing_algs/saga/shapes_tools.rst
+++ b/source/docs/user_manual/processing_algs/saga/shapes_tools.rst
@@ -458,4 +458,4 @@ See also
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/processing_algs/saga/shapes_transect.rst
+++ b/source/docs/user_manual/processing_algs/saga/shapes_transect.rst
@@ -54,4 +54,4 @@ See also
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/processing_algs/saga/simulation_fire_spreading.rst
+++ b/source/docs/user_manual/processing_algs/saga/simulation_fire_spreading.rst
@@ -166,4 +166,4 @@ See also
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/processing_algs/saga/simulation_hydrology.rst
+++ b/source/docs/user_manual/processing_algs/saga/simulation_hydrology.rst
@@ -133,4 +133,4 @@ See also
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/processing_algs/saga/table_calculus.rst
+++ b/source/docs/user_manual/processing_algs/saga/table_calculus.rst
@@ -146,4 +146,4 @@ See also
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/processing_algs/saga/table_tools.rst
+++ b/source/docs/user_manual/processing_algs/saga/table_tools.rst
@@ -146,4 +146,4 @@ See also
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/processing_algs/saga/terrain_analysis_channels.rst
+++ b/source/docs/user_manual/processing_algs/saga/terrain_analysis_channels.rst
@@ -319,4 +319,4 @@ See also
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/processing_algs/saga/terrain_analysis_hydrology.rst
+++ b/source/docs/user_manual/processing_algs/saga/terrain_analysis_hydrology.rst
@@ -1081,4 +1081,4 @@ See also
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/processing_algs/saga/terrain_analysis_lighting.rst
+++ b/source/docs/user_manual/processing_algs/saga/terrain_analysis_lighting.rst
@@ -217,4 +217,4 @@ See also
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/processing_algs/saga/terrain_analysis_morphometry.rst
+++ b/source/docs/user_manual/processing_algs/saga/terrain_analysis_morphometry.rst
@@ -1202,4 +1202,4 @@ See also
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/processing_algs/saga/terrain_analysis_profiles.rst
+++ b/source/docs/user_manual/processing_algs/saga/terrain_analysis_profiles.rst
@@ -154,4 +154,4 @@ See also
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/processing_algs/taudem/basic_grid_analysis_tools.rst
+++ b/source/docs/user_manual/processing_algs/taudem/basic_grid_analysis_tools.rst
@@ -573,4 +573,4 @@ See also
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/processing_algs/taudem/index.rst
+++ b/source/docs/user_manual/processing_algs/taudem/index.rst
@@ -6,7 +6,7 @@
 TauDEM algorithm provider
 *************************
 
-`TauDEM <http://hydrology.usu.edu/taudem/taudem5.html>`_
+`TauDEM <http://hydrology.usu.edu/taudem/taudem5/index.html>`_
 (Terrain Analysis Using Digital Elevation Models) is a set of Digital Elevation
 Model (DEM) tools for the extraction and analysis of hydrologic information
 from topography as represented by a DEM. This is software developed at Utah
@@ -38,4 +38,4 @@ documentation <http://hydrology.usu.edu/taudem/taudem5/documentation.html>`_
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/processing_algs/taudem/specialized_grid_analysis_tools.rst
+++ b/source/docs/user_manual/processing_algs/taudem/specialized_grid_analysis_tools.rst
@@ -1106,4 +1106,4 @@ See also
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/processing_algs/taudem/stream_network_analysis_tools.rst
+++ b/source/docs/user_manual/processing_algs/taudem/stream_network_analysis_tools.rst
@@ -832,4 +832,4 @@ See also
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/working_with_gps/index.rst
+++ b/source/docs/user_manual/working_with_gps/index.rst
@@ -21,4 +21,4 @@ Working with GPS Data
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/working_with_gps/live_GPS_tracking.rst
+++ b/source/docs/user_manual/working_with_gps/live_GPS_tracking.rst
@@ -145,7 +145,7 @@ MS Windows
 ..........
 
 Easiest way to make it work is to use a middleware (freeware, not open) called
-`GPSGate <http://update.gpsgate.com/install/GpsGateClient.exe>`_.
+`GPSGate <https://update.gpsgate.com/install/GpsGateClient.exe>`_.
 
 Launch the program, make it scan for GPS devices (works for both USB and BT
 ones) and then in QGIS just click :guilabel:`Connect` in the Live tracking panel
@@ -235,4 +235,4 @@ or without it, by connecting the QGIS live tracking tool directly to the device
 .. |radioButtonOff| image:: /static/common/radiobuttonoff.png
 .. |radioButtonOn| image:: /static/common/radiobuttonon.png
 .. |slider| image:: /static/common/slider.png
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/working_with_gps/plugins_gps.rst
+++ b/source/docs/user_manual/working_with_gps/plugins_gps.rst
@@ -78,14 +78,14 @@ Each feature type will be loaded in a separate layer when you click
    downloading a GPX file (from your GPS unit or a web site) and then loading it
    in QGIS, be sure that the data stored in the GPX file uses WGS 84
    (latitude/longitude). QGIS expects this, and it is the official GPX
-   specification. See http://www.topografix.com/GPX/1/1/.
+   specification. See https://www.topografix.com/GPX/1/1/.
 
 GPSBabel
 --------
 
 Since QGIS uses GPX files, you need a way to convert other GPS file formats to
 GPX. This can be done for many formats using the free program GPSBabel, which is
-available at http://www.gpsbabel.org. This program can also transfer GPS
+available at https://www.gpsbabel.org. This program can also transfer GPS
 data between your computer and a GPS device. QGIS uses GPSBabel to do these
 things, so it is recommended that you install it. However, if you just want to
 load GPS data from GPX files you will not need it. Version 1.2.3 of GPSBabel is
@@ -188,7 +188,7 @@ file for the layer that is being uploaded, and ``%out`` is replaced by the port
 name.
 
 You can learn more about GPSBabel and its available command line options at
-http://www.gpsbabel.org.
+https://www.gpsbabel.org.
 
 Once you have created a new device type, it will appear in the device lists for
 the download and upload tools.
@@ -199,7 +199,7 @@ Download of points/tracks from GPS units
 As described in previous sections QGIS uses GPSBabel to download points/tracks
 directly in the project. QGIS comes out of the box with a pre-defined profile
 to download from Garmin devices. Unfortunately there is a `bug #6318
-<http://hub.qgis.org/issues/6318>`_ that does not allow create other profiles,
+<https://issues.qgis.org/issues/6318>`_ that does not allow create other profiles,
 so downloading directly in QGIS using the GPS Tools is at the moment limited to
 Garmin USB units.
 
@@ -209,7 +209,7 @@ Garmin GPSMAP 60cs
 **MS Windows**
 
 Install the Garmin USB drivers ​from
-http://www8.garmin.com/support/download_details.jsp?id=591
+https://www8.garmin.com/support/download_details.jsp?id=591
 
 Connect the unit. Open GPS Tools and use ``type=garmin serial`` and ``port=usb:``
 Fill the fields :guilabel:`Layer name` and :guilabel:`Output file`. Sometimes
@@ -234,7 +234,7 @@ loaded
   rmmod garmin_gps
 
 and then you can use the GPS Tools. Unfortunately there seems to be a `bug #7182
-<http://hub.qgis.org/issues/7182>`_ and usually QGIS freezes several times
+<https://issues.qgis.org/issues/7182>`_ and usually QGIS freezes several times
 before the operation work fine.
 
 BTGP-38KM datalogger (only Bluetooth)
@@ -317,6 +317,6 @@ system port, then run GPSBabel
    :width: 1em
 .. |showPluginManager| image:: /static/common/mActionShowPluginManager.png
    :width: 1.5em
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
 .. |win| image:: /static/common/win.png
    :width: 1em

--- a/source/docs/user_manual/working_with_ogc/index.rst
+++ b/source/docs/user_manual/working_with_ogc/index.rst
@@ -21,4 +21,4 @@ Working with OGC Data
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/working_with_ogc/ogc_client_support.rst
+++ b/source/docs/user_manual/working_with_ogc/ogc_client_support.rst
@@ -23,7 +23,7 @@ GIS data processing and exchange.
 Describing a basic data model for geographic features, an increasing number
 of specifications are developed by OGC to serve specific needs for interoperable
 location and geospatial technology, including GIS. Further information
-can be found at http://www.opengeospatial.org/.
+can be found at https://www.opengeospatial.org/.
 
 .. index:: WMS, WFS, WCS, CAT, SFS, GML
 
@@ -125,7 +125,7 @@ them to QGIS differently.
 
    ::
 
-      http://opencache.statkart.no/gatekeeper/gk/gk.open_wmts?\
+      https://opencache.statkart.no/gatekeeper/gk/gk.open_wmts?\
         service=WMTS&request=GetCapabilities
 
    For testing the topo2 layer in this WMTS works nicely. Adding this string indicates
@@ -141,12 +141,12 @@ them to QGIS differently.
    This format helps you to recognize that it is a RESTful address. A RESTful WMTS is
    accessed in QGIS by simply adding its address in the WMS setup in the URL field of
    the form. An example of this type of address for the case of an Austrian basemap is
-   http://maps.wien.gv.at/basemap/1.0.0/WMTSCapabilities.xml.
+   https://maps.wien.gv.at/basemap/1.0.0/WMTSCapabilities.xml.
 
 .. note:: You can still find some old services called WMS-C. These services are quite similar
    to WMTS (i.e., same purpose but working a little bit differently). You can manage
    them the same as you do WMTS services. Just add ``?tiled=true`` at the end
-   of the url. See http://wiki.osgeo.org/wiki/Tile_Map_Service_Specification for more
+   of the url. See https://wiki.osgeo.org/wiki/Tile_Map_Service_Specification for more
    information about this specification.
 
    When you read WMTS, you can often think WMS-C also.
@@ -374,7 +374,7 @@ When using WMTS (Cached WMS) services like
 
 ::
 
-  http://opencache.statkart.no/gatekeeper/gk/gk.open_wmts?\
+  https://opencache.statkart.no/gatekeeper/gk/gk.open_wmts?\
     service=WMTS&request=GetCapabilities
 
 you are able to browse through the :guilabel:`Tilesets` tab given by the server.
@@ -560,7 +560,7 @@ details.
    If you need to access secured layers with secured methods other than basic
    authentication, you can use InteProxy as a transparent proxy, which does
    support several authentication methods. More information can be found in the
-   InteProxy manual at http://inteproxy.wald.intevation.org.
+   InteProxy manual at https://inteproxy.wald.intevation.org.
 
 .. index:: Mapserver
 
@@ -687,7 +687,7 @@ two and view the attribute table.
    :width: 1.5em
 .. |selectString| image:: /static/common/selectstring.png
    :width: 2.5em
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
 .. |wcs| image:: /static/common/mActionAddWcsLayer.png
    :width: 1.5em
 .. |wfs| image:: /static/common/mActionAddWfsLayer.png

--- a/source/docs/user_manual/working_with_ogc/server/config.rst
+++ b/source/docs/user_manual/working_with_ogc/server/config.rst
@@ -305,4 +305,4 @@ For linux, if you don't have a desktop environment installed (or you prefer the 
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/working_with_ogc/server/getting_started.rst
+++ b/source/docs/user_manual/working_with_ogc/server/getting_started.rst
@@ -109,7 +109,7 @@ QGIS Server is now available at http://localhost/cgi-bin/qgis-server.cgi.
 NGINX
 .....
 
-You can also use QGIS Server with `NGINX <http://nginx.org/>`_. Unlike Apache,
+You can also use QGIS Server with `NGINX <https://nginx.org/>`_. Unlike Apache,
 NGINX does not automatically spawn a FastCGI process. Actually, you have to use
 another component to start these processes.
 
@@ -608,4 +608,4 @@ the path to the SVG image so that it represents a valid relative path.
    :width: 1.3em
 .. |signPlus| image:: /static/common/symbologyAdd.png
    :width: 1.5em
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/working_with_ogc/server/index.rst
+++ b/source/docs/user_manual/working_with_ogc/server/index.rst
@@ -53,4 +53,4 @@ Manual <training_qgis_server>` or :ref:`server_plugins`.
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/working_with_ogc/server/plugins.rst
+++ b/source/docs/user_manual/working_with_ogc/server/plugins.rst
@@ -100,4 +100,4 @@ You can have a look at the default GetCapabilities of the QGIS server at:
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/working_with_ogc/server/services.rst
+++ b/source/docs/user_manual/working_with_ogc/server/services.rst
@@ -36,8 +36,8 @@ well as the image format to generate. Basic support is also available for the
 
 Specifications document according to the version number of the service:
 
-- `WMS 1.1.0 <http://portal.opengeospatial.org/files/?artifact_id=1081&version=1&format=pdf>`_
-- `WMS 1.3.0 <http://portal.opengeospatial.org/files/?artifact_id=14416>`_
+- `WMS 1.1.0 <https://portal.opengeospatial.org/files/?artifact_id=1081&version=1&format=pdf>`_
+- `WMS 1.3.0 <https://portal.opengeospatial.org/files/?artifact_id=14416>`_
 
 Standard requests provided by QGIS Server:
 
@@ -1065,4 +1065,4 @@ You can see there are several parameters in this request:
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/working_with_projections/working_with_projections.rst
+++ b/source/docs/user_manual/working_with_projections/working_with_projections.rst
@@ -313,4 +313,4 @@ transformations` group:
    :width: 1.5em
 .. |toggleEditing| image:: /static/common/mActionToggleEditing.png
    :width: 1.5em
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/working_with_raster/index.rst
+++ b/source/docs/user_manual/working_with_raster/index.rst
@@ -21,4 +21,4 @@ Working with Raster Data
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/working_with_raster/raster_analysis.rst
+++ b/source/docs/user_manual/working_with_raster/raster_analysis.rst
@@ -172,4 +172,4 @@ layers. You can also choose one or more other options (see figure_raster_align_)
    :width: 1.5em
 .. |symbologyEdit| image:: /static/common/symbologyEdit.png
    :width: 1.5em
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/working_with_raster/raster_properties.rst
+++ b/source/docs/user_manual/working_with_raster/raster_properties.rst
@@ -598,4 +598,4 @@ collected.
    :width: 2em
 .. |transparency| image:: /static/common/transparency.png
    :width: 2em
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/working_with_vector/attribute_table.rst
+++ b/source/docs/user_manual/working_with_vector/attribute_table.rst
@@ -932,6 +932,6 @@ It will appear as a **Many to many relation**.
    :width: 1.5em
 .. |unlink| image:: /static/common/mActionUnlink.png
    :width: 1.5em
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
 .. |zoomToSelected| image:: /static/common/mActionZoomToSelected.png
    :width: 1.5em

--- a/source/docs/user_manual/working_with_vector/editing_geometry_attributes.rst
+++ b/source/docs/user_manual/working_with_vector/editing_geometry_attributes.rst
@@ -1644,7 +1644,7 @@ To edit features in-place:
    :width: 1.3em
 .. |undo| image:: /static/common/mActionUndo.png
    :width: 1.5em
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
 .. |vertexTool| image:: /static/common/mActionVertexTool.png
    :width: 1.5em
 .. |vertexToolActiveLayer| image:: /static/common/mActionVertexToolActiveLayer.png

--- a/source/docs/user_manual/working_with_vector/expression.rst
+++ b/source/docs/user_manual/working_with_vector/expression.rst
@@ -1470,4 +1470,4 @@ Further information about creating Python code can be found in the
    :width: 1.5em
 .. |start| image:: /static/common/mActionStart.png
    :width: 1.5em
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/working_with_vector/index.rst
+++ b/source/docs/user_manual/working_with_vector/index.rst
@@ -24,4 +24,4 @@
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/working_with_vector/style_library.rst
+++ b/source/docs/user_manual/working_with_vector/style_library.rst
@@ -661,4 +661,4 @@ viewing the field.
    :width: 1.5em
 .. |unchecked| image:: /static/common/checkbox_unchecked.png
    :width: 1.3em
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/working_with_vector/vector_properties.rst
+++ b/source/docs/user_manual/working_with_vector/vector_properties.rst
@@ -2248,7 +2248,7 @@ Use the :guilabel:`Edit UI` to define the path to the file to use.
 
 You'll find some example in the :ref:`Creating a new form <creating-new-form>`
 lesson of the :ref:`QGIS-training-manual-index-reference`. For more advanced information,
-see http://nathanw.net/2011/09/05/qgis-tips-custom-feature-forms-with-python-logic/.
+see https://nathanw.net/2011/09/05/qgis-tips-custom-feature-forms-with-python-logic/.
 
 .. _form_custom_functions:
 
@@ -2811,15 +2811,15 @@ values of these fields can be used in the action with ``%(Derived).X`` and
 
 Two example actions are shown below:
 
-* ``konqueror http://www.google.com/search?q=%nam``
-* ``konqueror http://www.google.com/search?q=%%``
+* ``konqueror https://www.google.com/search?q=%nam``
+* ``konqueror https://www.google.com/search?q=%%``
 
 In the first example, the web browser konqueror is invoked and passed a URL
 to open. The URL performs a Google search on the value of the ``nam`` field
 from our vector layer. Note that the application or script called by the
 action must be in the path, or you must provide the full path. To be certain, we
 could rewrite the first example as:
-``/opt/kde3/bin/konqueror http://www.google.com/search?q=%nam``. This will
+``/opt/kde3/bin/konqueror https://www.google.com/search?q=%nam``. This will
 ensure that the konqueror application will be executed when the action is
 invoked.
 
@@ -2880,7 +2880,7 @@ As an exercise, we can create an action that does a Google search on the ``lakes
 layer. First, we need to determine the URL required to perform a search on a
 keyword. This is easily done by just going to Google and doing a simple
 search, then grabbing the URL from the address bar in your browser. From this
-little effort, we see that the format is http://google.com/search?q=QGIS,
+little effort, we see that the format is https://www.google.com//search?q=QGIS,
 where ``QGIS`` is the search term. Armed with this information, we can proceed:
 
 #. Make sure the ``lakes`` layer is loaded.
@@ -2899,15 +2899,15 @@ where ``QGIS`` is the search term. Armed with this information, we can proceed:
    need to provide the full path.
 #. Following the name of the external application, add the URL used for doing
    a Google search, up to but not including the search term:
-   ``http://google.com/search?q=``
+   ``https://www.google.com//search?q=``
 #. The text in the :guilabel:`Action` field should now look like this:
-   ``http://google.com/search?q=``
+   ``https://www.google.com//search?q=``
 #. Click on the drop-down box containing the field names for the ``lakes``
    layer. It's located just to the left of the :guilabel:`Insert` button.
 #. From the drop-down box, select 'NAMES' and click :guilabel:`Insert`.
 #. Your action text now looks like this:
 
-   ``http://google.com/search?q=[%NAMES%]``
+   ``https://www.google.com//search?q=[%NAMES%]``
 #. To finalize and add the action, click the :guilabel:`OK` button.
 
 .. _figure_add_action:
@@ -2922,7 +2922,7 @@ action should look like this:
 
 ::
 
-   http://google.com/search?q=[%NAMES%]
+   https://www.google.com//search?q=[%NAMES%]
 
 We can now use the action. Close the :guilabel:`Layer Properties` dialog and
 zoom in to an area of interest. Make sure the ``lakes`` layer is active and
@@ -2936,7 +2936,7 @@ identify a lake. In the result box you'll now see that our action is visible:
    Select feature and choose action
 
 When we click on the action, it brings up Firefox and navigates to the URL
-http://www.google.com/search?q=Tustumena. It is also possible to add further
+https://www.google.com/search?q=Tustumena. It is also possible to add further
 attribute fields to the action. Therefore, you can add a ``+`` to the end of
 the action text, select another field and click on :guilabel:`Insert Field`. In
 this example, there is just no other field available that would make sense
@@ -3431,4 +3431,4 @@ format of the image. Currently png, jpg and jpeg image formats are supported.
    :width: 1.5em
 .. |toggleEditing| image:: /static/common/mActionToggleEditing.png
    :width: 1.5em
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/substitutions.txt
+++ b/source/substitutions.txt
@@ -1,4 +1,4 @@
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit http://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
 .. |outofdate| replace:: `Despite our constant efforts, information beyond this line may not be updated for QGIS 3. Refer to https://qgis.org/pyqgis/master for the python API documentation or, give a hand to update the chapters you know about. Thanks.`
 .. |nix| image:: /static/common/nix.png
    :width: 1em


### PR DESCRIPTION
This was supposed to be a http-->https replacement but turns out to an external hyperlink checks. Many links have been replaced but there still are many http broken links (particularly in Training manual references), requiring more efforts to get fixed...