### PR TITLE
Add/raise focus on the original algorithm in GDAL docs

### DIFF
--- a/source/docs/user_manual/processing_algs/gdal/rasteranalysis.rst
+++ b/source/docs/user_manual/processing_algs/gdal/rasteranalysis.rst
@@ -21,7 +21,8 @@ Aspect is the compass direction that a slope faces. The pixels will
 have a value from 0-360° measured in degrees from north indicating the azimuth.
 On the northern hemisphere, the north side of slopes is often shaded (small azimuth from 0°-90°),
 while the southern side receives more solar radiation (higher azimuth from 180°-270°).
-The algorithm is derived from the `GDAL DEM utility <https://www.gdal.org/gdaldem.html>`_ .
+
+This algorithm is derived from the `GDAL DEM utility <https://www.gdal.org/gdaldem.html>`_ .
 
 ``Default menu``: :menuselection:`Raster --> Analysis`
 
@@ -72,7 +73,8 @@ Color reliefs can particularly be used to depict elevations.
 The Algorithm outputs a 4-band raster with values computed from the elevation
 and a text-based color configuration file. By default, the colors between the given
 elevation values are blended smoothly and the result is a nice colorized elevation raster.
-The algorithm is derived from the `GDAL DEM utility <https://www.gdal.org/gdaldem.html>`__ .
+
+This algorithm is derived from the `GDAL DEM utility <https://www.gdal.org/gdaldem.html>`_ .
 
 Parameters
 ..........
@@ -125,7 +127,8 @@ interpolating missing regions of fairly continuously varying rasters (such as el
 models for instance). It is also suitable for filling small holes and cracks in more irregularly
 varying images (like airphotos). It is generally not so great for interpolating a raster
 from sparse point data.
-The algorithm is derived from the `GDAL fillnodata utility <https://www.gdal.org/gdal_fillnodata.html>`__ .
+
+This algorithm is derived from the `GDAL fillnodata utility <https://www.gdal.org/gdal_fillnodata.html>`_ .
 
 ``Default menu``: :menuselection:`Raster --> Analysis`
 
@@ -176,6 +179,8 @@ The Moving Average is a simple data averaging algorithm. It uses a moving window
 and averages all data points within the window. Search ellipse can be rotated by specified angle, the center of ellipse
 located at the grid node. Also the minimum number of data points to average can be set, if there are not enough points
 in window, the grid node considered empty and will be filled with specified NODATA value.
+
+This algorithm is derived from the `GDAL grid utility <https://www.gdal.org/gdal_grid.html>`_ .
 
 ``Default menu``: :menuselection:`Raster --> Analysis`
 
@@ -253,7 +258,9 @@ See also
 
 Grid (Data metrics)
 -------------------
-This algorithm computes some data metrics using the specified window and output grid geometry.
+Computes some data metrics using the specified window and output grid geometry.
+
+This algorithm is derived from the `GDAL grid utility <https://www.gdal.org/gdal_grid.html>`_ .
 
 ``Default menu``: :menuselection:`Raster --> Analysis`
 
@@ -352,6 +359,8 @@ The Inverse Distance to a Power gridding method is a weighted average interpolat
 You should supply the input arrays with the scattered data values
 including coordinates of every data point and output grid geometry.
 The function will compute interpolated value for the given position in output grid.
+
+This algorithm is derived from the `GDAL grid utility <https://www.gdal.org/gdal_grid.html>`_ .
 
 ``Default menu``: :menuselection:`Raster --> Analysis`
 
@@ -453,6 +462,8 @@ Grid (IDW with nearest neighbor searching)
 Computes the Inverse Distance to a Power gridding combined to the nearest neighbor method.
 Ideal when a maximum number of data points to use is required.
 
+This algorithm is derived from the `GDAL grid utility <https://www.gdal.org/gdal_grid.html>`_ .
+
 Parameters
 ..........
 
@@ -537,6 +548,8 @@ within the triangle.
 If the point is not in any triangle, depending on the radius, the algorithm will
 use the value of the nearest point or the NODATA value.
 
