### PR TITLE
Updates for QGIS version 3.4 and above

### DIFF
--- a/source/docs/pyqgis_developer_cookbook/authentication.rst
+++ b/source/docs/pyqgis_developer_cookbook/authentication.rst
@@ -95,12 +95,12 @@ understand the snippet.
 
 .. code-block:: python
 
-  authMgr = QgsAuthManager.instance()
+  authMgr = QgsApplication.authManager()
   # check if QgsAuthManager has been already initialized... a side effect
   # of the QgsAuthManager.init() is that AuthDbPath is set.
   # QgsAuthManager.init() is executed during QGIS application init and hence
   # you do not normally need to call it directly.
-  if authMgr.authenticationDbPath():
+  if authMgr.authenticationDatabasePath():
       # already initilised => we are inside a QGIS app.
       if authMgr.masterPasswordIsSet():
           msg = 'Authentication master password not recognized'
@@ -142,7 +142,7 @@ credentials for an hypothetic alice user:
 
 .. code-block:: python
 
-  authMgr = QgsAuthManager.instance()
+  authMgr = QgsApplication.authManager()
   # set alice PKI data
   p_config = QgsAuthMethodConfig()
   p_config.setName("alice")
@@ -185,7 +185,7 @@ Populate Authorities
 
 .. code-block:: python
 
-    authMgr = QgsAuthManager.instance()
+    authMgr = QgsApplication.authManager()
     # add authorities
     cacerts = QSslCertificate.fromPath( "/path/to/ca_chains.pem" )
     assert cacerts is not None
@@ -232,7 +232,7 @@ We can remove an entry from :term:`Authentication Database` using it's
 
 .. code-block:: python
 
-  authMgr = QgsAuthManager.instance()
+  authMgr = QgsApplication.authManager()
   authMgr.removeAuthenticationConfig( "authCfg_Id_to_remove" )
 
 .. _Leave_AuthCfg_expansion_to_QgsAuthManager:
@@ -260,7 +260,7 @@ enabled service like a WMS or WFS or to a DB connection.
 
   .. code-block:: python
 
-    In [19]: authM = QgsAuthManager.instance()
+    In [19]: authM = QgsApplication.authManager()
     In [20]: authM.authMethod("Identity-Cert").supportedDataProviders()
     Out[20]: [u'ows', u'wfs', u'wcs', u'wms', u'postgres']
 
@@ -271,7 +271,7 @@ URL like in the following snippet:
 .. code-block:: python
 
   authCfg = 'fm1s770'
-  quri = QgsDataSourceURI()
+  quri = QgsDataSourceUri()
   quri.setParam("layers", 'usa:states')
   quri.setParam("styles", '')
   quri.setParam("format", 'image/png')
@@ -281,7 +281,7 @@ URL like in the following snippet:
   quri.setParam("authcfg", authCfg)   # <---- here my authCfg url parameter
   quri.setParam("contextualWMSLegend", '0')
   quri.setParam("url", 'https://my_auth_enabled_server_ip/wms')
-  rlayer = QgsRasterLayer(quri.encodedUri(), 'states', 'wms')
+  rlayer = QgsRasterLayer(str(quri.encodedUri(), "utf-8"), 'states', 'wms')
 
 In the upper case, the ``wms`` provider will take care to expand ``authcfg``
 URI parameter with credential just before setting the HTTP connection.


### PR DESCRIPTION
I have provided a number of changes to allow the examples provide to work with QGIS version 3.4.7 and python 3. The use of str(quri.encodedUri(), "utf-8") appears to make line 284 functional but I remain unclear on which option is being recommended? The sole purpose of this documentation appears to be to show how to use the authentication manager but the comment below the example seems to imply uri(False) should be used instead. Trouble is that I get a "Download of capabilities failed: Protocol "" is unknown" if I use that version.

### Description
<!---
Include a few sentences describing the overall goals for this Pull Request.
--->
Goal:

<!---
If your PR fixes a ticket, add `fix` in front of the ticket number. The ticket will be closed automatically.
Add as much as needed `fix #number` if the PR closes more than one ticket.
If your PR doesn't fix entirely the ticket, just add the ticket reference.
The complete list of the issues is at https://github.com/qgis/QGIS-Documentation/issues.
-->
Ticket: #

<!---
Indicate whether the fix should be backported to previous release.
Replace the space between square brackets by a `x` to make it checked.
-->
- [x] Backport to LTR documentation is required

### Minimal requirements for merging *(for maintainers)*
<!---
Reviewing is a process done by community members, mostly on a volunteer basis.
We try to keep the overhead as small as possible and appreciate if you help us.
In order for your PR to get merged it should satisfy some minimal requirements:
--->

- [ ] The description of this PR is coherent with the manual and does not provide wrong information.
- [ ] This PR passes the checks. <!---The results will be reported by travis-ci **after** opening the PR.-->

<!---
Please read carefully our writing guidelines at https://docs.qgis.org/testing/en/docs/documentation_guidelines/index.html
to help you fulfill these requirements. Feel free to ask in a comment if you have troubles with any of them.
--->
