### PR TITLE
Typo's

### DIFF
--- a/source/docs/user_manual/processing_algs/gdal/vectormiscellaneous.rst
+++ b/source/docs/user_manual/processing_algs/gdal/vectormiscellaneous.rst
@@ -56,7 +56,7 @@ Outputs
 
 Export to PostgreSQL (available connections)
 --------------------------------------------
-Imports vector layers inside a PostgreSqL database on the basis of
+Imports vector layers inside a PostgreSQL database on the basis of
 an available connection. The connection has to :ref:`be defined properly
 <vector_create_stored_connection>` beforehand. Be aware that the checkboxes 'Save Username'
 and 'Save Password' are activated. Then you can use the algorithm.
@@ -248,8 +248,8 @@ Parameters
 
 Export to PostgreSQL (new connection)
 -------------------------------------
-Imports vector layers inside a PostGreSQL database. A new connection
-to the PostGIS database must be created.
+Imports vector layers inside a PostgreSQL database. A new connection
+to the PostgreSQL database must be created.
 
 This algorithm is derived from the `GDAL ogr2ogr utility <https://www.gdal.org/ogr2ogr.html>`_ .
 


### PR DESCRIPTION
line 59   :  "PostgreSqL"  should be "PostgreSQL"
line 251 : "PostGreSQL" should be "PostgreSQL"
line 252 : "PostGIS" should probably be "PostgreSQL"

### Description

Goal: Display correct documentation

- [x] Backport to LTR documentation is required

### Minimal requirements for merging *(for maintainers)*

- [x] The description of this PR is coherent with the manual and does not provide wrong information.
- [x] This PR passes the checks. <!---The results will be reported by travis-ci **after** opening the PR.-->
