### PR TITLE
Isolate expressions tests in a group 

### DIFF
--- a/source/docs/documentation_guidelines/cookbook_guidelines.rst
+++ b/source/docs/documentation_guidelines/cookbook_guidelines.rst
@@ -135,35 +135,40 @@ in all testing groups, something normally usefull to use in the test setup::
 How to test snippets on your local machine
 ==========================================
 
-.. note:: instructions are valid for Linux system.
+.. note:: Instructions are valid for Linux system.
 
 To test Python code snippets, you need a *QGIS* installation. For this, there
-are many options:
+are many options. You can:
 
-* You can use your system *QGIS* installation with *Sphinx* from a Python virtual
+* Use your system *QGIS* installation with *Sphinx* from a Python virtual
   environment::
 
     make -f venv.mk doctest
 
-* You can use a manually built installation of *QGIS*, to do so, you need to
-  create a custom ``Makefile`` extension on top of the ``venv.mk`` file, for
-  example a ``user.mk`` file with the following content::
+* Use a manually built installation of *QGIS*. You'd need to:
 
-    # Root installation folder
-    QGIS_PREFIX_PATH = /home/user/apps/qgis-master
+  #. Create a custom ``Makefile`` extension on top of the :file:`venv.mk` file,
+     for example a :file:`user.mk` file with the following content::
 
-    # Or build output folder
-    QGIS_PREFIX_PATH = /home/user/dev/QGIS-build-master/output
+      # Root installation folder
+      QGIS_PREFIX_PATH = /home/user/apps/qgis-master
 
-    include venv.mk
+      include venv.mk
 
-  Then, use it to run target ``doctest``::
+     Or ::
 
-    make -f user.mk doctest
+      # build output folder
+      QGIS_PREFIX_PATH = /home/user/dev/QGIS-build-master/output
 
-* Or you can run target ``doctest`` inside the official *QGIS* docker image::
+      include venv.mk
+
+  #. Then, use it to run target ``doctest``::
+
+      make -f user.mk doctest
+
+* Run target ``doctest`` inside the official *QGIS* docker image::
 
     make -f docker.mk doctest
 
-  You have to install `Docker <https://www.docker.com/>`_ first because we will
-  use a docker image with QGIS in it.
+  You have to install `Docker <https://www.docker.com/>`_ first because this
+  uses a docker image with QGIS in it.

--- a/source/docs/pyqgis_developer_cookbook/expressions.rst
+++ b/source/docs/pyqgis_developer_cookbook/expressions.rst
@@ -4,7 +4,7 @@
 
 The code snippets on this page needs the following imports if you're outside the pyqgis console:
 
-.. testcode::
+.. testcode:: expr
 
    from qgis.core import (
       edit,
@@ -83,7 +83,7 @@ Parsing Expressions
 
 The following example shows how to check if a given expression can be parsed correctly:
 
-.. testcode::
+.. testcode:: expr
 
    exp = QgsExpression('1 + 1 = 2')
    assert(not exp.hasParserError())
@@ -109,7 +109,7 @@ Basic Expressions
 
 This basic expression evaluates to 1, meaning it is true: 
 
-.. testcode::
+.. testcode:: expr
 
    exp = QgsExpression('1 + 1 = 2')
    assert(exp.evaluate())
@@ -125,7 +125,7 @@ the feature's field values.
 The following example shows how to create a feature with a field called "Column" and how to add this
 feature to the expression context.
 
-.. testcode::
+.. testcode:: expr
 
    fields = QgsFields()
    field = QgsField('Column')
@@ -143,7 +143,7 @@ feature to the expression context.
 The following is a more complete example of how to use expressions in the context of a vector layer, in
 order to compute new field values:
 
-.. testcode::
+.. testcode:: expr
    
    from qgis.PyQt.QtCore import QVariant
    
@@ -198,9 +198,13 @@ order to compute new field values:
            f['Sum'] = expression2.evaluate(context)
            f['Fun'] = expression3.evaluate(context)
            vl.updateFeature(f)
-   
-.. testcleanup::
-   assert(f['Sum'] == 876.5)
+
+   print( f['Sum'])
+
+.. testoutput:: expr
+   :hide:
+
+   876.5
 
 
 Filtering a layer with expressions
@@ -209,7 +213,7 @@ Filtering a layer with expressions
 The following example can be used to filter a layer and return any feature that
 matches a predicate.
 
-.. testcode::
+.. testcode:: expr
 
    layer = QgsVectorLayer("Point?field=Test:integer",
                               "addfeat", "memory")
@@ -237,7 +241,7 @@ Handling expression errors
 
 Expression-related errors can occur during expression parsing or evaluation: 
 
-.. testcode::
+.. testcode:: expr
 
    exp = QgsExpression("1 + 1 = 2")
    if exp.hasParserError():


### PR DESCRIPTION
to avoid them changing results in other chapters.

This should fix the failures that from time to time occurred in the build. 
I won't insist anymore on this but we should decide whether we want to use the testing framework, hence make it mandatory for all codes (meaning that instructions and how-to are available, clear and explicit for everyone, we cover all the requirements of QGIS) or continue with old `.. code-block`, with unfortunately the limits it has but it'll spare build failure tracking time for some.
My choice would go for 1 but it's not an area I'm comfortable with...

<!---
If your PR fixes a ticket, add `fix` in front of the ticket number. The ticket will be closed automatically.
Add as much as needed `fix #number` if the PR closes more than one ticket.
If your PR doesn't fix entirely the ticket, just add the ticket reference.
The complete list of the issues is at https://github.com/qgis/QGIS-Documentation/issues.
-->
Ticket: #

<!---
Indicate whether the fix should be backported to previous release.
Replace the space between square brackets by a `x` to make it checked.
-->
- [x] Backport to LTR documentation is required

### Minimal requirements for merging *(for maintainers)*
<!---
Reviewing is a process done by community members, mostly on a volunteer basis.
We try to keep the overhead as small as possible and appreciate if you help us.
In order for your PR to get merged it should satisfy some minimal requirements:
--->

- [ ] The description of this PR is coherent with the manual and does not provide wrong information.
- [ ] This PR passes the checks. <!---The results will be reported by travis-ci **after** opening the PR.-->

<!---
Please read carefully our writing guidelines at https://docs.qgis.org/testing/en/docs/documentation_guidelines/index.html
to help you fulfill these requirements. Feel free to ask in a comment if you have troubles with any of them.
--->
