### PR TITLE
Cleaning TauDem and lastools algorithms description

### DIFF
--- a/source/docs/user_manual/processing_algs/lidartools/lastools.rst
+++ b/source/docs/user_manual/processing_algs/lidartools/lastools.rst
@@ -21,8 +21,9 @@ blast2dem
 Description
 ...........
 
-This tool can turn billions of points with via seamless Delaunay triangulation
+Turns points (up to billions) via seamless Delaunay triangulation
 implemented using streaming into large elevation, intensity, or RGB rasters.
+
 For more info see the `blast2dem <https://rapidlasso.com/blast2dem>`_ page and 
 its online `README <http://lastools.org/download/blast2dem_README.txt>`__ file.
 
@@ -82,18 +83,6 @@ Outputs
   and JPG for false color, gray ramps, and hillshades. Use value rasters 
   like TIF, BIL, IMG, ASC, DTM, FLT, XYZ, and CSV for actual values.
 
-Console usage
-.............
-
-::
-
-  processing.runalg('blast2dem', verbose, gui, input, filter, step, attribute, product, use_tile_bb, additional, output)
-
-See also
-........
-
-See also the `blast2dem <https://rapidlasso.com/blast2dem>`_ page and its online
-`README <http://lastools.org/download/blast2dem_README.txt>`__ file.
 
 blast2iso
 ---------
@@ -101,8 +90,9 @@ blast2iso
 Description
 ...........
 
-This tool can turn billions of points with via seamless Delaunay triangulation
+Turns points (up to billions) via seamless Delaunay triangulation
 implemented using streaming into large iso-contour lines (optionally tiled).
+
 For more info see the `blast2iso <https://rapidlasso.com/blast2iso>`_ page and
 its online `README <http://lastools.org/download/blast2iso_README.txt>`__ file.
 
@@ -163,18 +153,6 @@ Outputs
   If your input LiDAR file is in geographic coordinates (long/lat) or has 
   geo-referencing information (but only then) you can also create a KML output file.
 
-Console usage
-.............
-
-::
-
-  processing.runalg('blast2iso', verbose, gui, input, smooth, isoline_spacing, clean, simplify, simplify_area, additional, output)
-
-See also
-.........
-
-See also the `blast2iso <https://rapidlasso.com/blast2iso>`_ page and its online
-`README <http://lastools.org/download/blast2iso_README.txt>`__ file.
 
 las2dem
 -------
@@ -182,9 +160,11 @@ las2dem
 Description
 ...........
 
-This tool turns points (up to 20 million) via a temporary Delaunay triangulation
-that is rastered with a user-defined step size into an elevation, intensity, or
-RGB raster. For more info see the `las2dem <https://rapidlasso.com/las2dem>`_ page
+Turns points (up to 20 million) via a temporary Delaunay triangulation
+that is rasterized with a user-defined step size into an elevation, intensity, or
+RGB raster.
+
+For more info see the `las2dem <https://rapidlasso.com/las2dem>`_ page
 and its online `README <http://lastools.org/download/las2dem_README.txt>`__ file.
 
 Parameters
@@ -243,18 +223,6 @@ Outputs
   and JPG for false color, gray ramps, and hillshades. Use value rasters like
   TIF, BIL, IMG, ASC, DTM, FLT, XYZ, and CSV for actual values.
 
-Console usage
-.............
-
-::
-
-  processing.runalg('lidartools:las2dem', verbose, gui, input, filter, step, attribute, product, use_tile_bb, additional, output)
-
-See also
-........
-
-See also the `las2dem <https://rapidlasso.com/las2dem>`_ page and its online
-`README <http://lastools.org/download/las2dem_README.txt>`__ file.
 
 las2iso
 -------
@@ -262,8 +230,9 @@ las2iso
 Description
 ...........
 
-This tool turns point clouds (up to 20 million per file) into iso-contour lines
+Turns point clouds (up to 20 million per file) into iso-contour lines
 by creating a temporary Delaunay triangulation on which the contours are then traced.
+
 For more info see the `las2iso <https://rapidlasso.com/las2iso>`_ page and its
 online `README <http://lastools.org/download/las2iso_README.txt>`__ file.
 
@@ -324,18 +293,6 @@ Outputs
   If your input LiDAR file is in geographic coordinates (long/lat) or has geo-referencing
   information (but only then) you can also create a KML output file.
 
-Console usage
-.............
-
-::
-
-  processing.runalg('las2iso', verbose, gui, input, smooth, isoline_spacing, clean, simplify, simplify_area, additional, output)
-
-See also
-........
-
-See also the `las2iso <https://rapidlasso.com/las2iso>`_ page and its online
-`README <http://lastools.org/download/las2iso_README.txt>`__ file.
 
 las2las_filter
 --------------
