### PR TITLE
Missing space

### DIFF
--- a/source/docs/user_manual/processing_algs/qgis/vectorgeometry.rst
+++ b/source/docs/user_manual/processing_algs/qgis/vectorgeometry.rst
@@ -2233,7 +2233,7 @@ Parameters
   Allows to consider the Z coordinate when detecting duplicate vertices ie two points
   at the same X,Y coordinate but with different Z value are not set as duplicates.
 
-  Default:*False*
+  Default: *False*
 
 Outputs
 .......


### PR DESCRIPTION
Line 2236: "Default:*False*" should be *Default: *False*"

### Description

Goal: Correct displayed documentation

- [x] Backport to LTR documentation is required

### Minimal requirements for merging *(for maintainers)*

- [x] The description of this PR is coherent with the manual and does not provide wrong information.
- [x] This PR passes the checks. <!---The results will be reported by travis-ci **after** opening the PR.-->

