### PR TITLE
Add QgsProcessingParameterColor

### DIFF
--- a/source/docs/user_manual/processing/console.rst
+++ b/source/docs/user_manual/processing/console.rst
@@ -455,6 +455,7 @@ input and output. Below is an alphabetically sorted list:
 
 * :class:`QgsProcessingParameterBand <qgis.core.QgsProcessingParameterBand>`
 * :class:`QgsProcessingParameterBoolean <qgis.core.QgsProcessingParameterBoolean>`
+* :class:`QgsProcessingParameterColor <qgis.core.QgsProcessingParameterColor>`
 * :class:`QgsProcessingParameterCrs <qgis.core.QgsProcessingParameterCrs>`
 * :class:`QgsProcessingParameterDistance <qgis.core.QgsProcessingParameterDistance>`
 * :class:`QgsProcessingParameterEnum <qgis.core.QgsProcessingParameterEnum>`

--- a/source/docs/user_manual/processing/scripts.rst
+++ b/source/docs/user_manual/processing/scripts.rst
@@ -420,6 +420,9 @@ Processing with their corresponding alg decorator constants
    * - :class:`QgsProcessingParameterBoolean <qgis.core.QgsProcessingParameterBoolean>`
      - ``alg.BOOL``
      - A boolean value
+   * - :class:`QgsProcessingParameterColor <qgis.core.QgsProcessingParameterColor>`
+     - Currently missing
+     - A color
    * - :class:`QgsProcessingParameterCrs <qgis.core.QgsProcessingParameterCrs>`
      - ``alg.CRS``
      - A Coordinate Reference System


### PR DESCRIPTION
Added QgsProcessingParameterColor (fixes #3925).

### Description
<!---
Include a few sentences describing the overall goals for this Pull Request.
--->
Goal:

<!---
If your PR fixes a ticket, add `fix` in front of the ticket number. The ticket will be closed automatically.
Add as much as needed `fix #number` if the PR closes more than one ticket.
If your PR doesn't fix entirely the ticket, just add the ticket reference.
The complete list of the issues is at https://github.com/qgis/QGIS-Documentation/issues.
-->
Ticket: #3925

<!---
Indicate whether the fix should be backported to previous release.
Replace the space between square brackets by a `x` to make it checked.
-->
- [ ] Backport to LTR documentation is required

### Minimal requirements for merging *(for maintainers)*
<!---
Reviewing is a process done by community members, mostly on a volunteer basis.
We try to keep the overhead as small as possible and appreciate if you help us.
In order for your PR to get merged it should satisfy some minimal requirements:
--->

- [ ] The description of this PR is coherent with the manual and does not provide wrong information.
- [ ] This PR passes the checks. <!---The results will be reported by travis-ci **after** opening the PR.-->

<!---
Please read carefully our writing guidelines at https://docs.qgis.org/testing/en/docs/documentation_guidelines/index.html
to help you fulfill these requirements. Feel free to ask in a comment if you have troubles with any of them.
--->
