### PR TITLE
Missing space

### DIFF
--- a/source/docs/training_manual/vector_analysis/network_analysis.rst
+++ b/source/docs/training_manual/vector_analysis/network_analysis.rst
@@ -175,7 +175,7 @@ manually choose the start and end points.
   and choose the location tagged with ``Start Point`` in the picture. The menu
   is filled with the coordinates of the clicked point;
 * Do the same thing but choosing the location tagged with ``End point`` for
-  :guilabel:`End point(x, y)`;
+  :guilabel:`End point (x, y)`;
 * Open the :guilabel:`Advanced parameters` menu;
 * Choose the ``speed`` field as the :guilabel:`Speed Field` parameter. With this
   option the algorithm will take into account the speed values for each road;


### PR DESCRIPTION
Line 178 : missing space between "point"and "(x,y)" (As with 'Start point (x,y)"in line 174)

### Description

Goal: correct language in documentation

- [x] Backport to LTR documentation is required

### Minimal requirements for merging *(for maintainers)*

- [x] The description of this PR is coherent with the manual and does not provide wrong information.
- [x] This PR passes the checks. <!---The results will be reported by travis-ci **after** opening the PR.-->

