### PR TITLE
Missing colon

### DIFF
--- a/source/docs/user_manual/introduction/qgis_gui.rst
+++ b/source/docs/user_manual/introduction/qgis_gui.rst
@@ -401,7 +401,7 @@ Database
 
 This is what the :guilabel:`Database` menu looks like if all the core plugins
 are enabled.
-If no database plugins are enabled, there will be no guilabel:`Database` menu.
+If no database plugins are enabled, there will be no :guilabel:`Database` menu.
 
 ===============================================  ============================  ===============================
 Menu Option                                      Toolbar                       Reference


### PR DESCRIPTION
line 404 : missing colon before "guilabel:"  
               "no guilabel:`Database`" should probably be : "no :guilabel:`Database`"

### Description

Goal: Display well formed documentation

- [x] Backport to LTR documentation is required

### Minimal requirements for merging *(for maintainers)*

- [x] The description of this PR is coherent with the manual and does not provide wrong information.
- [x] This PR passes the checks. <!---The results will be reported by travis-ci **after** opening the PR.-->
