### PR TITLE
Modifies wrong path for startup.py initialization file.

### DIFF
--- a/source/docs/pyqgis_developer_cookbook/intro.rst
+++ b/source/docs/pyqgis_developer_cookbook/intro.rst
@@ -127,9 +127,9 @@ The :file:`startup.py` file
 
 Every time QGIS starts, the user's Python home directory
 
-* Linux: :file:`.local/share/QGIS/QGIS3/profiles/default/python`
-* Windows: :file:`AppData\\Roaming\\QGIS\\QGIS3\\profiles\\default\\python`
-* macOS: :file:`Library/Application Support/QGIS/QGIS3/profiles/default`
+* Linux: :file:`.local/share/QGIS/QGIS3`
+* Windows: :file:`AppData\\Roaming\\QGIS\\QGIS3`
+* macOS: :file:`Library/Application Support/QGIS/QGIS3`
 
 is searched for a file named :file:`startup.py`. If that file exists, it
 is executed by the embedded Python interpreter.


### PR DESCRIPTION
### Description
<!---
Include a few sentences describing the overall goals for this Pull Request.
--->
Goal: Solved wrong path for startup.py initialization file.

<!---
If your PR fixes a ticket, add `fix` in front of the ticket number. The ticket will be closed automatically.
Add as much as needed `fix #number` if the PR closes more than one ticket.
If your PR doesn't fix entirely the ticket, just add the ticket reference.
The complete list of the issues is at https://github.com/qgis/QGIS-Documentation/issues.
-->
Ticket: fix #3722 

<!---
Indicate whether the fix should be backported to previous release.
Replace the space between square brackets by a `x` to make it checked.
-->
- [X] Backport to LTR documentation is required

### Minimal requirements for merging *(for maintainers)*
<!---
Reviewing is a process done by community members, mostly on a volunteer basis.
We try to keep the overhead as small as possible and appreciate if you help us.
In order for your PR to get merged it should satisfy some minimal requirements:
--->

- [X] The description of this PR is coherent with the manual and does not provide wrong information.
- [x] This PR passes the checks. <!---The results will be reported by travis-ci **after** opening the PR.-->

<!---
Please read carefully our writing guidelines at https://docs.qgis.org/testing/en/docs/documentation_guidelines/index.html
to help you fulfill these requirements. Feel free to ask in a comment if you have troubles with any of them.
--->
