### PR TITLE
Indent code block to ease reading at first glance

### DIFF
--- a/source/docs/pyqgis_developer_cookbook/processing.rst
+++ b/source/docs/pyqgis_developer_cookbook/processing.rst
@@ -71,7 +71,7 @@ You can create a folder :file:`processing_provider` with three files in it:
 
 * :file:`provider.py` which will create the Processing provider and expose your algorithms.
 
-.. code-block:: python
+  .. code-block:: python
 
    from qgis.core import QgsProcessingProvider
 


### PR DESCRIPTION
The "processing provider" code block should be rendered aligned with the provider bullet point it belongs to. and not like it's currently https://docs.qgis.org/3.4/en/docs/pyqgis_developer_cookbook/processing.html

<!---
If your PR fixes a ticket, add `fix` in front of the ticket number. The ticket will be closed automatically.
Add as much as needed `fix #number` if the PR closes more than one ticket.
If your PR doesn't fix entirely the ticket, just add the ticket reference.
The complete list of the issues is at https://github.com/qgis/QGIS-Documentation/issues.
-->
Ticket: #

<!---
Indicate whether the fix should be backported to previous release.
Replace the space between square brackets by a `x` to make it checked.
-->
- [x] Backport to LTR documentation is required

### Minimal requirements for merging *(for maintainers)*
<!---
Reviewing is a process done by community members, mostly on a volunteer basis.
We try to keep the overhead as small as possible and appreciate if you help us.
In order for your PR to get merged it should satisfy some minimal requirements:
--->

- [ ] The description of this PR is coherent with the manual and does not provide wrong information.
- [ ] This PR passes the checks. <!---The results will be reported by travis-ci **after** opening the PR.-->

<!---
Please read carefully our writing guidelines at https://docs.qgis.org/testing/en/docs/documentation_guidelines/index.html
to help you fulfill these requirements. Feel free to ask in a comment if you have troubles with any of them.
--->
