### PR TITLE
Döuble reference ":ref:`qgisbufferbym` in one sentence

### DIFF
--- a/source/docs/user_manual/processing_algs/qgis/vectorgeometry.rst
+++ b/source/docs/user_manual/processing_algs/qgis/vectorgeometry.rst
@@ -683,7 +683,7 @@ Outputs
 
 See also
 ........
-:ref:`qgisbuffer`, :ref:`qgisbufferbym`, :ref:`qgistaperedbuffer`, :ref:`qgisbufferbym`
+:ref:`qgisbuffer`, :ref:`qgisbufferbym`, :ref:`qgistaperedbuffer`
 
 
 .. _qgisdelaunaytriangulation:


### PR DESCRIPTION
line 686 : this sentence contains a double reference to ":ref:`qgisbufferbym`" Removed last one.

### Description

Goal: correct documentation

- [x] Backport to LTR documentation is required

### Minimal requirements for merging *(for maintainers)*

- [x] The description of this PR is coherent with the manual and does not provide wrong information.
- [x] This PR passes the checks. <!---The results will be reported by travis-ci **after** opening the PR.-->