+This algorithm is derived from the `GDAL grid utility <https://www.gdal.org/gdal_grid.html>`_ .
+
 Parameters
 ..........
 
@@ -586,11 +599,6 @@ Outputs
 ``Output file`` [raster]
   Interpolated raster file.
 
-See also
-........
-
-`GDAL grid <https://www.gdal.org/gdal_grid.html>`_
-
 
 .. _gdalgridnearestneighbor:
 
@@ -599,6 +607,8 @@ Grid (Nearest neighbor)
 The Nearest Neighbor method doesn't perform any interpolation or smoothing, it just takes the value of nearest point
 found in grid node search ellipse and returns it as a result. If there are no points found, the specified NODATA value
 will be returned.
+
+This algorithm is derived from the `GDAL grid utility <https://www.gdal.org/gdal_grid.html>`_ .
 
 ``Default menu``: :menuselection:`Raster --> Analysis`
 
@@ -672,7 +682,8 @@ Hillshade
 Outputs a raster with a nice shaded relief effect. It’s very useful for visualizing
 the terrain. You can optionally specify the azimuth and altitude of the light source, a vertical
 exaggeration factor and a scaling factor to account for differences between vertical and horizontal units.
-The algorithm is derived from the `GDAL DEM utility <https://www.gdal.org/gdaldem.html>`__ .
+
+This algorithm is derived from the `GDAL DEM utility <https://www.gdal.org/gdaldem.html>`__ .
 
 ``Default menu``: :menuselection:`Raster --> Analysis`
 
@@ -731,11 +742,13 @@ Outputs
 
 Near black
 ----------
-Convert nearly black/white borders to black.
+Converts nearly black/white borders to black.
 
-This utility will scan an image and try to set all pixels that are nearly or exactly black, white or one or more custom
+This algorithm will scan an image and try to set all pixels that are nearly or exactly black, white or one or more custom
 colors around the collar to black or white. This is often used to "fix up" lossy compressed airphotos so that color
 pixels can be treated as transparent when mosaicking.
+
+This algorithm is derived from the `GDAL nearblack utility <https://www.gdal.org/nearblack.html>`_ .
 
 ``Default menu``: :menuselection:`Raster --> Analysis`
 
@@ -762,19 +775,16 @@ Outputs
 ``Output layer`` [raster]
   Raster file in output.
 
-See also
-........
-
-`GDAL nearblack <https://www.gdal.org/nearblack.html>`_
-
 
 .. _gdalproximity:
 
 Proximity (raster distance)
 ---------------------------
-The proximity algorithm generates a raster proximity map indicating the distance from the center of each pixel
+Generates a raster proximity map indicating the distance from the center of each pixel
 to the center of the nearest pixel identified as a target pixel. Target pixels are those in the source raster for which
 the raster pixel value is in the set of target pixel values.
+
+This algorithm is derived from the `GDAL proximity utility <https://www.gdal.org/gdal_proximity.html>`_ .
 
 ``Default menu``: :menuselection:`Raster --> Analysis`
 
@@ -845,11 +855,6 @@ Outputs
 ``Output layer`` [raster]
   Raster file in output.
 
-See also
-........
-
-`GDAL proximity algorithm <https://www.gdal.org/gdal_proximity.html>`_
-
 
 .. _gdalroughness:
 
@@ -861,7 +866,8 @@ difference of a central pixel and its surrounding cell.
 The determination of the roughness plays a role in the analysis of terrain elevation data,
 it's useful for calculations of the river morphology, in climatology and physical geography
 in general.
-The algorithm is derived from the `GDAL DEM utility <https://www.gdal.org/gdaldem.html>`__ .
+
+This algorithm is derived from the `GDAL DEM utility <https://www.gdal.org/gdaldem.html>`_ .
 
 ``Default menu``: :menuselection:`Raster --> Analysis`
 
@@ -895,7 +901,8 @@ Sieve
 Removes raster polygons smaller than a provided threshold size (in pixels) and
 replaces them with the pixel value of the largest neighbour polygon. It is
 useful if you have a large amount of small areas on your raster map.
