### PR TITLE
Remove a leftover text

### DIFF
--- a/source/docs/user_manual/working_with_ogc/server/services.rst
+++ b/source/docs/user_manual/working_with_ogc/server/services.rst
@@ -1282,7 +1282,6 @@ Extra parameters supported by all request types
     defined it will use the MAP parameter in the request and finally look at
     the server executable directory.
 
-  the first feature, skipping none.
 
 .. _`qgisserver-redlining`:
 


### PR DESCRIPTION
the text is at https://docs.qgis.org/testing/en/docs/user_manual/working_with_ogc/server/services.html#extra-parameters-supported-by-all-request-types I don't really know if it's at the wrong place or was leftover by some [other changes](https://github.com/qgis/QGIS-Documentation/blame/master/source/docs/user_manual/working_with_ogc/server/services.rst#L1285). @pblottiere any idea?