### PR TITLE
Typo corrected

### DIFF
--- a/source/docs/pyqgis_developer_cookbook/processing.rst
+++ b/source/docs/pyqgis_developer_cookbook/processing.rst
@@ -112,7 +112,7 @@ You can create a folder :file:`processing_provider` with three files in it:
   https://github.com/qgis/QGIS/blob/master/python/plugins/processing/script/ScriptTemplate.py
 
 Now you can reload your plugin in QGIS and you should see your example script in
-the Processing toolbox and modeller.
+the Processing toolbox and modeler.
 
 .. Substitutions definitions - AVOID EDITING PAST THIS LINE
    This will be automatically updated by the find_set_subst.py script.


### PR DESCRIPTION
line 115 : "modeller"  should probably be "modeler"

### Description
<!---
Include a few sentences describing the overall goals for this Pull Request.
--->
Goal: correct language in documentation

<!---
Indicate whether the fix should be backported to previous release.
Replace the space between square brackets by a `x` to make it checked.
-->
- [ X] Backport to LTR documentation is required
