### PR TITLE
Move down the General Tools chapter

### DIFF
--- a/source/docs/user_manual/index.rst
+++ b/source/docs/user_manual/index.rst
@@ -18,9 +18,9 @@ QGIS User Guide
     preamble/whats_new
     introduction/getting_started
     introduction/qgis_gui
-    introduction/general_tools
     introduction/qgis_configuration
     working_with_projections/working_with_projections
+    introduction/general_tools
     managing_data_source/index
     working_with_vector/index
     working_with_raster/index
@@ -36,7 +36,6 @@ QGIS User Guide
     preamble/contributors
     appendices/appendices
     literature_web/literature_and_web_references
-
 
 
 .. Substitutions definitions - AVOID EDITING PAST THIS LINE


### PR DESCRIPTION
placed after QGIS GUI --> QGIS Configuration --> Working with projections
As general tools is about the tools and manipulations, I think these chapters showing the GUI and how to understand the settings should have precedence.
I even wonder if it should not move after "Managing data source"...