### PR TITLE
Reorganize topology checks description and images

### DIFF
--- a/source/docs/user_manual/working_with_vector/vector_properties.rst
+++ b/source/docs/user_manual/working_with_vector/vector_properties.rst
@@ -3333,33 +3333,19 @@ features. Since other features may be present in the same area, topological
 errors concerning these features are reported as well as errors introduced
 in the current edit session.
 
-The |checkbox| :guilabel:`Gap` check will check for gaps between neighbouring polygons.
+.. list-table::
 
-.. _figure_gapcheck:
-
-.. figure:: img/gapcheck.png
-   :align: center
-
-
-The |checkbox| :guilabel:`Overlap` check will check for overlaps between neighbouring
-polygons.
-
-.. _figure_overlapcheck:
-
-.. figure:: img/overlapcheck.png
-   :align: center
-
-
-The |checkbox| :guilabel:`Missing vertex` check will check for shared boundaries of
-neighbouring polygons where one border misses a vertex which is present on the
-other one.
-
-.. _figure_missingvertexcheck:
-
-.. figure:: img/missingvertexcheck.png
-   :align: center
-
-
+   * - The |checkbox| :guilabel:`Gap` check will check for
+       gaps between neighbouring polygons.
+     - |gapcheck|
+   * - The |checkbox| :guilabel:`Overlap` check will check
+       for overlaps between neighbouring polygons.
+     - |overlapcheck|
+   * - The |checkbox| :guilabel:`Missing vertex` check will
+       check for shared boundaries of neighbouring polygons
+       where one border misses a vertex which is present on
+       the other one. 
+     - |missingvertexcheck|
 
 .. Substitutions definitions - AVOID EDITING PAST THIS LINE
    This will be automatically updated by the find_set_subst.py script.
@@ -3526,4 +3512,7 @@ other one.
    :width: 1.5em
 .. |toggleEditing| image:: /static/common/mActionToggleEditing.png
    :width: 1.5em
+.. |gapcheck| image:: img/gapcheck.png
+.. |overlapcheck| image:: img/overlapcheck.png
+.. |missingvertexcheck| image:: img/missingvertexcheck.png
 .. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`

--- a/source/docs/user_manual/working_with_vector/vector_properties.rst
+++ b/source/docs/user_manual/working_with_vector/vector_properties.rst
@@ -3334,7 +3334,10 @@ errors concerning these features are reported as well as errors introduced
 in the current edit session.
 
 .. list-table::
+   :header-rows: 1
 
+   * - Topology check option
+     - Illustration
    * - The |checkbox| :guilabel:`Gap` check will check for
        gaps between neighbouring polygons.
      - .. image:: img/gapcheck.png

--- a/source/docs/user_manual/working_with_vector/vector_properties.rst
+++ b/source/docs/user_manual/working_with_vector/vector_properties.rst
@@ -3337,15 +3337,15 @@ in the current edit session.
 
    * - The |checkbox| :guilabel:`Gap` check will check for
        gaps between neighbouring polygons.
-     - |gapcheck|
+     - .. image:: img/gapcheck.png
    * - The |checkbox| :guilabel:`Overlap` check will check
        for overlaps between neighbouring polygons.
-     - |overlapcheck|
+     - .. image:: img/overlapcheck.png
    * - The |checkbox| :guilabel:`Missing vertex` check will
        check for shared boundaries of neighbouring polygons
        where one border misses a vertex which is present on
        the other one. 
-     - |missingvertexcheck|
+     - .. image:: img/missingvertexcheck.png
 
 .. Substitutions definitions - AVOID EDITING PAST THIS LINE
    This will be automatically updated by the find_set_subst.py script.
@@ -3512,7 +3512,4 @@ in the current edit session.
    :width: 1.5em
 .. |toggleEditing| image:: /static/common/mActionToggleEditing.png
    :width: 1.5em
-.. |gapcheck| image:: img/gapcheck.png
-.. |overlapcheck| image:: img/overlapcheck.png
-.. |missingvertexcheck| image:: img/missingvertexcheck.png
 .. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`


### PR DESCRIPTION
Make sure that the illustrations for the topology checks in digitizing options are placed with the explaining text by using a table of images (avoid using `.. figure` for these).