-The algorithm is derived from the `GDAL sieve utility <https://www.gdal.org/gdal_sieve.html>`_ .
+
+This algorithm is derived from the `GDAL sieve utility <https://www.gdal.org/gdal_sieve.html>`_ .
 
 ``Default menu``: :menuselection:`Raster --> Analysis`
 
@@ -931,10 +938,11 @@ Outputs
 
 Slope
 -----
-Generate a slope map from any GDAL-supported elevation raster. Slope is the
+Generates a slope map from any GDAL-supported elevation raster. Slope is the
 angle of inclination to the horizontal. You have the option of specifying the
 type of slope value you want: degrees or percent slope.
-The algorithm is derived from the `GDAL DEM utility <https://www.gdal.org/gdaldem.html>`__ .
+
+This algorithm is derived from the `GDAL DEM utility <https://www.gdal.org/gdaldem.html>`_ .
 
 ``Default menu``: :menuselection:`Raster --> Analysis`
 
@@ -981,8 +989,10 @@ Outputs
 TPI (Topographic Position Index)
 --------------------------------
 Outputs a single-band raster with values computed from the elevation.
-TPI stands for Topographic Position Index, which is defined as the difference between a central pixel and the mean
-of its surrounding cells.
+TPI stands for Topographic Position Index, which is defined as the difference
+between a central pixel and the mean of its surrounding cells.
+
+This algorithm is derived from the `GDAL DEM utility <https://www.gdal.org/gdaldem.html>`_ .
 
 ``Default menu``: :menuselection:`Raster --> Analysis`
 
@@ -1008,19 +1018,16 @@ Outputs
 ``Output file`` [raster]
   TPI raster in output.
 
-See also
-........
-
-`GDAL DEM utility <https://www.gdal.org/gdaldem.html#gdaldem_TPI>`__
-
 
 .. _gdaltriterrainruggednessindex:
 
 TRI (Terrain Ruggedness Index)
 ------------------------------
 Outputs a single-band raster with values computed from the elevation.
-TRI stands for Terrain Ruggedness Index, which is defined as the mean difference between a central pixel and its
-surrounding cells.
+TRI stands for Terrain Ruggedness Index, which is defined as the mean difference
+between a central pixel and its surrounding cells.
+
+This algorithm is derived from the `GDAL DEM utility <https://www.gdal.org/gdaldem.html>`_ .
 
 ``Default menu``: :menuselection:`Raster --> Analysis`
 
@@ -1045,10 +1052,6 @@ Outputs
 
 ``Output file`` [raster]
   TRI raster file.
-
-See also
-........
-`GDAL DEM utility <https://www.gdal.org/gdaldem.html#gdaldem_TRI>`__
 
 
 .. Substitutions definitions - AVOID EDITING PAST THIS LINE

--- a/source/docs/user_manual/processing_algs/gdal/rasterconversion.rst
+++ b/source/docs/user_manual/processing_algs/gdal/rasterconversion.rst
@@ -46,8 +46,9 @@ Outputs
 PCT to RGB
 ----------
 Converts an 8bit paletted image to 24bit RGB.
+It will convert a pseudocolor band on the input file into an output RGB file of the desired format.
 
-This utility will convert a pseudocolor band on the input file into an output RGB file of the desired format.
+This algorithm is derived from the `GDAL pct2rgb utility <https://www.gdal.org/pct2rgb.html>`_ .
 
 ``Default menu``: :menuselection:`Raster --> Conversion`
 
@@ -101,10 +102,6 @@ Outputs
 ``PCT to RGB`` [raster]
   24bit RGB raster image
 
-See also
-........
-`GDAL pct2rgb utility <https://www.gdal.org/pct2rgb.html>`_
-
 
 .. _gdalpolygonize:
 
@@ -113,7 +110,8 @@ Polygonize (raster to vector)
 Creates vector polygons for all connected regions of pixels in the
 raster sharing a common pixel value. Each polygon is created with an
 attribute indicating the pixel value of that polygon.
