### PR TITLE
[3.4] Move the geoJSON parameters section to supported data 

### DIFF
--- a/source/docs/user_manual/managing_data_source/create_layers.rst
+++ b/source/docs/user_manual/managing_data_source/create_layers.rst
@@ -343,22 +343,6 @@ decide whether to:
 
 For formats like ESRI Shapefile, MapInfo .tab, feature append is also available.
 
-.. index:: GeoJSON Export
-.. _export_geojson_files:
-
-GeoJSON specific parameters
----------------------------
-
-GeoJSON has some specific :guilabel:`Layer Options` available. These options
-actually come from GDAL which is responsible for the writing of the file.
-
-* :guilabel:`COORDINATE_PRECISION` the maximum number of digits after the
-  decimal separator to write in coordinates. Defaults to 15 (note: for Lat Lon
-  coordinates 6 is considered enough). Truncation will occur to remove
-  trailing zeros.
-* :guilabel:`WRITE_BBOX` set to YES to write a bbox property with the bounding
-  box of the geometries at the feature and feature collection level
-
 .. index:: DXF Export
 .. _create_dxf_files:
 

--- a/source/docs/user_manual/managing_data_source/supported_data.rst
+++ b/source/docs/user_manual/managing_data_source/supported_data.rst
@@ -533,6 +533,22 @@ If you want to create a new SpatiaLite layer, please refer to section
  recommended). If necessary, they can be downloaded and installed with the
  Plugin Installer.
 
+.. index:: GeoJSON Export
+.. _export_geojson_files:
+
+GeoJSON specific parameters
+---------------------------
+
+GeoJSON has some specific :guilabel:`Layer Options` available. These options
+actually come from GDAL which is responsible for the writing of the file.
+
+* :guilabel:`COORDINATE_PRECISION` the maximum number of digits after the
+  decimal separator to write in coordinates. Defaults to 15 (note: for Lat Lon
+  coordinates 6 is considered enough). Truncation will occur to remove
+  trailing zeros.
+* :guilabel:`WRITE_BBOX` set to YES to write a bbox property with the bounding
+  box of the geometries at the feature and feature collection level
+
 .. index:: DB2 Spatial
 .. _label_db2_spatial:
 

--- a/source/docs/user_manual/managing_data_source/supported_data.rst
+++ b/source/docs/user_manual/managing_data_source/supported_data.rst
@@ -539,8 +539,9 @@ If you want to create a new SpatiaLite layer, please refer to section
 GeoJSON specific parameters
 ---------------------------
 
-GeoJSON has some specific :guilabel:`Layer Options` available. These options
-actually come from GDAL which is responsible for the writing of the file.
+When :ref:`exporting layers <general_saveas>` to GeoJSON, this format has
+some specific :guilabel:`Layer Options` available. These options
+actually come from GDAL which is responsible for the writing of the file:
 
 * :guilabel:`COORDINATE_PRECISION` the maximum number of digits after the
   decimal separator to write in coordinates. Defaults to 15 (note: for Lat Lon


### PR DESCRIPTION
Backports idea of #4009

<!---
If your PR fixes a ticket, add `fix` in front of the ticket number. The ticket will be closed automatically.
Add as much as needed `fix #number` if the PR closes more than one ticket.
If your PR doesn't fix entirely the ticket, just add the ticket reference.
The complete list of the issues is at https://github.com/qgis/QGIS-Documentation/issues.
-->
Ticket: #

<!---
Indicate whether the fix should be backported to previous release.
Replace the space between square brackets by a `x` to make it checked.
-->
- [ ] Backport to LTR documentation is required

### Minimal requirements for merging *(for maintainers)*
<!---
Reviewing is a process done by community members, mostly on a volunteer basis.
We try to keep the overhead as small as possible and appreciate if you help us.
In order for your PR to get merged it should satisfy some minimal requirements:
--->

- [ ] The description of this PR is coherent with the manual and does not provide wrong information.
- [ ] This PR passes the checks. <!---The results will be reported by travis-ci **after** opening the PR.-->

<!---
Please read carefully our writing guidelines at https://docs.qgis.org/testing/en/docs/documentation_guidelines/index.html
to help you fulfill these requirements. Feel free to ask in a comment if you have troubles with any of them.
--->
