### PR TITLE
Update getting_started.rst (qgz / qgs)

### DIFF
--- a/source/docs/user_manual/introduction/getting_started.rst
+++ b/source/docs/user_manual/introduction/getting_started.rst
@@ -128,7 +128,7 @@ This means that you can launch QGIS by:
 
 * using |nix| the Applications menu, |win| the Start menu, or |osx| the Dock
 * double clicking the icon in your Applications folder or desktop shortcut
-* double clicking an existing QGIS project (``.qgz``/``.qgs``) file. (Note that this will
+* double clicking an existing QGIS project file (with :file:`.qgz` or :file:`.qgs` extension). Note that this will
   also open the project.)
 * typing ``qgis`` in a command prompt (assuming that QGIS is added to your PATH
   or you are in its installation folder)

--- a/source/docs/user_manual/introduction/getting_started.rst
+++ b/source/docs/user_manual/introduction/getting_started.rst
@@ -496,7 +496,7 @@ The extension for QGIS projects is ``.qgs`` but when saving from QGIS, the
 default is to save using a compressed format with the ``.qgz`` extension.
 The ``.qgs`` file is embedded in the ``.qgz`` file (a zip archive),
 so you can get to it by unzipping.
-To zip a project, select the corresponding extension (`.qgz``) with
+To zip a project, select the corresponding extension (``.qgz``) with
 :menuselection:`Project -->` |fileSaveAs| :menuselection:`Save As...`. Once
 zipped, a :menuselection:`Project -->` |fileSave| :menuselection:`Save` action
 will automatically zip your current project.

--- a/source/docs/user_manual/introduction/getting_started.rst
+++ b/source/docs/user_manual/introduction/getting_started.rst
@@ -129,7 +129,7 @@ This means that you can launch QGIS by:
 * using |nix| the Applications menu, |win| the Start menu, or |osx| the Dock
 * double clicking the icon in your Applications folder or desktop shortcut
 * double clicking an existing QGIS project file (with :file:`.qgz` or :file:`.qgs` extension). Note that this will
-  also open the project.)
+   also open the project.
 * typing ``qgis`` in a command prompt (assuming that QGIS is added to your PATH
   or you are in its installation folder)
 

--- a/source/docs/user_manual/introduction/getting_started.rst
+++ b/source/docs/user_manual/introduction/getting_started.rst
@@ -495,7 +495,7 @@ extension ``.qgs~`` and stored in the same directory as the project file.
 The extension for QGIS projects is ``.qgs`` but when saving from QGIS, the
 default is to save using a compressed format with the ``.qgz`` extension.
 The ``.qgs`` file is embedded in the ``.qgz`` file (a zip archive), together
-with its associated sqlite database (``.qgd``) for auxiliary data.
+with its associated sqlite database (``.qgd``) for ref:`auxiliary data <vector_auxiliary_storage>`.
 You can get to these files by unzipping.
 
 .. note::

--- a/source/docs/user_manual/introduction/getting_started.rst
+++ b/source/docs/user_manual/introduction/getting_started.rst
@@ -495,7 +495,7 @@ extension ``.qgs~`` and stored in the same directory as the project file.
 The extension for QGIS projects is ``.qgs`` but when saving from QGIS, the
 default is to save using a compressed format with the ``.qgz`` extension.
 The ``.qgs`` file is embedded in the ``.qgz`` file (a zip archive),
-so you can get to it by unzipping. ``.qgz`` files can be opened like ``.qgs`` files.
+so you can get to it by unzipping.
 To zip a project, select the corresponding extension (`.qgz``) with
 :menuselection:`Project -->` |fileSaveAs| :menuselection:`Save As...`. Once
 zipped, a :menuselection:`Project -->` |fileSave| :menuselection:`Save` action

--- a/source/docs/user_manual/introduction/getting_started.rst
+++ b/source/docs/user_manual/introduction/getting_started.rst
@@ -128,7 +128,7 @@ This means that you can launch QGIS by:
 
 * using |nix| the Applications menu, |win| the Start menu, or |osx| the Dock
 * double clicking the icon in your Applications folder or desktop shortcut
-* double clicking an existing QGIS project (``.qgs``) file. (Note that this will
+* double clicking an existing QGIS project (``.qgz``/``.qgs``) file. (Note that this will
   also open the project.)
 * typing ``qgis`` in a command prompt (assuming that QGIS is added to your PATH
   or you are in its installation folder)
@@ -489,18 +489,17 @@ may not work properly any more.
   :guilabel:`General` tab, you should tick |checkbox|
   :guilabel:`Warn when opening a project file saved with an older version of QGIS`.
 
-Whenever you save a project in QGIS a backup of the project file is created with the
+Whenever you save a ``.qgs`` project in QGIS, a backup of the project file is created with the
 extension ``.qgs~`` and stored in the same directory as the project file.
 
-The default extension for QGIS projects is ``.qgs`` but a project may be
-zipped in a ``.qgz`` file too. Actually, the ``.qgs`` file is just embedded
-in an archive, so you still have the possibility to unzip it in order to
-manually edit XML information in a text editor. These ``.qgz`` files can also
-be opened like default ``.qgs`` files. To zip a project, the corresponding
-extension has just to be selected in
+The extension for QGIS projects is ``.qgs`` but when saving from QGIS, the
+default is to save using a compressed format with the ``.qgz`` extension.
+The ``.qgs`` file is embedded in the ``.qgz`` file (a zip archive),
+so you can get to it by unzipping. ``.qgz`` files can be opened like ``.qgs`` files.
+To zip a project, select the corresponding extension (`.qgz``) with
 :menuselection:`Project -->` |fileSaveAs| :menuselection:`Save As...`. Once
 zipped, a :menuselection:`Project -->` |fileSave| :menuselection:`Save` action
-automatically zip your current project.
+will automatically zip your current project.
 
 .. note::
 

--- a/source/docs/user_manual/introduction/getting_started.rst
+++ b/source/docs/user_manual/introduction/getting_started.rst
@@ -494,12 +494,9 @@ extension ``.qgs~`` and stored in the same directory as the project file.
 
 The extension for QGIS projects is ``.qgs`` but when saving from QGIS, the
 default is to save using a compressed format with the ``.qgz`` extension.
-The ``.qgs`` file is embedded in the ``.qgz`` file (a zip archive),
-so you can get to it by unzipping.
-To zip a project, select the corresponding extension (``.qgz``) with
-:menuselection:`Project -->` |fileSaveAs| :menuselection:`Save As...`. Once
-zipped, a :menuselection:`Project -->` |fileSave| :menuselection:`Save` action
-will automatically zip your current project.
+The ``.qgs`` file is embedded in the ``.qgz`` file (a zip archive), together
+with its associated sqlite database (``.qgd``) for auxiliary data.
+You can get to these files by unzipping.
 
 .. note::
 


### PR DESCRIPTION
An attempt to updated the "description" of ``.qgs`` and ``.qgz`` to reflect current behaviour (``.qgz`` is now the default when saving a project in QGIS, so it may be confusing to use the term "default" for ``.qgs``).