### PR TITLE
Double wording "the"

### DIFF
--- a/source/docs/pyqgis_developer_cookbook/vector.rst
+++ b/source/docs/pyqgis_developer_cookbook/vector.rst
@@ -416,7 +416,7 @@ wrapped into undo commands. (If you do not care about undo/redo and want to
 have the changes stored immediately, then you will have easier work by
 :ref:`editing with data provider <editing>`.)
 
-Here is how you can use the the undo functionality:
+Here is how you can use the undo functionality:
 
 .. code-block:: python
 


### PR DESCRIPTION
Line 419 :  "use the the undo functionality"  should be:  "use the undo functionality"

Removed second occurrence of "the"

### Description
<!---
Include a few sentences describing the overall goals for this Pull Request.
--->
Goal: Display correct documentation

- [x] Backport to LTR documentation is required

### Minimal requirements for merging *(for maintainers)*

- [x] The description of this PR is coherent with the manual and does not provide wrong information.
- [x] This PR passes the checks. <!---The results will be reported by travis-ci **after** opening the PR.-->

