### PR TITLE
Uppercase "coordinate" letters (x,y,z,m) in description and when done in the GUI

### DIFF
--- a/source/docs/gentle_gis_introduction/coordinate_reference_systems.rst
+++ b/source/docs/gentle_gis_introduction/coordinate_reference_systems.rst
@@ -346,36 +346,36 @@ distortion and to get accurate analysis results, we should use **UTM zone 35S**
 as the coordinate reference system.
 
 The position of a coordinate in UTM south of the equator must be indicated with
-the **zone number** (35) and with its **northing (y) value** and **easting (x)
+the **zone number** (35) and with its **northing (Y) value** and **easting (X)
 value** in meters. The **northing value** is the distance of the position from
 the **equator** in meters. The **easting value** is the distance from the
 **central meridian** (longitude) of the used UTM zone. For UTM zone 35S it is
 **27 degrees** **East** as shown in figure_utm_for_sa_. Furthermore, because we
 are south of the equator and negative values are not allowed in the UTM coordinate
 reference system, we have to add a so called **false northing value** of
-10,000,000 m to the northing (y) value and a false easting value of 500,000 m to
-the easting (x) value. This sounds difficult, so, we will do an example that
+10,000,000 m to the northing (Y) value and a false easting value of 500,000 m to
+the easting (X) value. This sounds difficult, so, we will do an example that
 shows you how to find the correct **UTM 35S** coordinate for the **Area of
 Interest**.
 
-The northing (y) value
+The northing (Y) value
 ----------------------
 
 The place we are looking for is 3,550,000 meters south of the equator, so the
-northing (y) value gets a **negative sign** and is -3,550,000 m. According to
+northing (Y) value gets a **negative sign** and is -3,550,000 m. According to
 the UTM definitions we have to add a **false northing value** of 10,000,000 m.
