### PR TITLE
Missing colon after :file

### DIFF
--- a/source/docs/pyqgis_developer_cookbook/authentication.rst
+++ b/source/docs/pyqgis_developer_cookbook/authentication.rst
@@ -50,7 +50,7 @@ Here are some definition of the most common objects treated in this chapter.
     Authentication DB
 
   Authentication Database
-    A :term:`Master Password` crypted sqlite db :file`qgis-auth.db`
+    A :term:`Master Password` crypted sqlite db :file:`qgis-auth.db`
     where :term:`Authentication Configuration` are stored. e.g user/password,
     personal certificates and keys, Certificate Authorities
 


### PR DESCRIPTION
Line 53 : It seems there is missing a colon after ":file" in ":file`qgis-auth.db`", should be: ":file:`qgis-auth.db`"

### Description

Goal: correct display of used placeholders in documentation

- [x] Backport to LTR documentation is required
