### PR TITLE
Update doc copyright

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -45,7 +45,7 @@ master_doc = 'docs/index'
 
 # General information about the project.
 project = u'QGIS Documentation Project'
-copyright = u'2014, QGIS project'
+copyright = u'2002-now, QGIS project'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the


### PR DESCRIPTION
to match what is used in [3.4 branch](https://github.com/qgis/QGIS-Documentation/blob/release_3.4/source/conf.py#L48)
The copyright is also mentioned at https://docs.qgis.org/testing/en/docs/user_manual/preamble/preamble.html, stating 
> Copyright (c) 2004 - 2017 QGIS Development Team

Should it be changed? To what (aka, how to make it dynamic if need be?)?
<!---
If your PR fixes a ticket, add `fix` in front of the ticket number. The ticket will be closed automatically.
Add as much as needed `fix #number` if the PR closes more than one ticket.
If your PR doesn't fix entirely the ticket, just add the ticket reference.
The complete list of the issues is at https://github.com/qgis/QGIS-Documentation/issues.
-->
Ticket: #

<!---
Indicate whether the fix should be backported to previous release.
Replace the space between square brackets by a `x` to make it checked.
-->
- [ ] Backport to LTR documentation is required

### Minimal requirements for merging *(for maintainers)*
<!---
Reviewing is a process done by community members, mostly on a volunteer basis.
We try to keep the overhead as small as possible and appreciate if you help us.
In order for your PR to get merged it should satisfy some minimal requirements:
--->

- [ ] The description of this PR is coherent with the manual and does not provide wrong information.
- [ ] This PR passes the checks. <!---The results will be reported by travis-ci **after** opening the PR.-->

<!---
Please read carefully our writing guidelines at https://docs.qgis.org/testing/en/docs/documentation_guidelines/index.html
to help you fulfill these requirements. Feel free to ask in a comment if you have troubles with any of them.
--->
