### PR TITLE
Replace the sphinx image role with figure's

### DIFF
--- a/source/docs/developers_guide/qtcreator.rst
+++ b/source/docs/developers_guide/qtcreator.rst
@@ -48,7 +48,7 @@ Then use the resulting file selection dialog to browse to and open this file:
 
   $HOME/dev/cpp/QGIS/CMakeLists.txt
 
-.. image:: images/image01.jpeg
+.. figure:: images/image01.jpeg
 
 Next you will be prompted for a build location. I create a specific build dir
 for QtCreator to work in under:
@@ -60,7 +60,7 @@ for QtCreator to work in under:
 Its probably a good idea to create separate build directories for different
 branches if you can afford the disk space.
 
-.. image:: images/image02.jpeg
+.. figure:: images/image02.jpeg
 
 
 Next you will be asked if you have any CMake build options to pass to CMake. We
@@ -70,7 +70,7 @@ will tell CMake that we want a debug build by adding this option:
 
   -DCMAKE_BUILD_TYPE=Debug
 
-.. image:: images/image03.jpeg
+.. figure:: images/image03.jpeg
 
 
 That's the basics of it. When you complete the Wizard, QtCreator will start
@@ -84,18 +84,18 @@ Setting up your build environment
 
 Click on the 'Projects' icon on the left of the QtCreator window.
 
-.. image:: images/image04.jpeg
+.. figure:: images/image04.jpeg
 
 Select the build settings tab (normally active by default).
 
-.. image:: images/image05.jpeg
+.. figure:: images/image05.jpeg
 
 We now want to add a custom process step. Why? Because QGIS can currently only
 run from an install directory, not its build directory, so we need to ensure
 that it is installed whenever we build it. Under 'Build Steps', click on the
 'Add BuildStep' combo button and choose 'Custom Process Step'.
 
-.. image:: images/image06.jpeg
+.. figure:: images/image06.jpeg
 
 Now we set the following details:
 
@@ -107,7 +107,7 @@ Now we set the following details:
 
  Command arguments: install
 
-.. image:: images/image07.jpeg
+.. figure:: images/image07.jpeg
 
 You are almost ready to build. Just one note: QtCreator will need write
 permissions on the install prefix. By default (which I am using here) QGIS is
@@ -117,7 +117,7 @@ machine, I just gave myself write permissions to the /usr/local directory.
 To start the build, click that big hammer icon on the bottom left of the
 window.
 
-.. image:: images/image08.jpeg
+.. figure:: images/image08.jpeg
 
 
 Setting your run environment
@@ -128,21 +128,21 @@ we need to create a custom run target to tell QtCreator to run QGIS from the
 install dir (in my case ``/usr/local/``). To do that, return to the projects
 configuration screen.
 
-.. image:: images/image04.jpeg
+.. figure:: images/image04.jpeg
 
 Now select the 'Run Settings' tab
 
-.. image:: images/image09.jpeg
+.. figure:: images/image09.jpeg
 
 We need to update the default run settings from using the 'qgis' run
 configuration to using a custom one.
 
-.. image:: images/image10.jpeg
+.. figure:: images/image10.jpeg
 
 Do do that, click the 'Add v' combo button next to the Run configuration
 combo and choose 'Custom Executable' from the top of the list.
 
-.. image:: images/image11.jpeg
+.. figure:: images/image11.jpeg
 
 Now in the properties area set the following details:
 
@@ -161,7 +161,7 @@ Now in the properties area set the following details:
 Then click the 'Rename' button and give your custom executable a meaningful
 name e.g. 'Installed QGIS'
 
-.. image:: images/image12.jpeg
+.. figure:: images/image12.jpeg
 
 Running and debugging
 ======================
@@ -169,9 +169,9 @@ Running and debugging
 Now you are ready to run and debug QGIS. To set a break point, simply open a
 source file and click in the left column.
 
-.. image:: images/image14.jpeg
+.. figure:: images/image14.jpeg
 
 Now launch QGIS under the debugger by clicking the icon with a bug on it in the
 bottom left of the window.
 
-.. image:: images/image13.jpeg
+.. figure:: images/image13.jpeg

--- a/source/docs/documentation_guidelines/writing.rst
+++ b/source/docs/documentation_guidelines/writing.rst
@@ -178,57 +178,14 @@ see :ref:`Label and reference <my_anchor>` for more information.
 
 .. _`image`:
 
-Figures and Images
-------------------
+Figures, Images and Tables
+--------------------------
 
 
 Pictures
 ........
 
-To insert an image, use
-
-.. code-block:: rst
-
-   .. figure:: /static/common/logo.png
-      :width: 10 em
-
-which returns
-
-.. figure:: /static/common/logo.png
-    :width: 10 em
-
-Replacement
-...........
-
-You can put an image inside text or add an alias to use everywhere. To use an image
-inside a paragraph, first create an alias:
-
-
-.. code-block:: rst
-
-   .. |nice_logo| image:: /static/common/logo.png
-                  :width: 2 em
-
-and then call it in your paragraph:
-
-.. code-block:: rst
-
-   my paragraph begins here with a nice logo |nice_logo|.
-
-This is how the example will be displayed:
-
-.. |nice_logo| image:: /static/common/logo.png
-               :width: 2 em
-
-my paragraph begins here with a nice logo |nice_logo|.
-
-.. note::
-
-   Currently, to ensure consistency and help in the use of QGIS icons
-   a list of aliases is built and available in the :ref:`substitutions` chapter.
-
-Figure
-......
+To insert an image or a figure, you can use:
 
 .. code-block:: rst
 

--- a/source/docs/documentation_guidelines/writing.rst
+++ b/source/docs/documentation_guidelines/writing.rst
@@ -189,12 +189,12 @@ To insert an image, use
 
 .. code-block:: rst
 
-   .. image:: /static/common/logo.png
+   .. figure:: /static/common/logo.png
       :width: 10 em
 
 which returns
 
-.. image:: /static/common/logo.png
+.. figure:: /static/common/logo.png
     :width: 10 em
 
 Replacement

--- a/source/docs/gentle_gis_introduction/preamble.rst
+++ b/source/docs/gentle_gis_introduction/preamble.rst
@@ -10,7 +10,7 @@ A Gentle Introduction to GIS
 Brought to you with QGIS, a Free and Open Source Software GIS Application
 for everyone.
 
-.. image:: img/qgis_logo.png
+.. figure:: img/qgis_logo.png
     :align: center
     :width: 8em
 
@@ -19,14 +19,14 @@ T. Sutton, O. Dassau, M. Sutton
 Sponsored by: Chief Directorate: Spatial Planning & Information, Department of
 Land Affairs, Eastern Cape, South Africa.
 
-.. image:: img/dla_logo.png
+.. figure:: img/dla_logo.png
     :align: center
     :width: 6em
 
 In partnership with: Spatial Information Management Unit, Office of the Premier,
 Eastern Cape, South Africa.
 
-.. image:: img/eastern_cape_logo.jpg
+.. figure:: img/eastern_cape_logo.jpg
     :align: center
     :width: 25em
 
@@ -83,6 +83,6 @@ heartfelt thanks to the DLA!
 
 We hope you enjoy using and learning QGIS in the spirit of Ubuntu!
 
-.. image:: img/tims_sign.png
+.. figure:: img/tims_sign.png
 
 Tim Sutton, April 2009

--- a/source/docs/training_manual/answers/answers.rst
+++ b/source/docs/training_manual/answers/answers.rst
@@ -87,7 +87,7 @@ There should be five layers on your map:
   on the |symbology|:sup:`Open the Layer Styling panel` button. Change the color
   with the one you want and best fits the water layer.
 
-.. image:: img/answer_water_blue.png
+.. figure:: img/answer_water_blue.png
    :align: center
 
 .. note::  If you want to work on only one layer at a time and don't want the
@@ -105,7 +105,7 @@ There should be five layers on your map:
 
 Your map should now look like this:
 
-.. image:: img/answer_symbology1.png
+.. figure:: img/answer_symbology1.png
    :align: center
 
 If you are a Beginner-level user, you may stop here.
@@ -130,7 +130,7 @@ If you are a Beginner-level user, you may stop here.
 
 Here's an example:
 
-.. image:: img/answer_buildings_symbology.png
+.. figure:: img/answer_buildings_symbology.png
    :align: center
 
 :ref:`Back to text <backlink-symbology-layers-1>`
@@ -143,7 +143,7 @@ Here's an example:
 
 To make the required symbol, you need three symbol layers:
 
-.. image:: img/answer_road_symbology.png
+.. figure:: img/answer_road_symbology.png
    :align: center
 
 The lowest symbol layer is a broad, solid gray line. On top of it there is a
@@ -152,12 +152,12 @@ slightly thinner solid yellow line and finally another thinner solid black line.
 * If your symbol layers resemble the above but you're not getting the result
   you want, check that your symbol levels look something like this:
 
-  .. image:: img/answer_road_symbol_levels.png
+  .. figure:: img/answer_road_symbol_levels.png
      :align: center
 
 * Now your map should look like this:
 
-  .. image:: img/target_road_symbology.png
+  .. figure:: img/target_road_symbology.png
      :align: center
 
 :ref:`Back to text <backlink-symbology-levels-1>`
@@ -170,7 +170,7 @@ slightly thinner solid yellow line and finally another thinner solid black line.
 
 * Adjust your symbol levels to these values:
 
-.. image:: img/answer_road_symbol_layers.png
+.. figure:: img/answer_road_symbol_layers.png
    :align: center
 
 * Experiment with different values to get different results.
@@ -221,7 +221,7 @@ Your map should now show the marker points and the labels should be offset by
 :kbd:`2.0 mm`: The style of the markers and labels should allow both to be
 clearly visible on the map:
 
-.. image:: img/customised_labels_one.png
+.. figure:: img/customised_labels_one.png
    :align: center
 
 :ref:`Back to text <backlink-label-tool-1>`
@@ -234,7 +234,7 @@ clearly visible on the map:
 
 One possible solution has this final product:
 
-.. image:: img/possible_outcome_map.png
+.. figure:: img/possible_outcome_map.png
    :align: center
 
 To arrive at this result:
@@ -245,7 +245,7 @@ To arrive at this result:
 * In addition, this example uses the :guilabel:`Wrap label on character`
   option:
 
-  .. image:: img/wrap_character_settings.png
+  .. figure:: img/wrap_character_settings.png
      :align: center
 
 * Enter a :kbd:`space` in this field and click :guilabel:`Apply` to achieve the
@@ -269,12 +269,12 @@ To arrive at this result:
   layer and select :kbd:`FONT_SIZE` in the :guilabel:`Attribute field` of the
   font size data override dropdown:
 
-  .. image:: img/font_size_override.png
+  .. figure:: img/font_size_override.png
      :align: center
 
   Your results, if using the above values, should be this:
 
-  .. image:: img/font_override_results.png
+  .. figure:: img/font_override_results.png
      :align: center
 
 :ref:`Back to text <backlink-label-data-defined-1>`
@@ -291,14 +291,14 @@ To arrive at this result:
 * Use the same method as in the first exercise of the lesson to get rid of the
   borders:
 
-  .. image:: img/gradient_map_no_pen.png
+  .. figure:: img/gradient_map_no_pen.png
      :align: center
 
 The settings you used might not be the same, but with the values
 :guilabel:`Classes` = :kbd:`6` and :guilabel:`Mode` = :guilabel:`Natural Breaks
 (Jenks)` (and using the same colors, of course), the map will look like this:
 
-.. image:: img/gradient_map_new_mode.png
+.. figure:: img/gradient_map_new_mode.png
    :align: center
 
 :ref:`Back to text <backlink-classification-refine-1>`
@@ -315,7 +315,7 @@ The settings you used might not be the same, but with the values
 The symbology doesn't matter, but the results should look more or less like
 this:
 
-.. image:: img/routes_layer_result.png
+.. figure:: img/routes_layer_result.png
    :align: center
 
 :ref:`Back to text <backlink-create-vector-digitize-1>`
@@ -329,7 +329,7 @@ this:
 The exact shape doesn't matter, but you should be getting a hole in the middle
 of your feature, like this one:
 
-.. image:: img/ring_tool_result.png
+.. figure:: img/ring_tool_result.png
    :align: center
 
 * Undo your edit before continuing with the exercise for the next tool.
@@ -344,12 +344,12 @@ of your feature, like this one:
 
 * First select the |largeLandUseArea|:
 
-.. image:: img/park_selected.png
+.. figure:: img/park_selected.png
    :align: center
 
 * Now add your new part:
 
-.. image:: img/new_park_area.png
+.. figure:: img/new_park_area.png
    :align: center
 
 * Undo your edit before continuing with the exercise for the next tool.
@@ -372,7 +372,7 @@ of your feature, like this one:
    original polygon's :guilabel:`OGC_FID` will not be :kbd:`1`. Just choose the
    feature which has an :guilabel:`OGC_FID`.
 
-  .. image:: img/merge_feature_dialog.png
+  .. figure:: img/merge_feature_dialog.png
      :align: center
 
 .. Note:: Using the :guilabel:`Merge Attributes of Selected Features` tool
@@ -396,14 +396,14 @@ that they are predefined.
   :guilabel:`highway` for both the :guilabel:`Value` and :guilabel:`Description`
   options:
 
-  .. image:: img/value_map_settings.png
+  .. figure:: img/value_map_settings.png
      :align: center
 
 * Click :guilabel:`Ok` three times.
 * If you use the :guilabel:`Identify` tool on a street now while edit mode is
   active, the dialog you get should look like this:
 
-  .. image:: img/highway_as_value_map.png
+  .. figure:: img/highway_as_value_map.png
      :align: center
 
 :ref:`Back to text <backlink-create-vector-forms-1>`
@@ -419,7 +419,7 @@ that they are predefined.
 
 * Your buffer dialog should look like this:
 
-  .. image:: img/schools_buffer_setup.png
+  .. figure:: img/schools_buffer_setup.png
      :align: center
 
   The :guilabel:`Buffer distance` is :guilabel:`1` kilometer.
@@ -428,12 +428,12 @@ that they are predefined.
   optional, but it's recommended, because it makes the output buffers look
   smoother. Compare this:
 
-  .. image:: img/schools_buffer_5.png
+  .. figure:: img/schools_buffer_5.png
      :align: center
 
   To this:
 
-  .. image:: img/schools_buffer_6.png
+  .. figure:: img/schools_buffer_6.png
      :align: center
 
 The first image shows the buffer with the :guilabel:`Segments to approximate`
@@ -454,21 +454,21 @@ process:
 * First, create a buffer of 500m around the restaurants and add the layer to
   the map:
 
-  .. image:: img/restaurants_buffer.png
+  .. figure:: img/restaurants_buffer.png
      :align: center
 
-  .. image:: img/restaurants_buffer_result.png
+  .. figure:: img/restaurants_buffer_result.png
      :align: center
 
 * Next, extract buildings within that buffer area:
 
-  .. image:: img/select_within_restaurants.png
+  .. figure:: img/select_within_restaurants.png
      :align: center
 
 Your map should now show only those buildings which are within 50m of a road,
 1km of a school and 500m of a restaurant:
 
-.. image:: img/restaurant_buffer_result.png
+.. figure:: img/restaurant_buffer_result.png
    :align: center
 
 :ref:`Back to text <backlink-vector-analysis-basic-2>`
@@ -484,7 +484,7 @@ Your map should now show only those buildings which are within 50m of a road,
 Open :menuselection:`Network Analysis --> Shortest Path (Point to Point)` and
 fill the dialog as:
 
-.. image:: img/fastest_path_result.png
+.. figure:: img/fastest_path_result.png
    :align: center
 
 Make sure that the :guilabel:`Path type to calculate` is ``Fastest``.
@@ -494,7 +494,7 @@ Click on :guilabel:`Run` and close the dialog.
 Open now the attribute table of the output layer. The :guilabel:`cost` field
 contains the travel time between the two points (as fraction of hours):
 
-.. image:: img/fastest_path_attribute.png
+.. figure:: img/fastest_path_attribute.png
    :align: center
 
 :ref:`Back to text <backlink-network_analysis_1>`
@@ -510,12 +510,12 @@ contains the travel time between the two points (as fraction of hours):
 
 * Set your :guilabel:`DEM (Terrain analysis)` dialog up like this:
 
-  .. image:: img/answer_dem_aspect.png
+  .. figure:: img/answer_dem_aspect.png
      :align: center
 
 Your result:
 
-.. image:: img/answer_aspect_result.png
+.. figure:: img/answer_aspect_result.png
    :align: center
 
 :ref:`Back to text <backlink-raster-analysis-1>`
@@ -528,7 +528,7 @@ Your result:
 
 * Set your :guilabel:`Raster calculator` dialog up like this:
 
-  .. image:: img/answer_raster_calculator_slope.png
+  .. figure:: img/answer_raster_calculator_slope.png
      :align: center
 
 * For the 5 degree version, replace the :kbd:`2` in the expression and file
@@ -538,12 +538,12 @@ Your results:
 
 * 2 degrees:
 
-  .. image:: img/answer_2degree_result.png
+  .. figure:: img/answer_2degree_result.png
      :align: center
 
 * 5 degrees:
 
-  .. image:: img/answer_5degree_result.png
+  .. figure:: img/answer_5degree_result.png
      :align: center
 
 :ref:`Back to text <backlink-raster-analysis-2>`
@@ -566,7 +566,7 @@ Your results:
 
 When viewed over the original raster, the areas should overlap perfectly:
 
-.. image:: img/polygonize_raster.png
+.. figure:: img/polygonize_raster.png
    :align: center
 
 * You can save this layer by right-clicking on the :guilabel:`all_terrain`
@@ -596,19 +596,19 @@ We can therefore sensibly eliminate those buildings from our dataset
 
 At the moment, your analysis should look something like this:
 
-.. image:: img/new_solution_example.png
+.. figure:: img/new_solution_example.png
    :align: center
 
 Consider a circular area, continuous for 100 meters in all directions.
 
-.. image:: img/circle_100.png
+.. figure:: img/circle_100.png
    :align: center
 
 If it is greater than 100 meters in radius, then subtracting 100 meters from
 its size (from all directions) will result in a part of it being left in the
 middle.
 
-.. image:: img/circle_with_remainder.png
+.. figure:: img/circle_with_remainder.png
    :align: center
 
 Therefore, you can run an *interior buffer* of 100 meters on your existing
@@ -622,7 +622,7 @@ To demonstrate:
   the Buffer(s) dialog.
 * Set it up like this:
 
-  .. image:: img/suitable_terrain_buffer.png
+  .. figure:: img/suitable_terrain_buffer.png
      :align: center
 
 * Use the :guilabel:`suitable_terrain` layer with :kbd:`10` segments and a
@@ -635,14 +635,14 @@ To demonstrate:
 
 Your results will look like something like this:
 
-.. image:: img/suitable_buffer_results.png
+.. figure:: img/suitable_buffer_results.png
    :align: center
 
 * Now use the :guilabel:`Select by Location` tool (:menuselection:`Vector -->
   Research Tools --> Select by location`).
 * Set up like this:
 
-  .. image:: img/select_by_location.png
+  .. figure:: img/select_by_location.png
      :align: center
 
 * Select features in :guilabel:`new_solution` that intersect features in
@@ -650,7 +650,7 @@ Your results will look like something like this:
 
 This is the result:
 
-.. image:: img/buffer_select_result.png
+.. figure:: img/buffer_select_result.png
    :align: center
 
 The yellow buildings are selected. Although some of the buildings fall partly
@@ -674,7 +674,7 @@ requirements.
 
 Your map should look like this (you may need to re-order the layers):
 
-.. image:: img/geology_layer_result.png
+.. figure:: img/geology_layer_result.png
    :align: center
 
 :ref:`Back to text <backlink-wms-1>`
@@ -688,16 +688,16 @@ Your map should look like this (you may need to re-order the layers):
 * Use the same approach as before to add the new server and the appropriate
   layer as hosted on that server:
 
-  .. image:: img/add_ogc_server.png
+  .. figure:: img/add_ogc_server.png
      :align: center
 
-  .. image:: img/add_bluemarble_layer.png
+  .. figure:: img/add_bluemarble_layer.png
      :align: center
 
 * If you zoom into the |majorUrbanName| area, you'll notice that this dataset has a
   low resolution:
 
-.. image:: img/low_resolution_dataset.png
+.. figure:: img/low_resolution_dataset.png
    :align: center
 
 Therefore, it's better not to use this data for the current map. The Blue
@@ -760,7 +760,7 @@ containing the rules you just have saved.
 Click on :guilabel:`Run` and then on :guilabel:`View Output`. You can change the
 colors and the final result should look like the following picture:
 
-.. image:: img/grass_reclass.png
+.. figure:: img/grass_reclass.png
   :align: center
 
 :ref:`Back to text <backlink-grass_reclass>`
@@ -853,7 +853,7 @@ linking them to our `people` table via 'one to many' relationships::
 
 An ER Diagram to represent this would look like this:
 
-.. image:: img/er-people-normalised-example.png
+.. figure:: img/er-people-normalised-example.png
    :align: center
 
 :ref:`Back to text <backlink-database-concepts-3>`

--- a/source/docs/training_manual/appendix/contribute.rst
+++ b/source/docs/training_manual/appendix/contribute.rst
@@ -275,7 +275,7 @@ Images
 * When adding an image, save it to the folder :kbd:`_static/lesson_name/`.
 * Include it in the document like this::
   
-    .. image:: img/image_file.extension
+    .. figure:: img/image_file.extension
        :align: center
 
 * Remember to leave a line open above and below the image markup.

--- a/source/docs/training_manual/basic_map/symbology.rst
+++ b/source/docs/training_manual/basic_map/symbology.rst
@@ -41,7 +41,7 @@ begin by changing the color of the :guilabel:`landuse` layer.
 
 #. In the :guilabel:`Layer Properties` window, select the :guilabel:`Symbology` tab:
 
-   .. image:: img/layer_properties_style.png
+   .. figure:: img/layer_properties_style.png
       :align: center
 
 #. Click the color select button next to the :guilabel:`Color` label.
@@ -78,7 +78,7 @@ areas so as to make the map less visually cluttered.
 #. in the :guilabel:`Symbol layers` panel, expand the :guilabel:`Fill` dropdown
    (if necessary) and select the :guilabel:`Simple fill` option:
 
-   .. image:: img/simple_fill_selected.png
+   .. figure:: img/simple_fill_selected.png
       :align: center
 
 #. Click on the :guilabel:`Stroke style` dropdown. At the moment, it should be
@@ -114,7 +114,7 @@ dataset at inappropriate scales.
 In our case, we may decide to hide the buildings from view at small scales. This
 map, for example ...
 
-.. image:: img/buildings_small_scale.png
+.. figure:: img/buildings_small_scale.png
    :align: center
 
 ... is not very useful. The buildings are hard to distinguish at that scale.
@@ -127,7 +127,7 @@ To enable scale-based rendering:
 #. Enable scale-based rendering by clicking on the checkbox labeled
    :guilabel:`Scale dependent visibility`:
 
-   .. image:: img/scale_dependent_visibility.png
+   .. figure:: img/scale_dependent_visibility.png
       :align: center
 
 #. Change the :guilabel:`Minimum` value to :kbd:`1:10,000`.
@@ -158,12 +158,12 @@ layers.
 #. Select the :guilabel:`Fill` in the :guilabel:`Symbol layers` panel. Then click
    the :guilabel:`Add symbol layer` button:
 
-   .. image:: img/add_symbol_layer_button.png
+   .. figure:: img/add_symbol_layer_button.png
       :align: center
 
 #. Click on it and the dialog will change to look somewhat like this:
 
-   .. image:: img/new_symbol_layer.png
+   .. figure:: img/new_symbol_layer.png
       :align: center
 
    It may appear somewhat different in color, for example, but you're going
@@ -185,7 +185,7 @@ With the new :guilabel:`Simple Fill` layer selected:
 #. Change the fill style to something other than :guilabel:`Solid` or
    :guilabel:`No brush`. For example:
 
-   .. image:: img/new_fill_settings.png
+   .. figure:: img/new_fill_settings.png
       :align: center
 
 #. Click :guilabel:`OK`.
@@ -194,7 +194,7 @@ Now you can see your results and tweak them as needed.
 You can even add multiple extra symbol layers and create a kind of texture for
 your layer that way.
 
-.. image:: img/multiple_symbol_layers.png
+.. figure:: img/multiple_symbol_layers.png
    :align: center
 
 It's fun! But it probably has too many colors to use in a real map...
@@ -224,7 +224,7 @@ having many symbol layers in one symbol can cause unexpected results.
 
 You'll notice that this happens:
 
-.. image:: img/bad_roads_symbology.png
+.. figure:: img/bad_roads_symbology.png
    :align: center
 
 Well, roads have now a *street* like symbology, but you see that lines are
@@ -239,12 +239,12 @@ To change the order of the symbol layers:
 #. Click :menuselection:`Advanced --> Symbol levels...` in the
    bottom right-hand corner of the window.
 
-   .. image:: img/symbol_levels_main_dialog.png
+   .. figure:: img/symbol_levels_main_dialog.png
       :align: center
 
    This will open a dialog like this:
 
-   .. image:: img/symbol_levels_dialog.png
+   .. figure:: img/symbol_levels_dialog.png
       :align: center
 
 #. Select :guilabel:`Enable symbol levels`. You can then set the layer ordering
@@ -253,7 +253,7 @@ To change the order of the symbol layers:
 
    In our case, we just want to activate the option, like this:
 
-   .. image:: img/correct_symbol_layers.png
+   .. figure:: img/correct_symbol_layers.png
       :align: center
 
    This will render the white line above the thick black line borders:
@@ -262,7 +262,7 @@ To change the order of the symbol layers:
 
    The map will now look like this:
 
-   .. image:: img/better_roads_symbology.png
+   .. figure:: img/better_roads_symbology.png
       :align: center
 
 When you're done, remember to save the symbol itself so as not to lose your
@@ -287,7 +287,7 @@ replacing will be lost.
   thin black line in the middle. Remember that you may need to change the layer
   rendering order via the :menuselection:`Advanced --> Symbol levels...` dialog.
 
-  .. image:: img/target_road_symbology.png
+  .. figure:: img/target_road_symbology.png
      :align: center
 
 :ref:`Check your results <symbology-levels-1>`
@@ -309,7 +309,7 @@ rudimentary pre-classified data.
 #. Using symbol layers, ensure that the outlines of layers flow into one another
    as per the image below:
 
-   .. image:: img/correct_advanced_levels.png
+   .. figure:: img/correct_advanced_levels.png
       :align: center
 
 :ref:`Check your results <symbology-levels-2>`