-This means the northing (y) value of our coordinate is 6,450,000 m (-3,550,000 m
+This means the northing (Y) value of our coordinate is 6,450,000 m (-3,550,000 m
 + 10,000,000 m).
 
-The easting (x) value
+The easting (X) value
 ---------------------
 
 First we have to find the **central meridian** (longitude) for the **UTM zone
 35S**. As we can see in figure_utm_for_sa_ it is **27 degrees East**. The place
 we are looking for is **85,000 meters West** from the central meridian. Just like
-the northing value, the easting (x) value gets a negative sign, giving a result
+the northing value, the easting (X) value gets a negative sign, giving a result
 of **-85,000 m**. According to the UTM definitions we have to add a **false
-easting value** of 500,000 m. This means the easting (x) value of our coordinate
+easting value** of 500,000 m. This means the easting (X) value of our coordinate
 is 415,000 m (-85,000 m + 500,000 m). Finally, we have to add the **zone number**
 to the easting value to get the correct value.
 
@@ -458,7 +458,7 @@ If you don't have a computer available, you can show your pupils the principles
 of the three map projection families. Get a globe and paper and demonstrate how
 cylindrical, conical and planar projections work in general. With the help of a
 transparency sheet you can draw a two-dimensional coordinate reference system
-showing X axes and Y axes. Then, let your pupils define coordinates (x and y
+showing X axes and Y axes. Then, let your pupils define coordinates (X and Y
 values) for different places.
 
 Further reading

--- a/source/docs/gentle_gis_introduction/vector_data.rst
+++ b/source/docs/gentle_gis_introduction/vector_data.rst
@@ -32,7 +32,7 @@ the features.
 
 A vector feature has its shape represented using **geometry**. The geometry is
 made up of one or more interconnected **vertices**. A vertex describes a position
-in space using an **X**, **Y** and optionally **z** axis. Geometries which have
+in space using an **X**, **Y** and optionally **Z** axis. Geometries which have
 vertices with a ``Z`` axis are often referred to as **2.5D** since they describe
 height or depth at each vertex, but not both.
 

--- a/source/docs/pyqgis_developer_cookbook/loadlayer.rst
+++ b/source/docs/pyqgis_developer_cookbook/loadlayer.rst
@@ -101,7 +101,7 @@ providers:
   pair: Loading; Delimited text files
 
 * CSV or other delimited text files --- to open a file with a semicolon as a
-  delimiter, with field "x" for x-coordinate and field "y" for y-coordinate
+  delimiter, with field "x" for X coordinate and field "y" for Y coordinate
   you would use something like this:
 
   .. code-block:: python

--- a/source/docs/training_manual/forestry/map_georeferencing.rst
+++ b/source/docs/training_manual/forestry/map_georeferencing.rst
@@ -78,7 +78,7 @@ panning tools as you usually do in QGIS to inspect the image in the
 Georeferencer's window.
 
 * Zoom in to the left lower corner of the map and note that there is a cross-hair
-  with a coordinate pair, x and y, that as mentioned before are in :kbd:`KKJ / Finland
+  with a coordinate pair, X and Y, that as mentioned before are in :guilabel:`KKJ / Finland
   zone 2` CRS. You will use this point as the first ground control point for the
   georeferencing your map.
 * Select the :guilabel:`Add point` tool and click in the intersection of the

--- a/source/docs/training_manual/spatial_databases/simple_feature_model.rst
+++ b/source/docs/training_manual/spatial_databases/simple_feature_model.rst
@@ -101,8 +101,8 @@ which tables in the database contain geometry data.
    this table has already been registered and you don't need to do anything
    more.
 
-The value :kbd:`2` refers to the number of dimensions; in this case, two: **x**
-and **y**.
+The value ``2`` refers to the number of dimensions; in this case, two: **X**
+and **Y**.
 
 The value :kbd:`4326` refers to the projection we are using; in this case, WGS
 84, which is referred to by the number 4326 (refer to the earlier discussion

--- a/source/docs/training_manual/spatial_databases/spatial_functions.rst
+++ b/source/docs/training_manual/spatial_databases/spatial_functions.rst
@@ -31,8 +31,8 @@ Really, it's that easy...
 
 .. note:: Depending on which version of Ubuntu you are using, and which
    repositories you have configured, these commands will install PostGIS 1.5,
-   or 2.x. You can find the version installed by issuing a :kbd:`select
-   PostGIS_full_version();` query with psql or another tool.
+   or 2.x. You can find the version installed by issuing a ``select
+   PostGIS_full_version();`` query with psql or another tool.
 
 To install the absolute latest version of PostGIS, you can use the following
 commands.

--- a/source/docs/user_manual/introduction/qgis_configuration.rst
+++ b/source/docs/user_manual/introduction/qgis_configuration.rst
@@ -565,7 +565,7 @@ You can define the :guilabel:`Default font` used within the :ref:`print layout
 **Grid and guide defaults**
 
 * Define the :guilabel:`Grid spacing` |selectNumber|
-* Define the :guilabel:`Grid offset` |selectNumber| for x and y
+* Define the :guilabel:`Grid offset` |selectNumber| for X and Y
 * Define the :guilabel:`Snap tolerance` |selectNumber|
 
 

--- a/source/docs/user_manual/managing_data_source/supported_data.rst
+++ b/source/docs/user_manual/managing_data_source/supported_data.rst
@@ -31,7 +31,7 @@ aerial photography, or satellite imagery and modelled data, such as an elevation
 matrix.
 
 Unlike vector data, raster data typically do not have an associated database
-record for each cell. They are geocoded by pixel resolution and the x/y
+record for each cell. They are geocoded by pixel resolution and the X/Y
 coordinate of a corner pixel of the raster layer. This allows QGIS to position
 the data correctly in the map canvas.
 

--- a/source/docs/user_manual/print_composer/composer_items/composer_label.rst
+++ b/source/docs/user_manual/print_composer/composer_items/composer_label.rst
@@ -106,7 +106,7 @@ should be surrounded by ``[%`` and ``%]`` in the :guilabel:`Main properties` fra
 
     concat( 'Page ', @atlas_featurenumber, '/', @atlas_totalfeatures )
 
-* Return the x coordinate of the bottom left corner of a map canvas:
+* Return the X coordinate of the bottom left corner of a map canvas:
 
   ::
 

--- a/source/docs/user_manual/print_composer/composer_items/composer_map.rst
+++ b/source/docs/user_manual/print_composer/composer_items/composer_map.rst
@@ -237,7 +237,7 @@ Also you can choose to set visible or not each side of the grid frame.
 When compatible, it's possible to set the :guilabel:`Frame size`,
 :guilabel:`Frame line thickness`, :guilabel:`Frame fill colors`.
 With ``Latitude/Y only`` and ``Longitude/X only`` settings in the divisions
-section you have the possibility to prevent a mix of latitude/y and longitude/x
+section you have the possibility to prevent a mix of latitude/Y and longitude/X
 coordinates showing on a side when working with rotated maps or reprojected
 grids.
 

--- a/source/docs/user_manual/processing_algs/lidartools/lastools.rst
+++ b/source/docs/user_manual/processing_algs/lidartools/lastools.rst
@@ -1073,7 +1073,7 @@ Parameters
   The file containing the points to be processed.
 
 ``transform (coordinates)`` [enumeration]
-  Either translate, scale, or clamp the x, y, or z coordinate by the value specified below.
+  Either translate, scale, or clamp the X, Y, or Z coordinate by the value specified below.
 
   Options:
 
@@ -1096,7 +1096,7 @@ Parameters
   Default: *(not set)*
 
 ``second transform (coordinates)`` [enumeration]
-  Also either translate, scale, or clamp the x, y, or z coordinate by the value
+  Also either translate, scale, or clamp the X, Y, or Z coordinate by the value
   specified below.
 
   Options:

--- a/source/docs/user_manual/processing_algs/qgis/graphics.rst
+++ b/source/docs/user_manual/processing_algs/qgis/graphics.rst
@@ -203,10 +203,10 @@ Parameters
   Input vector layer to use for the plot.
 
 ``X attribute`` [tablefield: any]
-  Field to use for the x axis.
+  Field to use for the X axis.
 
 ``Y attribute`` [tablefield: any]
-  Field to use for the y axis.
+  Field to use for the Y axis.
 
 Outputs
 .......
@@ -230,13 +230,13 @@ Parameters
   Input vector layer to use for the plot.
 
 ``X attribute`` [tablefield: any]
-  Field to use for the x axis.
+  Field to use for the X axis.
 
 ``Y attribute`` [tablefield: any]
-  Field to use for the y axis.
+  Field to use for the Y axis.
 
 ``Z attribute`` [tablefield: any]
-  Field to use for the z axis.
+  Field to use for the Z axis.
 
 Outputs
 .......

--- a/source/docs/user_manual/processing_algs/qgis/vectorcreation.rst
+++ b/source/docs/user_manual/processing_algs/qgis/vectorcreation.rst
@@ -86,7 +86,7 @@ See also
 Array of translated features |34|
 ---------------------------------
 Creates copies of features in a layer, by creating multiple translated versions of each.
-Each copy is incrementally displaced by a preset amount in the x/y/z axis.
+Each copy is incrementally displaced by a preset amount in the X, Y and/or Z axis.
 
 M values present in the geometry can also be translated.
 

--- a/source/docs/user_manual/processing_algs/qgis/vectorgeometry.rst
+++ b/source/docs/user_manual/processing_algs/qgis/vectorgeometry.rst
@@ -758,7 +758,7 @@ Densify by count
 Takes a polygon or line layer and generates a new one in which the geometries have
 a larger number of vertices than the original one.
 
-If the geometries have z or m values present then these will be linearly interpolated
+If the geometries have Z or M values present then these will be linearly interpolated
 at the added vertices.
 
 The number of new vertices to add to each segment is specified as an input parameter.
@@ -805,7 +805,7 @@ The geometries are densified by adding regularly placed extra vertices inside ea
 segment so that the maximum distance between any two vertices does not exceed the
 specified distance.
 
-If the geometries have z or m values present then these will be linearly interpolated
+If the geometries have Z or M values present then these will be linearly interpolated
 at the added vertices.
 
 **Example**
@@ -891,9 +891,9 @@ Outputs
 
 .. _qgissetzfromraster:
 
-Drape (set z-value from raster) |34|
+Drape (set Z value from raster) |34|
 ------------------------------------
-Sets the z value of every vertex in the feature geometry to a value sampled from
+Sets the Z value of every vertex in the feature geometry to a value sampled from
 a band within a raster layer.
 
 The raster values can optionally be scaled by a preset amount.
@@ -901,13 +901,13 @@ The raster values can optionally be scaled by a preset amount.
 Parameters
 ..........
 ``Input layer`` [vector: any]
-  Input vector layer to set the z values to.
+  Input vector layer to set the Z values to.
 
 ``Raster layer`` [raster]
-  Raster layer to take the z values from.
+  Raster layer to take the Z values from.
 
 ``Band number`` [raster band]
-  The raster band to take the z values from if the raster is multiband.
+  The raster band to take the Z values from if the raster is multiband.
 
 ``Value for nodata or non-intersecting vertices`` [number |dataDefined|]
   Value to use in case the vertex does not intersect (a valid pixel of) the raster.
@@ -923,7 +923,7 @@ Outputs
 .......
 
 ``Updated`` [vector: any]
-  Vector layer in output with the updated z values extracted.
+  Vector layer in output with the updated Z values extracted.
 
 See also
 ........
@@ -1133,10 +1133,10 @@ Outputs
 
 .. _qgisfilterverticesbym:
 
-Filter vertices by m value |34|
+Filter vertices by M value |34|
 -------------------------------
-Filters away vertices based on their m-value, returning geometries with only vertex
-points that have a m-value greater than or equal to the specified minimum value and/or
+Filters away vertices based on their M value, returning geometries with only vertex
+points that have a M value greater than or equal to the specified minimum value and/or
 less than or equal to the maximum value.
 
 If the minimum value is not specified then only the maximum value is tested, and
@@ -1145,7 +1145,7 @@ similarly if the maximum value is not specified then only the minimum value is t
 .. figure:: img/filter_zm.png
    :align: center
 
-   The red line represents the black line with only vertices whose m-value is <=10.
+   The red line represents the black line with only vertices whose M value is <=10.
 
 .. note:: Depending on the input geometry attributes and the filters used,
   the resultant geometries created by this algorithm may no longer be valid.
@@ -1159,14 +1159,14 @@ Parameters
 ``Minimum`` [number |dataDefined|]
   Optional
 
-  Minimum m-value allowed to keep a vertex.
+  Minimum M value allowed to keep a vertex.
 
   Default: *Not set*
 
 ``Maximum`` [number |dataDefined|]
   Optional
 
-  Maximum m-value allowed to keep a vertex.
+  Maximum M value allowed to keep a vertex.
 
   Default: *Not set*
 
@@ -1183,10 +1183,10 @@ See also
 
 .. _qgisfilterverticesbyz:
 
-Filter vertices by z value |34|
+Filter vertices by Z value |34|
 -------------------------------
-Filters away vertices based on their z-value, returning geometries with only vertex
-points that have a z-value greater than or equal to the specified minimum value and/or
+Filters away vertices based on their Z value, returning geometries with only vertex
+points that have a Z value greater than or equal to the specified minimum value and/or
 less than or equal to the maximum value.
 
 If the minimum value is not specified then only the maximum value is tested, and
@@ -1195,7 +1195,7 @@ similarly if the maximum value is not specified then only the minimum value is t
 .. figure:: img/filter_zm.png
    :align: center
 
-   The red line represents the black line with only vertices whose z-value is <=10.
+   The red line represents the black line with only vertices whose Z value is <=10.
 
 .. note:: Depending on the input geometry attributes and the filters used,
   the resultant geometries created by this algorithm may no longer be valid.
@@ -1210,14 +1210,14 @@ Parameters
 ``Minimum`` [number |dataDefined|]
   Optional
 
-  Minimum z-value allowed to keep a vertex.
+  Minimum Z value allowed to keep a vertex.
 
   Default: *Not set*
 
 ``Maximum`` [number |dataDefined|]
   Optional
 
-  Maximum z-value allowed to keep a vertex.
+  Maximum Z value allowed to keep a vertex.
 
   Default: *Not set*
 
@@ -1289,12 +1289,12 @@ Parameters
   Default: *0*
 
 ``Output geometry has z dimension`` [boolean]
-  Choose if the output geometry should have the z dimension.
+  Choose if the output geometry should have the Z dimension.
 
   Default: *False*
 
 ``Output geometry has m values`` [boolean]
-  Choose if the output geometry should have the m dimension.
+  Choose if the output geometry should have the M dimension.
 
   Default: *False*
 
@@ -2170,10 +2170,10 @@ result in a degenerate geometry.
 The tolerance parameter specifies the tolerance for coordinates when determining
 whether vertices are identical.
 
-By default, z values are not considered when detecting duplicate vertices.
-E.g. two vertices with the same x and y coordinate but different z values will still
+By default, Z values are not considered when detecting duplicate vertices.
+E.g. two vertices with the same X and Y coordinate but different Z values will still
 be considered duplicate and one will be removed. If the Use Z Value parameter is true,
-then the z values are also tested and vertices with the same x and y but different z
+then the Z values are also tested and vertices with the same X and Y but different Z
 will be maintained.
 
 .. note:: Duplicate vertices are not tested between different parts of a multipart
@@ -2394,7 +2394,7 @@ Outputs
 Set M value from raster |34|
 ----------------------------
 
-Sets the m value for every vertex in the feature geometry to a value sampled from
+Sets the M value for every vertex in the feature geometry to a value sampled from
 a band within a raster layer.
 
 The raster values can optionally be scaled by a preset amount.
@@ -2402,13 +2402,13 @@ The raster values can optionally be scaled by a preset amount.
 Parameters
 ..........
 ``Input layer`` [vector: any]
-  Input vector layer to set the m values to.
+  Input vector layer to set the M values to.
 
 ``Raster layer`` [raster]
-  Raster layer to take the m values from.
+  Raster layer to take the M values from.
 
 ``Band number`` [raster band]
-  The raster band to take the m values from if the raster is multiband.
+  The raster band to take the M values from if the raster is multiband.
 
 ``Value for nodata or non-intersecting vertices`` [number |dataDefined|]
   Value to use in case the vertex does not intersect (a valid pixel of) the raster..
@@ -2424,7 +2424,7 @@ Outputs
 .......
 
 ``Updated`` [vector: any]
-  Vector layer in output with the updated m values extracted.
+  Vector layer in output with the updated M values extracted.
 
 See also
 ........
@@ -2985,9 +2985,9 @@ See also
 
 .. _qgisbufferbym:
 
-Variable width buffer (by m-value) |32|
+Variable width buffer (by M value) |32|
 ---------------------------------------
-Creates variable width buffers along lines, using the m-value of the line geometries
+Creates variable width buffers along lines, using the M value of the line geometries
 as the diameter of the buffer at each vertex.
 
 .. figure:: img/variable_buffer_m.png

--- a/source/docs/user_manual/working_with_ogc/server/services.rst
+++ b/source/docs/user_manual/working_with_ogc/server/services.rst
@@ -594,7 +594,7 @@ Parameters in the GetPrint request are:
 * **<map_id>:EXTENT** gives the extent for a layout map item as xmin,ymin,xmax,ymax.
 * **<map_id>:ROTATION** map rotation in degrees
 * **<map_id>:GRID_INTERVAL_X**, **<map_id>:GRID_INTERVAL_Y** Grid line density for a
-  map in x- and y-direction
+  map in X and Y directions
 * **<map_id>:SCALE** Sets a map scale to a layout map item. This is useful to ensure
   scale based visibility of layers and labels even if client and server may
   have different algorithms to calculate the scale denominator

--- a/source/docs/user_manual/working_with_vector/editing_geometry_attributes.rst
+++ b/source/docs/user_manual/working_with_vector/editing_geometry_attributes.rst
@@ -489,7 +489,8 @@ The Vertex Editor Panel
 
 When using the :guilabel:`Vertex tool` on a feature, it is possible to right click to open the
 :guilabel:`Vertex Editor` panel listing all the vertices of the feature with
-their x, y (z, m if applicable) coordinates and r (for the radius, in case of
+their :guilabel:`x`, :guilabel:`y` (:guilabel:`z`, :guilabel:`m` if applicable)
+coordinates and :guilabel:`r` (for the radius, in case of
 circular geometry). Simply select a row in the table does select the corresponding
 vertex in the map canvas, and vice versa. Simply change a coordinate in the table
 and your vertex position is updated. You can also select multiple rows and delete
@@ -1296,9 +1297,9 @@ shorcuts available:
 +----------+-------------------+-------------------------------+---------------------------------------+
 | :kbd:`A` | Set angle         | Lock angle                    | Toggle relative angle to last segment |
 +----------+-------------------+-------------------------------+---------------------------------------+
-| :kbd:`X` | Set x coordinate  | Lock x coordinate             | Toggle relative x to last vertex      |
+| :kbd:`X` | Set X coordinate  | Lock X coordinate             | Toggle relative X to last vertex      |
 +----------+-------------------+-------------------------------+---------------------------------------+
-| :kbd:`Y` | Set y coordinate  | Lock y coordinate             | Toggle relative y to last vertex      |
+| :kbd:`Y` | Set Y coordinate  | Lock Y coordinate             | Toggle relative Y to last vertex      |
 +----------+-------------------+-------------------------------+---------------------------------------+
 | :kbd:`C` | Toggle construction mode                                                                  |
 +----------+-------------------------------------------------------------------------------------------+
@@ -1372,13 +1373,13 @@ and the mouse pointer.
 For coordinates, click the |delta| buttons to the left of the :guilabel:`x` or
 :guilabel:`y` text boxes (or press :kbd:`Shift+X` or :kbd:`Shift+Y`) to
 toggle relative coordinates to the previous vertex. With these options on,
-coordinates measurement will consider the last vertex to be the x and y axes
+coordinates measurement will consider the last vertex to be the X and Y axes
 origin.
 
 Continuous lock
 ---------------
 
-Both in absolute or relative reference digitizing, angle, distance, x and y
+Both in absolute or relative reference digitizing, angle, distance, X and Y
 constraints can be locked continuously by clicking the |lockedRepeat|
 :guilabel:`Continuous lock` buttons. Using continuous lock allows you to
 digitize several points or vertexes using the same constraints.
@@ -1422,7 +1423,7 @@ You can enable and disable *construction* mode by clicking on the
 |cadConstruction| :sup:`Construction` icon or with the :kbd:`C` keyboard
 shortcut. While in construction mode, clicking the map canvas won't add new
 vertexes, but will capture the clicks' positions so that you can use them as
-reference points to then lock distance, angle or x and y relative values.
+reference points to then lock distance, angle or X and Y relative values.
 
 As an example, the construction mode can be used to draw some point
 at an exact distance from an existing point.

--- a/source/docs/user_manual/working_with_vector/expression.rst
+++ b/source/docs/user_manual/working_with_vector/expression.rst
@@ -551,14 +551,14 @@ This group contains functions that operate on geometry objects (e.g., length, ar
 | $perimeter             | Returns the perimeter of the current polygon      |
 |                        | feature                                           |
 +------------------------+---------------------------------------------------+
-| $x                     | Returns the x coordinate of the current feature   |
+| $x                     | Returns the X coordinate of the current feature   |
 +------------------------+---------------------------------------------------+
-| $x_at(n)               | Returns the x coordinate of the nth node of the   |
+| $x_at(n)               | Returns the X coordinate of the nth node of the   |
 |                        | current feature's geometry                        |
 +------------------------+---------------------------------------------------+
-| $y                     | Returns the y coordinate of the current feature   |
+| $y                     | Returns the Y coordinate of the current feature   |
 +------------------------+---------------------------------------------------+
-| $y_at(n)               | Returns the y coordinate of the nth node of the   |
+| $y_at(n)               | Returns the Y coordinate of the nth node of the   |
 |                        | current feature's geometry                        |
 +------------------------+---------------------------------------------------+
 | angle_at_vertex        | Returns the bisector angle (average angle) to the |
@@ -598,7 +598,7 @@ This group contains functions that operate on geometry objects (e.g., length, ar
 |                        | (see also :ref:`qgisbuffer`)                      |
 +------------------------+---------------------------------------------------+
 | buffer_by_m |32|       | Creates a buffer along a line geometry where the  |
-|                        | buffer diameter varies according to the m-values  |
+|                        | buffer diameter varies according to the M values  |
 |                        | at the line vertices                              |
 |                        | (see also :ref:`qgisbufferbym`)                   |
 +------------------------+---------------------------------------------------+
@@ -649,9 +649,9 @@ This group contains functions that operate on geometry objects (e.g., length, ar
 +------------------------+---------------------------------------------------+
 | extrude(geom,x,y)      | Returns an extruded version of the input (Multi-) |
 |                        | Curve or (Multi-)Linestring geometry with an      |
-|                        | extension specified by x and y                    |
+|                        | extension specified by X and Y                    |
 +------------------------+---------------------------------------------------+
-| flip_coordinates |32|  | Returns a copy of the geometry with the x and y   |
+| flip_coordinates |32|  | Returns a copy of the geometry with the X and Y   |
 |                        | coordinates swapped (see also :ref:`qgisswapxy`)  |
 +------------------------+---------------------------------------------------+
 | geom_from_gml          | Returns a geometry created from a GML             |
@@ -724,7 +724,7 @@ This group contains functions that operate on geometry objects (e.g., length, ar
 |                        | connected LineStrings from the input geometry     |
 |                        | have been merged into a single linestring.        |
 +------------------------+---------------------------------------------------+
-| m                      | Returns the m value of a point geometry           |
+| m                      | Returns the M value of a point geometry           |
 +------------------------+---------------------------------------------------+
 | make_circle            | Creates a circular geometry based on center point |
 |                        | and radius                                        |
@@ -735,11 +735,11 @@ This group contains functions that operate on geometry objects (e.g., length, ar
 | make_line              | Creates a line geometry from a series of point    |
 |                        | geometries                                        |
 +------------------------+---------------------------------------------------+
-| make_point(x,y,z,m)    | Returns a point geometry from x and y (and        |
-|                        | optional z or m) values                           |
+| make_point(x,y,z,m)    | Returns a point geometry from X and Y (and        |
+|                        | optional Z or M) values                           |
 +------------------------+---------------------------------------------------+
-| make_point_m(x,y,m)    | Returns a point geometry from x and y coordinates |
-|                        | and m values                                      |
+| make_point_m(x,y,m)    | Returns a point geometry from X and Y coordinates |
+|                        | and M values                                      |
 +------------------------+---------------------------------------------------+
 | make_polygon           | Creates a polygon geometry from an outer ring and |
 |                        | optional series of inner ring geometries          |
@@ -876,31 +876,31 @@ This group contains functions that operate on geometry objects (e.g., length, ar
 |                        | Returns 1 (true) if geometry a is completely      |
 |                        | inside geometry b                                 |
 +------------------------+---------------------------------------------------+
-| x                      | Returns the x coordinate of a point geometry, or  |
-|                        | the x coordinate of the centroid for a non-point  |
+| x                      | Returns the X coordinate of a point geometry, or  |
+|                        | the X coordinate of the centroid for a non-point  |
 |                        | geometry                                          |
 +------------------------+---------------------------------------------------+
-| x_min                  | Returns the minimum x coordinate of a geometry.   |
+| x_min                  | Returns the minimum X coordinate of a geometry.   |
 |                        | Calculations are in the Spatial Reference System  |
 |                        | of this geometry                                  |
 +------------------------+---------------------------------------------------+
-| x_max                  | Returns the maximum x coordinate of a geometry.   |
+| x_max                  | Returns the maximum X coordinate of a geometry.   |
 |                        | Calculations are in the Spatial Reference System  |
 |                        | of this geometry                                  |
 +------------------------+---------------------------------------------------+
-| y                      | Returns the y coordinate of a point geometry, or  |
-|                        | the y coordinate of the centroid for a non-point  |
+| y                      | Returns the Y coordinate of a point geometry, or  |
+|                        | the Y coordinate of the centroid for a non-point  |
 |                        | geometry                                          |
 +------------------------+---------------------------------------------------+
-| y_min                  | Returns the minimum y coordinate of a geometry.   |
+| y_min                  | Returns the minimum Y coordinate of a geometry.   |
 |                        | Calculations are in the Spatial Reference System  |
 |                        | of this geometry                                  |
 +------------------------+---------------------------------------------------+
-| y_max                  | Returns the maximum y coordinate of a geometry.   |
+| y_max                  | Returns the maximum Y coordinate of a geometry.   |
 |                        | Calculations are in the Spatial Reference System  |
 |                        | of this geometry                                  |
 +------------------------+---------------------------------------------------+
-| z                      | Returns the z coordinate of a point geometry      |
+| z                      | Returns the Z coordinate of a point geometry      |
 +------------------------+---------------------------------------------------+
 
 |
@@ -913,7 +913,7 @@ This group contains functions that operate on geometry objects (e.g., length, ar
    buffer( $geometry, 10 )
    point_on_surface( $geometry )
 
-* Return the x coordinate of the current feature's centroid::
+* Return the X coordinate of the current feature's centroid::
 
     x( $geometry )
 
@@ -997,7 +997,7 @@ This group contains math functions (e.g., square root, sin and cos).
  acos               Returns the inverse cosine of a value in radians
  asin               Returns the inverse sine of a value in radians
  atan               Returns the inverse tangent of a value in radians
- atan2(y,x)         Returns the inverse tangent of y/x by using the signs
+ atan2(y,x)         Returns the inverse tangent of Y/X by using the signs
                     of the two arguments to determine the quadrant of the
                     result
  azimuth(a,b)       Returns the north-based azimuth as the angle in radians
@@ -1354,7 +1354,7 @@ To use these functions in an expression, they should be preceded by @ character
 
 **Some examples:**
 
-* Return the x coordinate of a map item center to insert into a label in layout::
+* Return the X coordinate of a map item center to insert into a label in layout::
 
    x( map_get( item_variables( 'map1'), 'map_extent_center' ) )
 

--- a/source/docs/user_manual/working_with_vector/vector_properties.rst
+++ b/source/docs/user_manual/working_with_vector/vector_properties.rst
@@ -1044,12 +1044,12 @@ effect types, with custom options are available:
   horizontal` and :guilabel:`Reflect vertical`, which actually create a
   reflection on the horizontal and/or vertical axes. The other options are:
 
-  * :guilabel:`Shear X,Y`: Slants the feature along the x and/or y axis.
-  * :guilabel:`Scale X,Y`: Enlarges or minimizes the feature along the x
-    and/or y axis by the given percentage.
+  * :guilabel:`Shear X,Y`: Slants the feature along the X and/or Y axis.
+  * :guilabel:`Scale X,Y`: Enlarges or minimizes the feature along the X
+    and/or Y axis by the given percentage.
   * :guilabel:`Rotation`: Turns the feature around its center point.
   * and :guilabel:`Translate X,Y` changes the position of the item based on
-    a distance given on the x and/or y axis.
+    a distance given on the X and/or Y axis.
 
   .. _figure_effects_transform:
 
@@ -2351,7 +2351,7 @@ Default values
   For example, you can:
 
   * use ``$x``, ``$length``, ``$area`` to automatically populate a field with the
-    feature's x coordinate, length, area or any geometric information at its creation;
+    feature's X coordinate, length, area or any geometric information at its creation;
   * increment a field by 1 for each new feature using ``maximum("field")+1``;
   * save the feature creation datetime using ``now()``;
   * use :ref:`variables <general_tools_variables>` in expressions, making it
@@ -2536,7 +2536,7 @@ possible if the underlying data is read only. Moreover, configuring these
 data-defined properties may be very time consuming or not desirable! For
 example, if you want to fully use map tools coming with :ref:`label_toolbar`,
 then you need to add and configure more than 20 fields in your original data
-source (x and y positions, rotation angle, font style, color and so on).
+source (X and Y positions, rotation angle, font style, color and so on).
 
 The Auxiliary Storage mechanism provides the solution to these limitations
 and awkward configurations. Auxiliary fields are a roundabout way to


### PR DESCRIPTION
Fixes #3296 (though i don't know it'll be backported - not an issue imho)