### PR TITLE
Singular instead of multiple

### DIFF
--- a/source/docs/user_manual/processing_algs/qgis/vectorgeometry.rst
+++ b/source/docs/user_manual/processing_algs/qgis/vectorgeometry.rst
@@ -165,7 +165,7 @@ For **lines geometries**, the boundaries are the vertices between each features.
 .. figure:: img/boundary_lines.png
    :align: center
 
-   Boundary layer for lines. In yellow a selected features.
+   Boundary layer for lines. In yellow a selected feature.
 
 Parameters
 ..........


### PR DESCRIPTION
Line 168 : "a selected features" should be "a selected feature" since there is only one segment selected.

### Description

Goal: Grammatical correct documentation

- [x] Backport to LTR documentation is required

### Minimal requirements for merging *(for maintainers)*

- [x] The description of this PR is coherent with the manual and does not provide wrong information.
- [x] This PR passes the checks. <!---The results will be reported by travis-ci **after** opening the PR.-->

<!---
Please read carefully our writing guidelines at https://docs.qgis.org/testing/en/docs/documentation_guidelines/index.html
to help you fulfill these requirements. Feel free to ask in a comment if you have troubles with any of them.
--->
