### PR TITLE
Fixing "Add cell size parameter to native interpolation algorithms"

### DIFF
--- a/source/docs/user_manual/processing_algs/qgis/interpolation.rst
+++ b/source/docs/user_manual/processing_algs/qgis/interpolation.rst
@@ -48,6 +48,18 @@ Parameters
   double the number of columns and the cell sizes will also be halved.
   The extent of the output raster will remain the same.
 
+  ``Number of rows`` [number]
+    Total number of rows of the output raster layer.
+
+  ``Number of columns`` [number]
+    Total number of columns of the output raster layer.
+
+  ``Pixel Size X`` [number]
+    Horizontal resolution of each pixel in output raster, in layer units.
+
+  ``Pixel Size Y`` [number]
+    Vertical resolution of each pixel in output raster, in layer units.
+
 ``Radius from field`` [tablefield: numeric]
   Optional
 
@@ -213,20 +225,29 @@ Parameters
 
   Default: *2.0*
 
-``Number of columns`` [number]
-  Total number of columns of the output raster layer.
-
-  Default: *300*
-
-``Number of rows`` [number]
-  Total number of rows of the output raster layer.
-
-  Default: *300*
-
 ``Extent (xmin, xmax, ymin, ymax)`` [extent]
   Extent of the output raster layer. You have to declare the output extent by
   either choosing it from the map canvas, selecting it from another layer or type
   it manually.
+
+``Output raster size`` [number]
+  Allows to set the size of the interpolated output raster layer by specifying the rows and columns
+  **or** the X and Y pixel size.
+
+  Increasing the number of rows or columns will decrease the cell size. Similarly, the values in ``Rows`` and
+  ``Columns`` will be updated when one of them are changed.
+
+  ``Number of rows`` [number]
+    Total number of rows of the output raster layer.
+
+  ``Number of columns`` [number]
+    Total number of columns of the output raster layer.
+
+  ``Pixel Size X`` [number]
+    Horizontal resolution of each pixel in output raster, in layer units.
+
+  ``Pixel Size Y`` [number]
+    Vertical resolution of each pixel in output raster, in layer units.
 
 Outputs
 .......
@@ -271,22 +292,29 @@ Parameters
   * 0 --- Linear
   * 1 --- Clough-Toucher (cubic)
 
-  Default: *0*
-
-``Number of columns`` [number]
-  Total number of columns of the output raster layer.
-
-  Default: *300*
-
-``Number of rows`` [number]
-  Total number of rows of the output raster layer.
-
-  Default: *300*
-
 ``Extent (xmin, xmax, ymin, ymax)`` [extent]
   Extent of the output raster layer. You have to declare the output extent by
   either choosing it from the map canvas, selecting it from another layer or type
   it manually.
+
+``Output raster size`` [number]
+  Allows to set the size of the interpolated output raster layer by specifying the rows and columns
+  **or** the X and Y pixel size.
+
+  Increasing the number of rows or columns will decrease the cell size. Similarly, the values in ``Rows`` and
+  ``Columns`` will be updated when one of them are changed.
+
+  ``Number of rows`` [number]
+    Total number of rows of the output raster layer.
+
+  ``Number of columns`` [number]
+    Total number of columns of the output raster layer.
+
+  ``Pixel Size X`` [number]
+    Horizontal resolution of each pixel in output raster, in layer units.
+
+  ``Pixel Size Y`` [number]
+    Vertical resolution of each pixel in output raster, in layer units.
 
 Outputs
 .......


### PR DESCRIPTION
### Description
<!---
Include a few sentences describing the overall goals for this Pull Request.
--->
Goal:
Adding parameters Size X and Size Y for interpolations algs. Also, reordering extent, rows and columns to align with the order in dialogs. 
Ticket: Fix #3286

- [x ] Backport to LTR documentation is required

### Minimal requirements for merging *(for maintainers)*
<!---
Reviewing is a process done by community members, mostly on a volunteer basis.
We try to keep the overhead as small as possible and appreciate if you help us.
In order for your PR to get merged it should satisfy some minimal requirements:
--->

- [ x] The description of this PR is coherent with the manual and does not provide wrong information.
- [ x] This PR passes the checks. <!---The results will be reported by travis-ci **after** opening the PR.-->

<!---
Please read carefully our writing guidelines at https://docs.qgis.org/testing/en/docs/documentation_guidelines/index.html
to help you fulfill these requirements. Feel free to ask in a comment if you have troubles with any of them.
--->
