### PR TITLE
Wrong menu mentioned ??

### DIFF
--- a/source/docs/user_manual/working_with_vector/vector_properties.rst
+++ b/source/docs/user_manual/working_with_vector/vector_properties.rst
@@ -144,7 +144,7 @@ MSSQL...) level.
 
 
 You can also open the :guilabel:`Query Builder` dialog using the :guilabel:`Filter...`
-option from the :menuselection:`View` menu or the layer contextual menu.
+option from the :menuselection:`Layer` menu or the layer contextual menu.
 The :guilabel:`Fields`, :guilabel:`Values` and :guilabel:`Operators` sections in
 the dialog help you to construct the SQL-like query exposed in the
 :guilabel:`Provider specific filter expression` box.


### PR DESCRIPTION
Line 147 :  states: "from the :menuselection:`View` menu" for the option 'Filter…"
however I can't find such an option in the View menu, but there is in the Layer menu.
Am I doing something wrong or should it indeed be "Layer menu"
(for what its worth: I'm on Win10 and QGIS 3.8)

### Description
<!---
Include a few sentences describing the overall goals for this Pull Request.
--->
Goal: Display corect documentation

- [x] Backport to LTR documentation is required

### Minimal requirements for merging *(for maintainers)*

- [x] The description of this PR is coherent with the manual and does not provide wrong information.
- [x] This PR passes the checks. <!---The results will be reported by travis-ci **after** opening the PR.-->

