### PR TITLE
confusing note (repetition)

### DIFF
--- a/source/docs/user_manual/introduction/general_tools.rst
+++ b/source/docs/user_manual/introduction/general_tools.rst
@@ -1478,14 +1478,6 @@ should be identified:
   identify features from. Operates like a right-click. Only the chosen features
   will be shown in the result panel.
 
-.. note:: **Identify tool configuration**
-
-   You can configure the identify feature in :menuselection:`Project -->
-   Properties...` in the :guilabel:`Identify Layers` tab. The table allows
-   you to select layer(s) whose features can be identified with by this tool
-   (column :guilabel:`Identifiable`). You can also put this layer in read-only
-   mode with the checkbox in the last column.
-
 The :guilabel:`View` can be set as **Tree**, **Table** or **Graph**.
 'Table' and 'Graph' views can only be set for raster layers.
 


### PR DESCRIPTION
This is already explained in previous tip (line 1377) "Filter layers to query with Identify Features tool". 
Unchecking the column "Identifiable" only affect not current layers (we can still identify features if these are in the current layer even if it is unchecked ).
Furthermore the "read only" mode does't affect the Identify tool, it prevent the layer to be modified.