### PR TITLE
Superfluous `

### DIFF
--- a/source/docs/training_manual/complete_analysis/analysis_exercise.rst
+++ b/source/docs/training_manual/complete_analysis/analysis_exercise.rst
@@ -558,7 +558,7 @@ you'll need to know the size of one of your existing rasters.
 
 #. Open the :guilabel:`Properties` dialog of any of the three existing rasters.
 #. Switch to the :guilabel:`Metadata` tab.
-#. Make a note of the :`guilabel:`X` and :guilabel:`Y` values under the heading
+#. Make a note of the :guilabel:`X` and :guilabel:`Y` values under the heading
    :guilabel:`Dimensions` in the Metadata table.
 #. Close the :guilabel:`Properties` dialog.
 #. Click on the :menuselection:`Raster --> Conversion --> Rasterize` menu item.


### PR DESCRIPTION
Line 561 : Superfluous ` disrupts format.
               ":`guilabel:`X`" should be ":guilabel:`X`"

### Description

Goal: Display correct format documentation

- [x] Backport to LTR documentation is required

### Minimal requirements for merging *(for maintainers)*

- [x] The description of this PR is coherent with the manual and does not provide wrong information.
- [x] This PR passes the checks. <!---The results will be reported by travis-ci **after** opening the PR.-->

