### PR TITLE
Tweak map theme description and fix link

### DIFF
--- a/source/docs/user_manual/introduction/general_tools.rst
+++ b/source/docs/user_manual/introduction/general_tools.rst
@@ -153,7 +153,8 @@ Use the :menuselection:`Remove Current Theme` button to delete the active theme.
 Map themes are helpful to switch quickly between different preconfigured
 combinations: select a map theme in the list to restore its combination.
 All configured themes are also accessible in the print layout, allowing you to
-create a map layout based on specific themes (see :ref:`layout_main_properties`).
+create different map items based on specific themes and independent of
+the current main canvas rendering (see :ref:`Map item layers <layout_layers`).
 
 
 Overview of the context menu of the Layers panel

--- a/source/docs/user_manual/introduction/general_tools.rst
+++ b/source/docs/user_manual/introduction/general_tools.rst
@@ -154,7 +154,7 @@ Map themes are helpful to switch quickly between different preconfigured
 combinations: select a map theme in the list to restore its combination.
 All configured themes are also accessible in the print layout, allowing you to
 create different map items based on specific themes and independent of
-the current main canvas rendering (see :ref:`Map item layers <layout_layers`).
+the current main canvas rendering (see :ref:`Map item layers <layout_layers>`).
 
 
 Overview of the context menu of the Layers panel

--- a/source/docs/user_manual/print_composer/composer_items/composer_map.rst
+++ b/source/docs/user_manual/print_composer/composer_items/composer_map.rst
@@ -54,6 +54,8 @@ In the :guilabel:`Main properties` group (see figure_layout_map_) of the map
   layout :ref:`annotations <sec_annotations>` that are placed on the main map
   canvas.
 
+.. _`layout_layers`:
+
 Layers
 ------
 


### PR DESCRIPTION
The map theme setting in layout map item was moved under another group and the link was not directly pointing to it.

<!---
If your PR fixes a ticket, add `fix` in front of the ticket number. The ticket will be closed automatically.
Add as much as needed `fix #number` if the PR closes more than one ticket.
If your PR doesn't fix entirely the ticket, just add the ticket reference.
The complete list of the issues is at https://github.com/qgis/QGIS-Documentation/issues.
-->
Ticket: #

<!---
Indicate whether the fix should be backported to previous release.
Replace the space between square brackets by a `x` to make it checked.
-->
- [x] Backport to LTR documentation is required

### Minimal requirements for merging *(for maintainers)*
<!---
Reviewing is a process done by community members, mostly on a volunteer basis.
We try to keep the overhead as small as possible and appreciate if you help us.
In order for your PR to get merged it should satisfy some minimal requirements:
--->

- [ ] The description of this PR is coherent with the manual and does not provide wrong information.
- [ ] This PR passes the checks. <!---The results will be reported by travis-ci **after** opening the PR.-->

<!---
Please read carefully our writing guidelines at https://docs.qgis.org/testing/en/docs/documentation_guidelines/index.html
to help you fulfill these requirements. Feel free to ask in a comment if you have troubles with any of them.
--->
