### PR TITLE
List available measurement units

### DIFF
--- a/source/docs/user_manual/introduction/general_tools.rst
+++ b/source/docs/user_manual/introduction/general_tools.rst
@@ -1139,7 +1139,7 @@ as well as the total, shows up in the measure window.
 To stop measuring, click your right mouse button.
 
 Note that you can use the drop-down list near the total to interactively change
-the measurement units while measuring ('Meters', 'Kilometers', 'Feet', 'Yards',
+the measurement units while working with the measure tool ('Meters', 'Kilometers', 'Feet', 'Yards',
 'Miles', 'Nautical miles', 'Centimeters', 'Millimeters', 'Degrees', 'Map units').
 This unit is kept for the widget until a new project is created or another project
 is opened.

--- a/source/docs/user_manual/introduction/general_tools.rst
+++ b/source/docs/user_manual/introduction/general_tools.rst
@@ -1113,11 +1113,13 @@ Properties... --> General` menu.
 .. note:: **Configuring the measure tool**
 
    While measuring length or area, clicking the :guilabel:`Configuration` button
-   at the bottom of the widget helps you define in menu :menuselection:`Settings -->
-   Options --> Map Tools` the rubberband color, the precision of the measurements
-   and the unit behavior. You can also choose your preferred measurement or angle
-   units but keep in mind that those values are superseded in the current project
-   by options made in :menuselection:`Project --> Properties... --> General` menu.
+   at the bottom of the widget opens the :menuselection:`Settings -->
+   Options --> Map Tools` menu, where you can select the rubberband color, the
+   precision of the measurements and the unit behavior. You can also choose your
+   preferred measurement or angle units but keep in mind that those values are
+   overridden in the current project by the selection made in the 
+   :menuselection:`Project --> Properties... --> General` menu, and by the
+   selection made in the measurement widget.
 
 All measuring modules use the snapping settings from the digitizing module (see
 section :ref:`snapping_tolerance`). So, if you want
@@ -1137,19 +1139,10 @@ as well as the total, shows up in the measure window.
 To stop measuring, click your right mouse button.
 
 Note that you can use the drop-down list near the total to interactively change
-the measurement units while measuring. This unit is kept for the widget until
-a new or another project is opened. Available units are:
-
-* meters
-* kilometers
-* feet
-* yards
-* miles
-* nautical miles
-* centimeters
-* millimeters
-* degrees
-* map units
+the measurement units while measuring ('Meters', 'Kilometers', 'Feet', 'Yards',
+'Miles', 'Nautical miles', 'Centimeters', 'Millimeters', 'Degrees', 'Map units').
+This unit is kept for the widget until a new project is created or another project
+is opened.
 
 The :guilabel:`Info` section in the dialog explains how calculations are made
 according to CRS settings available.
@@ -1168,20 +1161,9 @@ according to CRS settings available.
 |measureArea| :sup:`Measure Area`: Areas can also be measured. In the
 measure window, the accumulated area size appears. Right-click to stop drawing.
 The Info section is also available as well as the ability to switch between
-different area units. Available units are:
-
-* square meters
-* square kilometers
-* square feet
-* square yards
-* square miles
-* hectares
-* acres
-* square centimeters
-* square millimeters
-* square nautical miles
-* square degrees
-* map units
+different area units ('Square meters', 'Square kilometers', 'Square feet', 'Square yards',
+'Square miles', 'Hectares', 'Acres', 'Square nautical miles', 'Square centimeters',
+'Square millimeters', 'Square degrees', 'Map units').
 
 .. _figure_measure_area:
 

--- a/source/docs/user_manual/introduction/general_tools.rst
+++ b/source/docs/user_manual/introduction/general_tools.rst
@@ -1138,7 +1138,18 @@ To stop measuring, click your right mouse button.
 
 Note that you can use the drop-down list near the total to interactively change
 the measurement units while measuring. This unit is kept for the widget until
-a new or another project is opened.
+a new or another project is opened. Available units are:
+
+* meters
+* kilometers
+* feet
+* yards
+* miles
+* nautical miles
+* centimeters
+* millimeters
+* degrees
+* map units
 
 The :guilabel:`Info` section in the dialog explains how calculations are made
 according to CRS settings available.
@@ -1157,7 +1168,20 @@ according to CRS settings available.
 |measureArea| :sup:`Measure Area`: Areas can also be measured. In the
 measure window, the accumulated area size appears. Right-click to stop drawing.
 The Info section is also available as well as the ability to switch between
-different area units.
+different area units. Available units are:
+
+* square meters
+* square kilometers
+* square feet
+* square yards
+* square miles
+* hectares
+* acres
+* square centimeters
+* square millimeters
+* square nautical miles
+* square degrees
+* map units
 
 .. _figure_measure_area:
 


### PR DESCRIPTION
List the units available in the measurement widget, including the new centimeter and millimeter based units (#1741).

I'm still unclear on a couple of points:
* For the area measurement, should "map units" not properly be called "square map units"?
* I think it would make sense to explain what "map units" refers to. I thought it would be whatever linear units the project CRS uses, but when I tried this out using QGIS 3.2, the measurements were also done in meters with a geographic coordinate system (where I would have expected the linear measurement to be done in degrees). Is this the expected behaviour?
* In the Project Properties and in the Map Tools Options, the centimeter and millimeter units are still missing. Should I open a ticket for this?