@@ -332,14 +332,14 @@ Point Symbol Layer Types
 #. Uncheck all the layers except for :guilabel:`places`.
 #. Change the symbol properties for the :guilabel:`places` layer:
 
-   .. image:: img/places_layer_properties.png
+   .. figure:: img/places_layer_properties.png
       :align: center
 
 #. You can access the various symbol layer types by selecting the
    :guilabel:`Simple marker` layer in the :guilabel:`Symbol layers` panel, then
    click the :guilabel:`Symbol layer type` dropdown:
 
-   .. image:: img/marker_type_dropdown.png
+   .. figure:: img/marker_type_dropdown.png
       :align: center
 
 #. Investigate the various options available to you, and choose a symbol with
@@ -357,18 +357,18 @@ To see the various options available for line data:
 #. Change the :guilabel:`Symbol layer type` for the :guilabel:`roads` layer's
    topmost symbol layer to :guilabel:`Marker line`:
 
-   .. image:: img/change_to_marker_line.png
+   .. figure:: img/change_to_marker_line.png
       :align: center
 
 #. Select the :guilabel:`Simple marker` layer in the :guilabel:`Symbol layers`
    panel. Change the symbol properties to match this dialog:
 
-   .. image:: img/simple_marker_line_properties.png
+   .. figure:: img/simple_marker_line_properties.png
       :align: center
 
 #. Select the :guilabel:`Marker line` layer and change the interval to ``1.00``:
 
-   .. image:: img/marker_line_interval.png
+   .. figure:: img/marker_line_interval.png
       :align: center
 
 #. Ensure that the symbol levels are correct (via the
@@ -393,10 +393,10 @@ To see the various options available for polygon data:
 #. If in doubt, use the :guilabel:`Point pattern fill` with the following
    options:
 
-   .. image:: img/pattern_fill_size.png
+   .. figure:: img/pattern_fill_size.png
       :align: center
 
-   .. image:: img/pattern_fill_distances.png
+   .. figure:: img/pattern_fill_distances.png
       :align: center
 
 #. Add a new symbol layer with a normal :guilabel:`Simple fill`.
@@ -404,7 +404,7 @@ To see the various options available for polygon data:
 #. Move it underneath the point pattern symbol layer with the :guilabel:`Move
    down` button:
 
-   .. image:: img/simple_fill_move_down.png
+   .. figure:: img/simple_fill_move_down.png
       :align: center
 
 As a result, you have a textured symbol for the water layer, with the added
@@ -431,7 +431,7 @@ Let's give it a try!
 #. Click on :guilabel:`Simple fill` and change the :guilabel:`Symbol layer type`
    to :guilabel:`Geometry generator`.
 
-   .. image:: img/geometry_generator.png
+   .. figure:: img/geometry_generator.png
       :align: center
 
 #. Before to start writing the spatial query we have to choose the Geometry Type
@@ -441,14 +441,14 @@ Let's give it a try!
 
     centroid($geometry)
 
-   .. image:: img/geometry_generator_query.png
+   .. figure:: img/geometry_generator_query.png
       :align: center
 
 #. When you click on :guilabel:`OK` you will see that the :guilabel:`water` layer
    is rendered as a point layer! We have just run a spatial operation within the
    layer symbology itself, isn't that amazing?
 
-   .. image:: img/geometry_generator_result.png
+   .. figure:: img/geometry_generator_result.png
       :align: center
 
 With the Geometry generator symbology you can really go over the edge of *normal*
@@ -467,7 +467,7 @@ Change also the appearance of the Simple marker of the Geometry generator symbol
 
 The final result should look like this:
 
-.. image:: img/geometry_generator_preview.png
+.. figure:: img/geometry_generator_preview.png
    :align: center
 
 :ref:`Check your results <symbology-geom_generator>`
@@ -482,7 +482,7 @@ The final result should look like this:
 #. Start the Inkscape program.
    You will see the following interface:
 
-   .. image:: img/inkscape_default.png
+   .. figure:: img/inkscape_default.png
       :align: center
 
    You should find this familiar if you have used other vector image editing
@@ -499,7 +499,7 @@ The final result should look like this:
    page you are working with.
 #. Select the :guilabel:`Circle` tool:
 
-   .. image:: img/inkscape_circle_tool.png
+   .. figure:: img/inkscape_circle_tool.png
       :align: center
 
 #. Click and drag on the page to draw an ellipse. To make the ellipse turn into
@@ -511,7 +511,7 @@ The final result should look like this:
    #. Assign to the border a darker color in :guilabel:`Stroke paint` tab,
    #. And reduce the border thickness under :guilabel:`Stroke style` tab.
 
-   .. image:: img/inkscape_stroke_fill.png
+   .. figure:: img/inkscape_stroke_fill.png
       :align: center
 
 #. Draw a line using the :guilabel:`Pencil` tool:
@@ -525,7 +525,7 @@ The final result should look like this:
    #. Change the color and width of the triangle symbol to match the circle's stroke
       and move it around as necessary, so that you end up with a symbol like this one:
 
-   .. image:: img/inkscape_final_symbol.png
+   .. figure:: img/inkscape_final_symbol.png
       :align: center
 
 #. If the symbol you get satisfies you, then save it as :guilabel:`landuse_symbol`
@@ -543,7 +543,7 @@ In QGIS:
    It's added to the symbol tree and you can now customize its different
    characteristics (colors, angle, effects, units...).
 
-   .. image:: img/svg_symbol_settings.png
+   .. figure:: img/svg_symbol_settings.png
       :align: center
 
 Once you validate the dialog, features in :guilabel:`landuse` layer should now
@@ -551,7 +551,7 @@ be covered by a set of symbols, showing a texture like the one on the
 following map. If textures are not visible, you may need to zoom in the map
 canvas or set in the layer properties a bigger :guilabel:`Texture width`.
 
-.. image:: img/svg_symbol_result.png
+.. figure:: img/svg_symbol_result.png
    :align: center
 
 |IC|

--- a/source/docs/training_manual/basic_map/vector_data.rst
+++ b/source/docs/training_manual/basic_map/vector_data.rst
@@ -99,7 +99,7 @@ Let's add some layer from a SpatiaLite database.
 #. Click the :guilabel:`Connect` button. You should see this in the previously
    empty box:
 
-   .. image:: img/spatiallite_dialog_connected.png
+   .. figure:: img/spatiallite_dialog_connected.png
       :align: center
 
 #. Click on the :guilabel:`landuse` layer to select it, then click
@@ -132,7 +132,7 @@ because other layers are on top of it.
 
 For example, this layer order...
 
-.. image:: img/incorrect_layer_order.png
+.. figure:: img/incorrect_layer_order.png
    :align: center
 
 ... would result in roads and places being hidden as they run *underneath*
@@ -143,7 +143,7 @@ To resolve this problem:
 #. Click and drag on a layer in the Layers list.
 #. Reorder them to look like this:
 
-.. image:: img/correct_layer_order.png
+.. figure:: img/correct_layer_order.png
    :align: center
 
 You'll see that the map now makes more sense visually, with roads and buildings

--- a/source/docs/training_manual/complete_analysis/analysis_combination.rst
+++ b/source/docs/training_manual/complete_analysis/analysis_combination.rst
@@ -34,7 +34,7 @@ suitable plots.
 You should now have a layer showing certain buildings as your solution, for
 example:
 
-.. image:: img/new_solution_example.png
+.. figure:: img/new_solution_example.png
    :align: center
 
 .. note:: If you find that the :guilabel:`Intersect` tool does not produce any

--- a/source/docs/training_manual/complete_analysis/raster_to_vector.rst
+++ b/source/docs/training_manual/complete_analysis/raster_to_vector.rst
@@ -29,7 +29,7 @@ exercises.
   Vector)`. The tool dialog will appear.
 * Set it up like this:
 
-  .. image:: img/polygonize_raster.png
+  .. figure:: img/polygonize_raster.png
      :align: center
 
 * Change the field name (describing the values of the raster) to
@@ -66,7 +66,7 @@ opposite conversion from the one performed above. Convert to raster the
 * Click on :menuselection:`Raster --> Conversion --> Rasterize (Vector to
   Raster)` to start this tool, then set it up as in the screenshot below:
 
-.. image:: img/vector_to_raster.png
+.. figure:: img/vector_to_raster.png
    :align: center
 
 * :guilabel:`Input file` is :guilabel:`all_terrain`.

--- a/source/docs/training_manual/create_vector_data/actions.rst
+++ b/source/docs/training_manual/create_vector_data/actions.rst
@@ -33,24 +33,24 @@ property yet. First we'll create a field for this purpose.
 * Click on the :guilabel:`Fields` tab.
 * Toggle editing mode:
 
-.. image:: img/toggle_editing_mode.png
+.. figure:: img/toggle_editing_mode.png
    :align: center
 
 * Add a new column:
 
-.. image:: img/add_new_column.png
+.. figure:: img/add_new_column.png
    :align: center
 
 * Enter the values below:
 
-.. image:: img/column_settings.png
+.. figure:: img/column_settings.png
    :align: center
 
 * After the field has been created, click on the :guilabel:`Line edit` button
   next to the new field.
 * Set it up for a :guilabel:`File name`:
 
-.. image:: img/select_file_name.png
+.. figure:: img/select_file_name.png
    :align: center
 
 * Click :guilabel:`OK` on the :guilabel:`Layer Properties` dialog.
@@ -60,7 +60,7 @@ property yet. First we'll create a field for this purpose.
 Since you're still in edit mode, the dialog should be active and look like
 this:
 
-.. image:: img/school_property_no_image.png
+.. figure:: img/school_property_no_image.png
    :align: center
 
 * Click on the browse button (the :guilabel:`...` next to the :guilabel:`image`
@@ -80,7 +80,7 @@ this:
 * In the :kbd:`Action properties` panel, enter the words :kbd:`Show Image` into
   the :guilabel:`Name` field:
 
-.. image:: img/show_image_action.png
+.. figure:: img/show_image_action.png
    :align: center
 
 What to do next varies according to your operating system, so choose the
@@ -118,7 +118,7 @@ is.
 
 * Select :guilabel:`image` from the list:
 
-.. image:: img/select_image.png
+.. figure:: img/select_image.png
    :align: center
 
 * Click the :guilabel:`Insert field` button. QGIS will add the phrase :kbd:`[%
@@ -207,12 +207,12 @@ Now you want QGIS to tell the browser to tell Google to search for the value of
 * Select the :guilabel:`name` field.
 * Click :guilabel:`Insert field`:
 
-.. image:: img/google_search_action.png
+.. figure:: img/google_search_action.png
    :align: center
 
 This will tell QGIS to add the phrase next:
 
-.. image:: img/google_search_entry.png
+.. figure:: img/google_search_entry.png
    :align: center
 
 What this means is that QGIS is going to open the browser and send it to the
@@ -279,7 +279,7 @@ To create the layer action:
 
      from PyQt4.QtCore import QUrl; from PyQt4.QtWebKit import QWebView;  myWV = QWebView(None); myWV.load(QUrl('https://wikipedia.org/wiki/[% "name" %]')); myWV.show()
 
-.. image:: img/python_action_example.png
+.. figure:: img/python_action_example.png
    :align: center
 
 There are a couple of things going on here:

--- a/source/docs/training_manual/create_vector_data/create_new_vector.rst
+++ b/source/docs/training_manual/create_vector_data/create_new_vector.rst
@@ -27,7 +27,7 @@ to define a new layer.
 
 You'll be presented with the following dialog:
 
-.. image:: img/create_vector_layer.png
+.. figure:: img/create_vector_layer.png
    :align: center
 
 It's important to decide which kind of dataset you want at this stage. Each
@@ -39,7 +39,7 @@ areas. For such features, you'll need to create a polygon dataset.
 
 * Click on the :guilabel:`Polygon` radio button:
 
-.. image:: img/polygon_selected.png
+.. figure:: img/polygon_selected.png
    :align: center
 
 This has no impact on the rest of the dialog, but it will cause the correct
@@ -50,7 +50,7 @@ CRS specifies how to describe a point on Earth in terms of coordinates, and
 because there are many different ways to do this, there are many different CRSs.
 The CRS of this project is WGS84, so it's already correct by default:
 
-.. image:: img/default_crs.png
+.. figure:: img/default_crs.png
    :align: center
 
 Next there is a collection of fields grouped under :guilabel:`New attribute`.
@@ -63,12 +63,12 @@ will be enough to add one field called :kbd:`name`.
 * Replicate the setup below, then click the :guilabel:`Add to attributes list`
   button:
 
-.. image:: img/new_attribute.png
+.. figure:: img/new_attribute.png
    :align: center
 
 * Check that your dialog now looks like this:
 
-.. image:: img/new_attribute_added.png
+.. figure:: img/new_attribute_added.png
    :align: center
 
 * Click :guilabel:`OK`. A save dialog will appear.
@@ -106,7 +106,7 @@ are provided, so you'll need to import them as necessary.
   other layers.
 * Find and zoom to this area:
 
-.. image:: img/map_area_zoom.png
+.. figure:: img/map_area_zoom.png
    :align: center
 
 .. note:: If your :guilabel:`buildings` layer symbology is covering part or all of the
@@ -116,7 +116,7 @@ are provided, so you'll need to import them as necessary.
 
 You'll be digitizing these three fields:
 
-.. image:: img/field_outlines.png
+.. figure:: img/field_outlines.png
    :align: center
 
 In order to begin digitizing, you'll need to enter **edit mode**. GIS software
@@ -169,7 +169,7 @@ and dragging around in the map.
 
 The first feature you'll be digitizing is the |schoolAreaType1|:
 
-.. image:: img/school_area_one.png
+.. figure:: img/school_area_one.png
    :align: center
 
 * Start digitizing by clicking on a point somewhere along the edge of the
@@ -180,7 +180,7 @@ The first feature you'll be digitizing is the |schoolAreaType1|:
   This will finalize the feature and show you the :guilabel:`Attributes` dialog.
 * Fill in the values as below:
 
-.. image:: img/school_area_one_attributes.png
+.. figure:: img/school_area_one_attributes.png
    :align: center
 
 * Click :guilabel:`OK` and you've created a new feature!
@@ -191,7 +191,7 @@ digitizing until you're done creating the feature as above. Then:
 
 * Select the feature with the :guilabel:`Select Single Feature` tool:
 
-.. image:: img/single_feature_select.png
+.. figure:: img/single_feature_select.png
    :align: center
 
 You can use:
@@ -209,7 +209,7 @@ You can use:
 
 * Digitize the school itself and the upper field. Use this image to assist you:
 
-.. image:: img/field_outlines.png
+.. figure:: img/field_outlines.png
    :align: center
 
 Remember that each new feature needs to have a unique :kbd:`id` value!
@@ -235,12 +235,12 @@ Remember that each new feature needs to have a unique :kbd:`id` value!
 Our path runs along the southern edge of the suburb of Railton, starting and
 ending at marked roads:
 
-.. image:: img/path_start_end.png
+.. figure:: img/path_start_end.png
    :align: center
 
 Our track is a little further to the south:
 
-.. image:: img/track_start_end.png
+.. figure:: img/track_start_end.png
    :align: center
 
 One at a time, digitize the path and the track on the :guilabel:`routes` layer.

--- a/source/docs/training_manual/create_vector_data/forms.rst
+++ b/source/docs/training_manual/create_vector_data/forms.rst
@@ -41,7 +41,7 @@ Table` all the time.
 * Now, click again on any street in the map. Along the previous
   :guilabel:`Identify Results` dialog, you'll see the now-familiar form:
 
-  .. image:: img/roads_form.png
+  .. figure:: img/roads_form.png
      :align: center
 
 * Each time you click on a single feature with the :guilabel:`Identify` tool,
@@ -56,7 +56,7 @@ If you are in edit mode, you can use this form to edit a feature's attributes.
 * Using the :guilabel:`Identify` tool, click on the main street running through
   |majorUrbanName|:
 
-.. image:: img/main_street_selected.png
+.. figure:: img/main_street_selected.png
    :align: center
 
 * Edit its :guilabel:`highway` value to be :kbd:`secondary`.
@@ -78,14 +78,14 @@ allow you to edit data in various different ways.
 * Open the :guilabel:`roads` layer's :guilabel:`Layer Properties`.
 * Switch to the :guilabel:`Fields` tab. You'll see this:
 
-.. image:: img/fields_panel.png
+.. figure:: img/fields_panel.png
    :align: center
 
 * Click on the :guilabel:`Line edit` button in the same row as
   :guilabel:`man_made` and you'll be given a new dialog.
 * Select :guilabel:`Checkbox` in the list of options:
 
-.. image:: img/checkbox_selected.png
+.. figure:: img/checkbox_selected.png
    :align: center
 
 * Click :guilabel:`OK`.
@@ -115,7 +115,7 @@ You can also design your own custom form completely from scratch.
   * Name (text)
   * Age (text)
 
-.. image:: img/new_point_layer.png
+.. figure:: img/new_point_layer.png
    :align: center
 
 * Capture a few points on your new layer using the digitizing tools so
@@ -125,7 +125,7 @@ You can also design your own custom form completely from scratch.
 
 .. note:: You may need to disable Snapping if still enabled from earlier tasks.
 
-.. image:: img/new_point_entry.png
+.. figure:: img/new_point_entry.png
    :align: center
 
 .. _creating-new-form:
@@ -152,7 +152,7 @@ another OS. In Ubuntu, do the following in the terminal:
   approach is appropriate in your OS).
 * In the dialog that appears, create a new dialog:
 
-.. image:: img/qt4_new_dialog.png
+.. figure:: img/qt4_new_dialog.png
    :align: center
 
 * Look for the :guilabel:`Widget Box` along the left of your screen (default).
@@ -162,7 +162,7 @@ another OS. In Ubuntu, do the following in the terminal:
 * With the new line edit element selected, you'll see its *properties* along
   the side of your screen (on the right by default):
 
-.. image:: img/qt4_line_edit.png
+.. figure:: img/qt4_line_edit.png
    :align: center
 
 * Set its name to :kbd:`Name`.
@@ -191,7 +191,7 @@ another OS. In Ubuntu, do the following in the terminal:
 * Click the ellipsis button and choose the :kbd:`add_people.ui` file you just
   created:
 
-.. image:: img/provide_ui_file.png
+.. figure:: img/provide_ui_file.png
   :align: center
 
 * Click :guilabel:`OK` on the :guilabel:`Layer Properties` dialog.

--- a/source/docs/training_manual/create_vector_data/topo_editing.rst
+++ b/source/docs/training_manual/create_vector_data/topo_editing.rst
@@ -25,7 +25,7 @@ snapping options:
 * Navigate to the menu entry :menuselection:`Project --> Snapping Options...`.
 * Set up your :guilabel:`Snapping options` dialog as shown:
 
