### PR TITLE
Document EXTERNAL_WMS feature in QGIS server

### DIFF
--- a/source/docs/user_manual/working_with_ogc/server/services.rst
+++ b/source/docs/user_manual/working_with_ogc/server/services.rst
@@ -1341,9 +1341,19 @@ You can see there are several parameters in this request:
 External WMS layers
 ===================
 
-QGIS Server allows including layers from external WMS servers in WMS GetMap and WMS GetPrint requests. This is especially useful if a web client uses an external background layer in the web map. For performance reasons, such layers should be directly requested by the web client (not cascaded via QGIS server). For printing however, these layers should be cascaded via QGIS server in order to appear in the printed map.
+QGIS Server allows including layers from external WMS servers in WMS GetMap 
+and WMS GetPrint requests. This is especially useful if a web client uses an 
+external background layer in the web map. 
+For performance reasons, such layers should be directly requested by the web 
+client (not cascaded via QGIS server). For printing however, these layers 
+should be cascaded via QGIS server in order to appear in the printed map.
 
-External layers can be added to the LAYERS parameter as EXTERNAL_WMS:<layername>. The parameters for the external WMS layers (e.g. url, format, dpiMode, crs, layers, styles) can later be given as service parameters <layername>:<parameter>. In a GetMap request, this might look like this:
+External layers can be added to the LAYERS parameter as 
+EXTERNAL_WMS:<layername>. 
+The parameters for the external WMS layers (e.g. url, format, 
+dpiMode, crs, layers, styles) can later be given as service 
+parameters <layername>:<parameter>. 
+In a GetMap request, this might look like this:
 
 .. code-block:: none
 

--- a/source/docs/user_manual/working_with_ogc/server/services.rst
+++ b/source/docs/user_manual/working_with_ogc/server/services.rst
@@ -1346,3 +1346,42 @@ You can see there are several parameters in this request:
    source folder.
 
 .. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
+
+External WMS layers
+===================
+
+QGIS Server allows including layers from external WMS servers in WMS GetMap and WMS GetPrint requests. This is especially useful if a web client uses an external background layer in the web map. For performance reasons, such layers should be directly requested by the web client (not cascaded via QGIS server). For printing however, these layers should be cascaded via QGIS server in order to appear in the printed map.
+
+External layers can be added to the LAYERS parameter as EXTERNAL_WMS:<layername>. The parameters for the external WMS layers (e.g. url, format, dpiMode, crs, layers, styles) can later be given as service parameters <layername>:<parameter>. In a GetMap request, this might look like this:
+
+.. code-block:: none
+
+   http://localhost/qgis_server?
+   SERVICE=WMS&REQUEST=GetMap
+   &LAYERS=EXTERNAL_WMS:basemap,layer1,layer2
+   &STYLES=,,
+   &basemap:url=http://externalserver.com/wms.fcgi
+   &basemap:format=image/jpeg
+   &basemap:dpiMode=7
+   &basemap:crs=EPSG:2056
+   &basemap:layers=orthofoto
+   &basemap:styles=default
+
+Similarly, external layers can be used in GetPrint requests:
+
+.. code-block:: none
+
+   http://localhost/qgis_server?
+   SERVICE=WMS
+   &REQUEST=GetPrint&TEMPLATE=A4
+   &map0:layers=EXTERNAL_WMS:basemap,layer1,layer2
+   &map0:EXTENT=<minx,miny,maxx,maxy>
+   &basemap:url=http://externalserver.com/wms.fcgi
+   &basemap:format=image/jpeg
+   &basemap:dpiMode=7
+   &basemap:crs=EPSG:2056
+   &basemap:layers=orthofoto
+   &basemap:styles=default
+
+
+

--- a/source/docs/user_manual/working_with_ogc/server/services.rst
+++ b/source/docs/user_manual/working_with_ogc/server/services.rst
@@ -1338,15 +1338,6 @@ You can see there are several parameters in this request:
 
 * **HIGHLIGHT_LABELBUFFERSIZE**: This parameter controls the label buffer size.
 
-
-.. Substitutions definitions - AVOID EDITING PAST THIS LINE
-   This will be automatically updated by the find_set_subst.py script.
-   If you need to create a new substitution manually,
-   please add it also to the substitutions.txt file in the
-   source folder.
-
-.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`
-
 External WMS layers
 ===================
 
@@ -1358,6 +1349,7 @@ External layers can be added to the LAYERS parameter as EXTERNAL_WMS:<layername>
 
    http://localhost/qgis_server?
    SERVICE=WMS&REQUEST=GetMap
+   ...
    &LAYERS=EXTERNAL_WMS:basemap,layer1,layer2
    &STYLES=,,
    &basemap:url=http://externalserver.com/wms.fcgi
@@ -1373,6 +1365,7 @@ Similarly, external layers can be used in GetPrint requests:
 
    http://localhost/qgis_server?
    SERVICE=WMS
+   ...
    &REQUEST=GetPrint&TEMPLATE=A4
    &map0:layers=EXTERNAL_WMS:basemap,layer1,layer2
    &map0:EXTENT=<minx,miny,maxx,maxy>
@@ -1383,5 +1376,10 @@ Similarly, external layers can be used in GetPrint requests:
    &basemap:layers=orthofoto
    &basemap:styles=default
 
+.. Substitutions definitions - AVOID EDITING PAST THIS LINE
+   This will be automatically updated by the find_set_subst.py script.
+   If you need to create a new substitution manually,
+   please add it also to the substitutions.txt file in the
+   source folder.
 
-
+.. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/2.18 for QGIS 2.18 docs and translations.`


### PR DESCRIPTION
This PR adds a section about the feature to add external WMS layers in QGIS Server GetMap and GetPrint requests.