### PR TITLE
Place the GIS Intro and training manual at the first place in TOC

### DIFF
--- a/source/docs/index.rst
+++ b/source/docs/index.rst
@@ -10,10 +10,11 @@ Please have a look into one of the documents below.
 .. toctree::
    :maxdepth: 2
 
+   A Gentle Introduction to GIS <gentle_gis_introduction/index>
+   Training Manual <training_manual/index>
    User Guide/Manual (QGIS Testing) <user_manual/index>
    User Guide/Manual PDF's <https://docs.qgis.org/testing/pdf/>
    PyQGIS Cookbook (QGIS Testing) <pyqgis_developer_cookbook/index>
    Developers Guide <developers_guide/index>
    Documentation Guidelines <documentation_guidelines/index>
-   A Gentle Introduction to GIS <gentle_gis_introduction/index>
-   Training Manual <training_manual/index>
+


### PR DESCRIPTION
This makes them more discoverable and useful for beginners.
They don't necessarily know what they should read first, so that may help.
Advanced users would just skip and go to the manual they want.

We would end up with
![image](https://user-images.githubusercontent.com/7983394/60154185-c5e67d80-97e6-11e9-9dfc-39e8a850afec.png)

We'd need to reorganize https://www.qgis.org/en/docs/index.html also but I first wanted to know if it sounds good.

### Description
<!---
Include a few sentences describing the overall goals for this Pull Request.
--->
Goal:

<!---
If your PR fixes a ticket, add `fix` in front of the ticket number. The ticket will be closed automatically.
Add as much as needed `fix #number` if the PR closes more than one ticket.
If your PR doesn't fix entirely the ticket, just add the ticket reference.
The complete list of the issues is at https://github.com/qgis/QGIS-Documentation/issues.
-->
Ticket: #

<!---
Indicate whether the fix should be backported to previous release.
Replace the space between square brackets by a `x` to make it checked.
-->
- [x] Backport to LTR documentation is required

### Minimal requirements for merging *(for maintainers)*
<!---
Reviewing is a process done by community members, mostly on a volunteer basis.
We try to keep the overhead as small as possible and appreciate if you help us.
In order for your PR to get merged it should satisfy some minimal requirements:
--->

- [ ] The description of this PR is coherent with the manual and does not provide wrong information.
- [ ] This PR passes the checks. <!---The results will be reported by travis-ci **after** opening the PR.-->

<!---
Please read carefully our writing guidelines at https://docs.qgis.org/testing/en/docs/documentation_guidelines/index.html
to help you fulfill these requirements. Feel free to ask in a comment if you have troubles with any of them.
--->