-.. image:: img/set_snapping_options.png
+.. figure:: img/set_snapping_options.png
    :align: center
 
 * Ensure that the box in the :guilabel:`Avoid Int.` column is checked (set to
@@ -36,12 +36,12 @@ snapping options:
   :guilabel:`Advanced Digitizing` toolbar is enabled.
 * Zoom to this area (enable layers and labels if necessary):
 
-.. image:: img/zoom_to.png
+.. figure:: img/zoom_to.png
    :align: center
 
 * Digitize this new (fictional) area of the |largeLandUseArea|:
 
-.. image:: img/new_park_area.png
+.. figure:: img/new_park_area.png
    :align: center
 
 * When prompted, give it a :guilabel:`OGC_FID` of :kbd:`999`, but feel free to
@@ -63,7 +63,7 @@ Topology features can sometimes need to be updated. In our example, the
 :guilabel:`landuse` layer has some complex forest areas which have recently been
 joined to form one area:
 
-.. image:: img/forest_area_example.png
+.. figure:: img/forest_area_example.png
    :align: center
 
 Instead of creating new polygons to join the forest areas, we're going to use
@@ -74,24 +74,24 @@ the :guilabel:`Node Tool` to edit the existing polygons and join them.
 * Pick an area of forest, select a corner and move it to an adjoining corner so
   two forest sections meet:
 
-.. image:: img/corner_selected.png
+.. figure:: img/corner_selected.png
    :align: center
 
 * Click and drag the nodes until they snap into place.
 
-.. image:: img/corner_selected_move.png
+.. figure:: img/corner_selected_move.png
    :align: center
 
 The topologically correct border looks like this:
 
-.. image:: img/areas_joined.png
+.. figure:: img/areas_joined.png
    :align: center
 
 Go ahead and join a few more areas using the :guilabel:`Node Tool`. You can also
 use the :guilabel:`Add Feature` tool if it is appropriate. If you are using our
 example data, you should have a forest area looking something like this:
 
-.. image:: img/node_example_result.png
+.. figure:: img/node_example_result.png
    :align: center
 
 Don't worry if you have joined more, less or different areas of forest.
@@ -107,12 +107,12 @@ This is the :guilabel:`Simplify Feature` tool:
 * Click on one of the areas which you joined using either the
   :guilabel:`Node Tool` or :guilabel:`Add Feature` tool. You'll see this dialog:
 
-.. image:: img/simplify_line_dialog.png
+.. figure:: img/simplify_line_dialog.png
    :align: center
 
 * Move the slider from side to side and watch what happens:
 
-.. image:: img/simplify_line_example.png
+.. figure:: img/simplify_line_example.png
    :align: center
 
 This allows you to reduce the amount of nodes in complex features.
@@ -202,12 +202,12 @@ It can add a bump to an existing feature. With this tool selected:
   original polygon, forming an open-sided rectangle.
 * Right-click to finish marking points:
 
-.. image:: img/reshape_step_one.png
+.. figure:: img/reshape_step_one.png
    :align: center
 
 This will give a result similar to:
 
-.. image:: img/reshape_result.png
+.. figure:: img/reshape_result.png
    :align: center
 
 You can do the opposite, too:
@@ -216,12 +216,12 @@ You can do the opposite, too:
 * Draw a rectangle into the polygon.
 * Right-click outside the polygon again:
 
-.. image:: img/reshape_inverse_example.png
+.. figure:: img/reshape_inverse_example.png
    :align: center
 
 The result of the above:
 
-.. image:: img/reshape_inverse_result.png
+.. figure:: img/reshape_inverse_result.png
    :align: center
 
 
@@ -242,7 +242,7 @@ We will use the tool to split a corner from the |largeLandUseArea|.
   drawing a line. Click the vertex on the opposite side of the corner you wish
   to split and right-click to complete the line:
 
-.. image:: img/split_feature_example.png
+.. figure:: img/split_feature_example.png
    :align: center
 
 * At this point, it may seem as if nothing has happened. But remember that your
@@ -251,7 +251,7 @@ We will use the tool to split a corner from the |largeLandUseArea|.
 * Use the :guilabel:`Select Single Feature` tool to select the corner you just
   split; the new feature will now be highlighted:
 
-.. image:: img/new_corner_selected.png
+.. figure:: img/new_corner_selected.png
    :align: center
 
 .. _backlink-create-vector-topology-4:

--- a/source/docs/training_manual/database_concepts/data_model.rst
+++ b/source/docs/training_manual/database_concepts/data_model.rst
@@ -272,7 +272,7 @@ people and streets have a logical relationship. To express this relationship,
 we have to define a foreign key that points to the primary key of the streets
 table.
 
-.. image:: img/er-people-streets.png
+.. figure:: img/er-people-streets.png
    :align: center
 
 There are two ways to do this:

--- a/source/docs/training_manual/database_concepts/db_intro.rst
+++ b/source/docs/training_manual/database_concepts/db_intro.rst
@@ -298,7 +298,7 @@ We can then link the two tables using the 'keys' :kbd:`streets.id` and
 If we draw an ER Diagram for these two tables it would look something like
 this:
 
-.. image:: img/er-people-streets.png
+.. figure:: img/er-people-streets.png
    :align: center
 
 The ER Diagram helps us to express 'one to many' relationships. In this case

--- a/source/docs/training_manual/databases/db_browser.rst
+++ b/source/docs/training_manual/databases/db_browser.rst
@@ -28,7 +28,7 @@ interface.
   configured connection available (you may need to click the Refresh button at
   the top of the browser window).
 
-.. image:: img/browser_panel.png
+.. figure:: img/browser_panel.png
    :align: center
 
 * Double clicking on any of the table/layers listed here will add it to the Map
@@ -38,7 +38,7 @@ interface.
   Click on the :guilabel:`Properties` item to look at the properties of the 
   layer.
 
-.. image:: img/postgis_layer_properties.png
+.. figure:: img/postgis_layer_properties.png
    :align: center
 
 .. note:: Of course you can also use this interface to connect to PostGIS 
@@ -69,7 +69,7 @@ by using queries that we learned about in previous sections.
 
   "roadtype" = 'major'
 
-.. image:: img/pg_table_filter.png
+.. figure:: img/pg_table_filter.png
    :align: center
 
 * Click :guilabel:`OK` to complete editing the filter and click :guilabel:`Add`

--- a/source/docs/training_manual/databases/db_manager.rst
+++ b/source/docs/training_manual/databases/db_manager.rst
@@ -29,7 +29,7 @@ tables we have worked with in previous sections.
 The first thing you may notice is that you can now see some metadata about the
 Schemas contained in your database. 
 
-.. image:: img/db_manager_dialog.png
+.. figure:: img/db_manager_dialog.png
    :align: center
 
 Schemas are a way of grouping data tables and other objects in a PostgreSQL 
@@ -47,7 +47,7 @@ but now lets look at how to do this in DB Manager.
 First, its useful to just look at a table's metadata by clicking on its name in
 tree and looking in the :guilabel:`Info` tab.
 
-.. image:: img/table_info.png
+.. figure:: img/table_info.png
    :align: center
 
 In this panel you can see the :guilabel:`General Info` about the table as well
@@ -58,7 +58,7 @@ If you scroll down in the :guilabel:`Info` tab, you can see more information
 about the :guilabel:`Fields`, :guilabel:`Constraints` and :guilabel:`Indexes`
 for the table you are viewing.
 
-.. image:: img/table_info_fields.png
+.. figure:: img/table_info_fields.png
    :align: center
 
 Its also very useful to use DB Manager to simply look at the records in the
@@ -66,7 +66,7 @@ database in much the same way you might do this by viewing the attribute table
 of a layer in the Layer Tree. You can browse the data by selecting the 
 :guilabel:`Table` tab.
 
-.. image:: img/table_panel.png
+.. figure:: img/table_panel.png
    :align: center
 
 There is also a :guilabel:`Preview` tab which will show you the layer data in
@@ -83,7 +83,7 @@ perhaps? DB Manager allows you to do this directly.
 * Select :menuselection:`Table --> Edit Table` from the menu to open the 
   :guilabel:`Table Properties` dialog.
 
-.. image:: img/edit_table.png
+.. figure:: img/edit_table.png
    :align: center
 
 You can use this dialog to Add Columns, Add geometry columns, edit existing
@@ -92,13 +92,13 @@ columns or to remove a column completely.
 Using the :guilabel:`Constraints` tab, you can manage which fields are used as
 the primary key or to drop existing constraints.
 
-.. image:: img/constraints_panel.png
+.. figure:: img/constraints_panel.png
    :align: center
 
 The :guilabel:`Indexes` tab can be used to add and delete both spatial and normal
 indexes.
 
-.. image:: img/indexes_panel.png
+.. figure:: img/indexes_panel.png
    :align: center
  
 |basic| |FA| Creating a New Table
@@ -121,7 +121,7 @@ our database, let's use DB Manager to create a new table.
 * Click the checkbox to :guilabel:`Create spatial index` and click
   :guilabel:`Create` to create the table.
 
-.. image:: img/create_table.png
+.. figure:: img/create_table.png
    :align: center
  
 * Dismiss the dialog letting you know that the table was created and click
@@ -169,7 +169,7 @@ Manager.
 * Select the :kbd:`lines` table in the tree.
 * Select the :guilabel:`SQL window` button in the DB Manager toolbar.
 
-.. image:: img/sql_window_btn.png
+.. figure:: img/sql_window_btn.png
    :align: center
 
 * Compose the following :guilabel:`SQL query` in the space provided::
@@ -179,7 +179,7 @@ Manager.
 * Click the :guilabel:`Execute (F5)` button to run the query.
 * You should now see the records that match in the :guilabel:`Result` panel.
 
-.. image:: img/sql_results.png
+.. figure:: img/sql_results.png
    :align: center
 
 * Click the checkbox for :guilabel:`Load as new layer` to add the results to your map.
@@ -188,7 +188,7 @@ Manager.
 * Enter :kbd:`roads_primary` as the :guilabel:`Layer name (prefix)`.
 * Click :guilabel:`Load now!` to load the results as a new layer into your map.
  
-.. image:: img/sql_add_to_map.png
+.. figure:: img/sql_add_to_map.png
    :align: center
 
 The layers that matched your query are now displayed on your map. You can of
@@ -204,7 +204,7 @@ command line tools, so now let's learn how to use DB Manager to do imports.
 * Click the :guilabel:`Import layer/file` button on the toolbar in the DB
   Manager dialog.
 
-.. image:: img/import_layer_btn.png
+.. figure:: img/import_layer_btn.png
    :align: center
 
 * Select the :kbd:`urban_33S.shp` file from :kbd:`exercise_data/projected_data`
@@ -217,7 +217,7 @@ command line tools, so now let's learn how to use DB Manager to do imports.
 * Enable the checkbox to :guilabel:`Create Spatial Index`
 * Click :guilabel:`OK` to perform the import.
 
-.. image:: img/import_urban.png
+.. figure:: img/import_urban.png
    :align: center
 
 * Dismiss the dialog letting you know that the import was successful
@@ -227,7 +227,7 @@ You can now inspect the table in your database by clicking on it in the Tree.
 Verify that the data has been reprojected by checking that the
 :guilabel:`Spatial ref:` is listed as :kbd:`WGS 84 (4326)`
 
-.. image:: img/urban_info.png
+.. figure:: img/urban_info.png
    :align: center
 
 Right clicking on the table in the Tree and a selecting
@@ -248,7 +248,7 @@ databases, so lets take a look at how that is done.
 * Set the :guilabel:`Target SRID` as :kbd:`4326`.
 * Click :guilabel:`OK` to initialize the export.
 
-.. image:: img/export_to_vector.png
+.. figure:: img/export_to_vector.png
    :align: center
 
 * Dismiss the dialog letting you know the export was successful and close the
@@ -256,7 +256,7 @@ databases, so lets take a look at how that is done.
 
 You can now inspect the shapefile you created with the Browser panel.
 
-.. image:: img/inspect_vector_output.png
+.. figure:: img/inspect_vector_output.png
    :align: center
 
 |IC|

--- a/source/docs/training_manual/databases/spatialite.rst
+++ b/source/docs/training_manual/databases/spatialite.rst
@@ -46,13 +46,13 @@ any tables to this database. Let's go ahead and do that.
 * Add 2 attributes as shown in below
 * Click :guilabel:`OK` to create the table.
 
-.. image:: img/new_layer_setup.png
+.. figure:: img/new_layer_setup.png
    :align: center
 
 * Click the refresh button at the top of the Browser and you should now see
   your :kbd:`places` table listed.
 
-.. image:: img/new_layer_added.png
+.. figure:: img/new_layer_added.png
    :align: center
 
 You can right click on the table and view its properties as we did in the

--- a/source/docs/training_manual/forestry/basic_lidar.rst
+++ b/source/docs/training_manual/forestry/basic_lidar.rst
@@ -33,7 +33,7 @@ properly work with LAStools:
 * If you have a folder named :kbd:`lidar`, delete it. This is valid for some
   installations of QGIS 2.2 and 2.4.
 
-.. image:: img/remove_lidar_folder.png
+.. figure:: img/remove_lidar_folder.png
    :align: center
 
 * Go to the :file:`exercise_data\\forestry\\lidar\\` folder, there you can find
@@ -69,7 +69,7 @@ To setup the LAStools in QGIS:
 * For :guilabel:`LAStools folder` set :kbd:`c:\\lastools\\` (or the folder you
   extracted LAStools to).
 
-.. image:: img/processing_options.png
+.. figure:: img/processing_options.png
    :align: center
 
 |basic| |FA| Calculating a DEM with LAStools
@@ -82,7 +82,7 @@ to run some SAGA algorithms. Now you are going to use it to run LAStools program
 * In the dropdown menu at the bottom, select :guilabel:`Advanced interface`.
 * You should see the :guilabel:`Tools for LiDAR data` category.
 
-.. image:: img/processing_toolbox.png
+.. figure:: img/processing_toolbox.png
    :align: center
 
 * Expand it to see the tools available, and expand also the :guilabel:`LAStools`
@@ -91,14 +91,14 @@ to run some SAGA algorithms. Now you are going to use it to run LAStools program
 * At :guilabel:`Input LAS/LAZ file`, browse to :file:`exercise_data\\forestry\\lidar\\`
   and select the :file:`rautjarvi_lidar.laz` file.
 
-.. image:: img/lasview_dialog.png
+.. figure:: img/lasview_dialog.png
    :align: center
 
 * Click :guilabel:`Run`.
 
 Now you can see the LiDAR data in the :guilabel:`just a little LAS and LAZ viewer` dialog window:
 
-.. image:: img/full_lidar.png
+.. figure:: img/full_lidar.png
    :align: center
 
 There are many things you can do within this viewer, but for now you can just
@@ -118,7 +118,7 @@ a DEM using only the :kbd:`ground` points.
 * Note the :guilabel:`Search...` box, write :kbd:`lasground`.
 * Double click to open the :guilabel:`lasground` tool and set it as shown in this image:
 
-.. image:: img/lasground_dialog.png
+.. figure:: img/lasground_dialog.png
    :align: center
 
 * The output file is saved to the same folder where the :file:`rautjarvi_lidar.laz`
@@ -126,7 +126,7 @@ a DEM using only the :kbd:`ground` points.
 
 You can open it with :guilabel:`lasview` if you want to check it.
 
-.. image:: img/lasground_result.png
+.. figure:: img/lasground_result.png
    :align: center
 
 The brown points are the points classified as ground and the gray ones are the rest,
@@ -141,7 +141,7 @@ the viewer.
 * In the :guilabel:`Processing Toolbox`, search for :kbd:`las2dem`.
 * Open the :guilabel:`las2dem` tool and set it as shown in this image:
 
-.. image:: img/las2dem_dialog.png
+.. figure:: img/las2dem_dialog.png
    :align: center
 
 The result DEM is added to your map with the generic name :kbd:`Output raster file`.
@@ -161,7 +161,7 @@ For visualization purposes, a hillshade generated from a DEM gives a better
   and name the file :file:`hillshade.tif`.
 * Leave the rest of parameters with the default settings.
 
-.. image:: img/dem_hillshade.png
+.. figure:: img/dem_hillshade.png
    :align: center
 
 * Select :kbd:`ETRS89 / ETRS-TM35FIN` as the CRS when prompted.
@@ -170,7 +170,7 @@ Despite the diagonal lines remaining in the hillshade raster result, you can
 clearly see an accurate relief of the area. You can even see the different
 soil drains that have been dug in the forests.
 
-.. image:: img/hillshade_result.png
+.. figure:: img/hillshade_result.png
    :align: center
 
 

--- a/source/docs/training_manual/forestry/forest_maps.rst
+++ b/source/docs/training_manual/forestry/forest_maps.rst
@@ -80,7 +80,7 @@ you can review how it looks as you will be making changes in the layers symbolog
 * Click on the :guilabel:`Add New Map` button: |addMap|.
 * Click and drag a box on the canvas so that the map occupies most of it.
 
-.. image:: img/composer_1.png
+.. figure:: img/composer_1.png
    :align: center
 
 Notice how the mouse cursor snaps to the canvas grid. Use this function when
@@ -112,7 +112,7 @@ several vector layers and worrying about getting a good result.
 The current styling of the sample plots is not the best, but how does it look
 in the print layout?:
 
-.. image:: img/plots_zoom1-2.png
+.. figure:: img/plots_zoom1-2.png
    :align: center
 
 While during the last exercises, the white buffer was OK on top of the aerial
@@ -139,7 +139,7 @@ is to get the plots locations and their name to be as clearly visible as
 possible but always allowing to see the background map elements. You can take
 some guidance from this image:
 
-.. image:: img/plots_zoom2_symbology.png
+.. figure:: img/plots_zoom2_symbology.png
    :align: center
 
 You will use later the the green styling of the :kbd:`forest_stands_2012` layer.
@@ -159,7 +159,7 @@ below) but at a closer scale (right image below). Remember to use
 :guilabel:`Update preview` and :guilabel:`Set to map canvas extent` whenever
 you change the zoom in your map or the layout.
 
-.. image:: img/composer_2-3.png
+.. figure:: img/composer_2-3.png
    :align: center
 
 |basic| |TY| Create a Basic Map Template
@@ -176,7 +176,7 @@ to your printed map. Add at least the following elements:
 You have created a similar composition already in :doc:`../map_composer/index`.
 Go back to that module as you need. You can look at this example image for reference:
 
-.. image:: img/map_template1.png
+.. figure:: img/map_template1.png
    :align: center
 
 Export your map as an image and look at it.
@@ -205,7 +205,7 @@ general forest area:
 * Check also the :guilabel:`Frame` option with a black color and a
   :guilabel:`Thickness` of :kbd:`0.30`.
 
-.. image:: img/more_elements1.png
+.. figure:: img/more_elements1.png
    :align: center
 
 Notice that your overview map is not really giving an overview of the forest
@@ -242,7 +242,7 @@ small overview map is keeping the same view you had when you locked it.
 
 Note also that the overview is showing a shaded frame for the extent shown in the detail map.
 
-.. image:: img/more_elements2.png
+.. figure:: img/more_elements2.png
    :align: center
 
 Your template map is almost ready. Add now two text boxes below the map, one
@@ -271,7 +271,7 @@ The Atlas coverage is just a vector layer that will be used to generate the
 detail maps, one map for every feature in the coverage. To get an idea of what
 you will do next, here is a full set of detail maps for the forest area:
 
-.. image:: img/preview_atlas_results.png
+.. figure:: img/preview_atlas_results.png
    :align: center
 
 The coverage could be any existing layer, but usually it makes more sense to
@@ -281,7 +281,7 @@ the forest area:
 * In the QGIS map view, open :menuselection:`Vector --> Research Tools --> Vector grid`.
 * Set the tool as shown in this image:
 
-.. image:: img/coverage_polygons.png
+.. figure:: img/coverage_polygons.png
    :align: center
 
 * Save the output as :kbd:`atlas_coverage.shp`.
@@ -290,7 +290,7 @@ the forest area:
 The new polygons are covering the whole forest area and they give you an idea
 of what each map (created from each polygon) will contain.
 
-.. image:: img/atlas_coverage.png
+.. figure:: img/atlas_coverage.png
    :align: center
 
 |basic| |FA| Setting Up the Atlas Tool
@@ -302,7 +302,7 @@ The last step is to set up the Atlas tool:
 * In the panel on the right, go to the :guilabel:`Atlas generation` tab.
 * Set the options as follows:
 
-.. image:: img/atlas_settings.png
+.. figure:: img/atlas_settings.png
    :align: center
 
 That tells the Atlas tool to use the features (polygons) inside
@@ -323,7 +323,7 @@ your canvas:
   will be 10% bigger than the polygons, which means that your detail maps will
   have a 10% overlap.
 
-.. image:: img/controlled_by_atlas.png
+.. figure:: img/controlled_by_atlas.png
    :align: center
 
 Now you can use the preview tool for Atlas maps to review what your maps will look like:
@@ -349,7 +349,7 @@ also customize the text labels in your map to be generated with content from the
 * Remove the selected polygons.
 * Disable editing and save the edits.
 
-.. image:: img/remove_polygons.png
+.. figure:: img/remove_polygons.png
    :align: center
 
 You can go back to the :guilabel:`Print Layout` and check that the previews of
@@ -405,7 +405,7 @@ Do the same for the labels with the text :kbd:`Remarks:` using the field with
 the zone information. You can leave a break line before you enter the expression.
 You can see the result for the preview of zone 2 in the image below:
 
-.. image:: img/preview_zone2.png
+.. figure:: img/preview_zone2.png
    :align: center
 
 Use the Atlas preview to browse through all the maps you will be creating soon
@@ -435,7 +435,7 @@ You could just as easily create separate images for every map (remember to
 uncheck the single file creation), here you can see the thumbnails of the
 images that would be created:
 
-.. image:: img/maps_as_images.png
+.. figure:: img/maps_as_images.png
    :align: center
 
 In the :guilabel:`Print Layout`, save your map as a layout template as

--- a/source/docs/training_manual/forestry/index.rst
+++ b/source/docs/training_manual/forestry/index.rst
@@ -11,7 +11,7 @@ you are interested in learning about some basic forestry applications of GIS, fo
 module will give you the ability to apply what you have learned and will show you
 some new useful tools.
 
-.. image:: img/EUlogo_en.png
+.. figure:: img/EUlogo_en.png
 	:align: center
 	:width: 15 em
 

--- a/source/docs/training_manual/forestry/map_georeferencing.rst
+++ b/source/docs/training_manual/forestry/map_georeferencing.rst
@@ -41,7 +41,7 @@ For this exercise you will use a previously scanned map, you can find it as
 Open QGIS and set the project's CRS to :kbd:`ETRS89 / ETRS-TM35FIN` in
 :menuselection:`Project --> Properties --> CRS`, which is the currently used CRS in Finland. Make sure that :guilabel:`Enable 'on the fly' CRS transformation` is checked, since we will be working with old data that is another CRS.
 
-.. image:: img/f_1.png
+.. figure:: img/f_1.png
    :align: center
 
 Save the QGIS project as :kbd:`map_digitizing.qgs`.
@@ -67,7 +67,7 @@ Next you should define the transformation settings for georeferencing the map:
   as :kbd:`rautjarvi_georef.tif`.
 * Set the rest of parameters as shown below.
 
-.. image:: img/Clipboard10.png
+.. figure:: img/Clipboard10.png
    :align: center
    
 * Click :guilabel:`OK`.
@@ -99,7 +99,7 @@ points as far from each other as possible. Digitize at least three more ground
 control points in the same way you did the first one. You should end up with
 something similar to this:
 
-.. image:: img/Clipboard09.png
+.. figure:: img/Clipboard09.png
    :align: center
    
 With already three digitized ground control points you will be able to see the
@@ -132,7 +132,7 @@ in the :kbd:`exercise_data\\forestry` folder, named :kbd:`rautjarvi_aerial.tif`.
 Your map and this image should match quite well. Set the map transparency to 50%
 and compare it to the aerial image.
 
-.. image:: img/Clipboard14.png
+.. figure:: img/Clipboard14.png
    :align: center
 
 Save the changes to your QGIS project, you will continue from this point for the

--- a/source/docs/training_manual/forestry/parameters_calculation.rst
+++ b/source/docs/training_manual/forestry/parameters_calculation.rst
@@ -71,7 +71,7 @@ The average volume in the forest is ``135.2 m3/ha``.
 
 You can calculate the average for the number of stems in the same way, ``2745 stems/ha``.
 
-.. image:: img/statistics_pvol-pstem.png
+.. figure:: img/statistics_pvol-pstem.png
    :align: center
 
 |basic| |FA| Estimating Stand Parameters
@@ -112,7 +112,7 @@ and review the results you got. Note that a number of forest stands have
 sample plots. Select them all and view them in the map, they are some of the
 smaller stands:
 
-.. image:: img/stands_no_info.png
+.. figure:: img/stands_no_info.png
    :align: center
 
 Lets calculate now the same averages for the whole forest as you did before,
@@ -157,7 +157,7 @@ the sum of the areas of the stands containing information.
 #. Check the :guilabel:`Selected features only`
 #. Click :guilabel:`OK`.
 
-.. image:: img/stands_area_stats.png
+.. figure:: img/stands_area_stats.png
    :align: center
 
 As you can see, the total sum of the stands' areas is ``66.04 ha``.

--- a/source/docs/training_manual/forestry/results_map.rst
+++ b/source/docs/training_manual/forestry/results_map.rst
@@ -50,12 +50,12 @@ Now you can use a saved style for this layer:
 * Select the :kbd:`forest_stands_2012_results.qml` from the :kbd:`exercise_data\\forestry\\results\\` folder.
 * Click :guilabel:`OK`.
 
-.. image:: img/styling_forest_results.png
+.. figure:: img/styling_forest_results.png
    :align: center
 
 Your map will look something like this:
 
-.. image:: img/results_styles_applied.png
+.. figure:: img/results_styles_applied.png
    :align: center
 
 
@@ -64,7 +64,7 @@ Your map will look something like this:
 
 The style you loaded:
 
-.. image:: img/styling_forest_results.png
+.. figure:: img/styling_forest_results.png
    :align: center
 
 is using the :kbd:`Hard light` mode for the :guilabel:`Layer blending mode`.
@@ -83,14 +83,14 @@ Use a template prepared in advanced to present the results. The template
 :kbd:`forest_map.qpt` is located in the :kbd:`exercise_data\\forestry\\results\\`
 folder. Load it using the :menuselection:`Project --> Layout Manager...` dialog.
 
-.. image:: img/final_map_template.png
+.. figure:: img/final_map_template.png
    :align: center
 
 Open the print layout and edit the final map to get a result you are happy with.
 
 The map template you are using will give a map similar to this one:
 
-.. image:: img/final_map.png
+.. figure:: img/final_map.png
    :align: center
 
 Save your QGIS project for future references.

--- a/source/docs/training_manual/forestry/stands_digitazing.rst
+++ b/source/docs/training_manual/forestry/stands_digitazing.rst
@@ -42,7 +42,7 @@ original scanned map:
   represented as green lines (with the number of the stand also in green inside
   each polygon). 
 
-.. image:: img/gimp_map.png
+.. figure:: img/gimp_map.png
    :align: center
 
 Now you can select the pixels in the image that are making up the forest stands'
@@ -60,7 +60,7 @@ borders (the greenish pixels):
 * If you are not happy with the result, repeat the click and drag operation.
 * Your pixel selection should look something like the right image below.
 
-.. image:: img/green_px_selected.png
+.. figure:: img/green_px_selected.png
    :align: center
 
 Once you are done with the selection you need to copy this selection as a new
@@ -74,7 +74,7 @@ layer and then save it as separate image file:
 * Click the "eye" icon next to the original image layer to switch it off, so that
   only the :guilabel:`Pasted Layer` is visible:
 
-.. image:: img/saving_green_px.png
+.. figure:: img/saving_green_px.png
    :align: center
    
 * Finally, select :menuselection:`File --> Export...`, set :guilabel:`Select
@@ -120,7 +120,7 @@ using the snapping tools available in QGIS.
 
 Zoom in and see what the polygons look like. You will get something like this:
 
-.. image:: img/green_polygons.png
+.. figure:: img/green_polygons.png
    :align: center
 
 Next one option to get points out of those polygons is to get their centroids:
@@ -131,7 +131,7 @@ Next one option to get points out of those polygons is to get their centroids:
 * Check :menuselection:`Add result to canvas`.
 * Run the tool to calculate the centroids for the polygons.
 
-.. image:: img/green_points.png
+.. figure:: img/green_points.png
    :align: center
 
 Now you can remove the :guilabel:`rautjarvi_green_polygon` layer from the TOC.
@@ -156,7 +156,7 @@ there is a shapefile with part of the area of interest already digitized. You
 will just finish digitizing the half of the forest stands that are left between
 the main roads (wide pink lines) and the lake:
 
-.. image:: img/forest_stands_to_digitize.png
+.. figure:: img/forest_stands_to_digitize.png
    :align: center
 
 * Go to the :kbd:`digitizing` folder using your file manager browser.
@@ -178,7 +178,7 @@ Now, if you remember past modules, we have to set up and activate the snapping o
 * Check :guilabel:`Enable topological editing`.
 * Click :guilabel:`Apply`.
 
-.. image:: img/snapping_settings_forest.png
+.. figure:: img/snapping_settings_forest.png
    :align: center
 
 With these snapping settings, whenever you are digitizing and get close enough
@@ -208,7 +208,7 @@ Now you can start digitizing:
 * Start digitizing the stand :kbd:`357` by connecting some of the dots.
 * Note the pink crosses indicating the snapping.
 
-.. image:: img/dgitizing_357_1.png
+.. figure:: img/dgitizing_357_1.png
    :align: center
 
 * When you are done, right click to end digitizing that polygon.
@@ -221,7 +221,7 @@ go to :menuselection:`Settings --> Options --> Digitizing` and make sure that th
 
 Your digitized polygon will look like this:
 
-.. image:: img/dgitizing_357_3.png
+.. figure:: img/dgitizing_357_3.png
    :align: center
 
 Now for the second polygon, pick up the stand number 358. Make sure that the
@@ -240,7 +240,7 @@ to automatically obtain a common border.
 * Click :guilabel:`OK`, your new polygon should show a common border with the
   stand 357 as you can see in the image on the right.
 
-.. image:: img/dgitizing_358_5.png
+.. figure:: img/dgitizing_358_5.png
    :align: center
 
 The part of the polygon that was overlapping the existing polygon has been
@@ -268,7 +268,7 @@ edited at the same time for both polygons.
 
 Your result will look like this:
 
-.. image:: img/stands_fully_digitized.png
+.. figure:: img/stands_fully_digitized.png
    :align: center
 
 |basic| |FA| Joining the Forest Stand Data
@@ -290,7 +290,7 @@ in the same folder.
 * Open the :kbd:`.csv` in QGIS with the :menuselection:`Layer --> Add Delimited
   Text Layer...` tool. In the dialog, set it as follows:
 
-.. image:: img/inventory_csv_import.png
+.. figure:: img/inventory_csv_import.png
    :align: center
 
 To add the data from the :kbd:`.csv` file:
@@ -327,7 +327,7 @@ just added are no very useful. To solve this:
 * Then, go to :menuselection:`Vector --> Table Manager --> Table manager`.
 * Use the dialogue box to edit the names of the columns to match the ones in the :kbd:`.csv` file.
 
-.. image:: img/forestry_table_manager.png
+.. figure:: img/forestry_table_manager.png
    :align: center
 
 * Click on :guilabel:`Save`.

--- a/source/docs/training_manual/forestry/systematic_sampling.rst
+++ b/source/docs/training_manual/forestry/systematic_sampling.rst
@@ -79,7 +79,7 @@ You notice that the tool has used the whole extent of your stands layer to
 generate a rectangular grid of points. But you are only interested on those
 points that are actually inside your forest area (see the images below):
 
-.. image:: img/grid_full_and_clip.png
+.. figure:: img/grid_full_and_clip.png
    :align: center	
 
 * Open :menuselection:`Vector --> Geoprocessing Tools --> Clip`.
@@ -137,7 +137,7 @@ Now you have a new column with plot names that are meaningful to you. For the
 :kbd:`systematic_plots_clip` layer, change the field used for labeling to your
 new :kbd:`Plot_id` field.
 
-.. image:: img/labelled_plots.png
+.. figure:: img/labelled_plots.png
    :align: center
 
 |basic| |FA| Exporting Sample Plots as GPX format
@@ -164,7 +164,7 @@ save your data:
 * In the dialog that opens, select only the :kbd:`waypoints` layer (the rest of
   the layers are empty).
 
-.. image:: img/gpx_creation.png
+.. figure:: img/gpx_creation.png
    :align: center
 
 The inventory sample plots are now in a standard format that can be managed by

--- a/source/docs/training_manual/forestry/updating_stands.rst
+++ b/source/docs/training_manual/forestry/updating_stands.rst
@@ -73,7 +73,7 @@ of the forest stands.
 * Add the :kbd:`forest_stands_2012.shp` layer, located in the :kbd:`exercise_data\\forestry\\` folder.
 * Set the styling of this layer so that the polygons have no fill and the borders are visible.
 
-.. image:: img/stands_2012_1.png
+.. figure:: img/stands_2012_1.png
    :align: center
 
 You can see that a region to the North of the inventory area is still missing.
@@ -101,7 +101,7 @@ Some ideas about what you could identify from the images:
   A scale between 1:3 000 and 1: 5 000 should be enough for this imagery.
   See the image below (1:4000 scale):
 
-.. image:: img/zoom_to_CIR_1-4000.png
+.. figure:: img/zoom_to_CIR_1-4000.png
    :align: center
 
 |basic| |TY| Digitizing Forest Stands from CIR Imagery
@@ -120,7 +120,7 @@ With this indications in mind, you can now digitize the missing forest stands.
 * Set up the snapping and topology options as in the image.
 * Remember to click :guilabel:`Apply` or :guilabel:`OK`.
 
-.. image:: img/snapping_2012.png
+.. figure:: img/snapping_2012.png
    :align: center
 
 Start digitizing as you did in the previous lesson, with the only difference
@@ -130,7 +130,7 @@ should get around 14 new forest stands. While digitizing, fill in the
 
 When you are finished your layer should look something like:
 
-.. image:: img/new_stands_ready.png
+.. figure:: img/new_stands_ready.png
    :align: center
 
 Now you have a  new set of polygons defining the different forest stands for
@@ -189,7 +189,7 @@ the :guilabel:`Join attributes by location`:
 * Select :guilabel:`Yes` when prompted to add the layer to the TOC.
 * Close the dialogue box.
 
-.. image:: img/join_squirrel_point.png
+.. figure:: img/join_squirrel_point.png
    :align: center
    
 Now you have a new forest stands layer, :kbd:`stands_squirrel` where there are
@@ -200,7 +200,7 @@ Open the table of the new layer and order it so that the forest stands with
 information for the :guilabel:`Protection` attribute are on top. You should
 have now two forest stands where the squirrel has been located:
 
-.. image:: img/joined_squirrel_point.png
+.. figure:: img/joined_squirrel_point.png
    :align: center
 
 Although this information might be enough, look at what areas related to the
@@ -211,7 +211,7 @@ squirrels should be protected. You know that you have to leave a buffer of
 * Make a buffer of 15 meters for the :kbd:`squirrel` layer.
 * Name the result :kbd:`squirrel_15m.shp`.
 
-.. image:: img/squirrel_15m.png
+.. figure:: img/squirrel_15m.png
    :align: center
 
 You will notice that if you zoom in to the location in the Northern part of the
@@ -219,7 +219,7 @@ area, the buffer area extends to the neighbouring stand as well. This means that
 whenever a forest operation would take place in that stand, the protected
 location should also be taken into account.
 
-.. image:: img/north_squirrel_buffer.png
+.. figure:: img/north_squirrel_buffer.png
    :align: center
 
 From your previous analysis, you did not get that stand to register information
@@ -229,7 +229,7 @@ about the protection status. To solve this problem:
 * But this time use the :kbd:`squirrel_15m` layer as join layer.
 * Name the output file as :kbd:`stands_squirrel_15m.shp`.
 
-.. image:: img/joined_squirrel_buffer.png
+.. figure:: img/joined_squirrel_buffer.png
    :align: center
    
 Open the attribute table for the this new layer and note that now you have

--- a/source/docs/training_manual/foreword/foreword.rst
+++ b/source/docs/training_manual/foreword/foreword.rst
@@ -32,7 +32,7 @@ exercises complete with annotated answers throughout the text.
 License
 -------
 
-.. image:: img/license.png
+.. figure:: img/license.png
 
 The Free Quantum GIS Training Manual by Linfiniti Consulting CC. is based on
 an earlier version from Linfiniti and is licensed under a

--- a/source/docs/training_manual/foreword/preparing_data.rst
+++ b/source/docs/training_manual/foreword/preparing_data.rst
@@ -40,14 +40,14 @@ water, such as streams and rivers.
 #. In the :guilabel:`Browser` tab, expand the :guilabel:`XYZ Tiles` drop-down menu
    and double-click the :guilabel:`OpenStreetMap` item.
 
-   .. image:: img/browser_xyztiles.png
+   .. figure:: img/browser_xyztiles.png
       :align: center
 
    A map of the world is now visible on the map canvas;
 #. Close the :guilabel:`Data Source Manager` dialog;
 #. Move to the area you'd like to use as study area.
 
-   .. image:: img/swellendam_neighborhood.png
+   .. figure:: img/swellendam_neighborhood.png
       :align: center
 
 Now that we have the area we'll extract the data from, let's enable the extraction
@@ -58,7 +58,7 @@ tools.
 #. Select the QuickOSM plugin, press :guilabel:`Install Plugin` and then :guilabel:`Close`
    the dialog;
 
-   .. image:: img/quickosm_plugin_download.png
+   .. figure:: img/quickosm_plugin_download.png
       :align: center
 
 #. Execute the new plugin from :menuselection:`Vector --> QuickOSM --> QuickOSM`
@@ -71,7 +71,7 @@ tools.
    geometry types except :guilabel:`Multipolygons`;
 #. Press :guilabel:`Run query`;
 
-   .. image:: img/building_query_builder.png
+   .. figure:: img/building_query_builder.png
       :align: center
 
    A new ``building`` layer is added to the :guilabel:`Layers` panel, showing
@@ -88,7 +88,7 @@ tools.
 The above process adds the layers as temporary files (indicated by the
 |indicatorMemory| icon next to their name).
 
-   .. image:: img/osm_data_loaded.png
+   .. figure:: img/osm_data_loaded.png
       :align: center
 
 You can sample the data your region contains in order to see what kind of
@@ -109,7 +109,7 @@ course:
 #. Use the :guilabel:`...` button to browse to the :file:`exercise_data/shapefile/`
    folder and save the file as :file:`buildings.shp`;
 
-   .. image:: img/save_osm_building.png
+   .. figure:: img/save_osm_building.png
       :align: center
 
 #. Press :guilabel:`OK`;
@@ -141,7 +141,7 @@ use during the course:
    folder. By default, the :guilabel:`Layer name` is filled as the file name.
    Do not change it.
 
-   .. image:: img/save_osm_landuse.png
+   .. figure:: img/save_osm_landuse.png
       :align: center
 
 #. Press :guilabel:`OK`.
@@ -149,7 +149,7 @@ use during the course:
 You should now have a map which looks something like this (the symbology will
 certainly be very different, but that is fine):
 
-   .. image:: img/post_osm_import.png
+   .. figure:: img/post_osm_import.png
       :align: center
 
 The important thing is that you have 6 vector layers matching those shown above
@@ -189,7 +189,7 @@ school buildings, playgrounds or car parks).
 
 For reference, the image in the example data is:
 
-.. image:: img/field_outlines.png
+.. figure:: img/field_outlines.png
    :align: center
 
 

--- a/source/docs/training_manual/grass/grass_setup.rst
+++ b/source/docs/training_manual/grass/grass_setup.rst
@@ -20,7 +20,7 @@ plugin
 #. First, open a new QGIS project.
 #. In the :guilabel:`Plugin Manager`, enable :guilabel:`GRASS` in the list:
 
-   .. image:: img/enable_grass.png
+   .. figure:: img/enable_grass.png
       :align: center
 
    The GRASS toolbar and the GRASS panel will appear:
@@ -60,14 +60,14 @@ information visit the `GRASS website <https://grass.osgeo.org/grass75/manuals/gr
 
 #. Click on the :guilabel:`Plugins -> GRASS -> New Mapset` menu:
 
