### PR TITLE
Fixes example for "Use Filter, Opacities and Filter parameters"

### DIFF
--- a/source/docs/training_manual/qgis_server/wms.rst
+++ b/source/docs/training_manual/qgis_server/wms.rst
@@ -186,7 +186,7 @@ uses the standard STYLES parameter.
  &HEIGHT=551
  &FORMAT=image/jpeg
  &LAYERS=countries,countries_shapeburst
- &STYLES=classified_by_name,default
+ &STYLES=classified_by_name,blue
  &OPACITIES=255,30
  &FILTER=countries:"name" IN ( 'Germany' , 'Italy' )
 


### PR DESCRIPTION
A tiny typo in example part "Use Filter, Opacities and Filter parameters". There is no "default" style for countries_shapeburst in the demo project. 
Styles are blue or green, and the image is generated with blue style.

cc @pblottiere :wink:

### Description
<!---
Include a few sentences describing the overall goals for this Pull Request.
--->
Goal:

<!---
If your PR fixes a ticket, add `fix` in front of the ticket number. The ticket will be closed automatically.
Add as much as needed `fix #number` if the PR closes more than one ticket.
If your PR doesn't fix entirely the ticket, just add the ticket reference.
The complete list of the issues is at https://github.com/qgis/QGIS-Documentation/issues.
-->
Ticket: #

<!---
Indicate whether the fix should be backported to previous release.
Replace the space between square brackets by a `x` to make it checked.
-->
- [x] Backport to LTR documentation is required

### Minimal requirements for merging *(for maintainers)*
<!---
Reviewing is a process done by community members, mostly on a volunteer basis.
We try to keep the overhead as small as possible and appreciate if you help us.
In order for your PR to get merged it should satisfy some minimal requirements:
--->

- [ ] The description of this PR is coherent with the manual and does not provide wrong information.
- [ ] This PR passes the checks. <!---The results will be reported by travis-ci **after** opening the PR.-->

<!---
Please read carefully our writing guidelines at https://docs.qgis.org/testing/en/docs/documentation_guidelines/index.html
to help you fulfill these requirements. Feel free to ask in a comment if you have troubles with any of them.
--->
