### PR TITLE
Proj4 is no more, rename to 'Proj'

### DIFF
--- a/source/docs/pyqgis_developer_cookbook/crs.rst
+++ b/source/docs/pyqgis_developer_cookbook/crs.rst
@@ -58,7 +58,7 @@ class. Instances of this class can be created in several different ways:
      assert crs.isValid()
 
 * create an invalid CRS and then use one of the ``create*`` functions to
-  initialize it. In the following example we use a Proj4 string to initialize the
+  initialize it. In the following example we use a Proj string to initialize the
   projection.
 
   .. testcode::
@@ -90,7 +90,7 @@ Accessing spatial reference system information:
    print("Description:", crs.description())
    print("Projection Acronym:", crs.projectionAcronym())
    print("Ellipsoid Acronym:", crs.ellipsoidAcronym())
-   print("Proj4 String:", crs.toProj4())
+   print("Proj String:", crs.toProj4())
    # check whether it's geographic or projected coordinate system
    print("Is geographic:", crs.isGeographic())
    # check type of map units in this CRS (values defined in QGis::units enum)
@@ -105,7 +105,7 @@ Output:
    Description: WGS 84
    Projection Acronym: longlat
    Ellipsoid Acronym: WGS84
-   Proj4 String: +proj=longlat +datum=WGS84 +no_defs
+   Proj String: +proj=longlat +datum=WGS84 +no_defs
    Is geographic: True
    Map units: 6
 

--- a/source/docs/user_manual/processing_algs/gdal/rastermiscellaneous.rst
+++ b/source/docs/user_manual/processing_algs/gdal/rastermiscellaneous.rst
@@ -324,7 +324,7 @@ Parameters
   * 0 --- Auto
   * 1 --- Well-known text (WKT)
   * 2 --- EPSG
-  * 3 --- Proj.4
+  * 3 --- Proj
 
   Default: *0*
 

--- a/source/docs/user_manual/working_with_mesh/mesh_properties.rst
+++ b/source/docs/user_manual/working_with_mesh/mesh_properties.rst
@@ -147,8 +147,8 @@ The :guilabel:`Source` tab displays basic information about the selected mesh,
 including:
 
 * the Layer name to display in the :guilabel:`Layers` panel
-* setting the Coordinate Reference System: Displays the layer’s Coordinate
-  Reference System (CRS). You can change the layer’s CRS by
+* setting the Coordinate Reference System: Displays the layer’s
+  :ref:`Coordinate Reference System (CRS) <layer_crs>`. You can change the layer’s CRS by
   selecting a recently used one in the drop-down list or clicking on |setProjection|
   :guilabel:`Select CRS` button (see :ref:`crs_selector`).
   Use this process only if the CRS applied to the layer is wrong or

--- a/source/docs/user_manual/working_with_mesh/mesh_properties.rst
+++ b/source/docs/user_manual/working_with_mesh/mesh_properties.rst
@@ -148,7 +148,7 @@ including:
 
 * the Layer name to display in the :guilabel:`Layers` panel
 * setting the Coordinate Reference System: Displays the layer’s Coordinate
-  Reference System (CRS) as a PROJ.4 string. You can change the layer’s CRS by
+  Reference System (CRS). You can change the layer’s CRS by
   selecting a recently used one in the drop-down list or clicking on |setProjection|
   :guilabel:`Select CRS` button (see :ref:`crs_selector`).
   Use this process only if the CRS applied to the layer is wrong or

--- a/source/docs/user_manual/working_with_projections/working_with_projections.rst
+++ b/source/docs/user_manual/working_with_projections/working_with_projections.rst
@@ -42,6 +42,8 @@ Custom, user-created CRSs are stored in a user CRS database. See
 section :ref:`sec_custom_projections` for information on managing your custom
 coordinate reference systems.
 
+.. _layer_crs:
+
 Layer Coordinate Reference Systems
 ==================================
 

--- a/source/docs/user_manual/working_with_raster/raster_properties.rst
+++ b/source/docs/user_manual/working_with_raster/raster_properties.rst
@@ -72,7 +72,7 @@ raster, including:
 
 * the :guilabel:`Layer name` to display in the :guilabel:`Layers Panel`;
 * setting the :guilabel:`Coordinate Reference System`:
-  Displays the layer's Coordinate Reference System (CRS) as a PROJ.4 string. You
+  Displays the layer's Coordinate Reference System (CRS). You
   can change the layer's CRS, selecting a recently used one in the drop-down list
   or clicking on |setProjection| :sup:`Select CRS` button (see :ref:`crs_selector`).
   Use this process only if the CRS applied to the layer is a wrong one or if none

--- a/source/docs/user_manual/working_with_raster/raster_properties.rst
+++ b/source/docs/user_manual/working_with_raster/raster_properties.rst
@@ -72,7 +72,7 @@ raster, including:
 
 * the :guilabel:`Layer name` to display in the :guilabel:`Layers Panel`;
 * setting the :guilabel:`Coordinate Reference System`:
-  Displays the layer's Coordinate Reference System (CRS). You
+  Displays the layer's :ref:`Coordinate Reference System (CRS) <layer_crs>`. You
   can change the layer's CRS, selecting a recently used one in the drop-down list
   or clicking on |setProjection| :sup:`Select CRS` button (see :ref:`crs_selector`).
   Use this process only if the CRS applied to the layer is a wrong one or if none

--- a/source/docs/user_manual/working_with_vector/vector_properties.rst
+++ b/source/docs/user_manual/working_with_vector/vector_properties.rst
@@ -103,7 +103,7 @@ Other than setting the :guilabel:`Layer name` to display in the
 Coordinate Reference System
 ---------------------------
 
-* Displays the layer's Coordinate Reference System (CRS) as a PROJ.4 string.
+* Displays the layer's Coordinate Reference System.
   You can change the layer's CRS, selecting a recently used one
   in the drop-down list or clicking on |setProjection| :sup:`Select CRS` button
   (see :ref:`crs_selector`). Use this process only if the CRS applied to the

--- a/source/docs/user_manual/working_with_vector/vector_properties.rst
+++ b/source/docs/user_manual/working_with_vector/vector_properties.rst
@@ -103,7 +103,7 @@ Other than setting the :guilabel:`Layer name` to display in the
 Coordinate Reference System
 ---------------------------
 
-* Displays the layer's Coordinate Reference System.
+* Displays the layer's :ref:`Coordinate Reference System (CRS) <layer_crs>`.
   You can change the layer's CRS, selecting a recently used one
   in the drop-down list or clicking on |setProjection| :sup:`Select CRS` button
   (see :ref:`crs_selector`). Use this process only if the CRS applied to the


### PR DESCRIPTION
Changes references to "proj4" to just "proj". 4 was a version number, not a part of the name!