-   .. image:: img/grass_menu.png
+   .. figure:: img/grass_menu.png
       :align: center
 
    You'll be asked to choose the location of the GRASS database.
 
 #. Set it as the directory that will be used by GRASS to set up its database:
 
-   .. image:: img/grass_folder.png
+   .. figure:: img/grass_folder.png
       :align: center
 
 #. Click :guilabel:`Next`.
@@ -82,32 +82,32 @@ geographic area you'll be working in, also known as Grass ``Region``.
 
 #. Call the new location ``SouthAfrica``:
 
-   .. image:: img/new_location.png
+   .. figure:: img/new_location.png
       :align: center
 
 #. Click :guilabel:`Next`.
 #. We'll be working with ``WGS 84``, so search for and select this CRS:
 
-   .. image:: img/wgs_84_selected.png
+   .. figure:: img/wgs_84_selected.png
       :align: center
 
 #. Click :guilabel:`Next`.
 #. Now select the region :guilabel:`South Africa` from the dropdown and click
    :guilabel:`Set`:
 
-   .. image:: img/set_south_africa.png
+   .. figure:: img/set_south_africa.png
       :align: center
 
 #. Click :guilabel:`Next`.
 #. Create a mapset, which is the map file that you'll be working with.
 
-   .. image:: img/grass_mapset.png
+   .. figure:: img/grass_mapset.png
       :align: center
 
    Once you're done, you'll see a dialog asking with a summary of all the
    information entered.
 
-   .. image:: img/grass_final.png
+   .. figure:: img/grass_final.png
      :align: center
 
 #. Click :guilabel:`Finish`.
@@ -139,7 +139,7 @@ GRASS data are recognized from the QGIS Browser as *real* GRASS data and you can
 notice it because you will see the GRASS icon next to the GRASS Mapset. Moreover
 you will see the |grassMapsetOpen| icon next to the Mapset that is opened.
 
-.. image:: img/grass_browser.png
+.. figure:: img/grass_browser.png
    :align: center
 
 .. note:: You will see a replication of the GRASS Location as normal folder:
@@ -153,7 +153,7 @@ of the ``SouthAfrica`` Location.
 Open the :file:`shapefile/` folder and simply drag the :file:`roads.shp` layer
 into the ``grass_mapset`` Mapset.
 
-.. image:: img/grass_browser_import.png
+.. figure:: img/grass_browser_import.png
    :align: center
 
 That's it! If you expand the Mapset you will see the imported :file:`roads`
@@ -177,7 +177,7 @@ same Mapset.
    .. warning:: There are 2 similar tools: ``v.in.ogr.qgis`` and
      ``v.in.ogr.qgis.loc``. We are looking for the **first** one.
 
-   .. image:: img/grass_panel_import.png
+   .. figure:: img/grass_panel_import.png
       :align: center
 
    The ``v`` stands for *vector*, ``in`` means a function to import data into
@@ -189,7 +189,7 @@ same Mapset.
    the :guilabel:`rivers` layer in the :guilabel:`Loaded Layer` box and type and
    name it :file:`g_rivers` to prevent confusion:
 
-   .. image:: img/grass_tool_selected.png
+   .. figure:: img/grass_tool_selected.png
       :align: center
 
    .. note:: |hard| Note the extra import options provided under
@@ -226,7 +226,7 @@ We are going to import in the GRASS Mapset the layer |srtmFileName|.
    dialog.
 #. Set it up so that the input layer is |srtmFileName| and the output is :file:`g_dem`.
 
-   .. image:: img/g_dem_settings.png
+   .. figure:: img/g_dem_settings.png
       :align: center
 
 #. Click :guilabel:`Run`.
@@ -234,7 +234,7 @@ We are going to import in the GRASS Mapset the layer |srtmFileName|.
 #. :guilabel:`Close` the current tab, and then :guilabel:`Close` the whole
    dialog.
 
-   .. image:: img/g_dem_result.png
+   .. figure:: img/g_dem_result.png
       :align: center
 
 #. You may now remove the original |srtmFileName| layer.
@@ -273,7 +273,7 @@ Let's close the Mapset by clicking on the :guilabel:`Close Mapset` button of the
    not the GRASS Mapset one. Indeed GRASS will read all the ``Locations`` of the
    database and all the ``Mapsets`` of each ``Location``:
 
-   .. image:: img/grass_open_mapset.png
+   .. figure:: img/grass_open_mapset.png
       :align: center
 
 #. Choose the ``Location`` :kbd:`SouthAfrica` and the ``Mapset`` :kbd:`grass_mapset`
@@ -295,7 +295,7 @@ Even faster and easier is opening a ``Mapset`` using the QGIS Browser:
    next to it). You will see some options.
 #. Click on :guilabel:`Open mapset`:
 
-   .. image:: img/grass_open_mapset_browser.png
+   .. figure:: img/grass_open_mapset_browser.png
       :align: center
 
 The Mapset is now open and ready to use!

--- a/source/docs/training_manual/grass/grass_tools.rst
+++ b/source/docs/training_manual/grass/grass_tools.rst
@@ -20,13 +20,13 @@ capabilities of GRASS.
   :guilabel:`Filter` field of the :guilabel:`Modules List` tab.
 * Open the tool and set it up like this and click on the :guilabel:`Run` button:
 
-  .. image:: img/grass_aspect.png
+  .. figure:: img/grass_aspect.png
      :align: center
 
 * When the process is finished click on :guilabel:`View Output` to load the
   resulting layer in the canvas:
 
-.. image:: img/grass_aspect_result.png
+.. figure:: img/grass_aspect_result.png
    :align: center
 
 The :kbd:`g_aspect` layer is stored within the :kbd:`grass_mapset` Mapset so you
@@ -44,13 +44,13 @@ We want to know some basic statistics of the :kbd:`g_dem` raster layer.
 
 * Set up the tool like this and click on :guilabel:`Run`:
 
-  .. image:: img/grass_raster_info.png
+  .. figure:: img/grass_raster_info.png
      :align: center
 
 * Within the Output tab you will see some raster information printed, like the
   path of the file, the number of rows and columns and other useful information:
 
-  .. image:: img/grass_raster_info_result.png
+  .. figure:: img/grass_raster_info_result.png
      :align: center
 
 
@@ -80,7 +80,7 @@ rules is very simple and the GRASS Manual contains very good description.
   rules is in the :kbd:`exercise_data/grass/` folder, named :kbd:`reclass_aspect.txt`.
   Click on :guilabel:`Run` and wait until the process is finished:
 
-  .. image:: img/grass_reclass.png
+  .. figure:: img/grass_reclass.png
      :align: center
 
 * Click on :guilabel:`View Output` to load the reclassified raster in the canvas
@@ -88,7 +88,7 @@ rules is very simple and the GRASS Manual contains very good description.
 The new layer is made up by just 4 values (1, 2, 3, and 4) and it is easier to
 manage and to process.
 
-.. image:: img/grass_reclass_result.png
+.. figure:: img/grass_reclass_result.png
    :align: center
 
 .. tip:: Open the :kbd:`reclass_aspect.txt` with a text editor to see the rules
@@ -128,7 +128,7 @@ The Mapcalc dialog allows you to construct a sequence of analyses to be
 performed on a raster, or collection of rasters. You will use these tools to do
 so:
 
-.. image:: img/map_calc_tools.png
+.. figure:: img/map_calc_tools.png
    :align: center
 
 In order, they are:
@@ -153,13 +153,13 @@ Using these tools:
 
 * Construct the following algorithm:
 
-  .. image:: img/grass_mapcalc.png
+  .. figure:: img/grass_mapcalc.png
      :align: center
 
 * Click on :guilabel:`Run` and then on :guilabel:`View output` to see the output
   displayed in your map:
 
-  .. image:: img/grass_mapcalc_result.png
+  .. figure:: img/grass_mapcalc_result.png
      :align: center
 
 This shows all the areas where the terrain higher than 1000 meters.

--- a/source/docs/training_manual/introduction/overview.rst
+++ b/source/docs/training_manual/introduction/overview.rst
@@ -17,7 +17,7 @@ interface.
 
 .. _figure_gui_numbered:
 
-.. image:: img/gui_numbered.png
+.. figure:: img/gui_numbered.png
    :align: center
 
 The elements identified in the figure above are:

--- a/source/docs/training_manual/introduction/preparation.rst
+++ b/source/docs/training_manual/introduction/preparation.rst
@@ -38,7 +38,7 @@ Let's get started right away!
    You can also browse the files directly from the folder of your computer
    with the *Browser* tab (see :ref:`browser_panel_tm` section):
 
-   .. image:: img/add_data_dialog.png
+   .. figure:: img/add_data_dialog.png
       :align: center
 
 #. Click on the :guilabel:`Vector` tab, enable the |radioButtonOn|:guilabel:`File`
@@ -48,7 +48,7 @@ Let's get started right away!
    original dialog, but with the file path filled in. Click :guilabel:`Add` here
    as well. The data you specified will now load.
 
-   .. image:: img/add_vector_dialog.png
+   .. figure:: img/add_vector_dialog.png
       :align: center
 
 Congratulations! You now have a basic map. Now would be a good time to save
@@ -85,7 +85,7 @@ In order to load a layer from a GeoPackage:
    contained in the GeoPackage file.
 #. Select the :file:`roads` layer and click on the :guilabel:`Add` button.
 
-.. image:: img/add_data_dialog_geopackage.png
+.. figure:: img/add_data_dialog_geopackage.png
   :align: center
 
 Congratulations! You have loaded the first layer from a GeoPackage file.

--- a/source/docs/training_manual/map_composer/map_composer.rst
+++ b/source/docs/training_manual/map_composer/map_composer.rst
@@ -33,13 +33,13 @@ reason, it has a tool called the :guilabel:`Layout Manager`.
 (You could also close the dialog and navigate to a layout via the
 :menuselection:`Project --> Layouts -->` menu, as in the image below.)
 
-.. image:: img/print_composer_menu.png
+.. figure:: img/print_composer_menu.png
    :align: center
 
 Whichever route you take to get there, you will now see the :guilabel:`Print
 Layout` window:
 
-.. image:: img/print_composer_dialog.png
+.. figure:: img/print_composer_dialog.png
    :align: center
 
 
@@ -65,19 +65,19 @@ With this tool activated, you'll be able to place a map on the page.
 
 * Click and drag a box on the blank page:
 
-.. image:: img/drag_add_map.png
+.. figure:: img/drag_add_map.png
    :align: center
 
 The map will appear on the page.
 
 * Move the map by clicking and dragging it around:
 
-.. image:: img/move_map.png
+.. figure:: img/move_map.png
    :align: center
 
 * Resize it by clicking and dragging the boxes in the corners:
 
-.. image:: img/resize_map.png
+.. figure:: img/resize_map.png
    :align: center
 
 .. note::  Your map may look a lot different, of course! This depends on how
@@ -102,7 +102,7 @@ be at the wrong resolution and will look ugly or unreadable.
 
 * Force the map to refresh by clicking this button:
 
-.. image:: img/refresh_button.png
+.. figure:: img/refresh_button.png
    :align: center
 
 Remember that the size and position you've given the map doesn't need to be
@@ -143,7 +143,7 @@ However, there is also a tool to help position the title relative to the map
   dropdown arrow next to it to reveal the positioning options and click
   :guilabel:`Align center`:
 
-.. image:: img/align_center_dropdown.png
+.. figure:: img/align_center_dropdown.png
    :align: center
 
 To make sure that you don't accidentally move these elements around now that
@@ -165,7 +165,7 @@ contents of the label:
 
 * Use this interface to set the font and alignment options:
 