-The algorithm is derived from the `GDAL polygonize utility <https://www.gdal.org/gdal_polygonize.html>`_ .
+
+This algorithm is derived from the `GDAL polygonize utility <https://www.gdal.org/gdal_polygonize.html>`_ .
 
 ``Default menu``: :menuselection:`Raster --> Conversion`
 
@@ -150,6 +148,8 @@ Rearrange bands
 ---------------
 Creates a new raster using selected band(s) from a given raster layer.
 The algorithm also makes it possible to reorder the bands for the newly-created raster.
+
+This algorithm is derived from the `GDAL translate utility <https://www.gdal.org/gdal_translate.html>`_ .
 
 Parameters
 ..........
@@ -215,7 +215,8 @@ maximize output image visual quality.
 
 If you want to classify a raster map and want to reduce the number of classes it
 can be helpful to downsample your image with this algorithm before.
-The algorithm is derived from the `GDAL rgb2pct utility <https://www.gdal.org/rgb2pct.html>`_ .
+
+This algorithm is derived from the `GDAL rgb2pct utility <https://www.gdal.org/rgb2pct.html>`_ .
 
 ``Default menu``: :menuselection:`Raster --> Conversion`
 
@@ -241,6 +242,9 @@ Outputs
 
 Translate (convert format)
 --------------------------
+Converts raster data between different formats.
+
+This algorithm is derived from the `GDAL translate utility <https://www.gdal.org/gdal_translate.html>`_ .
 
 ``Default menu``: :menuselection:`Raster --> Conversion`
 

--- a/source/docs/user_manual/processing_algs/gdal/rasterextraction.rst
+++ b/source/docs/user_manual/processing_algs/gdal/rasterextraction.rst
@@ -17,7 +17,8 @@ Raster extraction
 Clip raster by extent
 ---------------------
 Clips any GDAL-supported raster file to a given extent.
-The algorithm is derived from the `GDAL grid utility <https://www.gdal.org/gdal_grid.html>`_ .
+
+This algorithm is derived from the `GDAL grid utility <https://www.gdal.org/gdal_grid.html>`_ .
 
 ``Default menu``: :menuselection:`Raster --> Extraction`
 
@@ -77,7 +78,8 @@ Outputs
 Clip raster by mask layer
 -------------------------
 Clips any GDAL-supported raster by a vector mask layer.
-The algorithm is derived from the `GDAL grid utility <https://www.gdal.org/gdal_grid.html>`_ .
+
+This algorithm is derived from the `GDAL grid utility <https://www.gdal.org/gdal_grid.html>`_ .
 
 ``Default menu``: :menuselection:`Raster --> Extraction`
 
@@ -150,7 +152,8 @@ Outputs
 Contour
 -------
 Extracts contour lines from any GDAL-supported elevation raster.
-The algorithm is derived from the `GDAL contour utility <https://www.gdal.org/gdal_contour.html>`_ .
+
+This algorithm is derived from the `GDAL contour utility <https://www.gdal.org/gdal_contour.html>`_ .
 
 ``Default menu``: :menuselection:`Raster --> Extraction`
 

--- a/source/docs/user_manual/processing_algs/gdal/rastermiscellaneous.rst
+++ b/source/docs/user_manual/processing_algs/gdal/rastermiscellaneous.rst
@@ -17,7 +17,8 @@ Build Virtual Raster
 --------------------
 Builds a VRT (Virtual Dataset) that is a mosaic of the list of input GDAL-supported rasters.
 With a mosaic you can merge several raster files.
-The algorithm is derived from the `GDAL buildvrt utility <https://www.gdal.org/gdalbuildvrt.html>`_ .
+
+This algorithm is derived from the `GDAL buildvrt utility <https://www.gdal.org/gdalbuildvrt.html>`_ .
 
 ``Default menu``: :menuselection:`Raster --> Miscellaneous`
 
@@ -65,7 +66,8 @@ Merge
 Merges raster files in a simple way. Here you can use a pseudocolor
 table from an input raster and define the output raster type. All
 the images must be in the same coordinate system.