@@ -343,10 +300,11 @@ las2las_filter
 Description
 ...........
 
-This tool uses las2las to filter LiDAR points based on different attributes and
-to write the surviving subset of points to a new LAZ or LAS file. For more info
-see the `las2las <https://rapidlasso.com/las2las>`_ page and its online
-`README <http://lastools.org/download/las2las_README.txt>`__ file.
+Uses las2las to filter LiDAR points based on different attributes and
+to write the surviving subset of points to a new LAZ or LAS file.
+
+For more info see the `las2las <https://rapidlasso.com/las2las>`_ page and
+its online `README <http://lastools.org/download/las2las_README.txt>`__ file.
 
 Parameters
 ..........
@@ -499,18 +457,6 @@ Outputs
   Specifies where the output point cloud is stored. Use LAZ for compressed output,
   LAS for uncompressed output, and TXT for ASCII.
 
-Console usage
-.............
-
-::
-
-  processing.runalg('lidartools:las2las_filter', verbose, input_laslaz, filter_return_class_flags1, filter_return_class_flags2, filter_coords_intensity1, filter_coords_intensity1_arg, filter_coords_intensity2, filter_coords_intensity2_arg, output_laslaz)
-
-See also
-........
-
-See also the `las2las <https://rapidlasso.com/las2las>`__ page and its online
-`README <http://lastools.org/download/las2las_README.txt>`__ file.
 
 las2las_project
 ---------------
@@ -1097,15 +1043,6 @@ Outputs
 ``output LAS/LAZ file`` [file]
   <put output description here>
 
-Console usage
-.............
-
-::
-
-  processing.runalg('lidartools:las2lasproject', verbose, input_laslaz, source_projection, source_utm, source_sp, target_projection, target_utm, target_sp, output_laslaz)
-
-See also
-........
 
 las2las_transform
 ------------------
@@ -1113,10 +1050,11 @@ las2las_transform
 Description
 ...........
 
-This tool uses las2las to filter LiDAR points based on different attributes and
-to write the surviving subset of points to a new LAZ or LAS file. For more info
-see the `las2las <https://rapidlasso.com/las2las>`_ page and its online
-`README <http://lastools.org/download/las2las_README.txt>`__ file.
+Uses las2las to filter LiDAR points based on different attributes and
+to write the surviving subset of points to a new LAZ or LAS file.
+
+For more info see the `las2las <https://rapidlasso.com/las2las>`_ page and
+its online `README <http://lastools.org/download/las2las_README.txt>`__ file.
 
 Parameters
 ..........
@@ -1279,18 +1217,6 @@ Outputs
   Specifies where the output point cloud is stored. Use LAZ for compressed output,
   LAS for uncompressed output, and TXT for ASCII.
 
-Console usage
-.............
-
-::
-
-  processing.runalg('lidartools:las2las_transform', verbose, input_laslaz, filter_return_class_flags1, filter_return_class_flags2, filter_coords_intensity1, filter_coords_intensity1_arg, filter_coords_intensity2, filter_coords_intensity2_arg, output_laslaz)
-
-See also
-........
-
-See also the `las2las <https://rapidlasso.com/las2las>`_ page and its online
-`README <http://lastools.org/download/las2las_README.txt>`__ file.
 
 las2txt
 -------
@@ -1324,15 +1250,6 @@ Outputs
 ``Output ASCII file`` [file]
   <put output description here>
 
-Console usage
-.............
-
-::
-
-  processing.runalg('lidartools:las2txt', verbose, input_laslaz, parse_string, output)
-
-See also
-........
 
 lasindex
 --------
@@ -1362,16 +1279,8 @@ Parameters
 
 Outputs
 .......
+  <put output description here>
 
-Console usage
-.............
-
-::
-
-  processing.runalg('lidartools:lasindex', verbose, input_laslaz, mobile_or_terrestrial)
-
-See also
-........
 
 lasgrid
 -------
@@ -1379,11 +1288,12 @@ lasgrid
 Description
 ...........
 
