### PR TITLE
Remove obsolete |outofdate| warning

### DIFF
--- a/source/docs/pyqgis_developer_cookbook/expressions.rst
+++ b/source/docs/pyqgis_developer_cookbook/expressions.rst
@@ -1,5 +1,3 @@
-.. only:: html
-
 
 The code snippets on this page needs the following imports if you're outside the pyqgis console:
 
@@ -21,8 +19,6 @@ The code snippets on this page needs the following imports if you're outside the
 *********************************************
 Expressions, Filtering and Calculating Values
 *********************************************
-
-.. warning:: |outofdate|
 
 .. contents::
    :local:
@@ -178,10 +174,3 @@ matches a predicate.
    assert(matches == 7)
 
 
-.. Substitutions definitions - AVOID EDITING PAST THIS LINE
-   This will be automatically updated by the find_set_subst.py script.
-   If you need to create a new substitution manually,
-   please add it also to the substitutions.txt file in the
-   source folder.
-
-.. |outofdate| replace:: `Despite our constant efforts, information beyond this line may not be updated for QGIS 3. Refer to https://qgis.org/pyqgis/master for the python API documentation or, give a hand to update the chapters you know about. Thanks.`

--- a/source/docs/pyqgis_developer_cookbook/vector.rst
+++ b/source/docs/pyqgis_developer_cookbook/vector.rst
@@ -1351,3 +1351,4 @@ Further Topics
 * working with color ramps (:class:`QgsColorRamp <qgis.core.QgsColorRamp>`)
 * exploring symbol layer and renderer registries
 
+.. _supported formats by OGR: https://www.gdal.org/ogr_formats.html

--- a/source/docs/pyqgis_developer_cookbook/vector.rst
+++ b/source/docs/pyqgis_developer_cookbook/vector.rst
@@ -1,5 +1,3 @@
-.. only:: html
-
 
 .. _vector:
 
@@ -750,6 +748,8 @@ categorizedSymbol  :class:`QgsCategorizedSymbolRenderer <qgis.core.QgsCategorize
 graduatedSymbol    :class:`QgsGraduatedSymbolRenderer  <qgis.core.QgsGraduatedSymbolRenderer>`    Renders features using a different symbol for each range of values
 =================  ============================================================================== ===================================================================
 
+|
+
 There might be also some custom renderer types, so never make an assumption
 there are just these types. You can query the application's :class:`QgsRendererRegistry <qgis.core.QgsRendererRegistry>`
 to find out currently available renderers:
@@ -1339,7 +1339,6 @@ of the metadata class. The icon can be loaded from a file (as shown above) or
 can be loaded from a `Qt resource <https://doc.qt.io/qt-5/resources.html>`_
 (PyQt5 includes .qrc compiler for Python).
 
-.. warning:: |outofdate|
 
 Further Topics
 ==============
@@ -1352,14 +1351,3 @@ Further Topics
 * working with color ramps (:class:`QgsColorRamp <qgis.core.QgsColorRamp>`)
 * exploring symbol layer and renderer registries
 
-
-.. _supported formats by OGR: https://www.gdal.org/ogr_formats.html
-
-
-.. Substitutions definitions - AVOID EDITING PAST THIS LINE
-   This will be automatically updated by the find_set_subst.py script.
-   If you need to create a new substitution manually,
-   please add it also to the substitutions.txt file in the
-   source folder.
-
-.. |outofdate| replace:: `Despite our constant efforts, information beyond this line may not be updated for QGIS 3. Refer to https://qgis.org/pyqgis/master for the python API documentation or, give a hand to update the chapters you know about. Thanks.`


### PR DESCRIPTION
and improve readability  (manual backport of #3658)

### Description
<!---
Include a few sentences describing the overall goals for this Pull Request.
--->
Goal:

<!---
If your PR fixes a ticket, add `fix` in front of the ticket number. The ticket will be closed automatically.
Add as much as needed `fix #number` if the PR closes more than one ticket.
If your PR doesn't fix entirely the ticket, just add the ticket reference.
The complete list of the issues is at https://github.com/qgis/QGIS-Documentation/issues.
-->
Ticket: #

<!---
Indicate whether the fix should be backported to previous release.
Replace the space between square brackets by a `x` to make it checked.
-->
- [ ] Backport to LTR documentation is required

### Minimal requirements for merging *(for maintainers)*
<!---
Reviewing is a process done by community members, mostly on a volunteer basis.
We try to keep the overhead as small as possible and appreciate if you help us.
In order for your PR to get merged it should satisfy some minimal requirements:
--->

- [ ] The description of this PR is coherent with the manual and does not provide wrong information.
- [ ] This PR passes the checks. <!---The results will be reported by travis-ci **after** opening the PR.-->

<!---
Please read carefully our writing guidelines at https://docs.qgis.org/testing/en/docs/documentation_guidelines/index.html
to help you fulfill these requirements. Feel free to ask in a comment if you have troubles with any of them.
--->
