### PR TITLE
Clarifies when the testoutput is mandatory

### DIFF
--- a/source/docs/documentation_guidelines/cookbook_guidelines.rst
+++ b/source/docs/documentation_guidelines/cookbook_guidelines.rst
@@ -65,11 +65,10 @@ to be placed before the ``.. testcode::``::
      crs = QgsCoordinateReferenceSystem(4326, QgsCoordinateReferenceSystem.PostgisCrsId)
      assert crs.isValid()
 
-If the code snippet is not creating an object (and therefore you cannot use
-something like ``assert object.isValid()``) you can still compare the output
-with another directive using the ``print()`` method. If your code has printed
-outputs, you need to add the expected results within a ``.. testoutput::`` to
-compare the expected output::
+If the code snippet doesn't create objects (and therefore you cannot use
+something like ``assert object.isValid()``), you can test the code using the
+``print()`` method, then add the expected results within a ``.. testoutput::``
+directive to compare the expected output::
 
   .. testcode::
 
@@ -81,7 +80,7 @@ compare the expected output::
      QGIS CRS ID: 3452
      PostGIS SRID: 4326
 
-By default, the content of `.. testoutput::` is shown in the HTLM output.
+By default, the content of ``.. testoutput::`` is shown in the HTML output.
 To hide it from the HTML use the `:hide:` option::
 
   .. testoutput::
@@ -89,6 +88,11 @@ To hide it from the HTML use the `:hide:` option::
 
      QGIS CRS ID: 3452
      PostGIS SRID: 4326
+
+.. note::
+
+   If the code snippet contains any print statements, you MUST add a ``testoutput``
+   with the expected outputs; otherwise the test will fail.
 
 Grouping tests
 ----------------------------


### PR DESCRIPTION
### Description
<!---
Include a few sentences describing the overall goals for this Pull Request.
--->

Not having a testoutput when the code snippet has a print() causes the test to fail. This PR tries to clarify the need to add the directive.

<!---
If your PR fixes a ticket, add `fix` in front of the ticket number. The ticket will be closed automatically.
Add as much as needed `fix #number` if the PR closes more than one ticket.
If your PR doesn't fix entirely the ticket, just add the ticket reference.
The complete list of the issues is at https://github.com/qgis/QGIS-Documentation/issues.
-->

<!---
Indicate whether the fix should be backported to previous release.
Replace the space between square brackets by a `x` to make it checked.
-->
- [x] Backport to LTR documentation is required

### Minimal requirements for merging *(for maintainers)*
<!---
Reviewing is a process done by community members, mostly on a volunteer basis.
We try to keep the overhead as small as possible and appreciate if you help us.
In order for your PR to get merged it should satisfy some minimal requirements:
--->

- [ ] The description of this PR is coherent with the manual and does not provide wrong information.
- [ ] This PR passes the checks. <!---The results will be reported by travis-ci **after** opening the PR.-->

<!---
Please read carefully our writing guidelines at https://docs.qgis.org/testing/en/docs/documentation_guidelines/index.html
to help you fulfill these requirements. Feel free to ask in a comment if you have troubles with any of them.
--->
