### PR TITLE
Fixes SVG customization example

### DIFF
--- a/source/docs/user_manual/working_with_vector/style_library.rst
+++ b/source/docs/user_manual/working_with_vector/style_library.rst
@@ -435,7 +435,7 @@ Appropriate for point geometry features, marker symbols have several
    .. code-block:: xml
   
     <svg width="100%" height="100%">
-    <rect fill="param(fill) #ff0000" stroke="param(outline) #00ff00" stroke-width="param(stroke-width) 10" width="100" height="100">
+    <rect fill="param(fill) #ff0000" stroke="param(outline) #00ff00" stroke-width="param(outline-width) 10" width="100" height="100">
     </rect>
     </svg>
  


### PR DESCRIPTION
The SVG example was using a wrong parameter name, and would not work properly.

### Description
<!---
Include a few sentences describing the overall goals for this Pull Request.
--->
Goal:

<!---
If your PR fixes a ticket, add `fix` in front of the ticket number. The ticket will be closed automatically.
Add as much as needed `fix #number` if the PR closes more than one ticket.
If your PR doesn't fix entirely the ticket, just add the ticket reference.
The complete list of the issues is at https://github.com/qgis/QGIS-Documentation/issues.
-->
Ticket: #

<!---
Indicate whether the fix should be backported to previous release.
Replace the space between square brackets by a `x` to make it checked.
-->
- [x] Backport to LTR documentation is required

### Minimal requirements for merging *(for maintainers)*
<!---
Reviewing is a process done by community members, mostly on a volunteer basis.
We try to keep the overhead as small as possible and appreciate if you help us.
In order for your PR to get merged it should satisfy some minimal requirements:
--->

- [ ] The description of this PR is coherent with the manual and does not provide wrong information.
- [ ] This PR passes the checks. <!---The results will be reported by travis-ci **after** opening the PR.-->

<!---
Please read carefully our writing guidelines at https://docs.qgis.org/testing/en/docs/documentation_guidelines/index.html
to help you fulfill these requirements. Feel free to ask in a comment if you have troubles with any of them.
--->
