### PR TITLE
refrase sentence

### DIFF
--- a/source/docs/pyqgis_developer_cookbook/communicating.rst
+++ b/source/docs/pyqgis_developer_cookbook/communicating.rst
@@ -49,7 +49,7 @@ You can set a duration to show it for a limited time
 
    QGIS Message bar with timer
 
-The examples above show an error bar, but the ``level`` parameter can be used
+The example above shows an error bar, but the ``level`` parameter can be used
 to creating warning messages or info messages, using the
 :class:`Qgis.MessageLevel <qgis.core.Qgis.MessageLevel>` enumeration. You can use up to 4 different levels:
 


### PR DESCRIPTION
Line  52 : "The examples above show"  should probably be "The example above shows"
               There is just one example above so it should be singular instead of multiple

### Description

Goal:  correct language in documentation

- [X] Backport to LTR documentation is required
