### PR TITLE
Fix page link generation for Transifex

### DIFF
--- a/themes/qgis-theme/languageswitch.html
+++ b/themes/qgis-theme/languageswitch.html
@@ -64,7 +64,7 @@
         // TODO: all template pages have the actual translation in sphinc.conf
         // documentation master only github links
         fix_translation_link = 'https://www.transifex.com/projects/p/qgis-documentation/translate/#' + 
-            currentLang.slice(1) + currentPage.replace(/\//g, "_").replace(/-/g, "_").replace(/\.html/g, "")
+            currentLang.slice(1) + currentPage.replace(/_/g, "-").replace(/\//g, "_").replace(/\.html/g, "")
         if ('/en/' != currentLang) {
             $('#fix_translation_link').attr('href', fix_translation_link);
         }


### PR DESCRIPTION
Now you get the right doc but not the right page
Eg `fr/docs/user_manual/introduction/general_tools.html` page currently returns `#fr/docs_user_manual_introduction_general_tools` (all underscored) while Transifex expects `#fr/docs_user-manual_introduction_general-tools` (underscore replaced with hyphen)

### Description
<!---
Include a few sentences describing the overall goals for this Pull Request.
--->
Goal:

<!---
If your PR fixes a ticket, add `fix` in front of the ticket number. The ticket will be closed automatically.
Add as much as needed `fix #number` if the PR closes more than one ticket.
If your PR doesn't fix entirely the ticket, just add the ticket reference.
The complete list of the issues is at https://github.com/qgis/QGIS-Documentation/issues.
-->
Ticket: #

<!---
Indicate whether the fix should be backported to previous release.
Replace the space between square brackets by a `x` to make it checked.
-->
- [ ] Backport to LTR documentation is required

### Minimal requirements for merging *(for maintainers)*
<!---
Reviewing is a process done by community members, mostly on a volunteer basis.
We try to keep the overhead as small as possible and appreciate if you help us.
In order for your PR to get merged it should satisfy some minimal requirements:
--->

- [ ] The description of this PR is coherent with the manual and does not provide wrong information.
- [ ] This PR passes the checks. <!---The results will be reported by travis-ci **after** opening the PR.-->

<!---
Please read carefully our writing guidelines at https://docs.qgis.org/testing/en/docs/documentation_guidelines/index.html
to help you fulfill these requirements. Feel free to ask in a comment if you have troubles with any of them.
--->