-.. image:: img/title_font_alignment.png
+.. figure:: img/title_font_alignment.png
    :align: center
 
 * Choose a large but sensible font (the example will use the default font with
@@ -185,7 +185,7 @@ you wish to add a frame, you can do so:
 
 In this example, we won't enable the frame, so here is our page so far:
 
-.. image:: img/page_so_far.png
+.. figure:: img/page_so_far.png
    :align: center
 
 |basic| |FA| Adding a Legend
@@ -200,7 +200,7 @@ add a new legend.
 
 * Click on the page to place the legend, and move it to where you want it:
 
-.. image:: img/legend_added.png
+.. figure:: img/legend_added.png
    :align: center
 
 |moderate| |FA| Customizing Legend Items
@@ -224,13 +224,13 @@ You can also rename items.
 * Set :kbd:`landuse` to :guilabel:`Hidden`, then click the down arrow and edit
   each category to name them on the legend. You can also reorder the items:
 
-.. image:: img/categories_reordered.png
+.. figure:: img/categories_reordered.png
    :align: center
 
 As the legend will likely be widened by the new layer names, you may wish to
 move and resize the legend and or map. This is the result:
 
-.. image:: img/map_composer_result.png
+.. figure:: img/map_composer_result.png
    :align: center
 
 |basic| |FA| Exporting Your Map

--- a/source/docs/training_manual/online_resources/wfs.rst
+++ b/source/docs/training_manual/online_resources/wfs.rst
@@ -26,20 +26,20 @@ WMS.
   and the :guilabel:`URL` as
   ``https://nsidc.org/cgi-bin/atlas_south?version=1.1.0``.
 
-  .. image:: img/new_wfs_connection.png
+  .. figure:: img/new_wfs_connection.png
      :align: center
 
 * Click :guilabel:`OK`, and the new connection will appear in your
   :guilabel:`Server connections`.
 * Click the :guilabel:`Connect`. A list of the available layers will appear:
 
-  .. image:: img/wfs_connection_layers.png
+  .. figure:: img/wfs_connection_layers.png
      :align: center
 
 * Find the layer :guilabel:`south_poles_wfs`.
 * Click on the layer to select it:
 
-  .. image:: img/south_poles_wfs.png
+  .. figure:: img/south_poles_wfs.png
      :align: center
 
 * Click :guilabel:`Add`.
@@ -48,7 +48,7 @@ It may take a while to load the layer. When it has loaded, it will appear in
 the map. Here it is over the outlines of Antarctica (available on the same
 server, and by the name of :guilabel:`antarctica_country_border`):
 
-.. image:: img/antarctica_border.png
+.. figure:: img/antarctica_border.png
    :align: center
 
 How is this different from having a WMS layer? That will become obvious when
@@ -57,13 +57,13 @@ you see the layers' attributes.
 * Open the :guilabel:`south_poles_wfs` layer's attribute table. You should see
   this:
 
-.. image:: img/poles_attribute_table.png
+.. figure:: img/poles_attribute_table.png
    :align: center
 
 Since the points have attributes, we are able to label them,
 as well as change their symbology. Here's an example:
 
-.. image:: img/labelling_example.png
+.. figure:: img/labelling_example.png
    :align: center
 
 * Add labels to your layer to take advantage of the attribute data in this
@@ -107,25 +107,25 @@ from the server.
 * Double-click next to the :guilabel:`countries ...` layer in the
   :guilabel:`Filter` field, or click :guilabel:`Build query`:
 
-  .. image:: img/select_country_filter.png
+  .. figure:: img/select_country_filter.png
      :align: center
 
 * In the dialog that appears, build the query :kbd:`"Countryeng" = 'South
   Africa'`:
 
-  .. image:: img/country_sa_builder.png
+  .. figure:: img/country_sa_builder.png
      :align: center
 
 * It will appear as the :guilabel:`Filter` value:
 
-  .. image:: img/country_filter_enabled.png
+  .. figure:: img/country_filter_enabled.png
      :align: center
 
 * Click :guilabel:`Add` with the :guilabel:`countries` layer selected as
   above. Only the country with the :kbd:`Countryeng` value of :kbd:`South
   Africa` will load from that layer:
 
-  .. image:: img/antarctica_sa.png
+  .. figure:: img/antarctica_sa.png
      :align: center
 
 You don't have to, but if you tried both methods, you'll notice that this is a

--- a/source/docs/training_manual/online_resources/wms.rst
+++ b/source/docs/training_manual/online_resources/wms.rst
@@ -27,7 +27,7 @@ the course, or just start a new map and load some existing layers into it. For
 this example, we used a new map and loaded the original :guilabel:`places` and
 :guilabel:`landuse` layers and adjusted the symbology:
 
-.. image:: img/new_map.png
+.. figure:: img/new_map.png
    :align: center
 
 * Load these layers into a new map, or use your original map with only these
@@ -55,7 +55,7 @@ available on the Internet. One of these is `terrestris
 
 * To make use of this WMS, set it up in your current dialog, like this:
 
-  .. image:: img/new_wms_connection.png
+  .. figure:: img/new_wms_connection.png
      :align: center
 
 * The value of the :guilabel:`Name` field should be ``terrestris``.
@@ -63,13 +63,13 @@ available on the Internet. One of these is `terrestris
   ``https://ows.terrestris.de/osm/service``.
 * Click :guilabel:`OK`. You should see the new WMS server listed:
 
-  .. image:: img/new_connection_listed.png
+  .. figure:: img/new_connection_listed.png
      :align: center
 
 * Click :guilabel:`Connect`. In the list below, you should now see these
   new entries loaded:
 
-  .. image:: img/new_wms_entries.png
+  .. figure:: img/new_wms_entries.png
      :align: center
 
   These are all the layers hosted by this WMS server.
@@ -77,7 +77,7 @@ available on the Internet. One of these is `terrestris
 * Click once on the :guilabel:`OSM-WMS` layer. This will display its
   :guilabel:`Coordinate Reference System`:
 
-  .. image:: img/osm_wms_selected.png
+  .. figure:: img/osm_wms_selected.png
      :align: center
 
 Since we're not using :kbd:`WGS 84` for our map, let's see all the CRSs we have
@@ -88,7 +88,7 @@ to choose from.
 * We want a *projected* CRS, so let's choose :guilabel:`WGS 84 / Pseudo
   Mercator`.
 
-  .. image:: img/pseudo_mercator_selected.png
+  .. figure:: img/pseudo_mercator_selected.png
      :align: center
 
 * Click :guilabel:`OK`.
@@ -105,7 +105,7 @@ but using the same projection as the :guilabel:`OSM-WMS` layer, which is
 * In the :guilabel:`CRS` tab (:guilabel:`Project Properties` dialog), enter the
   value :kbd:`pseudo` in the :guilabel:`Filter` field:
 
-  .. image:: img/enable_projection.png
+  .. figure:: img/enable_projection.png
      :align: center
 
 * Choose :guilabel:`WGS 84 / Pseudo Mercator` from the list.
@@ -114,7 +114,7 @@ but using the same projection as the :guilabel:`OSM-WMS` layer, which is
   click :guilabel:`Zoom to layer extent`. You should see the |majorUrbanName|
   area:
 
-  .. image:: img/wms_result.png
+  .. figure:: img/wms_result.png
      :align: center
 
 Note how the WMS layer's streets and our own streets overlap. That's a good
@@ -162,7 +162,7 @@ layer from the :guilabel:`terrestris` WMS server.
   :guilabel:`Tile size` option to :kbd:`200` by :kbd:`200`, so that it loads
   faster:
 
-  .. image:: img/bedrock_geology_layer.png
+  .. figure:: img/bedrock_geology_layer.png
      :align: center
 
 :ref:`Check your results <wms-1>`

--- a/source/docs/training_manual/processing/batch_conversion.rst
+++ b/source/docs/training_manual/processing/batch_conversion.rst
@@ -19,12 +19,12 @@ simplifies performing a multiple execution of a given algorithm. To run an
 algorithm as a batch process, find it in the toolbox, and instead of
 double--clicking on it, right--click on it and select *Run as batch process*.
 
-.. image:: img/batch_conversion/batch_menu.png
+.. figure:: img/batch_conversion/batch_menu.png
 
 For this example, we will use the *Reproject algorithm*, so find it and do
 as described above. You will get to the following dialog.
 
-.. image:: img/batch_conversion/batch_dialog.png
+.. figure:: img/batch_conversion/batch_dialog.png
 
 If you have a look at the data for this lesson, you will see that it contains
 a set of three shapefiles, but no QGIS project file. This is because, when an
@@ -49,7 +49,7 @@ dialog that will popup, select the three files to reproject. Since only one of
 them is needed for each row, the remaining ones will be used to fill the rows
 underneath.
 
-.. image:: img/batch_conversion/first_column_filled.png
+.. figure:: img/batch_conversion/first_column_filled.png
 
 The default number of rows is 3, which is exactly the number of layers we have
 to convert, but if you select more layers, new rows will be added automatically.
@@ -62,7 +62,7 @@ row (the one at the top) using the button in the corresponding cell, and then
 double click on the column header. That causes all the cells in the column to
 be filled using the value of the top cell.
 
-.. image:: img/batch_conversion/second_column_filled.png
+.. figure:: img/batch_conversion/second_column_filled.png
 
 Finally, we have to select an output file for each execution, which will contain
 the corresponding reprojected layer. Once again, let's do it just for the first row.
@@ -73,7 +73,7 @@ Now, when you click *OK* on the file selection dialog, the file does not
 automatically gets written to the cell, but an input box like the following
 one is shown instead.
 
-.. image:: img/batch_conversion/autofill.png
+.. figure:: img/batch_conversion/autofill.png
 
 If you select the first option, only the current cell will be filled. If you
 select any of the other ones, all the rows below will be filled with a given
@@ -83,7 +83,7 @@ That will cause the value in the *Input Layer* (that is, the layer name) to
 be added to the filename we have added, making each output filename different.
 The batch processing table should now look like this.
 
-.. image:: img/batch_conversion/complete.png
+.. figure:: img/batch_conversion/complete.png
 
 The last column sets whether or not to add the resulting layers to the
 current QGIS project. Leave the default *Yes* option, so you can see your

--- a/source/docs/training_manual/processing/crs.rst
+++ b/source/docs/training_manual/processing/crs.rst
@@ -18,7 +18,7 @@ some general rules about how they are handled by geoalgorithms when creating a n
   If you use layers with unmatching CRS's, QGIS will warn you about it. Notice that
   the CRS of input layers is shown along with its name in the parameters dialog.
 
-.. image:: img/crs/crs_layer.png
+.. figure:: img/crs/crs_layer.png
 
 * If there are no input layer, it will use the project CRS, unless the algorithm
   contains a specific CRS field (as it happenend in the last lesson with the
@@ -32,7 +32,7 @@ actually the same layer.
 
 Open the *Export/Add geometry columns* algorithm.
 
-.. image:: img/crs/add_geom.png
+.. figure:: img/crs/add_geom.png
 
 This algorithm add new columns to the attributes table of a vector layer.
 The content of the columns depend on the type of geometry of the layer.
@@ -59,7 +59,7 @@ of the layer, since QGIS already knows about it.
 If you open the attributes table of the new layer you will see that it
 contains two new fields with the X and Y coordinates of each point.
 
-.. image:: img/crs/attribs2.png
+.. figure:: img/crs/attribs2.png
 
 Those coordinate values are given in the layer CRS, since we chose that option.
 However, even if you choose another option, the output CRS of the layer would
@@ -76,7 +76,7 @@ EPSG:23030 CRS, since that was the one of the input layer.
 If you go to its attribute table, you will see values that are different to
 the ones in the first layer that we created.
 
-.. image:: img/crs/attribs.png
+.. figure:: img/crs/attribs.png
 
 This is because the original data is different (it uses a different CRS),
 and those coordinates are taken from it.
@@ -100,7 +100,7 @@ but it will not use its CRS for the output one.
 
 Open the *Reproject layer* algorithm.
 
-.. image:: img/crs/reprojection.png
+.. figure:: img/crs/reprojection.png
 
 Select any of the layers as input, and select EPSG:23029 as the destination CRS.
 Run the algorithm and you will get a new layer, identical to the input one,

--- a/source/docs/training_manual/processing/cutting_merging.rst
+++ b/source/docs/training_manual/processing/cutting_merging.rst
@@ -15,7 +15,7 @@ cover an area much larger than that around the city that we want to work with.
 If you open the project corresponding to this lesson, you will see something
 like this.
 
-.. image:: img/cutting_merging/medfordarea.png
+.. figure:: img/cutting_merging/medfordarea.png
 
 These layers have two problems:
 
@@ -33,29 +33,29 @@ covers a bit more that the strictly necessary.
 
 To calculate the bounding box , we can use the *Polygon from layer extent* algorithm
 
-.. image:: img/cutting_merging/bbox.png
+.. figure:: img/cutting_merging/bbox.png
 
 To buffer it, we use the *Fixed distance buffer* algorithm, with the following parameter values.
 
-.. image:: img/cutting_merging/buffer_dialog.png
+.. figure:: img/cutting_merging/buffer_dialog.png
 
 .. warning:: Syntax changed in recent versions; set both Distance and Arc vertex to .25
 
 Here is the resulting bounding box obtained using the parameters shown above
 
-.. image:: img/cutting_merging/buffer.png
+.. figure:: img/cutting_merging/buffer.png
 
 It is a rounded box, but we can easily get the equivalent box with square angles,
 by running the *Polygon from layer extent* algorithm on it. We could have buffered
 the city limits first, and then calculate the extent rectangle, saving one step.
 
-.. image:: img/cutting_merging/buffer_squared.png
+.. figure:: img/cutting_merging/buffer_squared.png
 
 You will notice that the rasters has a different projection from the vector.
 We should therefore reproject them before proceeding further, using the
 *Warp (reproject)* tool.
 
-.. image:: img/cutting_merging/warp.png
+.. figure:: img/cutting_merging/warp.png
 
 .. note:: Recent versions have a more complex interface. Make sure at least
  one compression method is selected.
@@ -64,11 +64,11 @@ With this layer that contains the bounding box of the raster layer that we want
 to obtain, we can crop both of the raster layers, using the *Clip raster with
 polygon* algorithm.
 
-.. image:: img/cutting_merging/clip.png 
+.. figure:: img/cutting_merging/clip.png 
 
 Once the layers have been cropped, they can be merged using the GDAL *Merge* algorithm.
 
-.. image:: img/cutting_merging/merge.png
+.. figure:: img/cutting_merging/merge.png
 
 .. note:: You can save time merging first and then cropping, and you will avoid
  calling the clipping algorithm twice. However, if there are several layers to
@@ -80,7 +80,7 @@ Once the layers have been cropped, they can be merged using the GDAL *Merge* alg
 
 With that, we get the final DEM we want.
 
-.. image:: img/cutting_merging/finaldem.png
+.. figure:: img/cutting_merging/finaldem.png
 
 Now it is time to compute the slope layer.
 
@@ -94,11 +94,11 @@ correctly calculate the slope, with either SAGA or GDAL.
 
 With the new DEM, slope can now be computed.
 
-.. image:: img/cutting_merging/slope.png
+.. figure:: img/cutting_merging/slope.png
 
 And here is the resulting slope layer.
 
-.. image:: img/cutting_merging/slopereproj.png
+.. figure:: img/cutting_merging/slopereproj.png
 
 The slope produced by the *Slope, Aspect, Curvature* algorithm can be expressed
 in degrees or radians; degrees are a more practical and common unit.
@@ -106,7 +106,7 @@ In case you calculated it in radians, the *Metric conversions* algorithm will
 help us to do the conversion (but in case you didn't know that algorithm existed,
 you could use the raster calculator that we have already used).
 
-.. image:: img/cutting_merging/metricconversions.png
+.. figure:: img/cutting_merging/metricconversions.png
 
 Reprojecting the converted slope layer back with the *Reproject raster layer*,
 we get the final layer we wanted.

--- a/source/docs/training_manual/processing/extents.rst
+++ b/source/docs/training_manual/processing/extents.rst
@@ -19,7 +19,7 @@ them in this lesson.
 First, let's open an algorithm that requires an extent to be defined.
 Open the *Rasterize* algorithm, which creates a raster layer from a vector layer.
 
-.. image:: img/extents/rasterize.png
+.. figure:: img/extents/rasterize.png
 
 All the parameters, except for the last two ones, are used to define which layer
 is to be rasterized, and configure how the rasterization process should work.
@@ -32,21 +32,21 @@ since vector layers do not have a cellsize).
 The first thing you can do is to type the 4 defining values explained before,
 separated by commas.
 
-.. image:: img/extents/type.png
+.. figure:: img/extents/type.png
 
 That doesn't need any extra explanation. While this is the most flexible option,
 it is also the less practical in some cases, and that's why other options are
 implemented. To access them, you have to click on the button on the right--hand
 side of the extent text box.
 
-.. image:: img/extents/menu.png
+.. figure:: img/extents/menu.png
 
 Let's see what each one of them does.
 
 The first option is *Use layer/canvas extent*, which will show the selection
 dialog shown below.
 
-.. image:: img/extents/layer.png
+.. figure:: img/extents/layer.png
 
 Here you can select the extent of the canvas (the extent covered by the current zoom),
 or the extension any of the available layers. Select it and click on *OK*,
@@ -56,7 +56,7 @@ The second option is *Select extent on canvas*. In this case, the algorithm
 dialog disappears and you can click and drag on the QGIS canvas to define
 the desired extent. 
 
-.. image:: img/extents/extent_drag.png
+.. figure:: img/extents/extent_drag.png
 
 Once you release the mouse button, the dialog will reappear and the text box
 will already have the values corresponding to the defined extent.
@@ -74,7 +74,7 @@ We will use this last method to execute our rasterization algorithm.
 
 Fill the parameters dialog as shown next, and press *OK*.
 
-.. image:: img/extents/parameters.png
+.. figure:: img/extents/parameters.png
 
 .. note:: In this case, better use an *Integer (1 byte)* instead of a
  *Floating point (4 byte)*, since the *NAME* is an integer with maximum
@@ -83,7 +83,7 @@ Fill the parameters dialog as shown next, and press *OK*.
 You will get a rasterized layer that covers exactly the area covered by the
 original vector layer.
 
-.. image:: img/extents/result.png
+.. figure:: img/extents/result.png
 
 In some cases, the last option, *Use min covering extent from input layers*,
 might not be available. This will happen in those algorithm that do not have

--- a/source/docs/training_manual/processing/first_alg.rst
+++ b/source/docs/training_manual/processing/first_alg.rst
@@ -18,7 +18,7 @@ centroids of set of polygons.
 First, open the QGIS project corresponding to this lesson. It contains just a
 single layer with two polygons
 
-.. image:: img/first_alg/canvas.png
+.. figure:: img/first_alg/canvas.png
 
 Now go to the text box at the top of the toolbox. That is the search box, and if
 you type text in it, it will filter the list of algorithms so just those ones
@@ -28,7 +28,7 @@ not active, an additional label will be shown in the lower part of the toolbox.
 
 Type ``centroids`` and you should see something like this.
 
-.. image:: img/first_alg/toolbox.png
+.. figure:: img/first_alg/toolbox.png
 
 The search box is a very practical way of finding the algorithm you are looking
 for. At the bottom of the dialog, an additional label shows that there are
@@ -38,13 +38,13 @@ include results from those inactive providers, which will be shown in light gray
 A link to activate each inactive provider is also shown. We'll see later how to
 activate other providers.
 
-.. image:: img/first_alg/toolbox_providers.png
+.. figure:: img/first_alg/toolbox_providers.png
 
 To execute an algorithm, you just have to double-click on its name in the
 toolbox. When you double-click on the *Polygon centroids* algorithm, you will
 see the following dialog.
 
-.. image::  img/first_alg/centroids.png
+.. figure::  img/first_alg/centroids.png
 
 All algorithms have a similar interface, which basically contains input
 parameters that you have to fill, and outputs that you have to select where to
@@ -77,7 +77,7 @@ algorithm.
 
 You will get the following output.
 
-.. image:: img/first_alg/canvas2.png
+.. figure:: img/first_alg/canvas2.png
 
 The output has the same CRS as the input. Geoalgorithms assumes all input layers
 share the same CRS and do not perform any reprojection. Except in the case of

--- a/source/docs/training_manual/processing/first_saga_alg.rst
+++ b/source/docs/training_manual/processing/first_saga_alg.rst
@@ -31,7 +31,7 @@ install QGIS using the standalone installer. It will take care of installing
 all the needed dependencies, including SAGA, so if you have used it, there is
 nothing else to do. You can open the settings dialog and go to the *Providers/SAGA* group.
 
-.. image:: img/first_saga_alg/saga_config.png
+.. figure:: img/first_saga_alg/saga_config.png
 
 The SAGA path should already be configured and pointing to the folder where SAGA is installed.
 
@@ -49,7 +49,7 @@ but they are not commonly installed and might have some issues, so if you prefer
 to use the more common and stable 2.0.8, you can do it by enabling 2.0.8
 compatibility in the configuration dialog, under the *SAGA* group.
 
-.. image:: img/first_saga_alg/enable208.png
+.. figure:: img/first_saga_alg/enable208.png
 
 Once SAGA is installed, you can launch a SAGA algorithm double clicking on its name,
 as with any other algorithm. Since we are using the simplified interface,
@@ -57,20 +57,20 @@ you do not know which algorithms are based on SAGA or in another external
 application, but if you happen to double--click on one of them and the
 corresponding application is not installed, you will see something like this.
 
-.. image:: img/first_saga_alg/missing_saga.png
+.. figure:: img/first_saga_alg/missing_saga.png
 
 In our case, and assuming that SAGA is correctly installed and configured,
 you should not see this window, and you will get to the parameters dialog instead.
 
 Let's try with a SAGA--based algorithm, the one called *Split shapes layer randomly*.
 
-.. image:: img/first_saga_alg/split.png
+.. figure:: img/first_saga_alg/split.png
 
 Use the points layer in the project corresponding to this lesson as input,
 and the default parameter values, and you will get something like this
 (the split is random, so your result might be different).
 
-.. image:: img/first_saga_alg/split_layer.png
+.. figure:: img/first_saga_alg/split_layer.png
 
 The input layer has been split in two layers, each one with the same number of
 points. This result has been computed by SAGA, and later taken by QGIS and
@@ -82,7 +82,7 @@ for some reason, not be able to produce a result and not generate the file that
 QGIS is expecting. In that case, there will be problems adding the result to the
 QGIS project, and an error message like this will be shown.
 
-.. image:: img/first_saga_alg/missing_result.png
+.. figure:: img/first_saga_alg/missing_result.png
 
 This kind of problems might happen, even if SAGA (or any other application that
 we are calling from the processing framework) is correctly installed, and it is
@@ -90,7 +90,7 @@ important to know how to deal with them. Let's produce one of those error messag
 
 Open the *Create graticule* algorithm and use the following values.
 
-.. image:: img/first_saga_alg/create_graticule.png
+.. figure:: img/first_saga_alg/create_graticule.png
 
 
 We are using  width and height values that is larger than the specified extent,

--- a/source/docs/training_manual/processing/html.rst
+++ b/source/docs/training_manual/processing/html.rst
@@ -19,7 +19,7 @@ Let's see one of those algorithms to understand how they work.
 Open the project with the data to be used in this lesson and then open the
 *Basic statistics for numeric fields* algorithm. 
 
-.. image:: img/html/paramdialog.png
+.. figure:: img/html/paramdialog.png
 
 The algorithm is rather simple, and you just have to select the layer to use
 and one of its field (a numeric one). The output is of type HTML, but the
@@ -33,7 +33,7 @@ Run the algorithm selecting the only layer in the project as input, and
 the *POP2000* field, and a new dialog like the one shown next will appear
 once the algorithm is executed and the parameters dialog is closed.
 
-.. image:: img/html/result.png
+.. figure:: img/html/result.png
 
 This is the *Results viewer*. It keeps all the HTML result generated during
 the current session, easily accessible, so you can check them quickly whenever

--- a/source/docs/training_manual/processing/hydro.rst
+++ b/source/docs/training_manual/processing/hydro.rst
@@ -16,7 +16,7 @@ we are going to extract a channel network, delineate watersheds and calculate so
 
 The first thing is to load the project with the lesson data, which just contains a DEM.
 
-.. image:: img/hydro/dem.png
+.. figure:: img/hydro/dem.png
 
 The first module to execute is *Catchment area* (in some SAGA versions it is called
 *Flow accumulation (Top Down)*). You can use anyone of  the others named *Catchment area*.
@@ -24,7 +24,7 @@ They have different algorithms underneath, but the results are basically the sam
 
 Select the DEM in the *Elevation* field, and leave the default values for the rest of parameters.
 
-.. image:: img/hydro/catchmentarea.png
+.. figure:: img/hydro/catchmentarea.png
 
 Some algorithms calculate many layers, but the *Catchment Area* one is the only one we will be using.
 
@@ -32,7 +32,7 @@ You can get rid of the other ones if you want.
 
 The rendering of the layer is not very informative. 
 
-.. image:: img/hydro/catchmentlayer.png
+.. figure:: img/hydro/catchmentlayer.png
 
 To know why, you can have a look at the histogram and you will see that value
 are not evenly distributed (there are a few cells with very high value, those
@@ -40,13 +40,13 @@ corresponding to the channel network). Calculating the logarithm of the catchmen
 area value yields a layer that conveys much more information (you can do it using
 the raster calculator).
 
-.. image:: img/hydro/catchmentlayerlog.png
+.. figure:: img/hydro/catchmentlayerlog.png
 
 The catchment area (also known as flow accumulation), can be used to set a
 threshold for channel initiation. This can be done using the *Channel network* algorithm.
 Here is how you have to set it up (note the *Initiation threshold* *Greater than* 10.000.000).
 
-.. image:: img/hydro/channelnetwork.png 
+.. figure:: img/hydro/channelnetwork.png 
 
 
 Use the original catchment area layer, not the logarithm one.
@@ -56,7 +56,7 @@ If you increase the *Initiation threshold* value, you will get a more sparse
 channel network. If you decrease it, you will get a denser one.
 With the proposed value, this is what you get.
 
-.. image:: img/hydro/channelnetworklayer.png 
+.. figure:: img/hydro/channelnetworklayer.png 
 
 
 The image above shows just the resulting vector layer and the DEM, but there
@@ -67,18 +67,18 @@ Now, we will use the *Watersheds basins* algorithm to delineate the subbasins
 corresponding to that channel network, using as outlet points all the junctions
 in it. Here is how you have to set the corresponding parameters dialog.
 
-.. image:: img/hydro/watersheds.png 
+.. figure:: img/hydro/watersheds.png 
 
 
 And this is what you will get.
 
-.. image:: img/hydro/watershedslayer.png 
+.. figure:: img/hydro/watershedslayer.png 
 
 This is a raster result. You can vectorise it using the *Vectorising grid classes* algorithm.
 
-.. image:: img/hydro/vectorising.png 
+.. figure:: img/hydro/vectorising.png 
 
-.. image:: img/hydro/watershedslayervector.png 
+.. figure:: img/hydro/watershedslayervector.png 
 
 
 Now, let's try to compute statistics about the elevation values in one of the
@@ -92,25 +92,25 @@ the area covered by that polygon, since the algorithm is aware of the selection.
 
 Select a polygon,
 
-.. image:: img/hydro/selectedpolygon.png 
+.. figure:: img/hydro/selectedpolygon.png 
 
 and call the clipping algorithm with the following parameters:
 
-.. image:: img/hydro/clipgrid.png 
+.. figure:: img/hydro/clipgrid.png 
 
 The element selected in the input field is, or course, the DEM we want to clip.
 
 You will get something like this.
 
-.. image:: img/hydro/clippeddem.png 
+.. figure:: img/hydro/clippeddem.png 
 
 This layer is ready to be used in the *Raster layer statistics* algorithm.
 
-.. image:: img/hydro/rasterstats.png 
+.. figure:: img/hydro/rasterstats.png 
 
 The resulting statistics are the following ones.
 
-.. image:: img/hydro/stats.png 
+.. figure:: img/hydro/stats.png 
 
 We will use both the basin calculations procedure and the statistics
 calculation in other lessons, to find out how other elements can help us

--- a/source/docs/training_manual/processing/interpolation.rst
+++ b/source/docs/training_manual/processing/interpolation.rst
@@ -15,7 +15,7 @@ a complete analysis routine.
 
 Open the example data for this lesson, which should look like this.
 
-.. image:: img/interpolation/project.png
+.. figure:: img/interpolation/project.png
 
 The data correspond to crop yield data, as produced by a modern harvester,
 and we will use it to get a raster layer of crop yield. We do not plan to do
@@ -31,11 +31,11 @@ can be considered outliers both in the upper and lower part of the distribution.
 
 For the first execution, use the following parameter values.
 
-.. image:: img/interpolation/filter.png
+.. figure:: img/interpolation/filter.png
 
 Now for the next one, use the configuration shown below.
 
-.. image:: img/interpolation/filter2.png
+.. figure:: img/interpolation/filter2.png
 
 Notice that we are not using the original layer as input, but the output of
 the previous run instead.
@@ -46,7 +46,7 @@ that by comparing their attribute tables.
 
 Now let's rasterize the layer using the *Rasterize* algorithm.
 
-.. image:: img/interpolation/rasterize.png
+.. figure:: img/interpolation/rasterize.png
 
 The *Filtered points* layer refers to the resulting one of the second filter.
 It has the same name as the one produced by the first filter, since the name
@@ -56,32 +56,32 @@ project to avoid confusion, and leave just the last filtered layer.
 
 The resulting raster layer looks like this.
 
-.. image:: img/interpolation/rasterized.png
+.. figure:: img/interpolation/rasterized.png
 
 It is already a raster layer, but it is missing data in some of its cells.
 It only contain valid values in those cells that contained a point from the
 vector layer that we have just rasterized, and a no--data value in all the
 other ones. To fill the missing values, we can use the *Close gaps* algorithm.
 
-.. image:: img/interpolation/close_gaps.png
+.. figure:: img/interpolation/close_gaps.png
 
 The layer without no--data values looks like this.
 
-.. image:: img/interpolation/filled.png
+.. figure:: img/interpolation/filled.png
 
 To restrict the area covered by the data to just the region where crop
 yield was measured, we can clip the raster layer with the provided limits layer.
 
-.. image:: img/interpolation/clip.png
+.. figure:: img/interpolation/clip.png
 
 And for a smoother result (less accurate but better for rendering in the
 background as a support layer), we can apply a *Gaussian filter* to the layer.
 
-.. image:: img/interpolation/gaussian.png
+.. figure:: img/interpolation/gaussian.png
 
 With the above parameters you will get the following result
 
-.. image:: img/interpolation/filtered_raster.png
+.. figure:: img/interpolation/filtered_raster.png
 
 
 .. Substitutions definitions - AVOID EDITING PAST THIS LINE

--- a/source/docs/training_manual/processing/interpolation_cross.rst
+++ b/source/docs/training_manual/processing/interpolation_cross.rst
@@ -13,47 +13,47 @@ The data for this lesson contains also a points layer, in this case with elevati
 
 First, we have to rasterize the points layer and fill the resulting no--data cells, but using just a fraction of the points in the layer. We will save 10% of the points for a later check, so we need to have 90% of the points ready for the interpolation. To do so, we could use the *Split shapes layer randomly* algorithm, which we have already used in a previous lesson, but there is a better way to do that, without having to create any new intermediate layer. Instead of that, we can just select the points we want to use for the interpolation (the 90% fraction), and then run the algorithm. As we have already seen, the rasterizing algorithm will use only those selected points and ignore the rest. The selection can be done using the *Random selection* algorithm. Run it with the following parameters.
 
-.. image:: img/interpolation_cross/select.png
+.. figure:: img/interpolation_cross/select.png
 
 That will select 90% of the points in the layer to rasterize
 
-.. image:: img/interpolation_cross/selected.png
+.. figure:: img/interpolation_cross/selected.png
 
 The selection is random, so your selection might differ from the selection shown in the above image.
 
 Now run the *Rasterize* algorithm to get the first raster layer, and then run the *Close gaps* algorithm to fill the no--data cells [Cell resolution: 100 m].
 
-.. image:: img/interpolation_cross/filled.png
+.. figure:: img/interpolation_cross/filled.png
 
 To check the quality of the interpolation, we can now use the points that are not selected. At this point, we know the real elevation (the value in the points layer) and the interpolated elevation (the value in the interpolated raster layer). We can compare the two by computing the differences between those values. 
 
 Since we are going to use the points that are not selected, first, let's invert the selection.
 
-.. image:: img/interpolation_cross/inverted.png
+.. figure:: img/interpolation_cross/inverted.png
 
 The points contain the original values, but not the interpolated ones. To add them in a new field, we can use the *Add raster values to points* algorithm
 
-.. image:: img/interpolation_cross/addgridvalues.png
+.. figure:: img/interpolation_cross/addgridvalues.png
 
 The raster layer to select (the algorithm supports multiple raster, but we just need one) is the resulting one from the interpolation. We have renamed it to *interpolate* and that layer name is the one that will be used for the name of the field to add.
 
 Now we have a vector layer that contains both values, with points that were not used for the interpolation.
 
-.. image:: img/interpolation_cross/extended_layer.png
+.. figure:: img/interpolation_cross/extended_layer.png
 
 Now, we will use the fields calculator for this task. Open the *Field calculator* algorithm and run it with the following parameters.
 
-.. image:: img/interpolation_cross/fields_calculator.png
+.. figure:: img/interpolation_cross/fields_calculator.png
 
 If your field with the values from the raster layer has a different name, you should modify the above formula accordingly. Running this algorithm, you will get a new layer with just the points that we haven't used for the interpolation, each of them containing the difference between the two elevation values.
 
 Representing that layer according to that value will give us a first idea of where the largest discrepancies are found.
 
-.. image:: img/interpolation_cross/diffs.png
+.. figure:: img/interpolation_cross/diffs.png
 
 Interpolating that layer will get you a raster layer with the estimated error in all points of the interpolated area.
 
-.. image:: img/interpolation_cross/raster_diffs.png
+.. figure:: img/interpolation_cross/raster_diffs.png
 
 You can also get the same information (difference between original point values and interpolated ones) directly with :menuselection:`GRASS --> v.sample`.
 

--- a/source/docs/training_manual/processing/iterative.rst
+++ b/source/docs/training_manual/processing/iterative.rst
@@ -11,7 +11,7 @@ We already know the graphical modeler, which is one way of automating processing
 
 Open the data corresponding to this chapter. It should look like this.
 
-.. image:: img/iterative/project.png
+.. figure:: img/iterative/project.png
 
 You will recognize our well-known DEM from previous chapters and a set of watersheds extracted from it. Imagine that you need to cut the DEM into several smaller layers, each of them containing just the elevation data corresponding to a single watershed. That will be useful if you later want to calculate some parameters related to each watershed, such as its mean elevation or it hypsographic curve.
 
@@ -19,33 +19,33 @@ This can be a lengthy and tedious task, especially if the number of watersheds i
 
 The algorithm to use for clipping a raster layer with a polygon layer is called *Clip raster with polygons*, and has the following parameters dialog.
 
-.. image:: img/iterative/clip.png
+.. figure:: img/iterative/clip.png
 
 You can run it using the watersheds layer and the DEM as input, and you will get the following result.
 
-.. image:: img/iterative/full_clip.png
+.. figure:: img/iterative/full_clip.png
 
 As you can see, the area covered by all the watershed polygons is used.
 
 You can have the DEM clipped with just a single watershed by selecting the desired watershed and then running the algorithm as we did before. 
 
-.. image:: img/iterative/selection.png
+.. figure:: img/iterative/selection.png
 
 Since only selected features are used, only the selected polygon will be used to crop the raster layer.
 
-.. image:: img/iterative/selection_clip.png
+.. figure:: img/iterative/selection_clip.png
 
 Doing this for all the watersheds will produce the result we are looking for, but it doesn't look like a very practical way of doing it. Instead, let's see how to automate that *select and crop* routine.
 
 First of all, remove the previous selection, so all polygons will be used again. Now open the *Clip raster with polygon* algorithm and select the same inputs as before, but this time click on the button that you will find in the right--hand side of the vector layer input where you have selected the watersheds layer.
 
-.. image:: img/iterative/iterate_button.png
+.. figure:: img/iterative/iterate_button.png
 
 This button will cause the selected input layer to be split into as many layer as feature are found in it, each of them containing a single polygon. With that, the algorithm will be called repeatedly, one for each one of those single-polygon layers. The result, instead of just one raster layer in the case of this algorithm, will be a set of raster layers, each one of them corresponding to one of the executions of the algorithm.
 
 Here's the result that you will get if you run the clipping algorithm as explained.
 
-.. image:: img/iterative/result_iterative.png
+.. figure:: img/iterative/result_iterative.png
 
 For each layer, the black and white color palette, (or whatever palette you are using), is adjusted differently, from its minimum to its maximum values. That's the reason why you can see the different pieces and the colors do not seem to match in the border between layers. Values, however, do match.
 

--- a/source/docs/training_manual/processing/iterative_model.rst
+++ b/source/docs/training_manual/processing/iterative_model.rst
@@ -19,21 +19,21 @@ You can find the model already created in the data folder for this lesson, but i
 
 The model should look like this:
 
-.. image:: img/iterative_model/model.png
+.. figure:: img/iterative_model/model.png
 
 Add the model to you models folder, so it is available in the toolbox, and now execute it.
 
-.. image:: img/iterative_model/model.png
+.. figure:: img/iterative_model/model.png
 
 Select the DEM and watersheds basins, and do not forget to toggle the button that indicates that the algorithm has to be run iteratively.
 
 The algorithm will be run several times, and the corresponding tables will be created and open in your QGIS project.
 
-.. image:: img/iterative_model/tables.png
+.. figure:: img/iterative_model/tables.png
 
 We can make this example more complex by extending the model and computing some slope statistics. Add the *Slope, aspect, curvature* algorithm to the model, and then the *Raster statistics* algorithm, which should use the slope output as its only input.
 
-.. image:: img/iterative_model/model2.png
+.. figure:: img/iterative_model/model2.png
 
 If you now run the model, apart from the tables you will get a set of pages with statistics. These pages will be available in the results dialog.
 

--- a/source/docs/training_manual/processing/john_snow.rst
+++ b/source/docs/training_manual/processing/john_snow.rst
@@ -14,44 +14,44 @@ We will be using the well-known dataset that John Snow used in 1854, in his grou
 
 The dataset contains shapefiles with cholera deaths and pump locations, and an OSM rendered map in TIFF format. Open the corresponding QGIS project for this lesson.
 
-.. image:: img/john_snow/project.png
+.. figure:: img/john_snow/project.png
 
 The first thing to do is to calculting the Voronoi diagram (a.k.a. Thyessen polygons) of the pumps layer, to get the influence zone of each pump. The *Voronoi Diagram* algorithm can be used for that.
 
 
-.. image:: img/john_snow/voronoi.png
+.. figure:: img/john_snow/voronoi.png
 
 Pretty easy, but it will already give us interesting information.
 
-.. image:: img/john_snow/voronoi2.png
+.. figure:: img/john_snow/voronoi2.png
 
 Clearly, most cases are within one of the polygons
 
 To get a more quantitative result, we can count the number of deaths in each polygon. Since each point represents a building where deaths occured, and the number of deaths is stored in an attribute, we cannot just count the points. We need a weighted count, so we will use the *Count points in polygon (weighted)* tool.
 
-.. image:: img/john_snow/pointsinpoly.png
+.. figure:: img/john_snow/pointsinpoly.png
 
 The new field will be called *DEATHS*, and we use the *COUNT* field as weighting field. The resulting table clearly reflects that the number of deaths in the polygon corresponding to the first pump is much larger than the other ones.
 
-.. image:: img/john_snow/pointsinpolytable.png
+.. figure:: img/john_snow/pointsinpolytable.png
 
 Another good way of visualizing the dependence of each point in the ``Cholera_deaths`` layer with a point in the ``Pumps`` layer is to draw a line to the closest one. This can be done with the *Distance to nearest hub* tool, and using the configuration shown next.
 
-.. image:: img/john_snow/nearest.png
+.. figure:: img/john_snow/nearest.png
 
 The result looks like this:
 
-.. image:: img/john_snow/nearestresult.png
+.. figure:: img/john_snow/nearestresult.png
 
 Although the number of lines is larger in the case of the central pump, do not forget that this does not represent the number of deaths, but the number of locations where cholera cases were found. It is a representative parameter, but it is not considering that some locations might have more cases than other.
 
 A density layer will also give us a very clear view of what is happening. We can create it with the *Kernel density* algorithm. Using the *Cholera_deaths* layer, its *COUNT* field as weight field, with a radius of 100, the extent and cellsize of the streets raster layer, we get something like this.
 
-.. image:: img/john_snow/density.png
+.. figure:: img/john_snow/density.png
 
 Remember that, to get the output extent, you do not have to type it. Click on the button on the right-hand side and select *Use layer/canvas extent*.
 
-.. image:: img/john_snow/layerextent.png
+.. figure:: img/john_snow/layerextent.png
 
 Select the streets raster layer and its extent will be automatically added to the text field. You must do the same with the cellsize, selecting the cellsize of that layer as well.
 

--- a/source/docs/training_manual/processing/log.rst
+++ b/source/docs/training_manual/processing/log.rst
@@ -17,7 +17,7 @@ Even if the algorithm could be executed, some algorithms might leave warnings in
 
 From the *Processing* menu, under the *History* section, you'll find *Algorithms*. All algorithms that are executed, even if they are executed from the GUI and not from the console (which will be explained later in this manual) are stored in this section as a console call. That means that everytime you run an algorithm, a console command is added to the log, and you have the full history of your working session. Here is how that history looks like:
 
-.. image:: img/log/history.png
+.. figure:: img/log/history.png
 
 This can be very useful when starting working with the console, to learn about the syntax of algorithms. We will use it when we discuss how to run analysis commands from the console.
 

--- a/source/docs/training_manual/processing/modeler_hydro.rst
+++ b/source/docs/training_manual/processing/modeler_hydro.rst
@@ -13,39 +13,39 @@ This lesson does not contain instructions about how to create you model. You alr
 
 In case you could not create the full model yourself and you need some extra help, the data folder corresponding to this lesson contains an 'almost' finished version of it. Open the modeler and then open the model file that you will find in the data folder. You should see something like this.
 
-.. image:: img/modeler_hydro/model.png
+.. figure:: img/modeler_hydro/model.png
 
 This model contains all the steps needed to complete the calculation, but it just has one input: the DEM. That means that the threshold for channel definition use a fixed value, which makes the model not as useful as it could be. That is not a problem, since we can edit the model, and that is exactly what we will do.
 
 First, let's add a numerical input. That will ask the user for a numerical input that we can use when such a value is needed in any of the algorithms included in our model. Click on the *Number* entry in the inputs tree, and you will see the corresponding dialog. Fill it with the values shown next.
 
-.. image:: img/modeler_hydro/threshold.png
+.. figure:: img/modeler_hydro/threshold.png
 
 Now your model should look like this.
 
-.. image:: img/modeler_hydro/model_with_threshold.png
+.. figure:: img/modeler_hydro/model_with_threshold.png
 
 The input that we have just added is not used, so the model hasn't actually changed. We have to link that input to the algorithm that uses it, in this case the *Channel network* one. To edit an algorithm that already exists in the modeler, just click on the pen icon on the corresponding box in the canvas. If you click on the *Channel network* algorithm, you will see something like this.
 
-.. image:: img/modeler_hydro/channel_network.png
+.. figure:: img/modeler_hydro/channel_network.png
 
 The dialog is filled with the current values used by the algorithm. You can see that the threshold parameter has a fixed value of 1,000,000 (this is also the default value of the algorithm, but any other value could be put in there). However, you might notice that the parameter is not entered in a common text box, but in an option menu. If you unfold it, you will see something like this.
 
-.. image:: img/modeler_hydro/unfolded.png
+.. figure:: img/modeler_hydro/unfolded.png
 
 The input that we added is there and we can select it. Whenever an algorithm in a model requires a numerical value, you can hardcode it and directly type it, or you can use any of the available inputs and values (remember that some algorithms generate single numerical values. We will see more about this soon). In the case of a string parameter, you will also see string inputs and you will be able to select one of them or type the desired fixed value.
 
 Select the *Threshold* input in the *Threshold* parameter and click on *OK* to apply the changes to your model. Now the design of the model should look like this.
 
-.. image:: img/modeler_hydro/model_linked_parameter.png
+.. figure:: img/modeler_hydro/model_linked_parameter.png
 
 The model is now complete. Try to run it using the DEM that we have used in previous lessons, and with different threshold values. Here you have a sample of the result obtained for different values. You can compare with the result for the default value, which is the one we obtained in the hydrological analysis lesson.
 
-.. image:: img/modeler_hydro/result_1.png
+.. figure:: img/modeler_hydro/result_1.png
 
 Threshold = 100,000
 
-.. image:: img/modeler_hydro/result_2.png
+.. figure:: img/modeler_hydro/result_2.png
 
 Threshold = 1,0000,000
 

--- a/source/docs/training_manual/processing/modeler_hydro_calculator.rst
+++ b/source/docs/training_manual/processing/modeler_hydro_calculator.rst
@@ -15,13 +15,13 @@ Starting with the aforementioned model, let's do the following modifications:
 
 First, calculate statistics of the flow accumulation layer using the *Raster layer statistics* algorithm.
 
-.. image:: img/modeler_hydro_calculator/stats.png
+.. figure:: img/modeler_hydro_calculator/stats.png
 
 This will generate a set of statistical values that will now be available for all numeric fields in other algorithms. 
 
 If you edit the  *Channel network* algorithm, as we did in the last lesson, you will see now that you have other options apart from the numeric input that you added.
 
-.. image:: img/modeler_hydro_calculator/unfolded.png
+.. figure:: img/modeler_hydro_calculator/unfolded.png
 
 However, none of this values is suitable for being used as a valid threshold, since they will result in channel networks that will not be very realistic. We can, instead, derive some new parameter based on them, to get a better result. For instance, we can use the mean plus 2 times the standard deviation.
 
@@ -29,21 +29,21 @@ To add that arithmetical operation, we can use the calculator that you will find
 
 The parameters dialog of the calculator algorithm looks like this:
 
-.. image:: img/modeler_hydro_calculator/calculator.png
+.. figure:: img/modeler_hydro_calculator/calculator.png
 
 As you can see, the dialog is different to the other ones we have seen, but you have in there the same variables that were available in the *Threshold* field in the *Channel network* algorithm. Enter the above formula and click on *OK* to add the algorithm. 
 
-.. image:: img/modeler_hydro_calculator/calculator_dependencies.png
+.. figure:: img/modeler_hydro_calculator/calculator_dependencies.png
 
 If you expand the outputs entry, as shown above, you will see that the model is connected to two of the values, namely the mean and the standard deviation, which are the ones that we have used in the formula.
 
 Adding this new algorithm will add a new numeric value. If you go again to the *Channel network* algorithm, you can now select that value in the *Threshold* parameter. 
 
-.. image:: img/modeler_hydro_calculator/unfolded2.png
+.. figure:: img/modeler_hydro_calculator/unfolded2.png
 
 Click on *OK* and your model should look like this.
 
-.. image:: img/modeler_hydro_calculator/calculator_output.png
+.. figure:: img/modeler_hydro_calculator/calculator_output.png
 
 We are not using the numeric input that we added to the model, so it can be removed. Right--click on it and select *Remove*
 

--- a/source/docs/training_manual/processing/modeler_only.rst
+++ b/source/docs/training_manual/processing/modeler_only.rst
@@ -13,31 +13,31 @@ The interpolation process involves two steps, as it has been already explained i
 
 Open the modeler and start the model by adding the required inputs. In this case we need a vector layer (restricted to points) and an attribute from it, with the values that we will use for rasterizing.
 
-.. image:: img/modeler_only/inputs.png
+.. figure:: img/modeler_only/inputs.png
 
 The next step is to compute the extent of the selected features. That's where we can use the model-only tool called *Vector layer bounds*. First, we will have to create a layer that has the extent of those selected features. Then, we can use this tool on that layer.
 
 An easy way of creating a layer with the extent of the selected features is to compute a convex hull of the input points layer. It will use only the selected point, so the convex hull will have the same bounding box as the selection. Then we can add the *Vector layer bounds* algorithm, and use the convex hull layer as input. It should look this in the modeler canvas:
 
-.. image:: img/modeler_only/convexhull_and_extent.png
+.. figure:: img/modeler_only/convexhull_and_extent.png
 
 The result from the *Vector layer bounds* is a set of four numeric values and a extent object. We will use both the numeric outputs and the extent for this exercise.
 
-.. image:: img/modeler_only/extent_outputs.png
+.. figure:: img/modeler_only/extent_outputs.png
 
 We can now add the algorithm that rasterizes the vector layer, using the extent from the *Vector layer bounds* algorithm as input.
 
 Fill the parameters of the algorithm as shown next:
 
-.. image:: img/modeler_only/rasterize.png
+.. figure:: img/modeler_only/rasterize.png
 
 The canvas should now look like.
 
-.. image:: img/modeler_only/canvas_rasterize.png
+.. figure:: img/modeler_only/canvas_rasterize.png
 
 Finally, fill the no-data values of the raster layer using the *Close gaps* algorithm.
 
-.. image:: img/modeler_only/close_gaps.png
+.. figure:: img/modeler_only/close_gaps.png
 
 The algorithm is now ready to be saved and added to the toolbox. You can run it and it will generate a raster layer from interpolating the selected points in the input layer, and the layer will have the same extent as the selection.
 
@@ -45,13 +45,13 @@ Here's an improvement to the algorithm. We have used a harcoded value for the ce
 
 We can use the modeler-only calculator, and compute that value from the extent coordinates. For instance, to create a layer with a fixed width of 100 pixels, we can use the following formula in the calculator.
 
-.. image:: img/modeler_only/calculator.png
+.. figure:: img/modeler_only/calculator.png
 
 Now we have to edit the rasterize algorithm, so it uses the output of the calculator instead of the hardcoded value.
 
 The final algorithm should look like this:
 
-.. image:: img/modeler_only/final.png
+.. figure:: img/modeler_only/final.png
 
 
 .. Substitutions definitions - AVOID EDITING PAST THIS LINE

--- a/source/docs/training_manual/processing/modeler_twi.rst
+++ b/source/docs/training_manual/processing/modeler_twi.rst
@@ -13,7 +13,7 @@ Using the graphical modeler, that workflow can be put into a model, which will r
 
 To start this lesson, we are going to calculate a parameter named Topographic Wetness Index. The algorithm that computes it is called *Topographic wetness index (twi)*
 
-.. image:: img/modeler_twi/twi.png
+.. figure:: img/modeler_twi/twi.png
 
 As you can see, there are two mandatory inputs: *Slope* and *Catchment area*. There is also an optional input, but we will not be using it, so we can ignore it. 
 
@@ -23,23 +23,23 @@ Here are the parameter dialogs that you should use to calculate the 2 intermedia
 
 .. note:: Slope must be calculated in radians, not in degrees.
 
-.. image:: img/modeler_twi/slope.png
+.. figure:: img/modeler_twi/slope.png
 
-.. image:: img/modeler_twi/area.png
+.. figure:: img/modeler_twi/area.png
 
 And this is how you have to set the parameters dialog of the TWI algorithm.
 
-.. image:: img/modeler_twi/twi_filled.png
+.. figure:: img/modeler_twi/twi_filled.png
 
 This is the result that you will obtain (the default singleband pseudocolor inverted palette has been used for rendering). You can use the ``twi.qml`` style provided.
 
-.. image:: img/modeler_twi/twi_layer.png
+.. figure:: img/modeler_twi/twi_layer.png
 
 What we will try to do now is to create an algorithm that calculates the TWI from a DEM in just one single step. That will save us work in case we later have to compute a TWI layer from another DEM, since we will need just one single step to do it instead of the 3 ones above. All the processes that we need are found in the  toolbox, so what we have to do is to define the workflow to wrap them. This is where the graphical modeler comes in.
 
 Open the modeler by selecting its menu entry in the processing menu.
 
-.. image:: img/modeler_twi/modeler.png
+.. figure:: img/modeler_twi/modeler.png
 
 Two things are needed to create a model: setting the inputs that it will need, and defining the algorithm that it contains. Both of them are done by adding elements from the two tabs in the left--hand side of the modeler window: *Inputs* and *Algorithms*
 
@@ -47,21 +47,21 @@ Let's start with the inputs. In this case we do not have much to add. We just ne
 
 Double click on the *Raster layer* input and you will see the following dialog.
 
-.. image:: img/modeler_twi/raster_input.png
+.. figure:: img/modeler_twi/raster_input.png
 
 Here we will have to define the input we want. Since we expect this raster layer to be a DEM, we will call it *DEM*. That's the name that the user of the model will see when running it. Since we need that layer to work, we will define it as a mandatory layer.
 
 Here is how the dialog should be configured.
 
-.. image:: img/modeler_twi/raster_input_filled.png
+.. figure:: img/modeler_twi/raster_input_filled.png
 
 Click on *OK* and the input will appear in the modeler canvas.
 
-.. image:: img/modeler_twi/canvas_1.png
+.. figure:: img/modeler_twi/canvas_1.png
 
 Now let's move to the *Algorithms* tab. The first algorithm we have to run is the *Slope, aspect, curvature* algorithm. Locate it in the algorithm list, double--click on it and you will see the dialog shown below.
 
-.. image:: img/modeler_twi/slope_modeler.png
+.. figure:: img/modeler_twi/slope_modeler.png
 
 This dialog is very similar to the one that you can find when running the algorithm from the toolbox, but the element that you can use as parameter values are not taken from the current QGIS project, but from the model itself. That means that, in this case, we will not have all the raster layers of our project available for the *Elevation* field, but just the ones defined in our model. Since we have added just one single raster input named *DEM*, that will be the only raster layer that we will see in the list corresponding to the *Elevation* parameter. 
 
@@ -71,19 +71,19 @@ When layers are not a final result, you should just leave the corresponding fiel
 
 There is not much to select in this first dialog, since we do not have but just one layer in or model (The DEM input that we created). Actually, the default configuration of the dialog is the correct one in this case, so you just have to press *OK*. This is what you will now have in the modeler canvas.
 
-.. image:: img/modeler_twi/canvas_2.png
+.. figure:: img/modeler_twi/canvas_2.png
 
 The second algorithm we have to add to our model is the catchment area algorithm. We will use the algorithm named *Catchment area (Paralell)*. We will use the DEM layer again as input, and none of the ouputs it produces are final, so here is how you have to fill the corresponding dialog.
 
-.. image:: img/modeler_twi/area_modeler.png
+.. figure:: img/modeler_twi/area_modeler.png
 
 Now your model should look like this.
 
-.. image:: img/modeler_twi/canvas_3.png
+.. figure:: img/modeler_twi/canvas_3.png
 
 The last step is to add the *Topographic wetness index* algorithm, with the following configuration.
 
-.. image:: img/modeler_twi/twi_modeler.png
+.. figure:: img/modeler_twi/twi_modeler.png
 
 In this case, we will not be using the DEM as input, but instead, we will use the slope and catchment area layers that are calculated by the algorithms that we previously added. As you add new algorithms, the outputs they produce become available for other algorithms, and using them you link the algorithms, creating the workflow.
 
@@ -91,21 +91,21 @@ In this case, the output TWI layer is a final layer, so we have to indicate so. 
 
 Now our model is finished and it should look like this.
 
-.. image:: img/modeler_twi/canvas_4.png
+.. figure:: img/modeler_twi/canvas_4.png
 
 Enter a name and a group name in the upper part of the model window, and then save it clicking on the *Save* button. 
 
-.. image:: img/modeler_twi/model_name.png
+.. figure:: img/modeler_twi/model_name.png
 
 You can save it anywhere you want and open it later, but if you save it in the models folder (which is the folder that you will see when the save file dialog appears), you model will also be available in the toolbox as well. So stay on that folder and save the model with the filename that you prefer.
 
 Now close the modeler dialog and go to the toolbox. In the *Models* entry you will find you model.
 
-.. image:: img/modeler_twi/toolbox.png
+.. figure:: img/modeler_twi/toolbox.png
 
 You can run it just like any normal algorithm, double--clicking on it.
 
-.. image:: img/modeler_twi/model_dialog.png
+.. figure:: img/modeler_twi/model_dialog.png
 
 As you can see, the parameters dialog, contain the input that you added to the model, along with the outputs that you set as final when adding the corresponding algorithms.
 

--- a/source/docs/training_manual/processing/no_data.rst
+++ b/source/docs/training_manual/processing/no_data.rst
@@ -17,7 +17,7 @@ Open the QGIS project corresponding to this lesson and you will see that it cont
 
 Now open the toolbox and open the dialog corresponding to the raster calculator.
 
-.. image:: img/no_data/calculator_dialog.png
+.. figure:: img/no_data/calculator_dialog.png
 
 .. note:: The interface is different in recent versions.
 
@@ -46,11 +46,11 @@ Open the algorithm dialog again, select the *accflow* layer as the only input la
 
 Here is the layer that you will get.
 
-.. image:: img/no_data/log.png
+.. figure:: img/no_data/log.png
 
 If you select the *Identify* tool to know the value of a layer at a given point, select the layer that we have just created, and click on a point outside of the basin, you will see that it contains a no--data value.
 
-.. image:: img/no_data/identify.png
+.. figure:: img/no_data/identify.png
 
 For the next exercise we are going to use two layers instead of one, and we are going to get a DEM with valid elevation values only within the basin defined in the second layer. Open the calculator dialog and select both layers of the project in the input layers field. Enter the following formula in the corresponding field:
 
@@ -62,7 +62,7 @@ For the next exercise we are going to use two layers instead of one, and we are 
 
 Here is the resulting layer.
 
-.. image:: img/no_data/masked.png
+.. figure:: img/no_data/masked.png
 
 
 This technique is used frequently to *mask* values in a raster layer, and is useful whenever you want to perform calculations for a region other that the arbitrary rectangular region that is used by raster layer. For instance, an elevation histogram of a raster layer doesn't have much meaning. If it is instead computed using only values corresponding to a basin (as in he case above), the result that we obtain is a meaningful one that actually gives information about the configuration of the basin.
@@ -88,7 +88,7 @@ As you can see, we can use the calculator not only to do simple algebraic operat
 
 The result has a value of 1 inside the range we want to work with, and no-data in cells outside of it.
 
-.. image:: img/no_data/elevation_mask.png
+.. figure:: img/no_data/elevation_mask.png
 
 The no-data value comes from the 0/0 expression. Since that is an undetermined value, SAGA will add a NaN (Not a Number) value, which is actually handled as a no-data value. With this little trick you can set a no-data value without needing to know what the no--data value of the cell is.
 

--- a/source/docs/training_manual/processing/r_intro.rst
+++ b/source/docs/training_manual/processing/r_intro.rst
@@ -27,7 +27,7 @@ Adding scripts
 Adding a script is very simple. Open the Processing toolbox and just click on
 the :menuselection:`R --> Tools --> Create new R script`.
 
-.. image:: img/r_intro/r_intro_1.png
+.. figure:: img/r_intro/r_intro_1.png
 
 .. note:: If you cannot see R in Processing, you have to activate it in
    :menuselection:`Processing --> Options --> Providers`
@@ -35,7 +35,7 @@ the :menuselection:`R --> Tools --> Create new R script`.
 It opens a *script editor window* in which you have to specify some parameters
 before you can add the script body.
 
-.. image:: img/r_intro/r_intro_2.png
+.. figure:: img/r_intro/r_intro_2.png
     :scale: 70%
     :align: center
 
@@ -100,7 +100,7 @@ The final script looks like this::
     ##X=Field Layer
     boxplot(Layer[[X]])
 
-.. image:: img/r_intro/r_intro_3.png
+.. figure:: img/r_intro/r_intro_3.png
 
 Save the script in the default path suggested by Processing. The name you choose
 will be the same as the name of the script you'll find in the Processing toolbox.
@@ -110,12 +110,12 @@ will be the same as the name of the script you'll find in the Processing toolbox
 
 Now just run it using the button on the top of the editor window:
 
-.. image:: img/r_intro/r_intro_4.png
+.. figure:: img/r_intro/r_intro_4.png
 
 Otherwise, once the editor window has been closed, use the text box of Processing
 to find your script:
 
-.. image:: img/r_intro/r_intro_5.png
+.. figure:: img/r_intro/r_intro_5.png
 
 You are now able to fill the parameters required in the Processing algorithm window:
 
@@ -124,14 +124,14 @@ You are now able to fill the parameters required in the Processing algorithm win
 
 Click on **Run**.
 
-.. image:: img/r_intro/r_intro_6.png
+.. figure:: img/r_intro/r_intro_6.png
 
 The **Result window** should be automatically opened, if not, just click on
 :menuselection:`Processing --> Result Viewer...`.
 
 This is the final result you'll see:
 
-.. image:: img/r_intro/r_intro_7.png
+.. figure:: img/r_intro/r_intro_7.png
 
 .. note:: You can open, copy and save the image by right clicking on the plot
 
@@ -197,19 +197,19 @@ The final script looks like this::
     pts=spsample(Layer,Size,type="random")
     Output=SpatialPointsDataFrame(pts, as.data.frame(pts))
 
-.. image:: img/r_intro/r_intro_8.png
+.. figure:: img/r_intro/r_intro_8.png
 
 Save it and run it, clicking on the running button.
 
 In the new window type in the right parameters:
 
-.. image:: img/r_intro/r_intro_9.png
+.. figure:: img/r_intro/r_intro_9.png
 
 and click on run.
 
 Resulting points will be displayed in the map canvas
 
-.. image:: img/r_intro/r_intro_10.png
+.. figure:: img/r_intro/r_intro_10.png
 
 
 R - Processing syntax

--- a/source/docs/training_manual/processing/second_alg.rst
+++ b/source/docs/training_manual/processing/second_alg.rst
@@ -20,21 +20,21 @@ This algorithm, like the one from the previous lesson, just generates a single o
 
 Your dialog should look like this.
 
-.. image:: img/second_alg/points_from_table.png
+.. figure:: img/second_alg/points_from_table.png
 
 Now press the *Run* button to get the following layer (you may need to zoom full to reenter the map around the newly created points):
 
-.. image:: img/second_alg/points.png
+.. figure:: img/second_alg/points.png
 
 The next thing we need is the polygon layer. We are going to create a regular grid of polygons using the *Create grid* algorithm, which has the following parameters dialog.
 
-.. image:: img/second_alg/graticule_dialog.png
+.. figure:: img/second_alg/graticule_dialog.png
 
 .. warning:: The options are simpler in recent versions of QGIS; you just need to enter min and max for X and Y (suggested values: -5.696226,-5.695122,40.24742,40.248171)
 
 The inputs required to create the grid are all numbers. When you have to enter a numerical value, you have two options: typing it directly on the corresponding box or clicking the button on the right--hand side to get to a dialog like the one shown next.
 
-.. image:: img/second_alg/number_dialog.png
+.. figure:: img/second_alg/number_dialog.png
 
 The dialog contains a simple calculator, so you can type expressions such as ``11 * 34.7 + 4.6``, and the result will be computed and put in the corresponding text box in the parameters dialog. Also, it contains constants that you can use, and values from other layers available.
 
@@ -46,28 +46,28 @@ As in the case of the last algorithm, we have to enter the CRS here as well. Sel
 
 In the end, you should have a parameters dialog like this:
 
-.. image:: img/second_alg/graticule_parameters.png
+.. figure:: img/second_alg/graticule_parameters.png
 
 (Better add one spacing on the width and height: Horizontal spacing: 0.0001, Vertical spacing: 0.0001, Width: 0.001004, Height: 0.000651, Center X: -5.695674, Center Y: 40.2477955)
 The case of X center is a bit tricky, see: -5.696126+(( -5.695222+ 5.696126)/2)
 
 Press *Run* and you will get the graticule layer.
 
-.. image:: img/second_alg/graticule.png
+.. figure:: img/second_alg/graticule.png
 
 The last step is to count the points in each one of the rectangles of that graticule. We will use the *Count points in polygons* algorithm.
 
-.. image:: img/second_alg/count_points.png
+.. figure:: img/second_alg/count_points.png
 
 Now we have the result we were looking for.
 
 Before finishing this lesson, here is a quick tip to make your life easier in case you want to persistently save your data. If you want all your output files to be saved in a given folder, you do not have to type the folder name each time. Instead, go to the processing menu and select the *Options and configuration* item. It will open the configuration dialog.
 
-.. image:: img/second_alg/config.png
+.. figure:: img/second_alg/config.png
 
 In the *Output folder* entry that you will find in the *General* group, type the path to your destination folder.
 
-.. image:: img/second_alg/output_folder.png
+.. figure:: img/second_alg/output_folder.png
 
 Now when you run an algorithm, just use the filename instead of the full path. For instance, with the configuration shown above, if you enter ``graticule.shp`` as the output path for the algorithm that we have just used, the result will be saved in ``D:\processing_output\graticule.shp``. You can still enter a full path in case you want a result to be saved in a different folder.
 

--- a/source/docs/training_manual/processing/selection.rst
+++ b/source/docs/training_manual/processing/selection.rst
@@ -18,15 +18,15 @@ You can test that yourself by selecting a few points in any of the layers that w
 
 To make a selection, you can use any of the available methods and tools in QGIS. However, you can also use a geoalgorithm to do so. Algorithms for creating a selection are found in the toolbox under *Vector/Selection*
 
-.. image:: img/selection/selection_algs.png
+.. figure:: img/selection/selection_algs.png
 
 Open the *Random selection* algorithm.
 
-.. image:: img/selection/random_selection.png
+.. figure:: img/selection/random_selection.png
 
 Leaving the default values, it will select 10 points from the current layer.
 
-.. image:: img/selection/selected.png
+.. figure:: img/selection/selected.png
 
 You will notice that this algorithm does not produce any output, but modifies the input layer (not the layer itself, but its selection). This is an uncommon behaviour, since all the other algorithms will produce new layers and not alter the input layers.
 

--- a/source/docs/training_manual/processing/set_up.rst
+++ b/source/docs/training_manual/processing/set_up.rst
@@ -18,18 +18,18 @@ it is included with QGIS. In case it is active, you should see a menu called
 *Processing* in your menu bar. There you will find an access to all the
 framework components.
 
-.. image:: img/set_up/menu.png
+.. figure:: img/set_up/menu.png
 
 If you cannot find that menu, you have to enable the plugin by going to the
 plugin manager and activating it.
 
-.. image:: img/set_up/installer.png
+.. figure:: img/set_up/installer.png
 
 The main element that we are going to work with is the toolbox. Click on the
 corresponding menu entry and you will see the toolbox docked at the right side
 of the QGIS window.
 
-.. image:: img/set_up/toolbox.png
+.. figure:: img/set_up/toolbox.png
 
 
 The toolbox contains a list of all the available algorithms, divided in groups

--- a/source/docs/training_manual/processing/vector_calculator.rst
+++ b/source/docs/training_manual/processing/vector_calculator.rst
@@ -10,7 +10,7 @@ Vector calculator
 
 We already know how to use the raster calculator to create new raster layers using mathematical expressions. A similar algorithm is available for vector layers, and generates a new layer with the same attributes of the input layer, plus an additional one with the result of the expression entered. The algorithm is called *Field calculator* and has the following parameters dialog.
 
-.. image:: img/vector_calculator/field_calculator.png
+.. figure:: img/vector_calculator/field_calculator.png
 
 .. note:: In newer versions of Processing the interface has changed considerably, it's more powerful and easier to use.
 
@@ -38,7 +38,7 @@ Enter the following formula
 
 This time the parameters window should look like this before pressing the *OK* button. 
 
-.. image:: img/vector_calculator/ratio.png
+.. figure:: img/vector_calculator/ratio.png
 
 
 In earlier version, since both fields are of type integer, the result would be truncated to an integer. In this case the formula should be: ``1.0 *  "MALES"  /  "FEMALES"``, to indicate that we want floating point number a result.
@@ -49,11 +49,11 @@ We can use conditional functions to have a new field with ``male`` or ``female``
 
 The parameters window should look like this.
 
-.. image:: img/vector_calculator/predominance.png
+.. figure:: img/vector_calculator/predominance.png
 
 A python field calculator is available in the *Advanced Python field calculator*, which will not be detailed here
 
-.. image:: img/vector_calculator/advanced.png
+.. figure:: img/vector_calculator/advanced.png
 
 
 .. Substitutions definitions - AVOID EDITING PAST THIS LINE

--- a/source/docs/training_manual/processing/warning.rst
+++ b/source/docs/training_manual/processing/warning.rst
@@ -20,7 +20,7 @@ Given a set of points and a value of a given variable value at each point,
 you can calculate a raster layer from them using the *Kriging* geoalgorithm.
 The parameters dialog for that module is like the following one.
 
-.. image:: img/warning/kriging.png
+.. figure:: img/warning/kriging.png
 
 It look complex, right? 
 

--- a/source/docs/training_manual/qgis_plugins/fetching_plugins.rst
+++ b/source/docs/training_manual/qgis_plugins/fetching_plugins.rst
@@ -18,7 +18,7 @@ and :guilabel:`Plugin Manager`.
   :menuselection:`Plugins --> Manage and Install Plugins`.
 * In the dialog that opens, find the :guilabel:`Processing` plugin:
 
-  .. image:: img/select_processing_plugin.png
+  .. figure:: img/select_processing_plugin.png
      :align: center
 
 * Click in the box next to this plugin and uncheck it to deactivate it.
@@ -47,13 +47,13 @@ that you currently have installed.
   will be listed here. This list will vary depending on your existing system
   setup.
 
-  .. image:: img/get_more_plugins.png
+  .. figure:: img/get_more_plugins.png
      :align: center
 
 * You can find information about each plugin by selecting it in the list of
   plugins displayed.
 
-  .. image:: img/plugin_details.png
+  .. figure:: img/plugin_details.png
      :align: center
 
 * A plugin can be installed by clicking the :guilabel:`Install Plugin` button
@@ -79,7 +79,7 @@ you want to configure additional repositories. To do this:
 * Open the :guilabel:`Settings` tab in the :guilabel:`Plugin Manager`
   dialog:
 
-  .. image:: img/plugin_manager_settings.png
+  .. figure:: img/plugin_manager_settings.png
      :align: center
 
 * Click :guilabel:`Add` to find and add a new repository.
@@ -87,13 +87,13 @@ you want to configure additional repositories. To do this:
 * Provide a Name and URL for the new repository you want to configure and make
   sure the :guilabel:`Enabled` checkbox is selected.
 
-  .. image:: img/new_plugins_setting.png
+  .. figure:: img/new_plugins_setting.png
      :align: center
 
 * You will now see the new plugin repo listed in the list of configured
   Plugin Repositories
 
-  .. image:: img/new_plugin_added.png
+  .. figure:: img/new_plugin_added.png
      :align: center
 
 * You can also select the option to display Experimental Plugins by selecting

--- a/source/docs/training_manual/qgis_plugins/plugin_examples.rst
+++ b/source/docs/training_manual/qgis_plugins/plugin_examples.rst
@@ -30,7 +30,7 @@ explore some of its features.
 #. The base map will be loaded and you will have a satellite background for the
    map.
 
-.. image:: img/qms_result.png
+.. figure:: img/qms_result.png
    :align: center
 
 QuickMapServices plugin has a lot of available base maps available.
@@ -39,7 +39,7 @@ Close the :guilabel:`Search QMS` panel we open before and click again on
 :menuselection:`Web --> QuickMapServices`. The first menu lists different map
 providers with all the available maps:
 
-.. image:: img/qms_menu.png
+.. figure:: img/qms_menu.png
    :align: center
 
 But there is more.
@@ -79,7 +79,7 @@ With an incredible simple interface, the QuickOSM plugin allows you to download
 #. Select :guilabel:`Extent of a layer` and choose :guilabel:`roads`.
 #. Click on the :guilabel:`Run query` button.
 
-   .. image:: img/quickosm_setup.png
+   .. figure:: img/quickosm_setup.png
       :align: center
 
 After some seconds the plugin will download all the features tagged in OpenStreetMap
@@ -88,7 +88,7 @@ as ``railway`` and load them directly into the map.
 Nothing more! All the layers are loaded in the legend and are shown in the map
 canvas.
 
-.. image:: img/quickosm_result.png
+.. figure:: img/quickosm_result.png
    :align: center
 
 .. warning:: QuickOSM creates temporary layer when downloading the data. If you
@@ -153,12 +153,12 @@ be more specific and write your own query. Let's try to do this.
 
 #. And click on :guilabel:`Run Query`:
 
-   .. image:: img/quickosm_advanced_query.png
+   .. figure:: img/quickosm_advanced_query.png
       :align: center
 
 The mountain peaks layer will be downloaded and shown in QGIS:
 
-.. image:: img/quickosm_advanced_result.png
+.. figure:: img/quickosm_advanced_result.png
    :align: center
 
 You can write complex queries using the `Overpass Query language <https://wiki.openstreetmap.org/wiki/Overpass_API/Overpass_QL>`_.
@@ -183,7 +183,7 @@ of :guilabel:`sample_point` layer.
 In the DataPlotly Panel choose :guilabel:`sample_point` in the Layer filter, :kbd:`cl`
 for the ``X Field`` and :kbd:`mg` for the ``Y Field``:
 
-.. image:: img/dataplotly_setup.png
+.. figure:: img/dataplotly_setup.png
    :align: center
 
 If you want you can change the colors, the marker type, the transparency and
@@ -191,7 +191,7 @@ many other settings: just try to change some parameters to create the plot as th
 following picture. Once you set up all the parameters click on the
 :guilabel:`Create Plot` button to create the plot:
 
-.. image:: img/dataplotly_scatterplot.png
+.. figure:: img/dataplotly_scatterplot.png
    :align: center
 
 The plot is interactive: this means you can use all the upper buttons to resize,
@@ -213,12 +213,12 @@ different plot types with different variables on the same page. Let's do this!
 #. In the lower part of the Panel change the ``Type of Plot`` from ``SinglePlot``
    to ``SubPlots`` and let the default option ``Plot in Rows`` selected:
 
-   .. image:: img/dataplotly_boxplot.png
+   .. figure:: img/dataplotly_boxplot.png
       :align: center
 
 #. Once done click on the :guilabel:`Create Plot` button to draw the plot:
 
-   .. image:: img/dataplotly_subplots.png
+   .. figure:: img/dataplotly_subplots.png
       :align: center
 
 Now both scatter plot and box plot are shown in the same plot page. You still

--- a/source/docs/training_manual/rasters/changing_symbology.rst
+++ b/source/docs/training_manual/rasters/changing_symbology.rst
@@ -30,7 +30,7 @@ are, for example.
 Once it's loaded, you'll notice that it's a basic stretched grayscale
 representation of the DEM. It's seen here with the vector layers on top:
 
-.. image:: img/greyscale_dem.png
+.. figure:: img/greyscale_dem.png
    :align: center
 
 QGIS has automatically applied a stretch to the image for visualization
@@ -44,7 +44,7 @@ purposes, and we will learn more about how this works as we continue.
   :guilabel:`Properties` option.
 * Switch to the :guilabel:`Symbology` tab.
 
-.. image:: img/dem_layer_properties.png
+.. figure:: img/dem_layer_properties.png
    :align: center
 
 These are the current settings that QGIS applied for us by default. Its just
@@ -55,12 +55,12 @@ one way to look at a DEM, so lets explore some others.
 * Click the :guilabel:`Classify` button to generate a new color classification,
   and click :guilabel:`OK` to apply this classification to the DEM.
 
-.. image:: img/dem_pseudocolor_properties.png
+.. figure:: img/dem_pseudocolor_properties.png
    :align: center
 
 You'll see the raster looking like this:
 
-.. image:: img/pseudocolor_raster.png
+.. figure:: img/pseudocolor_raster.png
    :align: center
 
 This is an interesting way of looking at the DEM, but maybe we don't want to
@@ -72,7 +72,7 @@ symbolize it using these colors.
 
 You will now see a totally gray rectangle that isn't very useful at all.
 
-.. image:: img/singleband_grey_raster.png
+.. figure:: img/singleband_grey_raster.png
    :align: center
 
 This is because we have lost the default settings which "stretch" the color
@@ -86,7 +86,7 @@ data in the DEM. This will make QGIS use  all of the available colors (in
 * Set the value :guilabel:`Contrast enhancement` to
   :guilabel:`Stretch To MinMax`:
 
-.. image:: img/singleband_grey_settings.png
+.. figure:: img/singleband_grey_settings.png
    :align: center
 
 But what are the minimum and maximum values that should be used for the
@@ -102,7 +102,7 @@ minimum and maximum values of the raster.
 Notice how the :guilabel:`Custom min / max values` have changed to reflect the
 actual values in our DEM:
 
-.. image:: img/grey_custom_min_max.png
+.. figure:: img/grey_custom_min_max.png
    :align: center
 
 * Click :guilabel:`OK` to apply these settings to the image.
@@ -110,7 +110,7 @@ actual values in our DEM:
 You'll now see that the values of the raster are again properly displayed,
 with the darker colors representing valleys and the lighter ones, mountains:
 
-.. image:: img/correct_black_white.png
+.. figure:: img/correct_black_white.png
    :align: center
 
 But isn't there a better or easier way?
@@ -125,7 +125,7 @@ know that there's a tool for doing all of this easily.
 * Enable the tool you'll need by enabling :menuselection:`View --> Toolbars -->
   Raster`. These icons will appear in the interface:
 
-  .. image:: img/raster_toolbar.png
+  .. figure:: img/raster_toolbar.png
      :align: center
 
 The third button from the left :guilabel:`Local Histogram Stretch` will

--- a/source/docs/training_manual/rasters/data_manipulation.rst
+++ b/source/docs/training_manual/rasters/data_manipulation.rst
@@ -49,7 +49,7 @@ projection. Luckily, we've already seen what to do in this situation.
 
 The rasters should fit nicely:
 
-.. image:: img/raster_step_one.png
+.. figure:: img/raster_step_one.png
    :align: center
 
 There we have it - four aerial photographs covering our whole study area.
@@ -87,7 +87,7 @@ writing that text for you. It's a long command that QGIS is going to run.
 
 * Click :guilabel:`OK` to run the command.
 
-.. image:: img/build_virtual_raster.png
+.. figure:: img/build_virtual_raster.png
    :align: center
 
 
@@ -123,7 +123,7 @@ Note that this tool features a handy batch option for reprojecting the contents
 of whole directories. You can also reproject virtual rasters (catalogs), as
 well as enabling a multithreaded processing mode.
 
-.. image:: img/warp_rasters.png
+.. figure:: img/warp_rasters.png
    :align: center
 
 Merging rasters
@@ -140,7 +140,7 @@ You can also add your own command line options using the :guilabel:`Creation
 Options` checkbox and list. This only applies if you have knowledge of the GDAL
 library's operation.
 
-.. image:: img/merge_rasters.png
+.. figure:: img/merge_rasters.png
    :align: center
 
 |IC|

--- a/source/docs/training_manual/rasters/terrain_analysis.rst
+++ b/source/docs/training_manual/rasters/terrain_analysis.rst
@@ -44,7 +44,7 @@ models)` analysis tool.
 You will now have a new layer called :guilabel:`hillshade` that looks like
 this:
 
-.. image:: img/hillshade_raster.png
+.. figure:: img/hillshade_raster.png
    :align: center
 
 That looks nice and 3D, but can we improve on this? On its own, the hillshade
@@ -73,7 +73,7 @@ transparent.
 * Click :guilabel:`OK` on the :guilabel:`Layer Properties` dialog. You'll get a
   result like this:
 
-  .. image:: img/hillshade_pseudocolor.png
+  .. figure:: img/hillshade_pseudocolor.png
      :align: center
 
 * Switch the :guilabel:`hillshade` layer off and back on in the
@@ -106,7 +106,7 @@ To do this, you need to use the :guilabel:`Slope` mode of the :guilabel:`DEM
 * Open the tool as before.
 * Select the :guilabel:`Mode` option :guilabel:`Slope`:
 
-  .. image:: img/dem_slope_dialog.png
+  .. figure:: img/dem_slope_dialog.png
      :align: center
 
 * Set the save location to
@@ -120,7 +120,7 @@ To do this, you need to use the :guilabel:`Slope` mode of the :guilabel:`DEM
   slope of the terrain, with black pixels being flat terrain and white pixels,
   steep terrain:
 
-  .. image:: img/slope_raster.png
+  .. figure:: img/slope_raster.png
      :align: center
 
 .. _backlink-raster-analysis-1:
@@ -170,12 +170,12 @@ needs to be greater than 270 degrees and less than 90 degrees.
 * Ensure that the box :guilabel:`Add result to project` is checked.
 * Click :guilabel:`OK` to begin processing.
 
-.. image:: img/raster_calculator.png
+.. figure:: img/raster_calculator.png
    :align: center
 
 Your result will be this:
 
-.. image:: img/aspect_result.png
+.. figure:: img/aspect_result.png
    :align: center
 
 
@@ -232,7 +232,7 @@ To calculate the areas that satisfy these criteria:
   :kbd:`all_conditions.tif`.
 * Click :guilabel:`OK` on the :guilabel:`Raster calculator`. Your results:
 
-  .. image:: img/development_analysis_results.png
+  .. figure:: img/development_analysis_results.png
      :align: center
 
 
@@ -252,13 +252,13 @@ get rid of all these tiny unusable areas.
 * Set both the :guilabel:`Threshold` and :guilabel:`Pixel connections` values
   to :kbd:`8`, then run the tool.
 
-.. image:: img/raster_seive_dialog.png
+.. figure:: img/raster_seive_dialog.png
    :align: center
 
 Once processing is done, the new layer will load into the canvas. But when you
 try to use the histogram stretch tool to view the data, this happens:
 
-.. image:: img/seive_result_incorrect.png
+.. figure:: img/seive_result_incorrect.png
    :align: center
 
 What's going on? The answer lies in the new raster file's metadata.
@@ -266,7 +266,7 @@ What's going on? The answer lies in the new raster file's metadata.
 * View the metadata under the :guilabel:`Metadata` tab of the :guilabel:`Layer
   Properties` dialog. Look in the :guilabel:`Properties` section at the bottom.
 
-.. image:: img/seive_metadata.png
+.. figure:: img/seive_metadata.png
    :align: center
 
 Whereas this raster, like the one it's derived from, should only
@@ -286,7 +286,7 @@ filtered out, let's set these null values to zero.
 
 Your output looks like this:
 
-.. image:: img/raster_seive_correct.png
+.. figure:: img/raster_seive_correct.png
    :align: center
 
 This is what was expected: a simplified version of the earlier results.

--- a/source/docs/training_manual/spatial_databases/geometry.rst
+++ b/source/docs/training_manual/spatial_databases/geometry.rst
@@ -129,7 +129,7 @@ Looking at Our Schema
 
 By now our schema should be looking like this:
 
-.. image:: img/final_schema.png
+.. figure:: img/final_schema.png
    :align: center
 
 
@@ -181,7 +181,7 @@ To avoid empty geometries, use:
 
   where not st_isempty(st_intersection(a.the_geom, b.the_geom))
 
-.. image:: img/qgis_001.png
+.. figure:: img/qgis_001.png
    :align: center
 
 .. code-block:: sql
@@ -191,7 +191,7 @@ To avoid empty geometries, use:
   where not st_isempty(st_intersection(st_setsrid(a.the_geom,32734),
     b.the_geom));
 
-.. image:: img/qgis_002.png
+.. figure:: img/qgis_002.png
    :align: center
 
 Building Geometries from Other Geometries
@@ -202,7 +202,7 @@ points is defined by their :kbd:`id`. Another ordering method could be a
 timestamp, such as the one you get when you capture waypoints with a GPS
 receiver.
 
-.. image:: img/qgis_006.png
+.. figure:: img/qgis_006.png
    :align: center
 
 To create a linestring from a new point layer called 'points', you can run the
@@ -221,7 +221,7 @@ To see how it works without creating a new layer, you could also run this
 command on the 'people' layer, although of course it would make little
 real-world sense to do this.
 
-.. image:: img/qgis_007.png
+.. figure:: img/qgis_007.png
    :align: center
 
 Geometry Cleaning

--- a/source/docs/training_manual/spatial_databases/simple_feature_model.rst
+++ b/source/docs/training_manual/spatial_databases/simple_feature_model.rst
@@ -28,7 +28,7 @@ The Simple Feature for SQL (SFS) Model is a *non-topological* way to store
 geospatial data in a database and defines functions for accessing, operating,
 and constructing these data.
 
-.. image:: img/ogc_sfs.png
+.. figure:: img/ogc_sfs.png
    :align: center
 
 The model defines geospatial data from Point, Linestring, and Polygon types
@@ -154,12 +154,12 @@ Layers` menu option or toolbar button:
 
 This will open the dialog:
 
-.. image:: img/add_postgis_layer_dialog.png
+.. figure:: img/add_postgis_layer_dialog.png
    :align: center
 
 Click on the :guilabel:`New` button to open this dialog:
 
-.. image:: img/new_postgis_connection.png
+.. figure:: img/new_postgis_connection.png
    :align: center
 
 Then define a new connection, e.g.::

--- a/source/docs/training_manual/spatial_databases/spatial_queries.rst
+++ b/source/docs/training_manual/spatial_databases/spatial_queries.rst
@@ -171,7 +171,7 @@ Or, if we create a view from it:
 
 Add the view as a layer and view it in QGIS:
 
-.. image:: img/kwazulu_view_result.png
+.. figure:: img/kwazulu_view_result.png
    :align: center
 
 Select neighbors
@@ -209,7 +209,7 @@ As a view:
 
 In QGIS:
 
-.. image:: img/adjoining_result.png
+.. figure:: img/adjoining_result.png
    :align: center
 
 Note the missing region (Queensland). This may be due to a topology error.
@@ -228,7 +228,7 @@ This creates a buffer of 100 meters around the region Hokkaido.
 
 The darker area is the buffer:
 
-.. image:: img/hokkaido_buffer.png
+.. figure:: img/hokkaido_buffer.png
    :align: center
 
 Select using the buffer:
@@ -254,7 +254,7 @@ because we don't want it; we only want the regions adjoining it.
 
 In QGIS:
 
-.. image:: img/hokkaido_buffer_select.png
+.. figure:: img/hokkaido_buffer_select.png
    :align: center
 
 It is also possible to select all objects within a given distance, without the
@@ -271,7 +271,7 @@ extra step of creating a buffer:
 
 This achieves the same result, without need for the interim buffer step:
 
-.. image:: img/hokkaido_distance_select.png
+.. figure:: img/hokkaido_distance_select.png
    :align: center
 
 

--- a/source/docs/training_manual/vector_analysis/basic_analysis.rst
+++ b/source/docs/training_manual/vector_analysis/basic_analysis.rst
@@ -69,7 +69,7 @@ We first need to load the data to work with.
 * If you want you can add a background map. Open the :guilabel:`Browser` and load
   the :guilabel:`OSM` background map from the :guilabel:`XYZ Tiles` menu.
 
-.. image:: img/osm_swellendam.png
+.. figure:: img/osm_swellendam.png
    :align: center
 
 In the :file:`training_data.gpkg` Geopackage database load all the files we will
@@ -111,7 +111,7 @@ features are available in the project.
 
 The map with all the data should look like the following one:
 
-.. image:: img/osm_swellendam_2.png
+.. figure:: img/osm_swellendam_2.png
    :align: center
 
 
@@ -143,7 +143,7 @@ But feel free to choose the best workflow for yourself.
 * Change the :guilabel:`CRS` parameter to :guilabel:`WGS 84 / UTM zone 34S`;
 * Finally click on :guilabel:`OK`:
 
-.. image:: img/save_roads_34S.png
+.. figure:: img/save_roads_34S.png
    :align: center
 
 This will create the new GeoPackage database and fill it with the
@@ -177,19 +177,19 @@ QGIS allows you to calculate distances from any vector object.
   :guilabel:`Buffer` algorithm. You can find it expanding the
   :menuselection:`Vector Geometry` group;
 
-  .. image:: img/processing_buffer_1.png
+  .. figure:: img/processing_buffer_1.png
      :align: center
 
   Or you can type ``buffer`` in the search menu in the upper part of the toolbox:
 
-  .. image:: img/processing_buffer_2.png
+  .. figure:: img/processing_buffer_2.png
      :align: center
 
 Double click on it to open the algorithm dialog.
 
 * Set it up like this;
 
-.. image:: img/vector_buffer_setup.png
+.. figure:: img/vector_buffer_setup.png
    :align: center
 
 The default :guilabel:`Distance` is in meters because our input dataset is in a
@@ -208,14 +208,14 @@ etc.
   :guilabel:`roads_buffer_50m` and save it in the :file:`vector_analysis.gpkg`
   file;
 
-  .. image:: img/buffer_saving.png
+  .. figure:: img/buffer_saving.png
      :align: center
 
 * Click on :guilabel:`Run` and then close the :guilabel:`Buffer` dialog.
 
 Now your map will look something like this:
 
-.. image:: img/roads_buffer_result.png
+.. figure:: img/roads_buffer_result.png
    :align: center
 
 If your new layer is at the top of the :guilabel:`Layers` list, it will probably
@@ -227,7 +227,7 @@ correspond to all the individual roads. To get rid of this problem, uncheck the
 :guilabel:`roads_buffer_50m` layer and re-create the buffer using the settings
 shown here:
 
-.. image:: img/dissolve_buffer_setup.png
+.. figure:: img/dissolve_buffer_setup.png
    :align: center
 
 * Note that we're now checking the :guilabel:`Dissolve result` box;
@@ -237,7 +237,7 @@ shown here:
 Once you've added the layer to the :guilabel:`Layers` panel, it will look like
 this:
 
-.. image:: img/dissolve_buffer_results.png
+.. figure:: img/dissolve_buffer_results.png
    :align: center
 
 Now there are no unnecessary subdivisions.
@@ -268,7 +268,7 @@ both of these criteria are satisfied. To do that, we'll need to use the
 :menuselection:`Vector Overlay` group within
 :menuselection:`Processing --> Toolbox`. Set it up like this:
 
-.. image:: img/school_roads_intersect.png
+.. figure:: img/school_roads_intersect.png
    :align: center
 
 The input layers are the two buffers; the saving location is, once again, the
@@ -279,13 +279,13 @@ The input layers are the two buffers; the saving location is, once again, the
 In the image below, the blue areas show us where both distance criteria are
 satisfied at once!
 
-.. image:: img/intersect_result.png
+.. figure:: img/intersect_result.png
    :align: center
 
 You may remove the two buffer layers and only keep the one that shows where
 they overlap, since that's what we really wanted to know in the first place:
 
-.. image:: img/final_intersect_result.png
+.. figure:: img/final_intersect_result.png
    :align: center
 
 .. _select-by-location:
@@ -301,7 +301,7 @@ extract the buildings in that area.
 
 * Set up the algorithm dialog like in the following picture;
 
-.. image:: img/location_select_dialog.png
+.. figure:: img/location_select_dialog.png
    :align: center
 
 * Click :guilabel:`Run` and then close the dialog;
@@ -309,7 +309,7 @@ extract the buildings in that area.
   :guilabel:`well_located_houses` layer to the top of the layers list, then
   zoom in.
 
-.. image:: img/select_zoom_result.png
+.. figure:: img/select_zoom_result.png
    :align: center
 
 The red buildings are those which match our criteria, while the buildings in green
@@ -345,7 +345,7 @@ first need to calculate their size.
   attribute table;
 * Set it up like this;
 
-.. image:: img/buildings_area_calculator.png
+.. figure:: img/buildings_area_calculator.png
    :align: center
 
 * We are creating the new field :guilabel:`AREA` that will contain the area of
@@ -356,7 +356,7 @@ first need to calculate their size.
   when prompted;
 * Build a query as earlier in this lesson;
 
-.. image:: img/buildings_area_query.png
+.. figure:: img/buildings_area_query.png
    :align: center
 
 * Click :guilabel:`OK`. Your map should now only show you those buildings which

--- a/source/docs/training_manual/vector_analysis/network_analysis.rst
+++ b/source/docs/training_manual/vector_analysis/network_analysis.rst
@@ -18,7 +18,7 @@ You can find all the network analysis algorithms in the
 :menuselection:`Processing --> Network Analysis` menu. You can see that there
 are many tools available:
 
-.. image:: img/select_network_algorithms.png
+.. figure:: img/select_network_algorithms.png
    :align: center
 
 Open the project :file:`exercise_data/network_analysis/network.qgz`, it contains
@@ -30,7 +30,7 @@ two layers:
 As you can see the :guilabel:`network_lines` layer has already a style that helps
 to understand the road network.
 
-.. image:: img/network_map.png
+.. figure:: img/network_map.png
    :align: center
 
 
@@ -55,7 +55,7 @@ points.
 In the following image we choose these two points as starting and ending point
 for the analysis:
 
-.. image:: img/start_end_point.png
+.. figure:: img/start_end_point.png
    :align: center
 
 * Open the :guilabel:`Shortest path (point to point)` algorithm;
@@ -68,13 +68,13 @@ for the analysis:
   :guilabel:`End point(x, y)`;
 * Click on the :guilabel:`Run` button:
 
-.. image:: img/shortest_point.png
+.. figure:: img/shortest_point.png
    :align: center
 
 A new line layer is created representing the shortest path between the chosen
 points. Uncheck the :guilabel:`network_lines` layer to see the result better:
 
-.. image:: img/shortest_point_result.png
+.. figure:: img/shortest_point_result.png
    :align: center
 
 Let's open the attribute table of the output layer. It contains three fields,
@@ -87,7 +87,7 @@ represent the **distance**, in layer units, between the two locations.
 In our case, the *shortest* distance between the chosen points is around ``1000``
 meters:
 
-.. image:: img/shortest_point_attributes.png
+.. figure:: img/shortest_point_attributes.png
    :align: center
 
 Now that you now how to use the tool, feel free to change them and test other
@@ -125,7 +125,7 @@ exercises.
 * Change the :guilabel:`Default speed (km/h)` from the default ``50`` value to
   ``4``;
 
-  .. image:: img/shortest_path_advanced.png
+  .. figure:: img/shortest_path_advanced.png
      :align: center
 
 * Click on :guilabel:`Run`.
@@ -142,7 +142,7 @@ readable *minutes* values.
 * Open the field calculator by clicking on the |calculateField| icon and add the
   new field :guilabel:`minutes` by multiplying the :guilabel:`cost` field by 60:
 
-  .. image:: img/shortest_path_conversion.png
+  .. figure:: img/shortest_path_conversion.png
      :align: center
 
 That's it! Now you know how many minutes it will take to get from one point to
@@ -154,7 +154,7 @@ the other one.
 The Network analysis toolbox has other interesting options. Looking at the
 following map:
 
-.. image:: img/speed_limit.png
+.. figure:: img/speed_limit.png
    :align: center
 
 we would like to know the **fastest** route considering the **speed limits** of
@@ -180,14 +180,14 @@ manually choose the start and end points.
 * Choose the ``speed`` field as the :guilabel:`Speed Field` parameter. With this
   option the algorithm will take into account the speed values for each road;
 
-  .. image:: img/speed_limit_parameters.png
+  .. figure:: img/speed_limit_parameters.png
      :align: center
 
 * Click on the :guilabel:`Run` button:
 
 Turn off the :guilabel:`network_lines` layer to better see the result.
 
-.. image:: img/speed_limit_result.png
+.. figure:: img/speed_limit_result.png
    :align: center
 
 As you can see the fastest route does not correspond to the shortest one.
@@ -214,13 +214,13 @@ network from each point of the :guilabel:`network_points` layer.
 * Enter ``250`` in the :guilabel:`Travel cost` parameter;
 * Click on :guilabel:`Run` and then close the dialog.
 
-.. image:: img/service_area.png
+.. figure:: img/service_area.png
    :align: center
 
 The output layer represents the maximum path you can reach from the point features
 given a distance of 250 meters:
 
-.. image:: img/service_area_result.png
+.. figure:: img/service_area_result.png
    :align: center
 
 Cool isn't it?

--- a/source/docs/training_manual/vector_analysis/reproject_transform.rst
+++ b/source/docs/training_manual/vector_analysis/reproject_transform.rst
@@ -109,14 +109,14 @@ But you can easily export the layer in another CRS.
 * In its :guilabel:`Filter` field, search for ``34S``;
 * Select :guilabel:`WGS 84 / UTM zone 34S` from the list;
 
-.. image:: img/CRSselector.png
+.. figure:: img/CRSselector.png
    :align: center
 
 * Leave the other options unchanged;
 
 The :guilabel:`Save Vector Layer as...` dialog now looks like this:
 
-.. image:: img/save_vector_dialog.png
+.. figure:: img/save_vector_dialog.png
    :align: center
 
 * Click :guilabel:`OK`;
@@ -135,7 +135,7 @@ You can also create your own projections.
 * Load the :file:`world/oceans.shp` dataset;
 * Go to :menuselection:`Settings --> Custom Projections...` and you'll see this dialog;
 
-.. image:: img/custom_crs.png
+.. figure:: img/custom_crs.png
    :align: center
 
 * Click on the |signPlus| button to create a new projection;
@@ -151,7 +151,7 @@ rectangular one, as most other projections do.
 
   +proj=vandg +lon_0=0 +x_0=0 +y_0=0 +R_A +a=6371000 +b=6371000 +units=m +no_defs
 
-.. image:: img/new_crs_parameters.png
+.. figure:: img/new_crs_parameters.png
    :align: center
 
 * Click :guilabel:`OK`;
@@ -160,7 +160,7 @@ rectangular one, as most other projections do.
   :guilabel:`Filter` field);
 * On applying this projection, the map will be reprojected thus:
 
-.. image:: img/van_grinten_projection.png
+.. figure:: img/van_grinten_projection.png
    :align: center
 
 |IC|

--- a/source/docs/training_manual/vector_analysis/spatial_statistics.rst
+++ b/source/docs/training_manual/vector_analysis/spatial_statistics.rst
@@ -41,7 +41,7 @@ We'll use the area covered by streets.
   generate an area enclosing all the roads by selecting ``Convex Hull`` as the
   :guilabel:`Geometry Type` parameter:
 
-.. image:: img/roads_hull_setup.png
+.. figure:: img/roads_hull_setup.png
    :align: center
 
 * As you know, if you don't specify the output, :guilabel:`Processing` creates
@@ -54,7 +54,7 @@ Creating random points
 * Create random points in this area using the tool at :menuselection:`Vector
   Creation --> Random points in layer bounds`:
 
-  .. image:: img/random_points_setup.png
+  .. figure:: img/random_points_setup.png
      :align: center
 
   .. note:: The yellow warning sign is telling you that that parameter concerns
@@ -65,7 +65,7 @@ Creating random points
 If needed, move the generated random point at the top of the legend to see them
 better:
 
-.. image:: img/random_points_result.png
+.. figure:: img/random_points_result.png
    :align: center
 
 Sampling the data
@@ -82,7 +82,7 @@ Sampling the data
   field is ``rvalue_N``, where ``N`` is the number of the raster band. You can
   change the name of the prefix if you want:
 
-  .. image:: img/sample_raster_dialog.png
+  .. figure:: img/sample_raster_dialog.png
      :align: center
 
 Now you can check the sampled data from the raster file in the attributes
@@ -91,7 +91,7 @@ the name you have chosen.
 
 A possible sample layer is shown here:
 
-.. image:: img/random_samples_result.png
+.. figure:: img/random_samples_result.png
    :align: center
 
 The sample points are classified by their ``rvalue_1`` field such that red
@@ -113,13 +113,13 @@ Now get the basic statistics for this layer.
 * The :guilabel:`Statistics` Panel will be automatically updated with the
   calculated statistics:
 
-.. image:: img/basic_statistics_results.png
+.. figure:: img/basic_statistics_results.png
    :align: center
 
 .. note:: You can copy the values by clicking on the |editCopy|:sup:`Copy Statistics To Clipboard`
     button and paste the results into a spreadsheet.
 
-.. image:: img/paste_to_spreadsheet.png
+.. figure:: img/paste_to_spreadsheet.png
    :align: center
 
 * Close the :guilabel:`Statistics` Panel when done.
@@ -181,7 +181,7 @@ To generate statistics on the distances between points in the two layers:
   :guilabel:`Sampled Points` layer as the target layer.
 * Set it up like this:
 
-.. image:: img/distance_matrix_setup.png
+.. figure:: img/distance_matrix_setup.png
    :align: center
 
 * If you want you can save the output layer as a file or just run the algorithm
@@ -191,7 +191,7 @@ To generate statistics on the distances between points in the two layers:
   between the :guilabel:`distance_points` features and their two nearest points
   in the :guilabel:`Sampled Points` layer:
 
-.. image:: img/distance_matrix_example.png
+.. figure:: img/distance_matrix_example.png
    :align: center
 
 
@@ -213,12 +213,12 @@ To do a nearest neighbor analysis of a point layer:
   click :guilabel:`Run`.
 * The results will appear in the Processing :guilabel:`Result Viewer` Panel.
 
-  .. image:: img/result_viewer.png
+  .. figure:: img/result_viewer.png
      :align: center
 
 * Click on the blue link to open the ``html`` page with the results:
 
-  .. image:: img/nearest_neighbour_example.png
+  .. figure:: img/nearest_neighbour_example.png
     :align: center
 
 |basic| |FA| Mean Coordinates
@@ -245,7 +245,7 @@ The centroid is the barycenter of the layer (the barycenter of a square is the
 center of the square) while the mean coordinates represent the average of all
 node coordinates.
 
-.. image:: img/polygon_centroid_mean.png
+.. figure:: img/polygon_centroid_mean.png
    :align: center
 
 |basic| |FA| Image Histograms
@@ -263,7 +263,7 @@ way to demonstrate this in QGIS is via the image histogram, available in the
   graph describing the frequency of values in the image.
 * You can export it as an image:
 
-.. image:: img/histogram_export.png
+.. figure:: img/histogram_export.png
    :align: center
 
 * Select the :guilabel:`Information` tab, you can see more detailed information
@@ -306,7 +306,7 @@ Here's a comparison of the original dataset (left) to the one constructed from
 our sample points (right). Yours may look different due to the random nature of
 the location of the sample points.
 
-.. image:: img/interpolation_comparison.png
+.. figure:: img/interpolation_comparison.png
    :align: center
 
 As you can see, 100 sample points aren't really enough to get a detailed
@@ -330,7 +330,7 @@ misleading as well.
 The results (depending on the positioning of your random points) will look more
 or less like this:
 
-.. image:: img/interpolation_comparison_10000.png
+.. figure:: img/interpolation_comparison_10000.png
    :align: center
 
 This is a much better representation of the terrain, due to the much greater

--- a/source/docs/training_manual/vector_classification/classification.rst
+++ b/source/docs/training_manual/vector_classification/classification.rst
@@ -10,7 +10,7 @@ individual places, but they can't be used for everything. For example, let's
 say that someone wants to know what each :guilabel:`landuse` area is used for.
 Using labels, you'd get this:
 
-.. image:: img/bad_landuse_labels.png
+.. figure:: img/bad_landuse_labels.png
    :align: center
 
 This makes the map's labeling difficult to read and even overwhelming if there
@@ -26,27 +26,27 @@ are numerous different landuse areas on the map.
 * Click on the dropdown that says :guilabel:`Single Symbol` and change it to
   :guilabel:`Categorized`:
 
-.. image:: img/categorised_styles.png
+.. figure:: img/categorised_styles.png
    :align: center
 
 * In the new panel, change the :guilabel:`Column` to :guilabel:`landuse`
   and the :guilabel:`Color ramp` to :guilabel:`Greens`.
 * Click the button labeled :guilabel:`Classify`:
 
-.. image:: img/categorised_style_settings.png
+.. figure:: img/categorised_style_settings.png
    :align: center
 
 * Click :guilabel:`OK`.
 
 You'll see something like this:
 
-.. image:: img/categorisation_result.png
+.. figure:: img/categorisation_result.png
    :align: center
 
 * Click the arrow (or plus sign) next to :guilabel:`landuse` in the
   :guilabel:`Layer list`, you'll see the categories explained:
 
-.. image:: img/categories_explained.png
+.. figure:: img/categories_explained.png
    :align: center
 
 Now our landuse polygons are appropriately colored and are classified so that
@@ -64,12 +64,12 @@ fill colours for each categorisation.
 * If you wish to, you can change the fill color for each landuse area by
   double-clicking the relevant color block:
 
-.. image:: img/change_layer_color.png
+.. figure:: img/change_layer_color.png
    :align: center
 
 Notice that there is one category that's empty:
 
-.. image:: img/empty_category.png
+.. figure:: img/empty_category.png
    :align: center
 
 This empty category is used to color any objects which do not have a landuse
@@ -129,18 +129,18 @@ have a size field, so we'll have to make one.
 
 * Enter edit mode by clicking this button:
 
-.. image:: /static/common/edit.png
+.. figure:: /static/common/edit.png
    :width: 1.5em
    :align: center
 
 * Add a new column with this button:
 
-.. image:: img/add_column_button.png
+.. figure:: img/add_column_button.png
    :align: center
 
 * Set up the dialog that appears, like this:
 
-.. image:: img/add_area_column.png
+.. figure:: img/add_area_column.png
    :align: center
 
 * Click :guilabel:`OK`.
@@ -153,23 +153,23 @@ To solve this problem, we'll need to calculate the areas.
 
 * Open the field calculator:
 
-.. image:: /static/common/mActionCalculateField.png
+.. figure:: /static/common/mActionCalculateField.png
    :width: 1.5em
    :align: center
 
 You'll get this dialog:
 
-.. image:: img/calculate_field_dialog.png
+.. figure:: img/calculate_field_dialog.png
    :align: center
 
 * Change the values at the top of the dialog to look like this:
 
-.. image:: img/field_calculator_top.png
+.. figure:: img/field_calculator_top.png
    :align: center
 
 * In the :guilabel:`Function List`, select :menuselection:`Geometry --> $area`:
 
-.. image:: img/geometry_area_select.png
+.. figure:: img/geometry_area_select.png
    :align: center
 
 * Double-click on it so that it appears in the :guilabel:`Expression` field.
@@ -190,13 +190,13 @@ column header to refresh the data). Save the edits and click :guilabel:`Ok`.
 * Under :guilabel:`Color ramp`, choose the option :guilabel:`New color ramp...`
   to get this dialog:
 
-.. image:: img/area_gradient_select.png
+.. figure:: img/area_gradient_select.png
    :align: center
 
 * Choose :guilabel:`Gradient` (if it's not selected already) and click
   :guilabel:`OK`. You'll see this:
 
-.. image:: img/gradient_color_select.png
+.. figure:: img/gradient_color_select.png
    :align: center
 
 You'll be using this to denote area, with small areas as :guilabel:`Color 1`
@@ -206,7 +206,7 @@ and large areas as :guilabel:`Color 2`.
 
 In the example, the result looks like this:
 
-.. image:: img/gradient_color_example.png
+.. figure:: img/gradient_color_example.png
    :align: center
 
 * Click :guilabel:`OK`.
@@ -215,14 +215,14 @@ In the example, the result looks like this:
 
 Now you'll have something like this:
 
-.. image:: img/landuse_gradient_selected.png
+.. figure:: img/landuse_gradient_selected.png
    :align: center
 
 Leave everything else as-is.
 
 * Click :guilabel:`Ok`:
 
-.. image:: img/gradient_result_map.png
+.. figure:: img/gradient_result_map.png
    :align: center
 
 
@@ -248,7 +248,7 @@ That's where rule-based classification comes in handy.
 * Switch to the :guilabel:`Symbology` tab.
 * Switch the classification style to :guilabel:`Rule-based`. You'll get this:
 
-.. image:: img/rule_based_classification.png
+.. figure:: img/rule_based_classification.png
    :align: center
 
 * Click the :guilabel:`Add rule` button: |signPlus|.
@@ -259,10 +259,10 @@ That's where rule-based classification comes in handy.
   click :guilabel:`Ok` and choose a pale blue-grey for it and
   remove the border:
 
-.. image:: img/query_builder_example.png
+.. figure:: img/query_builder_example.png
    :align: center
 
-.. image:: img/rule_style_result.png
+.. figure:: img/rule_style_result.png
    :align: center
 
 * Add a new criterion :kbd:`"landuse" != 'residential' AND "AREA" >= 0.00005`
@@ -282,14 +282,14 @@ give the default category a suitable pale green color.
 
 Your dialog should now look like this:
 
-.. image:: img/criterion_refined_list.png
+.. figure:: img/criterion_refined_list.png
    :align: center
 
 * Apply this symbology.
 
 Your map will look something like this:
 
-.. image:: img/rule_based_map_result.png
+.. figure:: img/rule_based_map_result.png
    :align: center
 
 Now you have a map with |majorUrbanName| the most prominent residential area and other

--- a/source/docs/training_manual/vector_classification/label_tool.rst
+++ b/source/docs/training_manual/vector_classification/label_tool.rst
@@ -40,14 +40,14 @@ most suitable one for this purpose.
 
 * Select :guilabel:`name` from the list:
 
-.. image:: img/select_label_with.png
+.. figure:: img/select_label_with.png
    :align: center
 
 * Click :guilabel:`OK`.
 
 The map should now have labels like this:
 
-.. image:: img/first_place_names.png
+.. figure:: img/first_place_names.png
    :align: center
 
 |basic| |FA| Changing Label Options
@@ -62,7 +62,7 @@ are too far away from their point markers.
   update the text formatting options to match those shown here:
 
 
-.. image:: img/label_formatting_options.png
+.. figure:: img/label_formatting_options.png
    :align: center
 
 That's the font problem solved! Now let's look at the problem of the labels
@@ -75,7 +75,7 @@ overlapping the points, but before we do that, let's take a look at the
   to match those shown here:
 
 
-.. image:: img/buffer_options.png
+.. figure:: img/buffer_options.png
    :align: center
 
 * Click :guilabel:`Apply`.
@@ -84,7 +84,7 @@ overlapping the points, but before we do that, let's take a look at the
 You'll see that this adds a colored buffer or border to the place labels, making
 them easier to pick out on the map:
 
-.. image:: img/buffer_results.png
+.. figure:: img/buffer_results.png
    :align: center
 
 Now we can address the positioning of the labels in relation to their point
@@ -95,7 +95,7 @@ markers.
   :guilabel:`Around point` is selected:
 
 
-.. image:: img/offset_placement_settings.png
+.. figure:: img/offset_placement_settings.png
    :align: center
 
 * Click :guilabel:`Apply`.
@@ -133,18 +133,18 @@ This will reveal the :guilabel:`Quadrant` options which you can use to set the
 position of the label in relation to the point marker. In this case, we want the
 label to be centered on the point, so choose the center quadrant:
 
-.. image:: img/quadrant_offset_options.png
+.. figure:: img/quadrant_offset_options.png
    :align: center
 
 * Hide the point symbols by editing the layer style as usual, and setting the
   size of the :guilabel:`Ellipse marker` width and height to :kbd:`0`:
 
-.. image:: img/hide_point_marker.png
+.. figure:: img/hide_point_marker.png
    :align: center
 
 * Click :guilabel:`OK` and you'll see this result:
 
-.. image:: img/hide_point_marker_results.png
+.. figure:: img/hide_point_marker_results.png
    :align: center
 
 If you were to zoom out on the map, you would see that some of the labels
@@ -179,7 +179,7 @@ Now that you know how labeling works, there's an additional problem. Points and
 polygons are easy to label, but what about lines? If you label them the same
 way as the points, your results would look like this:
 
-.. image:: img/bad_street_labels.png
+.. figure:: img/bad_street_labels.png
    :align: center
 
 We will now reformat the :guilabel:`roads` layer labels so that they are easy to
@@ -192,7 +192,7 @@ understand.
 * In the :guilabel:`Label tool` dialog's :guilabel:`Advanced` tab, choose the
   following settings:
 
-.. image:: img/street_label_settings.png
+.. figure:: img/street_label_settings.png
    :align: center
 
 You'll probably find that the text styling has used default values and the
@@ -201,7 +201,7 @@ dark-grey or black :kbd:`Color` and a light-yellow :kbd:`buffer`.
 
 The map will look somewhat like this, depending on scale:
 
-.. image:: img/street_label_formatted.png
+.. figure:: img/street_label_formatted.png
    :align: center
 
 You'll see that some of the road names appear more than once and that's not
@@ -211,7 +211,7 @@ always necessary. To prevent this from happening:
   :guilabel:`Rendering` option and select the
   :guilabel:`Merge connected lines to avoid duplicate labels`:
 
-.. image:: img/merge_lines_option.png
+.. figure:: img/merge_lines_option.png
    :align: center
 
 * Click :guilabel:`OK`
@@ -232,7 +232,7 @@ try the :guilabel:`curved` option instead.
 
 Here's the result:
 
-.. image:: img/final_street_labels.png
+.. figure:: img/final_street_labels.png
    :align: center
 
 As you can see, this hides a lot of the labels that were previously visible,
@@ -256,18 +256,18 @@ styles.
 * In the :guilabel:`Italic` dropdown, select :kbd:`Edit...` to open the
   :guilabel:`Expression string builder`:
 
-.. image:: img/expression_string_builder.png
+.. figure:: img/expression_string_builder.png
    :align: center
 
 In the text input, type: :kbd:`"place"  =  'town'` and click :guilabel:`Ok`
 twice:
 
-.. image:: img/expression_builder_settings.png
+.. figure:: img/expression_builder_settings.png
    :align: center
 
 Notice its effects:
 
-.. image:: img/italic_label_result.png
+.. figure:: img/italic_label_result.png
    :align: center
 
 
@@ -286,12 +286,12 @@ Notice its effects:
 
 * Add a new column:
 
-.. image:: img/add_column_button.png
+.. figure:: img/add_column_button.png
    :align: center
 
 * Configure it like this:
 
-.. image:: img/font_size_column.png
+.. figure:: img/font_size_column.png
    :align: center
 
 * Use this to set custom font sizes for each different type of place (i.e.,


### PR DESCRIPTION
This PR replaces all the `.. image::` calls in the docs with `.. figure::`.
Why? It was heavily suggested in #3142.
What does it improve? I'm not really sure. I thought this is what made the images in the [gentle introduction chapter](https://docs.qgis.org/testing/en/docs/gentle_gis_introduction/index.html) clickable, interactive (then more visible, a property it could be nice to add to some training manual screenshots) but it looks like it's due to the use of the `:width:` option (changes not on my todo list). Anyway, at least it harmonizes the way screenshots were referenced.
Also it updates the instructions regarding figure addition and referencing substitutions for GitHub preview