### PR TITLE
Error in format page

### DIFF
--- a/source/docs/user_manual/auth_system/auth_overview.rst
+++ b/source/docs/user_manual/auth_system/auth_overview.rst
@@ -231,9 +231,14 @@ authentication database and configurations:
 * **Input master password**:
   
   * Opens the master password input dialog, independent of performing any
-    authentication database command. Clear cached master password
-  * Unsets the master password if it has been set via input dialog. Reset master
-    password
+    authentication database command.
+    
+* **Clear cached master password**:
+
+  * Unsets the master password if it has been set via input dialog.
+  
+* **Reset master password**:
+
   * Opens a dialog to change the master password (the current password
     must be known) and optionally back up the current database.
 


### PR DESCRIPTION
Line 231 to 236 : It seems that something went wrong with the formatting. Options are probably inadvertably not formatted right.
First option "Input master password" was correct formatted, but "Clear cached master password" and "Reset master password" were not separately mentioned on the page, but joined together with the first option "Input master password"

### Description
Goal: correct display of the mentioned options on the page in documentation

- [x] Backport to LTR documentation is required