-This tool grids a selected attribute (e.g. elevation, intensity, classification,
+Grids a selected attribute (e.g. elevation, intensity, classification,
 scan angle, ...) of a large point clouds with a user-defined step size onto raster
-using a particular method (e.g. min, max, average). For more info see the
-`lasgrid <https://rapidlasso.com/lasgrid>`_ page and its online
-`README <http://lastools.org/download/lasgrid_README.txt>`__ file.
+using a particular method (e.g. min, max, average).
+
+For more info see the `lasgrid <https://rapidlasso.com/lasgrid>`_ page and
+its online `README <http://lastools.org/download/lasgrid_README.txt>`__ file.
 
 Parameters
 ..........
@@ -1449,18 +1359,6 @@ Outputs
   and JPG for false color or gray ramps. Use value rasters like TIF, BIL, IMG,
   ASC, DTM, FLT, XYZ, and CSV for actual values.
 
-Console usage
-.............
-
-::
-
-  processing.runalg('lidartools:lasgrid', verbose, gui, input, filter, step, attribute, method, use_tile_bb, additional, output)
-
-See also
-........
-
-See also the `lasgrid <https://rapidlasso.com/lasgrid>`_ page and its online
-`README <http://lastools.org/download/lasgrid_README.txt>`__ file.
 
 lasinfo
 -------
@@ -1489,15 +1387,6 @@ Outputs
 ``Output ASCII file`` [file]
   <put output description here>
 
-Console usage
-.............
-
-::
-
-  processing.runalg('lidartools:lasinfo', verbose, input_laslaz, output)
-
-See also
-........
 
 lasmerge
 --------
@@ -1561,15 +1450,6 @@ Outputs
 ``output LAS/LAZ file`` [file]
   <put output description here>
 
-Console usage
-.............
-
-::
-
-  processing.runalg('lidartools:lasmerge', verbose, files_are_flightlines, input_laslaz, file2, file3, file4, file5, file6, file7, output_laslaz)
-
-See also
-........
 
 lasprecision
 ------------
@@ -1598,15 +1478,6 @@ Outputs
 ``Output ASCII file`` [file]
   <put output description here>
 
-Console usage
-.............
-
-::
-
-  processing.runalg('lidartools:lasprecision', verbose, input_laslaz, output)
-
-See also
-........
 
 lasquery
 --------
@@ -1631,16 +1502,8 @@ Parameters
 
 Outputs
 .......
+  <put output description here>
 
-Console usage
-.............
-
-::
-
-  processing.runalg('lidartools:lasquery', verbose, aoi)
-
-See also
-........
 
 lasvalidate
 -----------
@@ -1669,15 +1532,6 @@ Outputs
 ``Output XML file`` [file]
   <put output description here>
 
-Console usage
-.............
-
-::
-
-  processing.runalg('lidartools:lasvalidate', verbose, input_laslaz, output)
-
-See also
-........
 
 laszip
 ------
@@ -1711,15 +1565,6 @@ Outputs
 ``output LAS/LAZ file`` [file]
   <put output description here>
 
-Console usage
-.............
-
-::
-
-  processing.runalg('lidartools:laszip', verbose, input_laslaz, report_size, output_laslaz)
-
-See also
-........
 
 txt2las
 -------
@@ -1767,16 +1612,6 @@ Outputs
 
 ``output LAS/LAZ file`` [file]
   <put output description here>
-
-Console usage
-.............
-
-::
-
-  processing.runalg('lidartools:txt2las', verbose, input, parse_string, skip, scale_factor_xy, scale_factor_z, output_laslaz)
-
-See also
-........
 
 
 .. Substitutions definitions - AVOID EDITING PAST THIS LINE

--- a/source/docs/user_manual/processing_algs/taudem/basic_grid_analysis_tools.rst
+++ b/source/docs/user_manual/processing_algs/taudem/basic_grid_analysis_tools.rst
@@ -88,15 +88,6 @@ Outputs
   plus the contribution from upslope neighbors that drain in to it according
   to the D8 flow model.
 
-Console usage
-.............
-
-::
-
-  processing.runalg('taudem:d8contributingarea', -p, -o, -wg, -nc, -ad8)
-
-See also
-........
 
 D8 Flow Directions
 ------------------
@@ -165,15 +156,6 @@ Outputs
 ``D8 Slope Grid`` [raster]
   A grid giving slope in the D8 flow direction. This is measured as drop/distance.
 
-Console usage
-.............
-
-::
-
-  processing.runalg('taudem:d8flowdirections', -fel, -p, -sd8)
-
-See also
-........
 
 D-Infinity Contributing Area
 ----------------------------
@@ -283,15 +265,6 @@ Outputs
   plus the contribution from upslope neighbors that have some fraction draining
   to it according to the D-infinity flow model.
 
-Console usage
-.............
-
-::
-
-  processing.runalg('taudem:dinfinitycontributingarea', -ang, -o, -wg, -nc, -sca)
-
-See also
-........
 
 D-Infinity Flow Directions
 --------------------------
@@ -367,15 +340,6 @@ Outputs
   triangular facets centered at each grid cell, measured as drop/distance, i.e.
   tan of the slope angle.
 
-Console usage
-.............
-
-::
-
-  processing.runalg('taudem:dinfinityflowdirections', -fel, -ang, -slp)
-
-See also
-........
 
 Grid Network
 ------------
@@ -470,15 +434,6 @@ Outputs
   second highest incoming flow path order + 1. This generalizes the common
   definition to cases where more than two flow paths join at a point.
 
-Console usage
-.............
-
-::
-
-  processing.runalg('taudem:gridnetwork', d8_flow_dir_grid, outlets_shape, mask_grid, threshold, longest_len_grid, total_len_grid, strahler_grid)
-
-See also
-........
 
 Pit Remove
 ----------
@@ -515,16 +470,6 @@ Outputs
   A grid of elevation values with pits removed so that flow is routed off of
   the domain.
 
-Console usage
-.............
-
-::
-
-  processing.runalg('taudem:pitremove', -z, -fel)
-
-See also
-........
-
 
 Select GT Threshold
 -------------------
@@ -555,16 +500,6 @@ Outputs
 
 ``Output Grid`` [raster]
   Output grid
-
-Console usage
-.............
-
-::
-
-  processing.runalg('taudem:selectgtthreshold', -z, -thresh, -t)
-
-See also
-........
 
 
 .. Substitutions definitions - AVOID EDITING PAST THIS LINE

--- a/source/docs/user_manual/processing_algs/taudem/specialized_grid_analysis_tools.rst
+++ b/source/docs/user_manual/processing_algs/taudem/specialized_grid_analysis_tools.rst
@@ -54,15 +54,6 @@ Outputs
   A grid giving the horizontal distance along the flow path as defined by the
   D8 Flow Directions Grid to the streams in the Stream Raster Grid.
 
-Console usage
-.............
-
-::
-
-  processing.runalg('taudem:d8distancetostreams', -p, -src, -thresh, -dist)
-
-See also
-........
 
 D-Infinity Avalanche Runout
 ---------------------------
@@ -191,15 +182,6 @@ Outputs
   This is a grid of the flow distance from the source site that has the highest
   angle to each cell.
 
-Console usage
-.............
-
-::
-
-  processing.runalg('taudem:dinfinityavalancherunout', -ang, -fel, -ass, -thresh, -alpha, -direct, -rz, -dfs)
-
-See also
-........
 
 D-Infinity Concentration Limited Accumulation
 ---------------------------------------------
@@ -315,15 +297,6 @@ Outputs
   A grid giving the resulting concentration of the compound of interest in
   the flow.
 
-Console usage
-.............
-
-::
-
-  processing.runalg('taudem:dinfinityconcentrationlimitedaccumulation', -ang, -dg, -dm, -q, -o, -csol, -nc, -ctpt)
-
-See also
-........
 
 D-Infinity Decaying Accumulation
 --------------------------------
@@ -406,15 +379,6 @@ Outputs
   mass at each location in the domain where mass moves with the D-infinity flow
   field, but is subject to first order decay in moving from cell to cell.
 
-Console usage
-.............
-
-::
-
-  processing.runalg('taudem:dinfinitydecayingaccumulation', -ang, -dm, -wg, -o, -nc, -dsca)
-
-See also
-........
 
 D-Infinity Distance Down
 ------------------------
@@ -519,15 +483,6 @@ Outputs
   Grid containing the distance to stream calculated using the D-infinity flow
   model and the statistical and path methods chosen.
 
-Console usage
-.............
-
-::
-
-  processing.runalg('taudem:dinfinitydistancedown', dinf_flow_dir_grid, pit_filled_grid, stream_grid, weight_path_grid, stat_method, dist_method, edge_contam, dist_down_grid)
-
-See also
-........
 
 D-Infinity Distance Up
 ----------------------
@@ -629,15 +584,6 @@ Outputs
   Grid containing the distances up to the ridge calculated using the D-Infinity
   flow model and the statistical and path methods chosen.
 
-Console usage
-.............
-
-::
-
-  processing.runalg('taudem:dinfinitydistanceup', dinf_flow_dir_grid, pit_filled_grid, slope_grid, stat_method, dist_method, threshold, edge_contam, dist_up_grid)
-
-See also
-........
 
 D-Infinity Reverse Accumulation
 -------------------------------
@@ -687,15 +633,6 @@ Outputs
   The grid giving the maximum of the weight loading grid downslope from each
   grid cell.
 
-Console usage
-.............
-
-::
-
-  processing.runalg('taudem:dinfinityreverseaccumulation', -ang, -wg, -racc, -dmax)
-
-See also
-........
 
 D-Infinity Transport Limited Accumulation - 2
 ---------------------------------------------
@@ -818,15 +755,6 @@ Outputs
   output and gives the concentration of a compound (contaminant) adhered or
   bound to the transported substance (e.g. sediment) is calculated.
 
-Console usage
-.............
-
-::
-
-  processing.runalg('taudem:dinfinitytransportlimitedaccumulation2', dinf_flow_dir_grid, supply_grid, capacity_grid, in_concentr_grid, outlets_shape, edge_contam, transp_lim_accum_grid, deposition_grid, out_concentr_grid)
-
-See also
-........
 
 D-Infinity Transport Limited Accumulation
 -----------------------------------------
@@ -938,15 +866,6 @@ Outputs
   minus the transport capacity out of the grid cell. The deposition grid is
   calculated as the transport in + the local supply - the tranport out.
 
-Console usage
-.............
-
-::
-
-  processing.runalg('taudem:dinfinitytransportlimitedaccumulation', dinf_flow_dir_grid, supply_grid, capacity_grid, outlets_shape, edge_contam, transp_lim_accum_grid, deposition_grid)
-
-See also
-........
 
 D-Infinity Upslope Dependence
 -----------------------------
@@ -996,15 +915,6 @@ Outputs
   A grid quantifing the amount each source point in the domain contributes to
   the zone defined by the destination grid.
 
-Console usage
-.............
-
-::
-
-  processing.runalg('taudem:dinfinityupslopedependence', -ang, -dg, -dep)
-
-See also
-........
 
 Slope Average Down
 ------------------
@@ -1045,15 +955,6 @@ Outputs
   This output is a grid of slopes calculated in the D8 downslope direction,
   averaged over the selected distance.
 
-Console usage
-.............
-
-::
-
-  processing.runalg('taudem:slopeaveragedown', -p, -fel, -dn, -slpd)
-
-See also
-........
 
 Slope Over Area Ratio
 ---------------------
@@ -1088,16 +989,6 @@ Outputs
   This is algebraically related to the more common ``ln(a/tan beta)`` wetness
   index, but contributing area is in the denominator to avoid divide by 0
   errors when slope is 0.
-
-Console usage
-.............
-
-::
-
-  processing.runalg('taudem:slopeoverarearatio', -slp, -sca, -sar)
-
-See also
-........
 
 
 .. Substitutions definitions - AVOID EDITING PAST THIS LINE

--- a/source/docs/user_manual/processing_algs/taudem/stream_network_analysis_tools.rst
+++ b/source/docs/user_manual/processing_algs/taudem/stream_network_analysis_tools.rst
@@ -74,15 +74,6 @@ Outputs
 ``Extreme Upslope Values Grid`` [raster]
   A grid of the maximum/minimum upslope values.
 
-Console usage
-.............
-
-::
-
-  processing.runalg('taudem:d8extremeupslopevalue', -p, -sa, -o, -nc, -min, -ssa)
-
-See also
-........
 
 Length Area Stream Source
 -------------------------
@@ -143,15 +134,6 @@ Outputs
   upslope path length, the D8 contributing area grid inputs, and parameters ``M``
   and ``y``. This grid indicates likely stream source grid cells.
 
-Console usage
-.............
-
-::
-
-  processing.runalg('taudem:lengthareastreamsource', length_grid, contrib_area_grid, threshold, exponent, stream_source_grid)
-
-See also
-........
 
 Move Outlets To Streams
 -----------------------
@@ -219,15 +201,6 @@ Outputs
   originally on a stream, -1 if it was not moved becuase there was not a stream
   within the maximum distance, or some positive value if it was moved.
 
-Console usage
-.............
-
-::
-
-  processing.runalg('taudem:moveoutletstostreams', -p, -src, -o, -md, -om)
-
-See also
-........
 
 Peuker Douglas
 --------------
@@ -280,13 +253,6 @@ Outputs
   and Douglas algorithm, and if viewed, resembles a channel network. This
   proto-channel network generally lacks connectivity and requires thinning,
   issues that were discussed in detail by Band (1986).
-
-Console usage
-.............
-
-::
-
-  processing.runalg('taudem:peukerdouglas', elevation_grid, center_weight, side_weight, diagonal_weight, stream_source_grid)
 
 See also
 ........


### PR DESCRIPTION
* Remove misleading console call and empty "see also" in TauDem algorithms
* Remove misleading console call and deduplicate the links to upstream docs for lastools algorithms, following the GDAL's route