-The algorithm is derived from the `GDAL merge utility <https://www.gdal.org/gdal_merge.html>`_ .
+
+This algorithm is derived from the `GDAL merge utility <https://www.gdal.org/gdal_merge.html>`_ .
 
 ``Default menu``: :menuselection:`Raster --> Miscellaneous`
 
@@ -119,7 +121,8 @@ Build overviews (pyramids)
 To speed up rendering time of raster layers overviews (pyramids) can
 be created. Overviews are lower resolution copies of the data which
 QGIS uses depending of the level of zoom.
-The algorithm is derived from the `GDAL addo utility <https://www.gdal.org/gdaladdo.html>`_ .
+
+This algorithm is derived from the `GDAL addo utility <https://www.gdal.org/gdaladdo.html>`_ .
 
 ``Default menu``: :menuselection:`Raster --> Miscellaneous`
 
@@ -179,6 +182,8 @@ Information
 -----------
 The gdalinfo program lists various information about a GDAL supported raster dataset.
 
+This algorithm is derived from the `GDAL info utility <https://www.gdal.org/gdalinfo.html>`_ .
+
 ``Default menu``: :menuselection:`Raster --> Miscellaneous`
 
 Parameters
@@ -204,18 +209,16 @@ Outputs
 ``Layer information`` [html]
   Raster information in output.
 
-See also
-........
-`GDAL info <https://www.gdal.org/gdalinfo.html>`_
-
 
 .. _gdaltileindex:
 
 Tile Index
 ----------
-This tool builds a vector layer with a record for each input raster file, an
+Builds a vector layer with a record for each input raster file, an
 attribute containing the filename, and a polygon geometry outlining the raster.
 This output is suitable for use with MapServer as a raster tileindex.
+
+This algorithm is derived from the `GDAL addo utility <`GDAL Tile Index utility <https://www.gdal.org/gdaltindex.html>`_ .
 
 ``Default menu``: :menuselection:`Raster --> Miscellaneous`
 
@@ -276,10 +279,6 @@ Outputs
   be created if it doesn't already exist, otherwise it will append to the
   existing file.
 
-See also
-........
-
-`GDAL Tile Index <https://www.gdal.org/gdaltindex.html>`_
 
 .. Substitutions definitions - AVOID EDITING PAST THIS LINE
    This will be automatically updated by the find_set_subst.py script.

--- a/source/docs/user_manual/processing_algs/gdal/rasterprojections.rst
+++ b/source/docs/user_manual/processing_algs/gdal/rasterprojections.rst
@@ -16,8 +16,9 @@ Raster projections
 
 Assign projection
 -----------------
-Applies a coordinate system to a raster dataset. 
-The algorithm is derived from the the `GDAL edit utility <https://www.gdal.org/gdal_edit.html>`_ .
+Applies a coordinate system to a raster dataset.
+
+This algorithm is derived from the the `GDAL edit utility <https://www.gdal.org/gdal_edit.html>`_ .
 
 ``Default menu``: :menuselection:`Raster --> Projections`
 
@@ -37,7 +38,8 @@ Extract projection |34|
 -----------------------
 Extracts the projection of a raster file and writes it into a *world*
 file with extension :file:`.wld`.
-The algorithm is derived from the `GDAL srsinfo utility <https://www.gdal.org/gdalsrsinfo.html>`_ .
+
+This algorithm is derived from the `GDAL srsinfo utility <https://www.gdal.org/gdalsrsinfo.html>`_ .
 
 ``Default menu``: :menuselection:`Raster --> Projections`
 
@@ -73,7 +75,8 @@ Warp (reproject)
 ----------------
 Transfers a raster layer into another Coordinate Reference System (CRS).
 The output file resolution and the resampling method can be chosen.
-The algorithm is derived from the `GDAL warp utility <https://www.gdal.org/gdalwarp.html>`_ .
+
+This algorithm is derived from the `GDAL warp utility <https://www.gdal.org/gdalwarp.html>`_ .
 
 ``Default menu``: :menuselection:`Raster --> Projections`
 

