### PR TITLE
Missing colon before :class:

### DIFF
--- a/source/docs/pyqgis_developer_cookbook/raster.rst
+++ b/source/docs/pyqgis_developer_cookbook/raster.rst
@@ -108,7 +108,7 @@ Single Band Rasters
 Let's say we want a render single band raster layer with colors ranging from
 green to yellow (corresponding to pixel values from 0 to 255).
 In the first stage we will prepare a
-class:`QgsRasterShader <qgis.core.QgsRasterShader>` object and configure
+:class:`QgsRasterShader <qgis.core.QgsRasterShader>` object and configure
 its shader function:
 
 .. code-block:: python


### PR DESCRIPTION
Line 111 : There seems to be a colon missing before "class:".  Added.

### Description

Goal: Display correct documentation

- [x] Backport to LTR documentation is required

### Minimal requirements for merging *(for maintainers)*

- [x] The description of this PR is coherent with the manual and does not provide wrong information.
- [x] This PR passes the checks. <!---The results will be reported by travis-ci **after** opening the PR.-->
