### PR TITLE
Changes methods and classes links to point to master API

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -106,7 +106,7 @@ pygments_style = 'sphinx'
 # If true, keep warnings as "system message" paragraphs in the built documents.
 #keep_warnings = False
 
-intersphinx_mapping = {'pyqgis_api': ('https://qgis.org/pyqgis/3.4/', None)}
+intersphinx_mapping = {'pyqgis_api': ('https://qgis.org/pyqgis/master/', None)}
 
 # -- Options for HTML output ---------------------------------------------------
 


### PR DESCRIPTION
The issue was raised in #3504, now the master branch of documentation points to the master version of the API and not to 3.4.
Fix #3504 