### PR TITLE
Double wording "the

### DIFF
--- a/source/docs/user_manual/working_with_vector/vector_properties.rst
+++ b/source/docs/user_manual/working_with_vector/vector_properties.rst
@@ -797,7 +797,7 @@ features of the layer:
 * :guilabel:`Opacity` |slider|: You can make the underlying layer in
   the map canvas visible with this tool. Use the slider to adapt the visibility
   of your vector layer to your needs. You can also make a precise definition of
-  the percentage of visibility in the the menu beside the slider.
+  the percentage of visibility in the menu beside the slider.
 
 * :guilabel:`Blending mode` at the :guilabel:`Layer` and :guilabel:`Feature` levels:
   You can achieve special rendering effects with these tools that you may previously


### PR DESCRIPTION
Line 800 :  "in the the menu beside the slider." should be "in the menu beside the slider."

Double wording "the", removed one.

### Description

Goal:  Display correct documentation

- [x] Backport to LTR documentation is required

### Minimal requirements for merging *(for maintainers)*

- [x] The description of this PR is coherent with the manual and does not provide wrong information.
- [x] This PR passes the checks. <!---The results will be reported by travis-ci **after** opening the PR.-->
