### PR TITLE
Document the WMS GetMap TILED parameter

### DIFF
--- a/source/docs/user_manual/working_with_ogc/server/services.rst
+++ b/source/docs/user_manual/working_with_ogc/server/services.rst
@@ -143,6 +143,8 @@ parameters:
 |                |          | - USE_TITLE_AS_LAYERNAME:  if enabled, the title of the layer will      |
 |                |          |   be used as layer name.                                                |
 +----------------+----------+-------------------------------------------------------------------------+
+| TILED           | No      | Working in *tiled mode*                                                 |
++----------------+----------+-------------------------------------------------------------------------+
 
 |
 
@@ -164,6 +166,7 @@ URL example:
   &FORMAT=image/png
   &TRANSPARENT=TRUE
   &DPI=300
+  &TILED=TRUE
 
 
 SERVICE
@@ -520,6 +523,18 @@ As those features id's correspond in the source dataset to **France** and
   Server response to a GetMap request with SELECTION parameter
 
 
+TILED
+^^^^^
+
+(|38|)
+
+Set the ``TILED`` parameter to ``TRUE`` to tell QGIS Server to work in *tiled* mode, and to apply
+the *Tile buffer* configured in the QGIS project.
+
+When ``TILED`` is ``TRUE`` and when a non-zero Tile buffer is configured in the QGIS project,
+features outside the tile extent are drawn to avoid cut symbols at tile boundaries.
+
+``TILED`` defaults to ``FALSE``.
 
 .. _server_wms_getfeatureinfo:
 
@@ -1709,4 +1724,5 @@ Similarly, external layers can be used in GetPrint requests:
    please add it also to the substitutions.txt file in the
    source folder.
 
+.. |38| replace:: ``NEW in 3.8``
 .. |updatedisclaimer| replace:: :disclaimer:`Docs in progress for 'QGIS testing'. Visit https://docs.qgis.org/3.4 for QGIS 3.4 docs and translations.`


### PR DESCRIPTION
### Description
<!---
Include a few sentences describing the overall goals for this Pull Request.
--->
Goal: this PR documents the WMS GetMap "TILED" parameter that was introduced with https://github.com/qgis/QGIS/pull/30071.

<!---
If your PR fixes a ticket, add `fix` in front of the ticket number. The ticket will be closed automatically.
Add as much as needed `fix #number` if the PR closes more than one ticket.
If your PR doesn't fix entirely the ticket, just add the ticket reference.
The complete list of the issues is at https://github.com/qgis/QGIS-Documentation/issues.
-->

<!---
Indicate whether the fix should be backported to previous release.
Replace the space between square brackets by a `x` to make it checked.
-->
- [ ] Backport to LTR documentation is required

### Minimal requirements for merging *(for maintainers)*
<!---
Reviewing is a process done by community members, mostly on a volunteer basis.
We try to keep the overhead as small as possible and appreciate if you help us.
In order for your PR to get merged it should satisfy some minimal requirements:
--->

- [ ] The description of this PR is coherent with the manual and does not provide wrong information.
- [ ] This PR passes the checks. <!---The results will be reported by travis-ci **after** opening the PR.-->

<!---
Please read carefully our writing guidelines at https://docs.qgis.org/testing/en/docs/documentation_guidelines/index.html
to help you fulfill these requirements. Feel free to ask in a comment if you have troubles with any of them.
--->
