### PR TITLE
Add links between "select by" and "extract by" algorithms (#4181)

### DIFF
--- a/source/docs/user_manual/processing_algs/qgis/vectorselection.rst
+++ b/source/docs/user_manual/processing_algs/qgis/vectorselection.rst
@@ -61,6 +61,10 @@ Outputs
 ``Extracted (non-matching)`` [vector: any]
   Vector layer with not matching features.
 
+See also
+........
+:ref:`qgisselectbyattribute`
+
 
 .. _qgisextractbyexpression:
 
@@ -90,6 +94,10 @@ Outputs
 
 ``Non-matching`` [vector: any]
   Vector layer with not matching features.
+
+See also
+........
+:ref:`qgisselectbyexpression`
 
 
 .. _qgisextractbylocation:
@@ -133,6 +141,10 @@ Outputs
 ``Extracted (location)`` [vector: any]
   Vector layer of the spatial intersection.
 
+See also
+........
+:ref:`qgisselectbylocation`
+
 
 .. _qgisrandomextract:
 
@@ -168,6 +180,10 @@ Outputs
 
 ``Extracted (random)`` [vector: any]
   Vector layer containing random selected features.
+
+See also
+........
+:ref:`qgisrandomselection`
 
 
 .. _qgisrandomextractwithinsubsets:
@@ -210,6 +226,10 @@ Outputs
 ``Extracted (random stratified)`` [vector: any]
   Vector layer containing random selected features.
 
+See also
+........
+:ref:`qgisrandomselectionwithinsubsets`
+
 
 .. _qgisrandomselection:
 
@@ -241,6 +261,10 @@ Parameters
   Number or percentage of features to select.
 
   Default: *10*
+
+See also
+........
+:ref:`qgisrandomextract`
 
 
 .. _qgisrandomselectionwithinsubsets:
@@ -284,6 +308,10 @@ Parameters
   Number or percentage of features to select.
 
   Default: *10*
+
+See also
+........
+:ref:`qgisrandomextractwithinsubsets`
 
 
 .. _qgisselectbyattribute:
@@ -338,6 +366,11 @@ Parameters
 
   Default: *0*
 
+See also
+........
+:ref:`qgisextractbyattribute`
+
+
 .. _qgisselectbyexpression:
 
 Select by expression
@@ -366,6 +399,10 @@ Parameters
   * 3 --- removing from current selection
 
   Default: *0*
+
+See also
+........
+:ref:`qgisextractbyexpression`
 
 
 .. _qgisselectbylocation:
@@ -414,3 +451,8 @@ Parameters
   * 3 --- removing from current selection
 
   Default: *0*
+
+See also
+........
+:ref:`qgisextractbylocation`
+


### PR DESCRIPTION
showing that each "extract by..." algorithm has its "select by..." alter ego (backports #4181)

<!---
If your PR fixes a ticket, add `fix` in front of the ticket number. The ticket will be closed automatically.
Add as much as needed `fix #number` if the PR closes more than one ticket.
If your PR doesn't fix entirely the ticket, just add the ticket reference.
The complete list of the issues is at https://github.com/qgis/QGIS-Documentation/issues.
-->
Ticket: #

<!---
Indicate whether the fix should be backported to previous release.
Replace the space between square brackets by a `x` to make it checked.
-->
- [ ] Backport to LTR documentation is required

### Minimal requirements for merging *(for maintainers)*
<!---
Reviewing is a process done by community members, mostly on a volunteer basis.
We try to keep the overhead as small as possible and appreciate if you help us.
In order for your PR to get merged it should satisfy some minimal requirements:
--->

- [ ] The description of this PR is coherent with the manual and does not provide wrong information.
- [ ] This PR passes the checks. <!---The results will be reported by travis-ci **after** opening the PR.-->

<!---
Please read carefully our writing guidelines at https://docs.qgis.org/testing/en/docs/documentation_guidelines/index.html
to help you fulfill these requirements. Feel free to ask in a comment if you have troubles with any of them.
--->
