### PR TITLE
Do not discourage people from using SSL to access postgres

### DIFF
--- a/docs/user_manual/managing_data_source/opening_data.rst
+++ b/docs/user_manual/managing_data_source/opening_data.rst
@@ -770,18 +770,21 @@ For the other database types, see their differences at
 * :guilabel:`Port`: Port number the PostgreSQL database server listens on. The default
   port for PostGIS is ``5432``.
 * :guilabel:`Database`: Name of the database.
-* :guilabel:`SSL mode`: How the SSL connection will be negotiated with the server.
-  Note that massive speed-ups in PostGIS layer rendering can be achieved
-  by disabling SSL in the connection editor.
-  The following options may be available:
+* :guilabel:`SSL mode`: SSL encryption setup
+  The following options are available:
 
-  * :guilabel:`Disable`: Only try an unencrypted SSL connection;
-  * :guilabel:`Allow`: Try a non-SSL connection. If that fails, try an SSL connection;
-  * :guilabel:`Prefer` (the default): Try an SSL connection. If that fails, try a
-    non-SSL connection;
-  * :guilabel:`Require`: Only try an SSL connection.
-  * :guilabel:`verify_ca`:
-  * :guilabel:`verify_full`:
+  * :guilabel:`Prefer` (the default): I don't care about encryption, but I wish to pay
+    the overhead of encryption if the server supports it.
+  * :guilabel:`Require`: I want my data to be encrypted, and I accept the overhead. I trust
+    that the network will make sure I always connect to the server I want.
+  * :guilabel:`Verify CA`: I want my data encrypted, and I accept the overhead. I want to
+    be sure that I connect to a server that I trust.
+  * :guilabel:`Verify Full`: I want my data encrypted, and I accept the overhead. I want to
+    be sure that I connect to a server I trust, and that it's the one I specify.
+  * :guilabel:`Allow`: I don't care about security, but I will pay the overhead of
+    encryption if the server insists on it.
+  * :guilabel:`Disable`: I don't care about security, and I don't want to pay the overhead
+    of encryption.
 
 * :guilabel:`Authentication`, basic.
 


### PR DESCRIPTION
The overhead of SSL is that the initial handshake needs additional messages to be exchanged, resulting in more messages being sent around. After that it should be mostly negligible.
Since we use a connection pool for postgres connections the initial added overhead is just paid once on opening the datasource. When working on the datasource after, the pooled connections are used which have already performed the SSL handshake and therefore carry no additional performance penalty.
Since QGIS already sends several queries (e.g. checking postgis version etc.) to the server when loading a layer, these additional SSL handshake messages are compensated in no time.

We should stop encouraging people to disable SSL by promissing "massive speed-ups", because 1. using SSL for transferring data over networks is standard nowadays (for a good reason) and 2. the argument is not on a solid base.

This PR

* adds a note relating to SSL discussing the topic instead of spreading FUD
* copies the explanation of the SSL modes from the postgres documentation

See e.g. https://www.postgresql.org/message-id/556CCCC6.6030109%402ndquadrant.com