### PR TITLE
Remove "sudo" ?  ** NOT SURE ABOUT THIS! **

### DIFF
--- a/source/docs/training_manual/qgis_server/install.rst
+++ b/source/docs/training_manual/qgis_server/install.rst
@@ -266,7 +266,7 @@ choose whatever name you like (``coco.bango``, ``super.duper.training``,
 * Let's set up the ``myhost`` name to point to the localhost IP by adding
   ``127.0.0.1 x`` to the :file:`/etc/hosts` with the following command:
   ``sh -c "echo '127.0.0.1 myhost' >> /etc/hosts"`` or by manually
-  editing the file with ``sudo gedit /etc/hosts``.
+  editing the file with ``gedit /etc/hosts``.
 * We can check that ``myhost`` points to the localhost by running in the terminal
   the  ``ping myhost`` command which should output:
 


### PR DESCRIPTION
line 269 ; ``sudo gedit /etc/hosts`` but I'm removing all "sudo"-s from this page. Should this one remain or should it go ?
I'm on Windows ( yeah, tell the wife :-) ) and my knowledge of Linux is limited

### Description

Goal: displaying correct information in documentation

- [x] Backport to LTR documentation is required
