### PR TITLE
Rewording "Project Properties" to "Properties" and removing icon

### DIFF
--- a/source/docs/user_manual/working_with_projections/working_with_projections.rst
+++ b/source/docs/user_manual/working_with_projections/working_with_projections.rst
@@ -51,8 +51,8 @@ specification of the CRS. This projection file has the same base name as the
 :file:`alaska.prj`.
 
 Whenever you select a new CRS, the layer units will automatically be
-changed in the :guilabel:`General` tab of the |options|
-:guilabel:`Project Properties` dialog under the :guilabel:`Project` menu.
+changed in the :guilabel:`General` tab of the
+:guilabel:`Properties` dialog under the :guilabel:`Project` menu.
 
 .. index:: CRS
    single: CRS; Default CRS

--- a/source/docs/user_manual/working_with_projections/working_with_projections.rst
+++ b/source/docs/user_manual/working_with_projections/working_with_projections.rst
@@ -52,7 +52,7 @@ specification of the CRS. This projection file has the same base name as the
 
 Whenever you select a new CRS, the layer units will automatically be
 changed in the :guilabel:`General` tab of the
-:guilabel:`Properties` dialog under the :guilabel:`Project` menu.
+:guilabel:`Project properties` dialog (:menuselection:`Project --> Properties...`).
 
 .. index:: CRS
    single: CRS; Default CRS


### PR DESCRIPTION
Line 54 and 55 :  the icon |option| is not visible in the menu Project next to "Properties" and should be removed
The option for the menu "Project Properties" in Project menu is throughout the application replaced by "Properties" (see also line 116)

### Description

Goal: correct display of items of the GUI in the documentation

- [x] Backport to LTR documentation is required