--- a/source/docs/user_manual/processing_algs/gdal/vectorconversion.rst
+++ b/source/docs/user_manual/processing_algs/gdal/vectorconversion.rst
@@ -16,8 +16,8 @@ Vector conversion
 
 Convert format
 --------------
-Converts any OGR-supported vector layer into another OGR-supported
-format.
+Converts any OGR-supported vector layer into another OGR-supported format.
+
 This algorithm is derived from the `ogr2ogr utility <https://www.gdal.org/ogr2ogr.html>`_ .
 
 Parameters
@@ -75,7 +75,8 @@ Outputs
 Rasterize (vector to raster)
 ----------------------------
 Converts vector geometries (points, lines and polygons) into a raster image.
-The algorithm is derived from the `GDAL rasterize utility <https://www.gdal.org/gdal_rasterize.html>`_ .
+
+This algorithm is derived from the `GDAL rasterize utility <https://www.gdal.org/gdal_rasterize.html>`_ .
 
 ``Default menu``: :menuselection:`Raster --> Conversion`
 

--- a/source/docs/user_manual/processing_algs/gdal/vectorgeoprocessing.rst
+++ b/source/docs/user_manual/processing_algs/gdal/vectorgeoprocessing.rst
@@ -17,7 +17,8 @@ Vector geoprocessing
 Clip vector by extent
 ----------------------
 Clips any OGR-supported vector file to a given extent.
-The algorithm is derived from the `ogr2ogr utility <https://www.gdal.org/ogr2ogr.html>`_ .
+
+This algorithm is derived from the `ogr2ogr utility <https://www.gdal.org/ogr2ogr.html>`_ .
 
 Parameters
 ..........
@@ -48,7 +49,8 @@ Outputs
 Clip vector by polygon
 -----------------------
 Clips any OGR-supported vector layer by a polygon.
-The algorithm is derived from the `ogr2ogr utility <https://www.gdal.org/ogr2ogr.html>`_ .
+
+This algorithm is derived from the `ogr2ogr utility <https://www.gdal.org/ogr2ogr.html>`_ .
 
 Parameters
 ..........

--- a/source/docs/user_manual/processing_algs/gdal/vectormiscellaneous.rst
+++ b/source/docs/user_manual/processing_algs/gdal/vectormiscellaneous.rst
@@ -17,6 +17,8 @@ Vector miscellaneous
 Execute SQL
 -----------
 
+This algorithm is derived from the `GDAL ogr2ogr utility <https://www.gdal.org/ogr2ogr.html>`_ .
+
 Parameters
 ..........
 
@@ -58,7 +60,8 @@ Imports vector layers inside a PostgreSqL database on the basis of
 an available connection. The connection has to :ref:`be defined properly
 <vector_create_stored_connection>` beforehand. Be aware that the checkboxes 'Save Username'
 and 'Save Password' are activated. Then you can use the algorithm.
-The algorithm is derived from the `ogr2ogr utility <https://www.gdal.org/ogr2ogr.html>`_ .
+
+This algorithm is derived from the `GDAL ogr2ogr utility <https://www.gdal.org/ogr2ogr.html>`_ .
 
 Parameters
 ..........
@@ -247,7 +250,8 @@ Export to PostgreSQL (new connection)
 -------------------------------------
 Imports vector layers inside a PostGreSQL database. A new connection
 to the PostGIS database must be created.
-The algorithm is derived from the `ogr2ogr utility <https://www.gdal.org/ogr2ogr.html>`_ .
+
+This algorithm is derived from the `GDAL ogr2ogr utility <https://www.gdal.org/ogr2ogr.html>`_ .
 
 Parameters
 ..........
@@ -468,6 +472,8 @@ data source. The output will be shown in a 'Result' window and can be written
 into a HTML-file.
 The information includes the geometry type, feature count, the spatial extent,
 the projection information and many more.
+
+This algorithm is derived from the `GDAL ogrinfo utility <https://www.gdal.org/ogrinfo.html>`_ .
 
 Parameters
 ..........


### PR DESCRIPTION
* adds the parent GDAL utility link to almost all algorithms
* places the information on top of alg description instead of as a "see also"
