### PR TITLE
Remove unavailable document links

### DIFF
--- a/readme.rst
+++ b/readme.rst
@@ -24,10 +24,7 @@ Previous releases are also available:
 
 - QGIS 2.18 docs http://docs.qgis.org/2.18 and http://docs.qgis.org/2.18/pdf/
 - QGIS 2.14 docs http://docs.qgis.org/2.14 and http://docs.qgis.org/2.14/pdf/
-- QGIS 2.6 docs http://docs.qgis.org/2.6 and http://docs.qgis.org/2.6/pdf/
-- QGIS 2.2 docs http://docs.qgis.org/2.2 and http://docs.qgis.org/2.2/pdf/
-- QGIS 2.0 docs http://docs.qgis.org/2.0 and http://docs.qgis.org/2.0/pdf/
-- QGIS 1.8 docs http://docs.qgis.org/1.8 and http://docs.qgis.org/1.8/pdf/
+- QGIS 2.8 docs http://docs.qgis.org/2.8 and http://docs.qgis.org/2.8/pdf/
 
 Translations of released docs are also available via the docs.qgis.org language path:
 for example for the 3.4 German language: http://docs.qgis.org/3.4/de.

--- a/readme.rst
+++ b/readme.rst
@@ -13,21 +13,25 @@ Introduction
 This repository is meant to write and manage the Official Documentation of
 `QGIS <https://qgis.org>`_, an Open Source GIS Software.
 
-Latest stable documentation is on http://docs.qgis.org/3.4 and its PDF versions
-are available at http://docs.qgis.org/3.4/pdf.
+Latest stable documentation is on https://docs.qgis.org/3.4 and its PDF versions
+are available at https://docs.qgis.org/3.4/pdf.
 
 The ongoing work for future releases is published as QGIS Testing Documentation.
 It's built from the ``master`` branch and NOT translated. QGIS Testing Documentation
-is on http://docs.qgis.org/testing and http://docs.qgis.org/testing/pdf/
+is on https://docs.qgis.org/testing and https://docs.qgis.org/testing/pdf/
 
 Previous releases are also available:
 
-- QGIS 2.18 docs http://docs.qgis.org/2.18 and http://docs.qgis.org/2.18/pdf/
-- QGIS 2.14 docs http://docs.qgis.org/2.14 and http://docs.qgis.org/2.14/pdf/
-- QGIS 2.8 docs http://docs.qgis.org/2.8 and http://docs.qgis.org/2.8/pdf/
+- QGIS 2.18 docs https://docs.qgis.org/2.18 and https://docs.qgis.org/2.18/pdf/
+- QGIS 2.14 docs https://docs.qgis.org/2.14 and https://docs.qgis.org/2.14/pdf/
+- QGIS 2.8 docs https://docs.qgis.org/2.8 and https://docs.qgis.org/2.8/pdf/
+- QGIS 2.6 docs https://docs.qgis.org/QGIS-Documentation-2.6/live/html/en/docs/index.html
+- QGIS 2.2 docs https://docs.qgis.org/QGIS-Documentation-2.2/live/html/en/docs/index.html	
+- QGIS 2.0 docs https://docs.qgis.org/QGIS-Documentation-2.0/live/html/en/docs/index.html	
+- QGIS 1.8 docs https://docs.qgis.org/QGIS-Documentation-1.8/live/html/en/docs/index.html
 
 Translations of released docs are also available via the docs.qgis.org language path:
-for example for the 3.4 German language: http://docs.qgis.org/3.4/de.
+for example for the 3.4 German language: https://docs.qgis.org/3.4/de.
 Note that only the current stable branch is available for translation.
 
 Documentation is static generated website using Sphinx (http://sphinx-doc.org/),


### PR DESCRIPTION
none of these links is working
@rduivenvoorde are these docs removed (i can see they are not listed at https://docs.qgis.org and I'm fine with that) but thought the link would still work (eg because they are listed in the readme file)

### Description
<!---
Include a few sentences describing the overall goals for this Pull Request.
--->
Goal:

<!---
If your PR fixes a ticket, add `fix` in front of the ticket number. The ticket will be closed automatically.
Add as much as needed `fix #number` if the PR closes more than one ticket.
If your PR doesn't fix entirely the ticket, just add the ticket reference.
The complete list of the issues is at https://github.com/qgis/QGIS-Documentation/issues.
-->
Ticket: #

<!---
Indicate whether the fix should be backported to previous release.
Replace the space between square brackets by a `x` to make it checked.
-->
- [ ] Backport to LTR documentation is required

### Minimal requirements for merging *(for maintainers)*
<!---
Reviewing is a process done by community members, mostly on a volunteer basis.
We try to keep the overhead as small as possible and appreciate if you help us.
In order for your PR to get merged it should satisfy some minimal requirements:
--->

- [ ] The description of this PR is coherent with the manual and does not provide wrong information.
- [ ] This PR passes the checks. <!---The results will be reported by travis-ci **after** opening the PR.-->

<!---
Please read carefully our writing guidelines at https://docs.qgis.org/testing/en/docs/documentation_guidelines/index.html
to help you fulfill these requirements. Feel free to ask in a comment if you have troubles with any of them.
--->
