### PR TITLE
QGIS Server: additional ENV vars

### DIFF
--- a/source/docs/user_manual/working_with_ogc/server/config.rst
+++ b/source/docs/user_manual/working_with_ogc/server/config.rst
@@ -162,6 +162,24 @@ QGIS_SERVER_CACHE_SIZE
 Sets the network cache size in MB. The default value is ``50`` MB.
 
 
+QGIS_SERVER_OVERRIDE_SYSTEM_LOCALE
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Sets LOCALE to be used by QGIS server. The default value is empty (no override).
+
+Example: ``de_CH.utf8``
+
+
+QGIS_SERVER_SHOW_GROUP_SEPARATOR 
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Defines whether a group separator (e.g. thousand separator) should be used for
+numeric values (e.g. in GetFeatureInfo responses). The default value is ``0``.
+
+* ``0`` or ``false`` (case insensitive)
+* ``1`` or ``true`` (case insensitive)
+
+
 Settings summary
 ================
 


### PR DESCRIPTION
QGIS_SERVER_OVERRIDE_SYSTEM_LOCALE and QGIS_SERVER_SHOW_GROUP_SEPARATOR

### Description
<!---
Two new QGIS Server environment variables to control display of numeric and other values in GetFeatureInfo requests.
--->
Goal:

<!---
If your PR fixes a ticket, add `fix` in front of the ticket number. The ticket will be closed automatically.
Add as much as needed `fix #number` if the PR closes more than one ticket.
If your PR doesn't fix entirely the ticket, just add the ticket reference.
The complete list of the issues is at https://github.com/qgis/QGIS-Documentation/issues.
-->
Ticket: fixes #3633 

<!---
Indicate whether the fix should be backported to previous release.
Replace the space between square brackets by a `x` to make it checked.
-->
- [ ] Backport to LTR documentation is required

### Minimal requirements for merging *(for maintainers)*
<!---
Reviewing is a process done by community members, mostly on a volunteer basis.
We try to keep the overhead as small as possible and appreciate if you help us.
In order for your PR to get merged it should satisfy some minimal requirements:
--->

- [x] The description of this PR is coherent with the manual and does not provide wrong information.
- [ ] This PR passes the checks. <!---The results will be reported by travis-ci **after** opening the PR.-->

<!---
Please read carefully our writing guidelines at https://docs.qgis.org/testing/en/docs/documentation_guidelines/index.html
to help you fulfill these requirements. Feel free to ask in a comment if you have troubles with any of them.
--->
