### PR TITLE
Add spacing between the two alg decorators tables

### DIFF
--- a/source/docs/user_manual/processing/scripts.rst
+++ b/source/docs/user_manual/processing/scripts.rst
@@ -506,6 +506,8 @@ Sorted on class name.
      - :class:`QgsProcessingParameterVectorDestination <qgis.core.QgsProcessingParameterVectorDestination>`
      - A vector layer
 
+|
+
 .. list-table:: Output types
    :widths: 50 20 30
    :header-rows: 1


### PR DESCRIPTION
near https://docs.qgis.org/testing/en/docs/user_manual/processing/scripts.html#id2

<!---
If your PR fixes a ticket, add `fix` in front of the ticket number. The ticket will be closed automatically.
Add as much as needed `fix #number` if the PR closes more than one ticket.
If your PR doesn't fix entirely the ticket, just add the ticket reference.
The complete list of the issues is at https://github.com/qgis/QGIS-Documentation/issues.
-->
Ticket: #

<!---
Indicate whether the fix should be backported to previous release.
Replace the space between square brackets by a `x` to make it checked.
-->
- [ ] Backport to LTR documentation is required

### Minimal requirements for merging *(for maintainers)*
<!---
Reviewing is a process done by community members, mostly on a volunteer basis.
We try to keep the overhead as small as possible and appreciate if you help us.
In order for your PR to get merged it should satisfy some minimal requirements:
--->

- [ ] The description of this PR is coherent with the manual and does not provide wrong information.
- [ ] This PR passes the checks. <!---The results will be reported by travis-ci **after** opening the PR.-->

<!---
Please read carefully our writing guidelines at https://docs.qgis.org/testing/en/docs/documentation_guidelines/index.html
to help you fulfill these requirements. Feel free to ask in a comment if you have troubles with any of them.
--->
