### PR TITLE
Superfluous colon

### DIFF
--- a/source/docs/user_manual/print_composer/create_reports.rst
+++ b/source/docs/user_manual/print_composer/create_reports.rst
@@ -116,7 +116,7 @@ to add to our report.
 |
 
 There are two options: :guilabel:`Add Static Layout Section` and a
-:guilabel:`Field Group Section`.  The :guilabel:`Add Static Layout Section` is a
+:guilabel:`Field Group Section`. The :guilabel:`Add Static Layout Section` is a
 single, static body layout. This can be used to embed static layouts mid-way
 through a report. Alternatively, a :guilabel:`Field Group Section` repeats its
 body layout for every feature in a layer. The features are sorted by the
@@ -130,7 +130,7 @@ For now we’ll add a Field Group to our report. At its
 most basic level, you can think of a :guilabel:`Field Group Section` as the equivalent
 of a :ref:`print atlas <atlas_generation>`. You select a layer to iterate over,
 and the report will insert a section for each feature found. Selecting the new
-:guilabel:`Field Group Section` section reveals a number of new related settings:
+:guilabel:`Field Group Section` reveals a number of new related settings:
 
 .. figure:: img/field_group.png
    :align: center

--- a/source/docs/user_manual/print_composer/create_reports.rst
+++ b/source/docs/user_manual/print_composer/create_reports.rst
@@ -130,7 +130,7 @@ For now we’ll add a Field Group to our report. At its
 most basic level, you can think of a :guilabel:`Field Group Section` as the equivalent
 of a :ref:`print atlas <atlas_generation>`. You select a layer to iterate over,
 and the report will insert a section for each feature found. Selecting the new
-::guilabel:`Field Group Section` section reveals a number of new related settings:
+:guilabel:`Field Group Section` section reveals a number of new related settings:
 
 .. figure:: img/field_group.png
    :align: center


### PR DESCRIPTION
line 133 :  "::guilabel:`Field Group Section`" contains one colon too many, should be: ":guilabel:`Field Group Section`"

### Description
<!---
Include a few sentences describing the overall goals for this Pull Request.
--->
Goal:

<!---
If your PR fixes a ticket, add `fix` in front of the ticket number. The ticket will be closed automatically.
Add as much as needed `fix #number` if the PR closes more than one ticket.
If your PR doesn't fix entirely the ticket, just add the ticket reference.
The complete list of the issues is at https://github.com/qgis/QGIS-Documentation/issues.
-->
Ticket: #

<!---
Indicate whether the fix should be backported to previous release.
Replace the space between square brackets by a `x` to make it checked.
-->
- [x] Backport to LTR documentation is required

### Minimal requirements for merging *(for maintainers)*
<!---
Reviewing is a process done by community members, mostly on a volunteer basis.
We try to keep the overhead as small as possible and appreciate if you help us.
In order for your PR to get merged it should satisfy some minimal requirements:
--->

- [ ] The description of this PR is coherent with the manual and does not provide wrong information.
- [ ] This PR passes the checks. <!---The results will be reported by travis-ci **after** opening the PR.-->

<!---
Please read carefully our writing guidelines at https://docs.qgis.org/testing/en/docs/documentation_guidelines/index.html
to help you fulfill these requirements. Feel free to ask in a comment if you have troubles with any of them.
--->
