### PR TITLE
Missing space

### DIFF
--- a/source/docs/training_manual/vector_analysis/network_analysis.rst
+++ b/source/docs/training_manual/vector_analysis/network_analysis.rst
@@ -65,7 +65,7 @@ for the analysis:
   and choose the location tagged with ``Starting Point`` in the picture. The menu
   is filled with the coordinates of the clicked point;
 * Do the same thing but choosing the location tagged with ``Ending point`` for
-  :guilabel:`End point(x, y)`;
+  :guilabel:`End point (x, y)`;
 * Click on the :guilabel:`Run` button:
 
 .. image:: img/shortest_point.png


### PR DESCRIPTION
Line 68 : missing space between "point"and "(x,y)" (As with 'Start point (x,y)"in line 64)

### Description

Goal: correct language in documentation

- [x] Backport to LTR documentation is required

### Minimal requirements for merging *(for maintainers)*

- [x] The description of this PR is coherent with the manual and does not provide wrong information.
- [x] This PR passes the checks. <!---The results will be reported by travis-ci **after** opening the PR.-->

