### PR TITLE
Double wording "the"

### DIFF
--- a/source/docs/user_manual/print_composer/composer_items/composer_attribute_table.rst
+++ b/source/docs/user_manual/print_composer/composer_items/composer_attribute_table.rst
@@ -108,7 +108,7 @@ following functionalities (see figure_layout_table_ppt_):
   In the :guilabel:`Columns` section you can:
 
   * Move attributes up or down the list by selecting the rows and then using the
-    the |arrowUp| and |arrowDown| buttons to shift the rows. Multiple rows can
+    |arrowUp| and |arrowDown| buttons to shift the rows. Multiple rows can
     be selected and moved at any one time.
   * Add an attribute with the |signPlus| button. This will add an empty row at
     the bottom of the table where you can select a field to be the attribute


### PR DESCRIPTION
line 110/111:  "the the"  should be "the"

### Description

Goal: display grammatical correct documentation

- [x] Backport to LTR documentation is required

- [x] The description of this PR is coherent with the manual and does not provide wrong information.
- [x] This PR passes the checks. <!---The results will be reported by travis-ci **after** opening the PR.-->

