### PR TITLE
Remove hyperlink on QgsMapServiceException class

### DIFF
--- a/source/docs/pyqgis_developer_cookbook/server.rst
+++ b/source/docs/pyqgis_developer_cookbook/server.rst
@@ -124,7 +124,7 @@ Raising exception from a plugin
 Some work has still to be done on this topic: the current implementation can
 distinguish between handled and unhandled exceptions by setting a
 :class:`QgsRequestHandler <qgis.server.QgsRequestHandler>` property to an
-instance of :class:`QgsMapServiceException <qgis.server.QgsMapServiceException>`,
+instance of QgsMapServiceException,
 this way the main C++ code can catch handled python exceptions and ignore
 unhandled exceptions (or better: log them).
 


### PR DESCRIPTION
Documentation build is broken because QgsMapServiceException is not accessible in master (I can find it in [3.8 pyqgis doc](https://qgis.org/pyqgis/3.8/server/QgsMapServiceException.html) but not in [master'](https://qgis.org/pyqgis/master/search.html?q=QgsMapServiceException&check_keywords=yes&area=default)
I don't know whether it's a bug in pyqgis doc, whether the class has been removed in master, hence description would be out of date(?) or... maybe @elpaso you know better.

This PR intention is to simply fix the build and avoid wrong warning on other PRs.

<!---
Indicate whether the fix should be backported to previous release.
Replace the space between square brackets by a `x` to make it checked.
-->
- [ ] Backport to LTR documentation is required

### Minimal requirements for merging *(for maintainers)*
<!---
Reviewing is a process done by community members, mostly on a volunteer basis.
We try to keep the overhead as small as possible and appreciate if you help us.
In order for your PR to get merged it should satisfy some minimal requirements:
--->

- [ ] The description of this PR is coherent with the manual and does not provide wrong information.
- [ ] This PR passes the checks. <!---The results will be reported by travis-ci **after** opening the PR.-->

<!---
Please read carefully our writing guidelines at https://docs.qgis.org/testing/en/docs/documentation_guidelines/index.html
to help you fulfill these requirements. Feel free to ask in a comment if you have troubles with any of them.
--->
