### PR TITLE
Add direct link to locator bar description

### DIFF
--- a/source/docs/user_manual/introduction/qgis_configuration.rst
+++ b/source/docs/user_manual/introduction/qgis_configuration.rst
@@ -745,7 +745,7 @@ https://doc.qt.io/qt-5.9/qnetworkproxy.html#ProxyType-enum
 Locator Settings
 ----------------
 
-|search| The :guilabel:`Locator` tab allows to configure the **Locator bar**, a
+|search| The :guilabel:`Locator` tab allows to configure the :ref:`Locator bar <locator_bar>`, a
 quick search widget available on the status bar that helps you perform searches
 anywhere in the application. It provides some default filters (with prefix) to use:
 

--- a/source/docs/user_manual/introduction/qgis_gui.rst
+++ b/source/docs/user_manual/introduction/qgis_gui.rst
@@ -779,6 +779,8 @@ Status Bar
 The status bar provides you with general information about the map view
 and processed or available actions, and offers you tools to manage the map view.
 
+.. _`locator_bar`:
+
 On the left side of the status bar, the locator bar, a quick search widget,
 helps you find and run any feature or options in QGIS. Simply type text
 associated with the item you are looking for (name, tag, keyword...) and you get


### PR DESCRIPTION
to allow cross link between widget and options descriptions

<!---
Include a few sentences describing the overall goals for this Pull Request.
--->


<!---
If your PR fixes a ticket, add `fix` in front of the ticket number. The ticket will be closed automatically.
Add as much as needed `fix #number` if the PR closes more than one ticket.
If your PR doesn't fix entirely the ticket, just add the ticket reference.
The complete list of the issues is at https://github.com/qgis/QGIS-Documentation/issues.
-->
Ticket: http://osgeo-org.1560.x6.nabble.com/locating-layer-td5400310.html (unable to provide a direct link to the feature while answering)

<!---
Indicate whether the fix should be backported to previous release.
Replace the space between square brackets by a `x` to make it checked.
-->
- [x] Backport to LTR documentation is required

### Minimal requirements for merging *(for maintainers)*
<!---
Reviewing is a process done by community members, mostly on a volunteer basis.
We try to keep the overhead as small as possible and appreciate if you help us.
In order for your PR to get merged it should satisfy some minimal requirements:
--->

- [ ] The description of this PR is coherent with the manual and does not provide wrong information.
- [ ] This PR passes the checks. <!---The results will be reported by travis-ci **after** opening the PR.-->

<!---
Please read carefully our writing guidelines at https://docs.qgis.org/testing/en/docs/documentation_guidelines/index.html
to help you fulfill these requirements. Feel free to ask in a comment if you have troubles with any of them.
--->
