### PR TITLE
Let's put some love into our PDF documentation

### DIFF
--- a/source/docs/user_manual/introduction/general_tools.rst
+++ b/source/docs/user_manual/introduction/general_tools.rst
@@ -165,6 +165,8 @@ frame listing vector or raster layers added to the project, optionally
 organized in groups. Depending on the item selected in the panel, a
 right-click shows a dedicated set of options presented below.
 
+.. tabularcolumns:: |l|c|c|c|
+
 =================================================================  ==================  =================  =============
 Option                                                             Vector Layer        Raster Layer       Group
 =================================================================  ==================  =================  =============
@@ -471,6 +473,8 @@ on any vector layer. This panel allows you to select:
 * the statistics to return using the drop-down button at the bottom-right of the
   dialog. Depending on the field's (or expression's values) type, available
   statistics are:
+
+.. tabularcolumns:: |l|c|c|c|c|
 
 ================================== ============ ============  ============  ============
  Statistics                         String       Integer       Float         Date
@@ -1324,6 +1328,8 @@ automatically filling the search box with existing values.
 Alongside each field, there is a drop-down list with options to
 control the search behaviour:
 
+.. tabularcolumns:: |l|c|c|c|
+
 ============================================= ============ ============  ============
  Field search option                           String       Numeric       Date
 ============================================= ============ ============  ============
@@ -1344,7 +1350,9 @@ control the search behaviour:
  :guilabel:`Ends with`                         |checkbox|
 ============================================= ============ ============  ============
 
-|
+.. only:: html
+
+   |
 
 For string comparisons, it is also possible to use the |checkbox|
 :guilabel:`Case sensitive` option.

--- a/source/docs/user_manual/introduction/qgis_gui.rst
+++ b/source/docs/user_manual/introduction/qgis_gui.rst
@@ -85,34 +85,36 @@ the :ref:`project file <sec_projects>`. It provides you with tools to:
   use a :ref:`print layout <label_printlayout>` for more complex output
 * Set the project properties and the snapping options when editing layers.
 
-=======================================================  ====================  =========================  ===============================
-Menu Option                                              Shortcut              Toolbar                    Reference
-=======================================================  ====================  =========================  ===============================
-|fileNew| :guilabel:`New`                                :kbd:`Ctrl+N`         :guilabel:`Project`        :ref:`sec_projects`
-:menuselection:`New from template -->`                   \                     \                          :ref:`sec_projects`
-|fileOpen| :guilabel:`Open...`                           :kbd:`Ctrl+O`         :guilabel:`Project`        :ref:`sec_projects`
-:menuselection:`Open from --> PostgreSQL`                \                     \                          :ref:`sec_projects`
-:menuselection:`Open Recent -->`                         \                     \                          :ref:`sec_projects`
-:guilabel:`Close`                                        \                     \                          :ref:`sec_projects`
-|fileSave| :guilabel:`Save`                              :kbd:`Ctrl+S`         :guilabel:`Project`        :ref:`sec_projects`
-|fileSaveAs| :guilabel:`Save As...`                      :kbd:`Ctrl+Shift+S`   :guilabel:`Project`        :ref:`sec_projects`
-:menuselection:`Save to --> PostgreSQL`                  \                     \                          :ref:`sec_projects`
-:guilabel:`Revert...`                                    \                     \                          \
-:guilabel:`Properties...`                                :kbd:`Ctrl+Shift+P`   \                          :ref:`project_properties`
-:guilabel:`Snapping Options...`                          \                     \                          :ref:`snapping_tolerance`
-:menuselection:`Import/Export -->`                       \                     \                          \
-|saveMapAsImage| :guilabel:`Export Map to Image...`      \                     \                          :ref:`sec_output`
-|saveAsPDF| :guilabel:`Export Map to PDF...`             \                     \                          :ref:`sec_output`
-:guilabel:`Export Project to DXF...`                     \                     \                          :ref:`sec_output`
-:guilabel:`Import Layers from DWG/DXF...`                \                     \                          :ref:`import_dxfdwg`
-|newLayout| :guilabel:`New Print Layout...`              :kbd:`Ctrl+P`         :guilabel:`Project`        :ref:`label_printlayout`
-|newReport| :guilabel:`New Report...`                    \                     \                          :ref:`label_printlayout`
-|layoutManager| :guilabel:`Layout Manager...`            \                     :guilabel:`Project`        :ref:`label_printlayout`
-:menuselection:`Layouts -->`                             \                     \                          :ref:`label_printlayout`
-|fileExit| :guilabel:`Exit QGIS`                         :kbd:`Ctrl+Q`         \                          \
-=======================================================  ====================  =========================  ===============================
+.. csv-table::
+   :header: "Menu Option", "Shortcut", "Toolbar", "Reference"
+   :widths: auto
 
-|
+   "|fileNew| :guilabel:`New`", ":kbd:`Ctrl+N`", ":guilabel:`Project`", ":ref:`sec_projects`"
+   ":menuselection:`New from template -->`", "", "", ":ref:`sec_projects`"
+   "|fileOpen| :guilabel:`Open...`", ":kbd:`Ctrl+O`", ":guilabel:`Project`", ":ref:`sec_projects`"
+   ":menuselection:`Open from --> PostgreSQL`", "", "", ":ref:`sec_projects`"
+   ":menuselection:`Open Recent -->`", "", "", ":ref:`sec_projects`"
+   ":guilabel:`Close`", "", "", ":ref:`sec_projects`"
+   "|fileSave| :guilabel:`Save`", ":kbd:`Ctrl+S`", ":guilabel:`Project`", ":ref:`sec_projects`"
+   "|fileSaveAs| :guilabel:`Save As...`", ":kbd:`Ctrl+Shift+S`", ":guilabel:`Project`", ":ref:`sec_projects`"
+   ":menuselection:`Save to --> PostgreSQL`", "", "", ":ref:`sec_projects`"
+   ":guilabel:`Revert...`"
+   ":guilabel:`Properties...`", ":kbd:`Ctrl+Shift+P`", "", ":ref:`project_properties`"
+   ":guilabel:`Snapping Options...`", "", "", ":ref:`snapping_tolerance`"
+   ":menuselection:`Import/Export -->`"
+   "|saveMapAsImage| :guilabel:`Export Map to Image...`", "", "", ":ref:`sec_output`"
+   "|saveAsPDF| :guilabel:`Export Map to PDF...`", "", "", ":ref:`sec_output`"
+   ":guilabel:`Export Project to DXF...`", "", "", ":ref:`sec_output`"
+   ":guilabel:`Import Layers from DWG/DXF...`", "", "", ":ref:`import_dxfdwg`"
+   "|newLayout| :guilabel:`New Print Layout...`", ":kbd:`Ctrl+P`", ":guilabel:`Project`", ":ref:`label_printlayout`"
+   "|newReport| :guilabel:`New Report...`", "", "", ":ref:`label_printlayout`"
+   "|layoutManager| :guilabel:`Layout Manager...`", "", ":guilabel:`Project`", ":ref:`label_printlayout`"
+   ":menuselection:`Layouts -->`", "", "", ":ref:`label_printlayout`"
+   "|fileExit| :guilabel:`Exit QGIS`", ":kbd:`Ctrl+Q`"
+
+.. only:: html
+
+   |
 
 Under |osx| macOS, the :guilabel:`Exit QGIS` command corresponds to
 :menuselection:`QGIS --> Quit QGIS` (:kbd:`Cmd+Q`).
@@ -123,62 +125,64 @@ Edit
 The :menuselection:`Edit` menu provides most of the native tools needed to edit
 layer attributes or geometry (see :ref:`editingvector` for details).
 
-=======================================================================  ====================  =================================   ===================================
-Menu Option                                                              Shortcut              Toolbar                             Reference
-=======================================================================  ====================  =================================   ===================================
-|undo| :guilabel:`Undo`                                                  :kbd:`Ctrl+Z`         :guilabel:`Digitizing`              :ref:`undoredo_edits`
-|redo| :guilabel:`Redo`                                                  :kbd:`Ctrl+Shift+Z`   :guilabel:`Digitizing`              :ref:`undoredo_edits`
-|editCut| :guilabel:`Cut Features`                                       :kbd:`Ctrl+X`         :guilabel:`Digitizing`              :ref:`clipboard_feature`
-|editCopy| :guilabel:`Copy Features`                                     :kbd:`Ctrl+C`         :guilabel:`Digitizing`              :ref:`clipboard_feature`
-|editPaste| :guilabel:`Paste Features`                                   :kbd:`Ctrl+V`         :guilabel:`Digitizing`              :ref:`clipboard_feature`
-:menuselection:`Paste Features as -->`                                   \                     \                                   :ref:`sec_attribute_table`
-:menuselection:`Select -->`                                              \                     :guilabel:`Attributes`              :ref:`sec_selection`
-|newTableRow| :guilabel:`Add Record`                                     :kbd:`Ctrl+.`         :guilabel:`Digitizing`              \
-|capturePoint| :guilabel:`Add Point Feature`                             :kbd:`Ctrl+.`         :guilabel:`Digitizing`              :ref:`add_feature`
-|capturePoint| :guilabel:`Add Line Feature`                              :kbd:`Ctrl+.`         :guilabel:`Digitizing`              :ref:`add_feature`
-|capturePolygon| :guilabel:`Add Polygon Feature`                         :kbd:`Ctrl+.`         :guilabel:`Digitizing`              :ref:`add_feature`
-|circularStringCurvePoint| :guilabel:`Add Circular String`               \                     :guilabel:`Shape Digitizing`        :ref:`add_circular_string`
-|circularStringRadius| :guilabel:`Add Circular String by Radius`         \                     :guilabel:`Shape Digitizing`        :ref:`add_circular_string`
-:menuselection:`Add Circle -->`                                          \                     :guilabel:`Shape Digitizing`        \
-:menuselection:`Add Rectangle -->`                                       \                     :guilabel:`Shape Digitizing`        \
-:menuselection:`Add Regular Polygon -->`                                 \                     :guilabel:`Shape Digitizing`        \
-:menuselection:`Add Ellipse -->`                                         \                     :guilabel:`Shape Digitizing`        \
-|moveFeature| :guilabel:`Move Feature(s)`                                \                     :guilabel:`Advanced Digitizing`     :ref:`move_feature`
-|moveFeatureCopy| :guilabel:`Copy and Move Feature(s)`                   \                     :guilabel:`Advanced Digitizing`     :ref:`move_feature`
-|deleteSelectedFeatures| :guilabel:`Delete Selected`                     \                     :guilabel:`Digitizing`              :ref:`delete_feature`
-|multiEdit| :guilabel:`Modify Attributes of Selected Features`           \                     :guilabel:`Digitizing`              :ref:`calculate_fields_values`
-|rotateFeature| :guilabel:`Rotate Feature(s)`                            \                     :guilabel:`Advanced Digitizing`     :ref:`rotate_feature`
-|simplifyFeatures| :guilabel:`Simplify Feature`                          \                     :guilabel:`Advanced Digitizing`     :ref:`simplify_feature`
-|addRing| :guilabel:`Add Ring`                                           \                     :guilabel:`Advanced Digitizing`     :ref:`add_ring`
-|addPart| :guilabel:`Add Part`                                           \                     :guilabel:`Advanced Digitizing`     :ref:`add_part`
-|fillRing| :guilabel:`Fill Ring`                                         \                     :guilabel:`Advanced Digitizing`     :ref:`fill_ring`
-|deleteRing| :guilabel:`Delete Ring`                                     \                     :guilabel:`Advanced Digitizing`     :ref:`delete_ring`
-|deletePart| :guilabel:`Delete Part`                                     \                     :guilabel:`Advanced Digitizing`     :ref:`delete_part`
-|reshape| :guilabel:`Reshape Features`                                   \                     :guilabel:`Advanced Digitizing`     :ref:`reshape_feature`
-|offsetCurve| :guilabel:`Offset Curve`                                   \                     :guilabel:`Advanced Digitizing`     :ref:`offset_curve`
-|splitFeatures| :guilabel:`Split Features`                               \                     :guilabel:`Advanced Digitizing`     :ref:`split_feature`
-|splitParts| :guilabel:`Split Parts`                                     \                     :guilabel:`Advanced Digitizing`     :ref:`split_part`
-|mergeFeatures| :guilabel:`Merge Selected Features`                      \                     :guilabel:`Advanced Digitizing`     :ref:`mergeselectedfeatures`
-|mergeFeatAttributes| :guilabel:`Merge Attributes of Selected Features`  \                     :guilabel:`Advanced Digitizing`     :ref:`mergeattributesfeatures`
-|vertexTool| :guilabel:`Vertex Tool (All Layers)`                        \                     :guilabel:`Digitizing`              :ref:`vertex_tool`
-|vertexToolActiveLayer| :guilabel:`Vertex Tool (Current Layer)`          \                     :guilabel:`Digitizing`              :ref:`vertex_tool`
-|rotatePointSymbols| :guilabel:`Rotate Point Symbols`                    \                     :guilabel:`Advanced Digitizing`     :ref:`rotate_symbol`
-|offsetPointSymbols| :guilabel:`Offset Point Symbols`                    \                     :guilabel:`Advanced Digitizing`     :ref:`offset_symbol`
-|reverseLine| :guilabel:`Reverse Line`                                   \                     :guilabel:`Advanced Digitizing`     \
-=======================================================================  ====================  =================================   ===================================
+.. csv-table::
+   :header: "Menu Option", "Shortcut", "Toolbar", "Reference"
+   :widths: 30, 18, 12, 35
+   :class: longtable
 
-|
+   "|undo| :guilabel:`Undo`", ":kbd:`Ctrl+Z`", ":guilabel:`Digitizing`", ":ref:`undoredo_edits`"
+   "|redo| :guilabel:`Redo`", ":kbd:`Ctrl+Shift+Z`", ":guilabel:`Digitizing`", ":ref:`undoredo_edits`"
+   "|editCut| :guilabel:`Cut Features`", ":kbd:`Ctrl+X`", ":guilabel:`Digitizing`", ":ref:`clipboard_feature`"
+   "|editCopy| :guilabel:`Copy Features`", ":kbd:`Ctrl+C`", ":guilabel:`Digitizing`", ":ref:`clipboard_feature`"
+   "|editPaste| :guilabel:`Paste Features`", ":kbd:`Ctrl+V`", ":guilabel:`Digitizing`", ":ref:`clipboard_feature`"
+   ":menuselection:`Paste Features as -->`", "", "", ":ref:`sec_attribute_table`"
+   ":menuselection:`Select -->`", "", ":guilabel:`Attributes`", ":ref:`sec_selection`"
+   "|newTableRow| :guilabel:`Add Record`", ":kbd:`Ctrl+.`", ":guilabel:`Digitizing`"
+   "|capturePoint| :guilabel:`Add Point Feature`", ":kbd:`Ctrl+.`", ":guilabel:`Digitizing`", ":ref:`add_feature`"
+   "|capturePoint| :guilabel:`Add Line Feature`", ":kbd:`Ctrl+.`", ":guilabel:`Digitizing`", ":ref:`add_feature`"
+   "|capturePolygon| :guilabel:`Add Polygon Feature`", ":kbd:`Ctrl+.`", ":guilabel:`Digitizing`", ":ref:`add_feature`"
+   "|circularStringCurvePoint| :guilabel:`Add Circular String`", "", ":guilabel:`Shape Digitizing`", ":ref:`add_circular_string`"
+   "|circularStringRadius| :guilabel:`Add Circular String by Radius`", "", ":guilabel:`Shape Digitizing`", ":ref:`add_circular_string`"
+   ":menuselection:`Add Circle -->`", "", ":guilabel:`Shape Digitizing`"
+   ":menuselection:`Add Rectangle -->`", "", ":guilabel:`Shape Digitizing`"
+   ":menuselection:`Add Regular Polygon -->`", "", ":guilabel:`Shape Digitizing`"
+   ":menuselection:`Add Ellipse -->`", "", ":guilabel:`Shape Digitizing`"
+   "|moveFeature| :guilabel:`Move Feature(s)`", "", ":guilabel:`Advanced Digitizing`", ":ref:`move_feature`"
+   "|moveFeatureCopy| :guilabel:`Copy and Move Feature(s)`", "", ":guilabel:`Advanced Digitizing`", ":ref:`move_feature`"
+   "|deleteSelectedFeatures| :guilabel:`Delete Selected`", "", ":guilabel:`Digitizing`", ":ref:`delete_feature`"
+   "|multiEdit| :guilabel:`Modify Attributes of Selected Features`", "", ":guilabel:`Digitizing`", ":ref:`calculate_fields_values`"
+   "|rotateFeature| :guilabel:`Rotate Feature(s)`", "", ":guilabel:`Advanced Digitizing`", ":ref:`rotate_feature`"
+   "|simplifyFeatures| :guilabel:`Simplify Feature`", "", ":guilabel:`Advanced Digitizing`", ":ref:`simplify_feature`"
+   "|addRing| :guilabel:`Add Ring`", "", ":guilabel:`Advanced Digitizing`", ":ref:`add_ring`"
+   "|addPart| :guilabel:`Add Part`", "", ":guilabel:`Advanced Digitizing`", ":ref:`add_part`"
+   "|fillRing| :guilabel:`Fill Ring`", "", ":guilabel:`Advanced Digitizing`", ":ref:`fill_ring`"
+   "|deleteRing| :guilabel:`Delete Ring`", "", ":guilabel:`Advanced Digitizing`", ":ref:`delete_ring`"
+   "|deletePart| :guilabel:`Delete Part`", "", ":guilabel:`Advanced Digitizing`", ":ref:`delete_part`"
+   "|reshape| :guilabel:`Reshape Features`", "", ":guilabel:`Advanced Digitizing`", ":ref:`reshape_feature`"
+   "|offsetCurve| :guilabel:`Offset Curve`", "", ":guilabel:`Advanced Digitizing`", ":ref:`offset_curve`"
+   "|splitFeatures| :guilabel:`Split Features`", "", ":guilabel:`Advanced Digitizing`", ":ref:`split_feature`"
+   "|splitParts| :guilabel:`Split Parts`", "", ":guilabel:`Advanced Digitizing`", ":ref:`split_part`"
+   "|mergeFeatures| :guilabel:`Merge Selected Features`", "", ":guilabel:`Advanced Digitizing`", ":ref:`mergeselectedfeatures`"
+   "|mergeFeatAttributes| :guilabel:`Merge Attributes of Selected Features`", "", ":guilabel:`Advanced Digitizing`", ":ref:`mergeattributesfeatures`"
+   "|vertexTool| :guilabel:`Vertex Tool (All Layers)`", "", ":guilabel:`Digitizing`", ":ref:`vertex_tool`"
+   "|vertexToolActiveLayer| :guilabel:`Vertex Tool (Current Layer)`", "", ":guilabel:`Digitizing`", ":ref:`vertex_tool`"
+   "|rotatePointSymbols| :guilabel:`Rotate Point Symbols`", "", ":guilabel:`Advanced Digitizing`", ":ref:`rotate_symbol`"
+   "|offsetPointSymbols| :guilabel:`Offset Point Symbols`", "", ":guilabel:`Advanced Digitizing`", ":ref:`offset_symbol`"
+   "|reverseLine| :guilabel:`Reverse Line`", "", ":guilabel:`Advanced Digitizing`"
+
+.. only:: html
+
+   |
 
 Tools dependent on the selected layer geometry type i.e. point, polyline or polygon, are activated accordingly:
 
-.. :tabularcolumns: |l|c|c|c|
+.. csv-table::
+   :header: "Menu Option", "Point", "Polyline", "Polygon"
+   :widths: auto
 
-=====================================  ========================  ========================  ==========================
-Menu Option                            Point                     Polyline                  Polygon
-=====================================  ========================  ========================  ==========================
-:guilabel:`Move Feature(s)`            |moveFeaturePoint|        |moveFeatureLine|         |moveFeature|
-:guilabel:`Copy and Move Feature(s)`   |moveFeatureCopyPoint|    |moveFeatureCopyLine|     |moveFeatureCopy|
-=====================================  ========================  ========================  ==========================
+   ":guilabel:`Move Feature(s)`", "|moveFeaturePoint|", "|moveFeatureLine|", "|moveFeature|"
+   ":guilabel:`Copy and Move Feature(s)`", "|moveFeatureCopyPoint|", "|moveFeatureCopyLine|", "|moveFeatureCopy|"
+
 
 .. _view_menu:
 
@@ -207,43 +211,46 @@ The menu also allows you to reorganize the QGIS interface itself using actions l
   and only shows the map canvas. Combined with the full screen option, it makes
   your screen display only the map
 
-=========================================================  =======================  =============================  ==========================================
-Menu Option                                                Shortcut                 Toolbar                        Reference
-=========================================================  =======================  =============================  ==========================================
-|newMap| :guilabel:`New Map View`                          :kbd:`Ctrl+M`            :guilabel:`Map Navigation`     \
-|new3DMap| :guilabel:`New 3D Map View`                     :kbd:`Ctrl+Shift+M`      \                              :ref:`label_3dmapview`
-|pan| :guilabel:`Pan Map`                                  \                        :guilabel:`Map Navigation`     :ref:`zoom_pan`
-|panToSelected| :guilabel:`Pan Map to Selection`           \                        :guilabel:`Map Navigation`     \
-|zoomIn| :guilabel:`Zoom In`                               :kbd:`Ctrl+Alt++`        :guilabel:`Map Navigation`     :ref:`zoom_pan`
-|zoomOut| :guilabel:`Zoom Out`                             :kbd:`Ctrl+Alt+-`        :guilabel:`Map Navigation`     :ref:`zoom_pan`
-|identify| :guilabel:`Identify Features`                   :kbd:`Ctrl+Shift+I`      :guilabel:`Attributes`         :ref:`identify`
-:menuselection:`Measure -->`                               \                        :guilabel:`Attributes`         :ref:`sec_measure`
-|sum| :guilabel:`Statistical Summary`                      \                        :guilabel:`Attributes`         :ref:`statistical_summary`
-|zoomFullExtent| :guilabel:`Zoom Full`                     :kbd:`Ctrl+Shift+F`      :guilabel:`Map Navigation`     \
-|zoomToLayer| :guilabel:`Zoom To Layer`                    \                        :guilabel:`Map Navigation`     \
-|zoomToSelected| :guilabel:`Zoom To Selection`             :kbd:`Ctrl+J`            :guilabel:`Map Navigation`     \
-|zoomLast| :guilabel:`Zoom Last`                           \                        :guilabel:`Map Navigation`     \
-|zoomNext| :guilabel:`Zoom Next`                           \                        :guilabel:`Map Navigation`     \
-|zoomActual| :guilabel:`Zoom To Native Resolution (100%)`  \                        :guilabel:`Map Navigation`     \
-:menuselection:`Decorations -->`                           \                        \                              :ref:`decorations`
-:menuselection:`Preview mode -->`                          \                        \                              \
-|mapTips| :guilabel:`Show Map Tips`                        \                        :guilabel:`Attributes`         :ref:`maptips`
-|newBookmark| :guilabel:`New Bookmark...`                  :kbd:`Ctrl+B`            :guilabel:`Map Navigation`     :ref:`sec_bookmarks`
-|showBookmarks| :guilabel:`Show Bookmarks`                 :kbd:`Ctrl+Shift+B`      :guilabel:`Map Navigation`     :ref:`sec_bookmarks`
-|draw| :guilabel:`Refresh`                                 :kbd:`F5`                :guilabel:`Map Navigation`     \
-|showAllLayers| :guilabel:`Show All Layers`                :kbd:`Ctrl+Shift+U`      \                              :ref:`label_legend`
-|hideAllLayers| :guilabel:`Hide All Layers`                :kbd:`Ctrl+Shift+H`      \                              :ref:`label_legend`
-|showSelectedLayers| :guilabel:`Show Selected Layers`      \                        \                              :ref:`label_legend`
-|hideSelectedLayers| :guilabel:`Hide Selected Layers`      \                        \                              :ref:`label_legend`
-|hideDeselectedLayers| :guilabel:`Hide Deselected Layers`  \                        \                              :ref:`label_legend`
-:menuselection:`Panels -->`                                \                        \                              :ref:`sec_panels_and_toolbars`
-:menuselection:`Toolbars -->`                              \                        \                              :ref:`sec_panels_and_toolbars`
-:guilabel:`Toggle Full Screen Mode`                        :kbd:`F11`               \                              \
-:guilabel:`Toggle Panel Visibility`                        :kbd:`Ctrl+Tab`          \                              \
-:guilabel:`Toggle Map Only`                                :kbd:`Ctrl+Shift+Tab`    \                              \
-=========================================================  =======================  =============================  ==========================================
+.. csv-table::
+   :header: "Menu Option", "Shortcut", "Toolbar", "Reference"
+   :widths: auto
+   :class: longtable
 
-|
+   "|newMap| :guilabel:`New Map View`", ":kbd:`Ctrl+M`", ":guilabel:`Map Navigation`"
+   "|new3DMap| :guilabel:`New 3D Map View`", ":kbd:`Ctrl+Shift+M`", "", ":ref:`label_3dmapview`"
+   "|pan| :guilabel:`Pan Map`", "", ":guilabel:`Map Navigation`", ":ref:`zoom_pan`"
+   "|panToSelected| :guilabel:`Pan Map to Selection`", "", ":guilabel:`Map Navigation`"
+   "|zoomIn| :guilabel:`Zoom In`", ":kbd:`Ctrl+Alt++`", ":guilabel:`Map Navigation`", ":ref:`zoom_pan`"
+   "|zoomOut| :guilabel:`Zoom Out`", ":kbd:`Ctrl+Alt+-`", ":guilabel:`Map Navigation`", ":ref:`zoom_pan`"
+   "|identify| :guilabel:`Identify Features`", ":kbd:`Ctrl+Shift+I`", ":guilabel:`Attributes`", ":ref:`identify`"
+   ":menuselection:`Measure -->`", "", ":guilabel:`Attributes`", ":ref:`sec_measure`"
+   "|sum| :guilabel:`Statistical Summary`", "", ":guilabel:`Attributes`", ":ref:`statistical_summary`"
+   "|zoomFullExtent| :guilabel:`Zoom Full`", ":kbd:`Ctrl+Shift+F`", ":guilabel:`Map Navigation`"
+   "|zoomToLayer| :guilabel:`Zoom To Layer`", "", ":guilabel:`Map Navigation`"
+   "|zoomToSelected| :guilabel:`Zoom To Selection`", ":kbd:`Ctrl+J`", ":guilabel:`Map Navigation`"
+   "|zoomLast| :guilabel:`Zoom Last`", "", ":guilabel:`Map Navigation`"
+   "|zoomNext| :guilabel:`Zoom Next`", "", ":guilabel:`Map Navigation`"
+   "|zoomActual| :guilabel:`Zoom To Native Resolution (100%)`", "", ":guilabel:`Map Navigation`"
+   ":menuselection:`Decorations -->`", "", "", ":ref:`decorations`"
+   ":menuselection:`Preview mode -->`"
+   "|mapTips| :guilabel:`Show Map Tips`", "", ":guilabel:`Attributes`", ":ref:`maptips`"
+   "|newBookmark| :guilabel:`New Bookmark...`", ":kbd:`Ctrl+B`", ":guilabel:`Map Navigation`", ":ref:`sec_bookmarks`"
+   "|showBookmarks| :guilabel:`Show Bookmarks`", ":kbd:`Ctrl+Shift+B`", ":guilabel:`Map Navigation`", ":ref:`sec_bookmarks`"
+   "|draw| :guilabel:`Refresh`", ":kbd:`F5`", ":guilabel:`Map Navigation`"
+   "|showAllLayers| :guilabel:`Show All Layers`", ":kbd:`Ctrl+Shift+U`", "", ":ref:`label_legend`"
+   "|hideAllLayers| :guilabel:`Hide All Layers`", ":kbd:`Ctrl+Shift+H`", "", ":ref:`label_legend`"
+   "|showSelectedLayers| :guilabel:`Show Selected Layers`", "", "", ":ref:`label_legend`"
+   "|hideSelectedLayers| :guilabel:`Hide Selected Layers`", "", "", ":ref:`label_legend`"
+   "|hideDeselectedLayers| :guilabel:`Hide Deselected Layers`", "", "", ":ref:`label_legend`"
+   ":menuselection:`Panels -->`", "", "", ":ref:`sec_panels_and_toolbars`"
+   ":menuselection:`Toolbars -->`", "", "", ":ref:`sec_panels_and_toolbars`"
+   ":guilabel:`Toggle Full Screen Mode`", ":kbd:`F11`"
+   ":guilabel:`Toggle Panel Visibility`", ":kbd:`Ctrl+Tab`"
+   ":guilabel:`Toggle Map Only`", ":kbd:`Ctrl+Shift+Tab`"
+
+.. only:: html
+
+   |
 
 Under |kde| Linux KDE, :menuselection:`Panels -->`, :menuselection:`Toolbars -->`
 and :guilabel:`Toggle Full Screen Mode` are in the :menuselection:`Settings`
@@ -268,52 +275,56 @@ same data sources, you can also:
 The :menuselection:`Layer` menu also contains tools to configure, copy
 or paste layer properties (style, scale, CRS...).
 
-============================================================  ====================  ================================  =====================================
-Menu Option                                                   Shortcut              Toolbar                           Reference
-============================================================  ====================  ================================  =====================================
-|dataSourceManager| :guilabel:`Data Source Manager`           :kbd:`Ctrl+L`         :guilabel:`Data Source Manager`    :ref:`Opening Data <datasourcemanager>`
-:menuselection:`Create Layer -->`                             \                     :guilabel:`Data Source Manager`    :ref:`sec_create_vector`
-:menuselection:`Add Layer -->`                                \                     :guilabel:`Data Source Manager`    :ref:`opening_data`
-:guilabel:`Embed Layers and Groups...`                        \                     \                                  :ref:`nesting_projects`
-:guilabel:`Add from Layer Definition File...`                 \                     \                                  :ref:`layer_definition_file`
-|editCopy| :guilabel:`Copy Style`                             \                     \                                  :ref:`save_layer_property`
-|editPaste| :guilabel:`Paste Style`                           \                     \                                  :ref:`save_layer_property`
-|editCopy| :guilabel:`Copy Layer`                             \                     \                                  \
-|editPaste| :guilabel:`Paste Layer/Group`                     \                     \                                  \
-|openTable| :guilabel:`Open Attribute Table`                  :kbd:`F6`             :guilabel:`Attributes`             :ref:`sec_attribute_table`
-|toggleEditing| :guilabel:`Toggle Editing`                    \                     :guilabel:`Digitizing`             :ref:`sec_edit_existing_layer`
-|fileSave| :guilabel:`Save Layer Edits`                       \                     :guilabel:`Digitizing`             :ref:`save_feature_edits`
-|allEdits| :menuselection:`Current Edits -->`                 \                     :guilabel:`Digitizing`             :ref:`save_feature_edits`
-:guilabel:`Save As...`                                        \                     \                                  :ref:`general_saveas`
-:guilabel:`Save As Layer Definition File...`                  \                     \                                  :ref:`layer_definition_file`
-|removeLayer| :guilabel:`Remove Layer/Group`                  :kbd:`Ctrl+D`         \                                  \
-|duplicateLayer| :guilabel:`Duplicate Layer(s)`               \                     \                                  \
-:guilabel:`Set Scale Visibility of Layer(s)`                  \                     \                                  \
-:guilabel:`Set CRS of Layer(s)`                               :kbd:`Ctrl+Shift+C`   \                                  \
-:guilabel:`Set Project CRS from Layer`                        \                     \                                  \
-:guilabel:`Layer Properties...`                               \                     \                                  :ref:`vector_properties_dialog`
-:guilabel:`Filter...`                                         :kbd:`Ctrl+F`         \                                  :ref:`vector_query_builder`
-|labeling| :guilabel:`Labeling`                               \                     \                                  :ref:`vector_labels_tab`
-|inOverview| :guilabel:`Show in Overview`                     \                     \                                  :ref:`overview_panels`
-|addAllToOverview| :guilabel:`Show All in Overview`           \                     \                                  :ref:`overview_panels`
-|removeAllOVerview| :guilabel:`Hide All from Overview`        \                     \                                  :ref:`overview_panels`
-============================================================  ====================  ================================  =====================================
+.. csv-table::
+   :header: "Menu Option", "Shortcut", "Toolbar", "Reference"
+   :widths: auto
+   :class: longtable
+
+   "|dataSourceManager| :guilabel:`Data Source Manager`", ":kbd:`Ctrl+L`", ":guilabel:`Data Source Manager`",":ref:`Opening Data <datasourcemanager>`"
+   ":menuselection:`Create Layer -->`", "", ":guilabel:`Data Source Manager`", ":ref:`sec_create_vector`"
+   ":menuselection:`Add Layer -->`", "", ":guilabel:`Data Source Manager`", ":ref:`opening_data`"
+   ":guilabel:`Embed Layers and Groups...`", "", "", ":ref:`nesting_projects`"
+   ":guilabel:`Add from Layer Definition File...`", "", "", ":ref:`layer_definition_file`"
+   "|editCopy| :guilabel:`Copy Style`", "", "", ":ref:`save_layer_property`"
+   "|editPaste| :guilabel:`Paste Style`", "", "", ":ref:`save_layer_property`"
+   "|editCopy| :guilabel:`Copy Layer`"
+   "|editPaste| :guilabel:`Paste Layer/Group`"
+   "|openTable| :guilabel:`Open Attribute Table`", ":kbd:`F6`", ":guilabel:`Attributes`", ":ref:`sec_attribute_table`"
+   "|toggleEditing| :guilabel:`Toggle Editing`", "", ":guilabel:`Digitizing`", ":ref:`sec_edit_existing_layer`"
+   "|fileSave| :guilabel:`Save Layer Edits`", "", ":guilabel:`Digitizing`", ":ref:`save_feature_edits`"
+   "|allEdits| :menuselection:`Current Edits -->`", "", ":guilabel:`Digitizing`", ":ref:`save_feature_edits`"
+   ":guilabel:`Save As...`", "", "", ":ref:`general_saveas`"
+   ":guilabel:`Save As Layer Definition File...`", "", "", ":ref:`layer_definition_file`"
+   "|removeLayer| :guilabel:`Remove Layer/Group`", ":kbd:`Ctrl+D`"
+   "|duplicateLayer| :guilabel:`Duplicate Layer(s)`"
+   ":guilabel:`Set Scale Visibility of Layer(s)`"
+   ":guilabel:`Set CRS of Layer(s)`", ":kbd:`Ctrl+Shift+C`"
+   ":guilabel:`Set Project CRS from Layer`"
+   ":guilabel:`Layer Properties...`", "", "", ":ref:`vector_properties_dialog`"
+   ":guilabel:`Filter...`", ":kbd:`Ctrl+F`", "", ":ref:`vector_query_builder`"
+   "|labeling| :guilabel:`Labeling`", "", "", ":ref:`vector_labels_tab`"
+   "|inOverview| :guilabel:`Show in Overview`", "", "", ":ref:`overview_panels`"
+   "|addAllToOverview| :guilabel:`Show All in Overview`", "", "", ":ref:`overview_panels`"
+   "|removeAllOVerview| :guilabel:`Hide All from Overview`", "", "", ":ref:`overview_panels`"
+
 
 Settings
 --------
 
-=================================================================  ===================================
-Menu Option                                                        Reference
-=================================================================  ===================================
-:menuselection:`User Profiles -->`                                 :ref:`user_profiles`
-|styleManager| :guilabel:`Style Manager...`                        :ref:`vector_style_manager`
-|customProjection| :guilabel:`Custom Projections...`               :ref:`sec_custom_projections`
-|keyboardShortcuts| :guilabel:`Keyboard Shortcuts...`              :ref:`shortcuts`
-|interfaceCustomization| :guilabel:`Interface Customization...`    :ref:`sec_customization`
-|options| :guilabel:`Options...`                                   :ref:`gui_options`
-=================================================================  ===================================
+.. csv-table::
+   :header: "Menu Option", "Reference"
+   :widths: auto
 
-|
+   ":menuselection:`User Profiles -->`", ":ref:`user_profiles`"
+   "|styleManager| :guilabel:`Style Manager...`", ":ref:`vector_style_manager`"
+   "|customProjection| :guilabel:`Custom Projections...`", ":ref:`sec_custom_projections`"
+   "|keyboardShortcuts| :guilabel:`Keyboard Shortcuts...`", ":ref:`shortcuts`"
+   "|interfaceCustomization| :guilabel:`Interface Customization...`", ":ref:`sec_customization`"
+   "|options| :guilabel:`Options...`", ":ref:`gui_options`"
+
+.. only :: html
+
+   |
 
 Under |kde| Linux KDE, you'll find more tools in the :menuselection:`Settings`
 menu such as :menuselection:`Panels -->`,
@@ -322,14 +333,16 @@ menu such as :menuselection:`Panels -->`,
 Plugins
 -------
 
-======================================================================  ====================  =======================  ===============================
-Menu Option                                                             Shortcut               Toolbar                 Reference
-======================================================================  ====================  =======================  ===============================
-|showPluginManager| :guilabel:`Manage and Install Plugins...`           \                     \                        :ref:`managing_plugins`
-|pythonFile| :guilabel:`Python Console`                                 :kbd:`Ctrl+Alt+P`     :guilabel:`Plugins`      :ref:`console`
-======================================================================  ====================  =======================  ===============================
+.. csv-table::
+   :header: "Menu Option", "Shortcut", "Toolbar", "Reference"
+   :widths: auto
 
-|
+   "|showPluginManager| :guilabel:`Manage and Install Plugins...`", "", "", ":ref:`managing_plugins`"
+   "|pythonFile| :guilabel:`Python Console`", ":kbd:`Ctrl+Alt+P`", ":guilabel:`Plugins`", ":ref:`console`"
+
+.. only:: html
+
+   |
 
 When starting QGIS for the first time not all core plugins are loaded.
 
@@ -339,21 +352,23 @@ Vector
 This is what the :guilabel:`Vector` menu looks like if all core plugins
 are enabled.
 
-==============================================================  =======================  =======================  ===============================
-Menu Option                                                     Shortcut                 Toolbar                  Reference
-==============================================================  =======================  =======================  ===============================
-|coordinateCapture| :guilabel:`Coordinate Capture`              \                        :guilabel:`Vector`       :ref:`coordcapt`
-|geometryChecker| :guilabel:`Check Geometries...`               \                        :guilabel:`Vector`       :ref:`geometry_checker`
-|gpsImporter| :guilabel:`GPS Tools`                             \                        :guilabel:`Vector`       :ref:`plugin_gps`
-|topologyChecker| :guilabel:`Topology Checker`                  \                        :guilabel:`Vector`       :ref:`topology`
-:menuselection:`Geoprocessing Tools -->`                        :kbd:`Alt+O` + :kbd:`G`  \                        :ref:`processing.options`
-:menuselection:`Geometry Tools -->`                             :kbd:`Alt+O` + :kbd:`E`  \                        :ref:`processing.options`
-:menuselection:`Analysis Tools -->`                             :kbd:`Alt+O` + :kbd:`A`  \                        :ref:`processing.options`
-:menuselection:`Data Management Tools -->`                      :kbd:`Alt+O` + :kbd:`D`  \                        :ref:`processing.options`
-:menuselection:`Research Tools -->`                             :kbd:`Alt+O` + :kbd:`R`  \                        :ref:`processing.options`
-==============================================================  =======================  =======================  ===============================
+.. csv-table::
+   :header: "Menu Option", "Shortcut", "Toolbar", "Reference"
+   :widths: auto
 
-|
+   "|coordinateCapture| :guilabel:`Coordinate Capture`", "", ":guilabel:`Vector`", ":ref:`coordcapt`"
+   "|geometryChecker| :guilabel:`Check Geometries...`", "", ":guilabel:`Vector`", ":ref:`geometry_checker`"
+   "|gpsImporter| :guilabel:`GPS Tools`", "", ":guilabel:`Vector`", ":ref:`plugin_gps`"
+   "|topologyChecker| :guilabel:`Topology Checker`", "", ":guilabel:`Vector`", ":ref:`topology`"
+   ":menuselection:`Geoprocessing Tools -->`", ":kbd:`Alt+O` + :kbd:`G`","", ":ref:`processing.options`"
+   ":menuselection:`Geometry Tools -->`", ":kbd:`Alt+O` + :kbd:`E`","", ":ref:`processing.options`"
+   ":menuselection:`Analysis Tools -->`", ":kbd:`Alt+O` + :kbd:`A`","", ":ref:`processing.options`"
+   ":menuselection:`Data Management Tools -->`", ":kbd:`Alt+O` + :kbd:`D`","", ":ref:`processing.options`"
+   ":menuselection:`Research Tools -->`", ":kbd:`Alt+O` + :kbd:`R`","", ":ref:`processing.options`"
+
+.. only:: html
+
+   |
 
 By default, QGIS adds :ref:`Processing <sec_processing_intro>` algorithms to the
 :guilabel:`Vector` menu, grouped by sub-menus. This provides shortcuts
@@ -371,20 +386,22 @@ Raster
 This is what the :guilabel:`Raster` menu looks like if all core plugins
 are enabled.
 
-==========================================================  ====================  ==================================
-Menu Option                                                 Toolbar               Reference
-==========================================================  ====================  ==================================
-|showRasterCalculator| :guilabel:`Raster calculator...`     \                     :ref:`label_raster_calc`
-:guilabel:`Align Raster...`                                 \                     :ref:`label_raster_align`
-:menuselection:`Analysis -->`                               \                     :ref:`processing.options`
-:menuselection:`Projection -->`                             \                     :ref:`processing.options`
-:menuselection:`Miscellaneous -->`                          \                     :ref:`processing.options`
-:menuselection:`Extraction -->`                             \                     :ref:`processing.options`
-:menuselection:`Conversion -->`                             \                     :ref:`processing.options`
-|georefRun| :guilabel:`Georeferencer`                       :guilabel:`Raster`    :ref:`georef`
-==========================================================  ====================  ==================================
+.. csv-table::
+   :header: "Menu Option", "Toolbar", "Reference"
+   :widths: auto
 
-|
+   "|showRasterCalculator| :guilabel:`Raster calculator...`", "", ":ref:`label_raster_calc`"
+   ":guilabel:`Align Raster...`", "", ":ref:`label_raster_align`"
+   ":menuselection:`Analysis -->`", "", ":ref:`processing.options`"
+   ":menuselection:`Projection -->`", "", ":ref:`processing.options`"
+   ":menuselection:`Miscellaneous -->`", "", ":ref:`processing.options`"
+   ":menuselection:`Extraction -->`", "", ":ref:`processing.options`"
+   ":menuselection:`Conversion -->`", "", ":ref:`processing.options`"
+   "|georefRun| :guilabel:`Georeferencer`", ":guilabel:`Raster`",":ref:`georef`"
+
+.. only:: html
+
+   |
 
 By default, QGIS adds :ref:`Processing <sec_processing_intro>` algorithms to the 
 :guilabel:`Raster` menu, grouped by sub-menus. This provides a shortcut
@@ -403,15 +420,17 @@ This is what the :guilabel:`Database` menu looks like if all the core plugins
 are enabled.
 If no database plugins are enabled, there will be no :guilabel:`Database` menu.
 
-===============================================  ============================  ===============================
-Menu Option                                      Toolbar                       Reference
-===============================================  ============================  ===============================
-|dbManager| :guilabel:`DB Manager`               :guilabel:`Database`          :ref:`dbmanager`
-:menuselection:`eVis -->`                        :guilabel:`Database`          :ref:`evis`
-:menuselection:`Offline Editing -->`             :guilabel:`Database`          :ref:`offlinedit`
-===============================================  ============================  ===============================
+.. csv-table::
+   :header: "Menu Option", "Toolbar", "Reference"
+   :widths: auto
 
-|
+   "|dbManager| :guilabel:`DB Manager`", ":guilabel:`Database`", ":ref:`dbmanager`"
+   ":menuselection:`eVis -->`", ":guilabel:`Database`", ":ref:`evis`"
+   ":menuselection:`Offline Editing -->`", ":guilabel:`Database`", ":ref:`offlinedit`"
+
+.. only:: html
+
+   |
 
 When starting QGIS for the first time not all core plugins are loaded.
 
@@ -423,13 +442,15 @@ This is what the :guilabel:`Web` menu looks like if all the core plugins
 are enabled.
 If no web plugins are enabled, there will be no guilabel:`Web` menu.
 
-===============================================  ===========================  ===============================
-Menu Option                                      Toolbar                      Reference
-===============================================  ===========================  ===============================
-|metasearch| :menuselection:`MetaSearch`         :guilabel:`Web`              :ref:`metasearch`
-===============================================  ===========================  ===============================
+.. csv-table::
+   :header: "Menu Option", "Toolbar", "Reference"
+   :widths: auto
 
-|
+   |metasearch| :menuselection:`MetaSearch`", ":guilabel:`Web`", ":ref:`metasearch`"
+
+.. only:: html
+
+   |
 
 When starting QGIS for the first time not all core plugins are loaded.
 
@@ -440,45 +461,48 @@ Mesh
 The :menuselection:`Mesh` menu provides tools needed to manipulate
 :ref:`mesh layers <label_meshdata>`.
 
-========================================================  ===========================  ===============================
-Menu Option                                               Toolbar                      Reference
-========================================================  ===========================  ===============================
-|showMeshCalculator| :menuselection:`Mesh Calculator`
-========================================================  ===========================  ===============================
+.. csv-table::
+   :header: "Menu Option", "Toolbar", "Reference"
+   :widths: auto
+
+   |showMeshCalculator| :menuselection:`Mesh Calculator`"
+
 
 
 Processing
 ----------
 
-==============================================================  ==========================  ==========================================
-Menu Option                                                     Shortcut                    Reference
-==============================================================  ==========================  ==========================================
-|processing| :guilabel:`Toolbox`                                :kbd:`Ctrl+Alt+T`           :ref:`processing.toolbox`
-|processingModel| :guilabel:`Graphical Modeler...`              :kbd:`Ctrl+Alt+M`           :ref:`processing.modeler`
-|processingHistory| :guilabel:`History...`                      :kbd:`Ctrl+Alt+H`           :ref:`processing.history`
-|processingResult| :guilabel:`Results Viewer`                   :kbd:`Ctrl+Alt+R`           :ref:`processing.results`
-|processSelected| :guilabel:`Edit Features In-Place`            \                           :ref:`processing_inplace_edit`
-==============================================================  ==========================  ==========================================
+.. csv-table::
+   :header: "Menu Option", "Shortcut", "Reference"
+   :widths: auto
 
-|
+   "|processing| :guilabel:`Toolbox`", ":kbd:`Ctrl+Alt+T`", ":ref:`processing.toolbox`"
+   "|processingModel| :guilabel:`Graphical Modeler...`", ":kbd:`Ctrl+Alt+M`", ":ref:`processing.modeler`"
+   "|processingHistory| :guilabel:`History...`", ":kbd:`Ctrl+Alt+H`", ":ref:`processing.history`"
+   "|processingResult| :guilabel:`Results Viewer`", ":kbd:`Ctrl+Alt+R`", ":ref:`processing.results`"
+   "|processSelected| :guilabel:`Edit Features In-Place`", "", ":ref:`processing_inplace_edit`"
+
+.. only:: html
+
+   |
 
 When starting QGIS for the first time not all core plugins are loaded.
 
 Help
 ----
 
-=======================================================  ===========================  ===============================
-Menu Option                                              Shortcut                     Toolbar
-=======================================================  ===========================  ===============================
-|helpContents| :guilabel:`Help Contents`                 :kbd:`F1`                    :guilabel:`Help`
-:guilabel:`API Documentation`                            \                            \
-:guilabel:`Report an Issue`                              \                            \
-:guilabel:`Need commercial support?`                     \                            \
-|qgisHomePage| :guilabel:`QGIS Home Page`                :kbd:`Ctrl+H`                \
-|success| :guilabel:`Check QGIS Version`                 \                            \
-|logo| :guilabel:`About`                                 \                            \
-|helpSponsors| :guilabel:`QGIS Sponsors`                 \                            \
-=======================================================  ===========================  ===============================
+.. csv-table::
+   :header: "Menu Option", "Shortcut", "Reference"
+   :widths: auto
+
+   "|helpContents| :guilabel:`Help Contents`", ":kbd:`F1`", ":guilabel:`Help`"
+   ":guilabel:`API Documentation`"
+   ":guilabel:`Report an Issue`"
+   ":guilabel:`Need commercial support?`"
+   "|qgisHomePage| :guilabel:`QGIS Home Page`", ":kbd:`Ctrl+H`"
+   "|success| :guilabel:`Check QGIS Version`"
+   "|logo| :guilabel:`About`"
+   "|helpSponsors| :guilabel:`QGIS Sponsors`"
 
 QGIS
 -----
@@ -486,22 +510,24 @@ QGIS
 This menu is only available under |osx| macOS and contains some OS related
 commands.
 
-================================  ====================  =========================
-Menu Option                       Shortcut              Reference
-================================  ====================  =========================
-:guilabel:`Preferences`           \                     \
-:guilabel:`About QGIS`            \                     \
-:guilabel:`Hide QGIS`             \                     \
- :guilabel:`Show All`              \                     \
-:guilabel:`Hide Others`           \                     \
-:guilabel:`Quit QGIS`             :kbd:`Cmd+Q`          \
-================================  ====================  =========================
+.. csv-table::
+   :header: "Menu Option", "Shortcut", "Reference"
+   :widths: auto
 
-|
+   ":guilabel:`Preferences`"
+   ":guilabel:`About QGIS`"
+   ":guilabel:`Hide QGIS`"
+   ":guilabel:`Show All`"
+   ":guilabel:`Hide Others`"
+   ":guilabel:`Quit QGIS`", ":kbd:`Cmd+Q`"
+
+.. only:: html
+
+  |
 
 :guilabel:`Preferences` and :guilabel:`About QGIS` are the same commands as
 :menuselection:`Settings --> Options` and :menuselection:`Help --> About`.
-:guilabel:`Quit QGIS` corresponds to :menuselection:`Project --> Exit QGIS`
+:guilabel:`Quit QGIS` corresponds to :menuselection:`Project --> Exit QGIS`"
 under the other platforms.
 
 .. _sec_panels_and_toolbars:
@@ -710,7 +736,7 @@ Navigation options for exploring the map in 3D:
     terrain around
   * Using the up/down/left/right keys moves the
     terrain closer, away, right and left, respectively
-        
+
 To reset the camera view, click the |zoomFullExtent| :sup:`Zoom Full`
 button on the top of the 3D canvas panel.
 

--- a/source/docs/user_manual/introduction/qgis_gui.rst
+++ b/source/docs/user_manual/introduction/qgis_gui.rst
@@ -527,7 +527,7 @@ commands.
 
 :guilabel:`Preferences` and :guilabel:`About QGIS` are the same commands as
 :menuselection:`Settings --> Options` and :menuselection:`Help --> About`.
-:guilabel:`Quit QGIS` corresponds to :menuselection:`Project --> Exit QGIS`"
+:guilabel:`Quit QGIS` corresponds to :menuselection:`Project --> Exit QGIS`
 under the other platforms.
 
 .. _sec_panels_and_toolbars:

--- a/source/docs/user_manual/plugins/core_plugins/plugins_evis.rst
+++ b/source/docs/user_manual/plugins/core_plugins/plugins_evis.rst
@@ -465,31 +465,20 @@ XML format for eVis predefined queries
 
 The XML tags read by eVis
 
-+------------------+------------------------------------------------------------------------------------------------+
-| Tag              | Description                                                                                    |
-+==================+================================================================================================+
-| query            | Defines the beginning and end of a query statement.                                            |
-+------------------+------------------------------------------------------------------------------------------------+
-| shortdescription | A short description of the query that appears in the eVis drop-down menu.                      |
-+------------------+------------------------------------------------------------------------------------------------+
-| description      | A more detailed description of the query displayed in the Predefined Query text window.        |
-+------------------+------------------------------------------------------------------------------------------------+
-| databasetype     | The database type, defined in the Database Type drop-down menu in the Database Connection tab. |
-+------------------+------------------------------------------------------------------------------------------------+
-| databaseport     | The port as defined in the Port text box in the Database Connection tab.                       |
-+------------------+------------------------------------------------------------------------------------------------+
-| databasename     | The database name as defined in the Database Name text box in the Database Connection tab.     |
-+------------------+------------------------------------------------------------------------------------------------+
-| databaseusername | The database username as defined in the Username text box in the Database Connection tab.      |
-+------------------+------------------------------------------------------------------------------------------------+
-| databasepassword | The database password as defined in the Password text box in the Database Connection tab.      |
-+------------------+------------------------------------------------------------------------------------------------+
-| sqlstatement     | The SQL command.                                                                               |
-+------------------+------------------------------------------------------------------------------------------------+
-| autoconnect      | A flag ("true"" or "false") to specify if the above tags should be used to automatically       |
-|                  | connect to the database without running the database connection routine in the Database        |
-|                  | Connection tab.                                                                                |
-+------------------+------------------------------------------------------------------------------------------------+
+.. csv-table::
+   :header: "Tag", "Description"
+   :widths: 18, 77
+
+   "query", "Defines the beginning and end of a query statement."
+   "shortdescription", "A short description of the query that appears in the eVis drop-down menu."
+   "description", "A more detailed description of the query displayed in the Predefined Query text window."
+   "databasetype", "The database type, defined in the Database Type drop-down menu in the Database Connection tab."
+   "databaseport", "The port as defined in the Port text box in the Database Connection tab."
+   "databasename", "The database name as defined in the Database Name text box in the Database Connection tab."
+   "databaseusername", "The database username as defined in the Username text box in the Database Connection tab."
+   "databasepassword", "The database password as defined in the Password text box in the Database Connection tab."
+   "sqlstatement", "The SQL command."
+   "autoconnect", "A flag (""true"" or ""false"") to specify if the above tags should be used to automatically connect to the database without running the database connection routine in the Database Connection tab."                                                                                
 
 A complete sample XML file with three queries is displayed below:
 

--- a/source/docs/user_manual/preamble/contributors.rst
+++ b/source/docs/user_manual/preamble/contributors.rst
@@ -28,54 +28,33 @@ Authors
 Below are listed people who dedicate their time and energy to write, review,
 and update the whole QGIS documentation.
 
+.. csv-table::
+   :widths: auto       
 
-+--------------------+---------------------+----------------------+-----------------------+----------------------+
-| Tara Athan         | Radim Blazek        | K\. Koy              | Godofredo Contreras   | Martin Dobias        |
-+--------------------+---------------------+----------------------+-----------------------+----------------------+
-| Peter Ersts        | Anne Ghisla         | Stephan Holl         | N. Horning            | Magnus Homann        |
-+--------------------+---------------------+----------------------+-----------------------+----------------------+
-| Werner Macho       | Denis Rouzaud       | Tyler Mitchell       | Claudia A. Engel      | Lars Luthman         |
-+--------------------+---------------------+----------------------+-----------------------+----------------------+
-| Otto Dassau        | Brendan Morely      | David Willis         | Jürgen E. Fischer     | Yoichi Kayama        |
-+--------------------+---------------------+----------------------+-----------------------+----------------------+
-| Alexander Bruy     | Anita Graser        | Victor Olaya         | Marco Hugentobler     | Gary E. Sherman      |
-+--------------------+---------------------+----------------------+-----------------------+----------------------+
-| Tim Sutton         | Larissa Junek       | Raymond Nijssen      | Richard Duivenvoorde  | Andreas Neumann      |
-+--------------------+---------------------+----------------------+-----------------------+----------------------+
-| Astrid Emde        | Yves Jacolin        | Alexandre Neto       | Alessandro Pasotti    | Hien Tran-Quang      |
-+--------------------+---------------------+----------------------+-----------------------+----------------------+
-| Andy Schmid        | Arnaud Morvan       | Akgar Gumbira        | Giovanni Allegri      | Diethard Jansen      |
-+--------------------+---------------------+----------------------+-----------------------+----------------------+
-| Andy Allan         | Matthias Kuhn       | Chris Berkhout       | Carson J.Q. Farmer    | Steven Cordwell      |
-+--------------------+---------------------+----------------------+-----------------------+----------------------+
-| Eric Goddard       | Frank Sokolic       | Luca Casagrande      | Harrissou Sant-anna   | Saber Razmjooei      |
-+--------------------+---------------------+----------------------+-----------------------+----------------------+
-| Ilkka Rinne        | Jacob Lanstorp      | Ujaval Gandhi        | Jean-Roc Morreale     | Salvatore Larosa     |
-+--------------------+---------------------+----------------------+-----------------------+----------------------+
-| João Gaspar        | Joshua Arnott       | Thomas Gratier       | Marco Bernasocchi     | Marie Silvestre      |
-+--------------------+---------------------+----------------------+-----------------------+----------------------+
-| Ko Nagase          | Larry Shaffer       | Luigi Pirelli        | Konstantinos Nikolaou | Maning Sambale       |
-+--------------------+---------------------+----------------------+-----------------------+----------------------+
-| Manel Clos         | Mattheo Ghetta      | Bernhard Ströbl      | Luca Manganelli       | Nathan Woodrow       |
-+--------------------+---------------------+----------------------+-----------------------+----------------------+
-| Nick Bearman       | Paul Blottière      | Vincent Picavet      | Maximilian Krambach   | René-Luc D'Hont      |
-+--------------------+---------------------+----------------------+-----------------------+----------------------+
-| Tom Chadwin        | Patrick Sunter      | Nyall Dawson         | Milo Van der Linden   | Paolo Cavallini      |
-+--------------------+---------------------+----------------------+-----------------------+----------------------+
-| Paolo Corti        | Hugo Mercier        | Gavin Macaulay       | Stefan Blumentrath    | Nicholas Duggan      |
-+--------------------+---------------------+----------------------+-----------------------+----------------------+
-| David Adler        | Vincent Mora        | Tudor Bărăscu        | QGIS Koran Translator | Stéphane Brunner     |
-+--------------------+---------------------+----------------------+-----------------------+----------------------+
-| Jaka Kranjc        | Tom Kralidis        | Zoltan Siki          | Sebastian Dietrich    | Uros Preloznik       |
-+--------------------+---------------------+----------------------+-----------------------+----------------------+
-| Dick Groskamp      | Mezene Worku        | Alexandre Busquets   | Dominic Keller        | Andre Mano           |
-+--------------------+---------------------+----------------------+-----------------------+----------------------+
-| Chris Mayo         | Håvard Tveite       | Mie Winstrup         | Jonathan Willitts     | Giovanni Manghi      |
-+--------------------+---------------------+----------------------+-----------------------+----------------------+
-| Martina Savarese   | icephale            | Andrei               | GiordanoPezzola       | zstadler             |
-+--------------------+---------------------+----------------------+-----------------------+----------------------+
-| Ramon              | embelding           | ajazepk              | Fran Raga             |                      |
-+--------------------+---------------------+----------------------+-----------------------+----------------------+
+   "Tim Sutton", "Yves Jacolin", "Jacob Lanstorp", "Gary E. Sherman", "Richard Duivenvoorde"
+   "Tara Athan", "Anita Graser", "Arnaud Morvan",  "Gavin Macaulay", "Luca Casagrande"
+   "K\. Koy", "Hugo Mercier", "Akgar Gumbira", "Marie Silvestre", "Jürgen E. Fischer"
+   "Fran Raga", "Eric Goddard", "Martin Dobias", "Diethard Jansen", "Saber Razmjooei"
+   "Ko Nagase", "Nyall Dawson", "Matthias Kuhn", "Andreas Neumann", "Harrissou Sant-anna"
+   "Manel Clos", "David Willis", "Larissa Junek", "Paul Blottière", "Sebastian Dietrich"
+   "Chris Mayo", "Stephan Holl", "Magnus Homann", "Bernhard Ströbl", "Alessandro Pasotti"
+   "N\. Horning", "Radim Blazek", "Joshua Arnott", "Luca Manganelli", "Marco Hugentobler"
+   "Andre Mano", "Mie Winstrup", "Frank Sokolic", "Vincent Picavet", "Jean-Roc Morreale"
+   "Andy Allan", "Victor Olaya", "Tyler Mitchell", "René-Luc D'Hont", "Marco Bernasocchi"
+   "Ilkka Rinne", "Werner Macho", "Chris Berkhout", "Nicholas Duggan", "Jonathan Willitts"
+   "David Adler", "Lars Luthman", "Brendan Morely", "Raymond Nijssen", "Carson J.Q. Farmer"
+   "Jaka Kranjc", "Mezene Worku", "Patrick Sunter", "Steven Cordwell", "Stefan Blumentrath"
+   "Andy Schmid", "Vincent Mora", "Alexandre Neto", "Hien Tran-Quang", "Alexandre Busquets"
+   "João Gaspar", "Tom Kralidis", "Alexander Bruy", "Paolo Cavallini", "Milo Van der Linden"
+   "Peter Ersts", "Ujaval Gandhi", "Dominic Keller", "Giovanni Manghi", "Maximilian Krambach"
+   "Anne Ghisla", "Dick Groskamp", "Uros Preloznik", "Stéphane Brunner", "QGIS Koran Translator"
+   "Zoltan Siki", "Håvard Tveite", "Mattheo Ghetta", "Salvatore Larosa", "Konstantinos Nikolaou"
+   "Tom Chadwin", "Larry Shaffer", "Nathan Woodrow", "Martina Savarese", "Godofredo Contreras"
+   "Astrid Emde", "Luigi Pirelli", "Thomas Gratier", "Giovanni Allegri", "GiordanoPezzola"
+   "Paolo Corti", "Tudor Bărăscu", "Maning Sambale",  "Claudia A. Engel", "Yoichi Kayama"
+   "Otto Dassau", "Denis Rouzaud", "Nick Bearman", "embelding", "ajazepk"
+   "Ramon", "Andrei", "zstadler",  "icephale"
+
 
 
 .. index:: 
@@ -93,54 +72,46 @@ please see https://qgis.org/en/site/getinvolved/index.html.
 
 The current translations are made possible thanks to:
 
-===================== ========================================================
- Language              Contributors
-===================== ========================================================
-Bahasian Indonesian   Emir Hartato, I Made Anombawa, Januar V. Simarmata, Muhammad
-                      Iqnaul Haq Siregar, Trias Aditya
-Chinese (Traditional) Calvin Ngei, Zhang Jun, Richard Xie
-Dutch                 Carlo van Rijswijk, Dick Groskamp, Diethard Jansen,
-                      Raymond Nijssen, Richard Duivenvoorde, Willem Hoffman
-Finnish               Matti Mäntynen, Kari Mikkonen
-French                Arnaud Morvan, Augustin Roche, Didier Vanden Berghe,
-                      Dofabien, Etienne Trimaille, Harrissou Sant-anna,
-                      Jean-Roc Morreale, Jérémy Garniaux, Loïc Buscoz, Lsam,
-                      Marc-André Saia, Marie Silvestre, Mathieu Bossaert,
-                      Mathieu Lattes, Mayeul Kauffmann, Médéric Ribreux,
-                      Mehdi Semchaoui, Michael Douchin, Nicolas Boisteault,
-                      Nicolas Rochard, Pascal Obstetar, Robin Prest, Rod Bera,
-                      Stéphane Henriod, Stéphane Possamai, sylther, Sylvain Badey,
-                      Sylvain Maillard, Vincent Picavet, Xavier Tardieu,
-                      Yann Leveille-Menez, yoda89
-Galician              Xan Vieiro
-German                Jürgen E. Fischer, Otto Dassau, Stephan Holl,
-                      Werner Macho
-Hindi                 Harish Kumar Solanki
-Italian               Alessandro Fanna, Anne Ghisla, Flavio Rigolon, Giuliano
-                      Curti, Luca Casagrande, Luca Delucchi, Marco Braida,
-                      Matteo Ghetta, Maurizio Napolitano, Michele Beneventi,
-                      Michele Ferretti, Roberto Angeletti, Paolo Cavallini,
-                      Stefano Campus
-Japanese              Baba Yoshihiko, Minoru Akagi, Norihiro Yamate,
-                      Takayuki Mizutani, Takayuki Nuimura, Yoichi Kayama
-Korean                OSGeo Korean Chapter
-Polish                Andrzej Świąder, Borys Jurgiel, Ewelina Krawczak, Jakub
-                      Bobrowski, Mateusz Łoskot, Michał Kułach, Michał Smoczyk,
-                      Milena Nowotarska, Radosław Pasiok, Robert Szczepanek,
-                      Tomasz Paul
-Portuguese            Alexandre Neto, Duarte Carreira, Giovanni Manghi, João Gaspar,
-                      Joana Simões, Leandro Infantini, Nelson Silva, Pedro Palheiro,
-                      Pedro Pereira, Ricardo Sena
-Portuguese (Brasil)   Arthur Nanni, Felipe Sodré Barros, Leônidas Descovi Filho,
-                      Marcelo Soares Souza, Narcélio de Sá Pereira Filho,
-                      Sidney Schaberle Goveia
-Romanian              Alex Bădescu, Bogdan Pacurar, Georgiana Ioanovici, Lonut
-                      Losifescu-Enescu, Sorin Călinică, Tudor Bărăscu
-Russian               Alexander Bruy, Artem Popov
-Spanish               Carlos Dávila, Diana Galindo, Edwin Amado, Gabriela Awad,
-                      Javier César Aldariz, Mayeul Kauffmann, Fran Raga
-Ukrainian             Alexander Bruy
-===================== ========================================================
+.. csv-table::
+   :header: "Language", "Contributors"
+   :widths: 15, 80              
+
+   "Bahasian Indonesian", "Emir Hartato, I Made Anombawa, Januar V. Simarmata,
+   Muhammad Iqnaul Haq Siregar, Trias Aditya"
+   "Chinese (Traditional)", "Calvin Ngei, Zhang Jun, Richard Xie"
+   "Dutch", "Carlo van Rijswijk, Dick Groskamp, Diethard Jansen, Raymond Nijssen,
+   Richard Duivenvoorde, Willem Hoffman"
+   "Finnish", "Matti Mäntynen, Kari Mikkonen"
+   "French", "Arnaud Morvan, Augustin Roche, Didier Vanden Berghe, Dofabien,
+   Etienne Trimaille, Harrissou Sant-anna, Jean-Roc Morreale, Jérémy Garniaux,
+   Loïc Buscoz, Lsam,  Marc-André Saia, Marie Silvestre, Mathieu Bossaert, Mathieu
+   Lattes, Mayeul Kauffmann, Médéric Ribreux, Mehdi Semchaoui, Michael Douchin,
+   Nicolas Boisteault, Nicolas Rochard, Pascal Obstetar, Robin Prest, Rod Bera,
+   Stéphane Henriod, Stéphane Possamai, sylther, Sylvain Badey, Sylvain Maillard,
+   Vincent Picavet, Xavier Tardieu, Yann Leveille-Menez, yoda89"
+   "Galician", "Xan Vieiro"
+   "German", "Jürgen E. Fischer, Otto Dassau, Stephan Holl, Werner Macho"
+   "Hindi", "Harish Kumar Solanki"
+   "Italian", "Alessandro Fanna, Anne Ghisla, Flavio Rigolon, Giuliano Curti,
+   Luca Casagrande, Luca Delucchi, Marco Braida, Matteo Ghetta, Maurizio Napolitano,
+   Michele Beneventi, Michele Ferretti, Roberto Angeletti, Paolo Cavallini, Stefano Campus"
+   "Japanese", "Baba Yoshihiko, Minoru Akagi, Norihiro Yamate, Takayuki Mizutani,
+   Takayuki Nuimura, Yoichi Kayama"
+   "Korean", "OSGeo Korean Chapter"
+   "Polish", "Andrzej Świąder, Borys Jurgiel, Ewelina Krawczak, Jakub Bobrowski,
+   Mateusz Łoskot, Michał Kułach, Michał Smoczyk, Milena Nowotarska, Radosław
+   Pasiok, Robert Szczepanek, Tomasz Paul"
+   "Portuguese", "Alexandre Neto, Duarte Carreira, Giovanni Manghi, João Gaspar,
+   Joana Simões, Leandro Infantini, Nelson Silva, Pedro Palheiro, Pedro Pereira,
+   Ricardo Sena"
+   "Portuguese (Brasil)", "Arthur Nanni, Felipe Sodré Barros, Leônidas Descovi Filho,
+   Marcelo Soares Souza, Narcélio de Sá Pereira Filho, Sidney Schaberle Goveia"
+   "Romanian", "Alex Bădescu, Bogdan Pacurar, Georgiana Ioanovici, Lonut Losifescu-Enescu,
+   Sorin Călinică, Tudor Bărăscu"
+   "Russian", "Alexander Bruy, Artem Popov"
+   "Spanish", "Carlos Dávila, Diana Galindo, Edwin Amado, Gabriela Awad,
+   Javier César Aldariz, Mayeul Kauffmann, Fran Raga"
+   "Ukrainian", "Alexander Bruy"
 
 
 .. Substitutions definitions - AVOID EDITING PAST THIS LINE

--- a/source/docs/user_manual/print_composer/overview_composer.rst
+++ b/source/docs/user_manual/print_composer/overview_composer.rst
@@ -278,27 +278,28 @@ the same place, from page to page.
 Below is a list of all the available tools in this menu with some convenient
 information.
 
-================================================= ========================== ========================== =====================================
- Tool                                              Shortcut                   Toolbar                    Reference
-================================================= ========================== ========================== =====================================
- |undo| :guilabel:`Undo (last change)`             :kbd:`Ctrl+Z`              :guilabel:`Layout`         :ref:`layout_undo_panel`
- |redo| :guilabel:`Redo (last reverted change)`    :kbd:`Ctrl+Y`              :guilabel:`Layout`         :ref:`layout_undo_panel`
- |deleteSelected| :guilabel:`Delete`               :kbd:`Del`
- |editCut| :guilabel:`Cut`                         :kbd:`Ctrl+X`
- |editCopy| :guilabel:`Copy`                       :kbd:`Ctrl+C`
- |editPaste| :guilabel:`Paste`                     :kbd:`Ctrl+V`
- :guilabel:`Paste in place`                        :kbd:`Ctrl+Shift+V`
- |selectAll| :guilabel:`Select All`                :kbd:`Ctrl+A`
- |deselectAll| :guilabel:`Deselect all`            :kbd:`Ctrl+Shift+A`
- |invertSelection| :guilabel:`Invert Selection`
- :guilabel:`Select Next Item Below`                :kbd:`Ctrl+Alt+[`
- :guilabel:`Select Next Item above`                :kbd:`Ctrl+Alt+]`
- |pan| :guilabel:`Pan Layout`                      :kbd:`P`                   :guilabel:`Toolbox`
- |zoomToArea| :guilabel:`Zoom`                     :kbd:`Z`                   :guilabel:`Toolbox`
- |select| :guilabel:`Select/Move Item`             :kbd:`V`                   :guilabel:`Toolbox`        :ref:`interact_layout_item`
- |moveItemContent| :guilabel:`Move Content`        :kbd:`C`                   :guilabel:`Toolbox`        :ref:`layout_map_item`
- |editNodesShape| :guilabel:`Edit Nodes Item`                                 :guilabel:`Toolbox`        :ref:`layout_node_based_shape_item`
-================================================= ========================== ========================== =====================================
+.. csv-table:: Available Tools
+   :header: "Tool", "Shortcut", "Toolbar", "Reference"
+   :widths: 30, 17, 10, 33
+
+   "|undo| :guilabel:`Undo (last change)`", ":kbd:`Ctrl+Z`", ":guilabel:`Layout`", ":ref:`layout_undo_panel`"
+   "|redo| :guilabel:`Redo (last reverted change)`", ":kbd:`Ctrl+Y`", ":guilabel:`Layout`", ":ref:`layout_undo_panel`"
+   "|deleteSelected| :guilabel:`Delete`", ":kbd:`Del`"
+   "|editCut| :guilabel:`Cut`", ":kbd:`Ctrl+X`"
+   "|editCopy| :guilabel:`Copy`", ":kbd:`Ctrl+C`"
+   "|editPaste| :guilabel:`Paste`", ":kbd:`Ctrl+V`"
+   ":guilabel:`Paste in place`", ":kbd:`Ctrl+Shift+V`"
+   "|selectAll| :guilabel:`Select All`", ":kbd:`Ctrl+A`"
+   "|deselectAll| :guilabel:`Deselect all`", ":kbd:`Ctrl+Shift+A`"
+   "|invertSelection| :guilabel:`Invert Selection`"
+   ":guilabel:`Select Next Item Below`", ":kbd:`Ctrl+Alt+[`"
+   ":guilabel:`Select Next Item above`", ":kbd:`Ctrl+Alt+]`"
+   "|pan| :guilabel:`Pan Layout`", ":kbd:`P`", ":guilabel:`Toolbox`"
+   "|zoomToArea| :guilabel:`Zoom`", ":kbd:`Z`", ":guilabel:`Toolbox`"
+   "|select| :guilabel:`Select/Move Item`", ":kbd:`V`", ":guilabel:`Toolbox`", ":ref:`interact_layout_item`"
+   "|moveItemContent| :guilabel:`Move Content`", ":kbd:`C`", ":guilabel:`Toolbox`", ":ref:`layout_map_item`"
+   "|editNodesShape| :guilabel:`Edit Nodes Item`", "", ":guilabel:`Toolbox`", ":ref:`layout_node_based_shape_item`"
+
 
 
 View menu

--- a/source/docs/user_manual/processing/scripts.rst
+++ b/source/docs/user_manual/processing/scripts.rst
@@ -405,7 +405,7 @@ Processing with their corresponding alg decorator constants
 Sorted on class name.
 
 .. list-table:: Input types
-   :widths: 50 20 30
+   :widths: 24 55 21
    :header-rows: 1
 
    * - Alg constant
@@ -509,7 +509,7 @@ Sorted on class name.
 |
 
 .. list-table:: Output types
-   :widths: 50 20 30
+   :widths: 25 50 25
    :header-rows: 1
 
    * - Alg constant

--- a/source/docs/user_manual/working_with_ogc/server/services.rst
+++ b/source/docs/user_manual/working_with_ogc/server/services.rst
@@ -42,29 +42,27 @@ Specifications document according to the version number of the service:
 
 Standard requests provided by QGIS Server:
 
-+--------------------+-----------------------------------------------------------+
-| Request            |  Description                                              |
-+====================+===========================================================+
-| GetCapabilities    | Return XML metadata with information about the server     |
-+--------------------+-----------------------------------------------------------+
-| GetMap             | Return a map                                              |
-+--------------------+-----------------------------------------------------------+
-| GetFeatureInfo     | Retrieves data (geometry and values) for a pixel location |
-+--------------------+-----------------------------------------------------------+
-| GetLegendGraphics  | Returns legend symbols                                    |
-+--------------------+-----------------------------------------------------------+
+.. csv-table::
+   :header: "Request", "Description"
+   :widths: auto
 
-|
+   "GetCapabilities", "Returns XML metadata with information about the server"
+   "GetMap", "Returns a map"
+   "GetFeatureInfo", "Retrieves data (geometry and values) for a pixel location"
+   "GetLegendGraphics", "Returns legend symbols"
+
+.. only :: html
+
+   |
 
 Vendor requests provided by QGIS Server:
 
-+---------------------+---------------------------------------------------+
-| Request             |  Description                                      |
-+=====================+===================================================+
-| GetPrint            | Returns a QGIS composition                        |
-+---------------------+---------------------------------------------------+
-| GetProjectSettings  | Returns specific information about QGIS Server    |
-+---------------------+---------------------------------------------------+
+.. csv-table::
+   :header: "Request", "Description"
+   :widths: auto
+
+   "GetPrint", "Returns a QGIS composition"
+   "GetProjectSettings", "Returns specific information about QGIS Server"
 
 
 .. _`qgisserver-wms-getmap`:
@@ -75,78 +73,57 @@ GetMap
 Standard parameters for the **GetMap** request according to the OGC WMS 1.1.0
 and 1.3.0 specifications:
 
-+---------------+----------+-----------------------------------------------------+
-| Parameter     | Required | Description                                         |
-+===============+==========+=====================================================+
-| SERVICE       | Yes      | Name of the service (WMS)                           |
-+---------------+----------+-----------------------------------------------------+
-| VERSION       | No       | Version of the service                              |
-+---------------+----------+-----------------------------------------------------+
-| REQUEST       | Yes      | Name of the request (GetMap)                        |
-+---------------+----------+-----------------------------------------------------+
-| LAYERS        | No       | Layers to display                                   |
-+---------------+----------+-----------------------------------------------------+
-| STYLES        | No       | Layers' style                                       |
-+---------------+----------+-----------------------------------------------------+
-| SRS / CRS     | Yes      | Coordinate reference system                         |
-+---------------+----------+-----------------------------------------------------+
-| BBOX          | No       | Map extent                                          |
-+---------------+----------+-----------------------------------------------------+
-| WIDTH         | Yes      | Width of the image in pixels                        |
-+---------------+----------+-----------------------------------------------------+
-| HEIGHT        | Yes      | Height of the image in pixels                       |
-+---------------+----------+-----------------------------------------------------+
-| FORMAT        | No       | Image format                                        |
-+---------------+----------+-----------------------------------------------------+
-| TRANSPARENT   | No       | Transparent background                              |
-+---------------+----------+-----------------------------------------------------+
+.. csv-table::
+   :header: "Parameter", "Required", "Description"
+   :widths: auto
 
-|
+   "SERVICE", "Yes", "Name of the service (WMS)"
+   "VERSION", "No", "Version of the service"
+   "REQUEST", "Yes", "Name of the request (GetMap)"
+   "LAYERS", "No", "Layers to display"
+   "STYLES", "No", "Layers' style"
+   "SRS / CRS", "Yes", "Coordinate reference system"
+   "BBOX", "No", "Map extent"
+   "WIDTH", "Yes", "Width of the image in pixels"
+   "HEIGHT", "Yes", "Height of the image in pixels"
+   "FORMAT", "No", "Image format"
+   "TRANSPARENT", "No", "Transparent background"
+
+.. only:: html
+
+   |
 
 In addition to the standard ones, QGIS Server supports the following extra
 parameters:
 
 
-+----------------+----------+-------------------------------------------------------------------------+
-| Parameter      | Required | Description                                                             |
-+================+==========+=========================================================================+
-| MAP            | Yes      | Specify the QGIS project file                                           |
-+----------------+----------+-------------------------------------------------------------------------+
-| BGCOLOR        | No       | Specify the background color                                            |
-+----------------+----------+-------------------------------------------------------------------------+
-| DPI            | No       | Specify the output resolution                                           |
-+----------------+----------+-------------------------------------------------------------------------+
-| IMAGE_QUALITY  | No       | JPEG compression                                                        |
-+----------------+----------+-------------------------------------------------------------------------+
-| OPACITIES      | No       | Opacity for layer or group                                              |
-+----------------+----------+-------------------------------------------------------------------------+
-| FILTER         | No       | Subset of features                                                      |
-+----------------+----------+-------------------------------------------------------------------------+
-| SELECTION      | No       | Highlight features                                                      |
-+----------------+----------+-------------------------------------------------------------------------+
-| FILE_NAME      | No       | Only for ``FORMAT=application/dxf``                                     |
-|                |          |                                                                         |
-|                |          | File name of the downloaded file                                        |
-+----------------+----------+-------------------------------------------------------------------------+
-| FORMAT_OPTIONS | No       | Only for ``FORMAT=application/dxf``                                     |
-|                |          |                                                                         |
-|                |          | key:value pairs separated by                                            |
-|                |          | semicolon.                                                              |
-|                |          |                                                                         |
-|                |          | - SCALE:  to be used for symbology rules, filters and styles (not       |
-|                |          |   actual scaling of the data - data remains in the original scale).     |
-|                |          | - MODE:NOSYMBOLOGY|FEATURESYMBOLOGY|SYMBOLLAYERSYMBOLOGY:               |
-|                |          |   corresponds to the three export options offered in the QGIS           |
-|                |          |   Desktop DXF export dialog.                                            |
-|                |          | - LAYERSATTRIBUTES:yourcolumn_with_values_to_be_used_for_dxf_layernames |
-|                |          |   if not specified, the original QGIS layer names are used.             |
-|                |          | - USE_TITLE_AS_LAYERNAME:  if enabled, the title of the layer will      |
-|                |          |   be used as layer name.                                                |
-+----------------+----------+-------------------------------------------------------------------------+
-| TILED           | No      | Working in *tiled mode*                                                 |
-+----------------+----------+-------------------------------------------------------------------------+
+.. csv-table::
+   :header: "Parameter", "Required", "Description"
+   :widths: 20, 10, 65
 
-|
+   "MAP", "Yes", "Specify the QGIS project file"
+   "BGCOLOR", "No", "Specify the background color"
+   "DPI", "No", "Specify the output resolution"
+   "IMAGE_QUALITY", "No", "JPEG compression"
+   "OPACITIES", "No", "Opacity for layer or group"
+   "FILTER", "No", "Subset of features"
+   "SELECTION", "No", "Highlight features"
+   "FILE_NAME", "No", "Only for ``FORMAT=application/dxf``
+
+   File name of the downloaded file"
+   "FORMAT_OPTIONS", "No", "Only for ``FORMAT=application/dxf``
+   key:value pairs separated by semicolon.
+   
+   * SCALE:  to be used for symbology rules, filters and styles (not actual scaling of the data - data remains in the original scale).
+   * MODE:NOSYMBOLOGY|FEATURESYMBOLOGY|SYMBOLLAYERSYMBOLOGY: corresponds to the three export options offered in the QGIS Desktop DXF export dialog.
+   * LAYERSATTRIBUTES:field_with_values_to_use_for_dxf_layernames if not specified, the original QGIS layer names are used.
+   * USE_TITLE_AS_LAYERNAME: if enabled, the title of the layer will  be used as layer name.
+   "
+   "TILED", "No", "Working in *tiled mode*"
+
+.. only:: html
+
+   |
 
 URL example:
 
@@ -544,71 +521,52 @@ GetFeatureInfo
 Standard parameters for the **GetFeatureInfo** request according to the OGC WMS 1.1.0
 and 1.3.0 specifications:
 
-+---------------+----------+----------------------------------------------+
-| Parameter     | Required | Description                                  |
-+===============+==========+==============================================+
-| SERVICE       | Yes      | Name of the service (WMS)                    |
-+---------------+----------+----------------------------------------------+
-| VERSION       | No       | :ref:`See GetMap <qgisserver-wms-getmap>`    |
-+---------------+----------+----------------------------------------------+
-| REQUEST       | Yes      | :ref:`See GetMap <qgisserver-wms-getmap>`    |
-+---------------+----------+----------------------------------------------+
-| LAYERS        | No       | :ref:`See GetMap <qgisserver-wms-getmap>`    |
-+---------------+----------+----------------------------------------------+
-| STYLES        | No       | :ref:`See GetMap <qgisserver-wms-getmap>`    |
-+---------------+----------+----------------------------------------------+
-| SRS / CRS     | Yes      | :ref:`See GetMap <qgisserver-wms-getmap>`    |
-+---------------+----------+----------------------------------------------+
-| BBOX          | No       | :ref:`See GetMap <qgisserver-wms-getmap>`    |
-+---------------+----------+----------------------------------------------+
-| WIDTH         | Yes      | :ref:`See GetMap <qgisserver-wms-getmap>`    |
-+---------------+----------+----------------------------------------------+
-| HEIGHT        | Yes      | :ref:`See GetMap <qgisserver-wms-getmap>`    |
-+---------------+----------+----------------------------------------------+
-| TRANSPARENT   | No       | :ref:`See GetMap <qgisserver-wms-getmap>`    |
-+---------------+----------+----------------------------------------------+
-| INFO_FORMAT   | No       | Output format                                |
-+---------------+----------+----------------------------------------------+
-| QUERY_LAYERS  | Yes      | Layers to query                              |
-+---------------+----------+----------------------------------------------+
-| FEATURE_COUNT | No       | Maximum number of features to return         |
-+---------------+----------+----------------------------------------------+
-| I             | No       | Pixel column of the point to query           |
-+---------------+----------+----------------------------------------------+
-| X             | No       | Same as `I` parameter, but in WMS 1.1.0      |
-+---------------+----------+----------------------------------------------+
-| J             | No       | Pixel row of the point to query              |
-+---------------+----------+----------------------------------------------+
-| Y             | No       | Same as `J` parameter, but in WMS 1.1.0      |
-+---------------+----------+----------------------------------------------+
+.. csv-table::
+   :header: "Parameter", "Required", "Description"
+   :widths: auto
 
-|
+   "SERVICE", "Yes", "Name of the service (WMS)"
+   "VERSION", "No", ":ref:`See GetMap <qgisserver-wms-getmap>`"
+   "REQUEST", "Yes", ":ref:`See GetMap <qgisserver-wms-getmap>`"
+   "LAYERS", "No", ":ref:`See GetMap <qgisserver-wms-getmap>`"
+   "STYLES", "No", ":ref:`See GetMap <qgisserver-wms-getmap>`"
+   "SRS / CRS", "Yes", ":ref:`See GetMap <qgisserver-wms-getmap>`"
+   "BBOX", "No", ":ref:`See GetMap <qgisserver-wms-getmap>`"
+   "WIDTH", "Yes", ":ref:`See GetMap <qgisserver-wms-getmap>`"
+   "HEIGHT", "Yes", ":ref:`See GetMap <qgisserver-wms-getmap>`"
+   "TRANSPARENT", "No", ":ref:`See GetMap <qgisserver-wms-getmap>`"
+   "INFO_FORMAT", "No", "Output format"
+   "QUERY_LAYERS", "Yes", "Layers to query"
+   "FEATURE_COUNT", "No", "Maximum number of features to return"
+   "I", "No", "Pixel column of the point to query"
+   "X", "No", "Same as `I` parameter, but in WMS 1.1.0"
+   "J", "No", "Pixel row of the point to query"
+   "Y", "No", "Same as `J` parameter, but in WMS 1.1.0"
+
+.. only:: html
+
+   |
 
 In addition to the standard ones, QGIS Server supports the following extra
 parameters:
 
 
-+----------------------+----------+------------------------------------------+
-| Parameter            | Required | Description                              |
-+======================+==========+==========================================+
-| MAP                  | Yes      | :ref:`See GetMap <qgisserver-wms-getmap>`|
-+----------------------+----------+------------------------------------------+
-| FILTER               | No       | :ref:`See GetMap <qgisserver-wms-getmap>`|
-+----------------------+----------+------------------------------------------+
-| FI_POINT_TOLERANCE   | No       | Tolerance in pixels for point layers     |
-+----------------------+----------+------------------------------------------+
-| FI_LINE_TOLERANCE    | No       | Tolerance in pixels for line layers      |
-+----------------------+----------+------------------------------------------+
-| FI_POLYGON_TOLERANCE | No       | Tolerance in pixels for polygon layers   |
-+----------------------+----------+------------------------------------------+
-| FILTER_GEOM          | No       | Geometry filtering                       |
-+----------------------+----------+------------------------------------------+
-| WITH_MAPTIP          | No       | Add map tips to the output               |
-+----------------------+----------+------------------------------------------+
-| WITH_GEOMETRY        | No       | Add geometry to the output               |
-+----------------------+----------+------------------------------------------+
+.. csv-table::
+   :header: "Parameter", "Required", "Description"
+   :widths: auto
 
-|
+   "MAP", "Yes", ":ref:`See GetMap <qgisserver-wms-getmap>`"
+   "FILTER", "No", ":ref:`See GetMap <qgisserver-wms-getmap>`"
+   "FI_POINT_TOLERANCE", "No", "Tolerance in pixels for point layers"
+   "FI_LINE_TOLERANCE", "No", "Tolerance in pixels for line layers"
+   "FI_POLYGON_TOLERANCE", "No", "Tolerance in pixels for polygon layers"
+   "FILTER_GEOM", "No", "Geometry filtering"
+   "WITH_MAPTIP", "No", "Add map tips to the output"
+   "WITH_GEOMETRY", "No", "Add geometry to the output"
+
+.. only:: html
+
+   |
 
 URL example:
 
@@ -754,51 +712,34 @@ parameters of the contained layout maps and labels.
 
 Parameters for the **GetPrint** request:
 
-+-----------------------+----------+------------------------------------------+
-| Parameter             | Required | Description                              |
-+=======================+==========+==========================================+
-| MAP                   | Yes      | Specify the QGIS project file            |
-+-----------------------+----------+------------------------------------------+
-| SERVICE               | Yes      | Name of the service (WMS)                |
-+-----------------------+----------+------------------------------------------+
-| VERSION               | No       | :ref:`See GetMap <qgisserver-wms-getmap>`|
-+-----------------------+----------+------------------------------------------+
-| REQUEST               | Yes      | Name of the request (GetPrint)           |
-+-----------------------+----------+------------------------------------------+
-| LAYERS                | No       | :ref:`See GetMap <qgisserver-wms-getmap>`|
-+-----------------------+----------+------------------------------------------+
-| TEMPLATE              | Yes      | Layout template to use                   |
-+-----------------------+----------+------------------------------------------+
-| SRS / CRS             | Yes      | :ref:`See GetMap <qgisserver-wms-getmap>`|
-+-----------------------+----------+------------------------------------------+
-| FORMAT                | Yes      | Output format                            |
-+-----------------------+----------+------------------------------------------+
-| ATLAS_PK              | No       | Atlas features                           |
-+-----------------------+----------+------------------------------------------+
-| STYLES                | No       | :ref:`See GetMap <qgisserver-wms-getmap>`|
-+-----------------------+----------+------------------------------------------+
-| TRANSPARENT           | No       | :ref:`See GetMap <qgisserver-wms-getmap>`|
-+-----------------------+----------+------------------------------------------+
-| OPACITIES             | No       | :ref:`See GetMap <qgisserver-wms-getmap>`|
-+-----------------------+----------+------------------------------------------+
-| SELECTION             | No       | :ref:`See GetMap <qgisserver-wms-getmap>`|
-+-----------------------+----------+------------------------------------------+
-| mapX:EXTENT           | No       | Extent of the map 'X'                    |
-+-----------------------+----------+------------------------------------------+
-| mapX:LAYERS           | No       | Layers of the map 'X'                    |
-+-----------------------+----------+------------------------------------------+
-| mapX:STYLES           | No       | Layers' style of the map 'X'             |
-+-----------------------+----------+------------------------------------------+
-| mapX:SCALE            | No       | Layers' scale of the map 'X'             |
-+-----------------------+----------+------------------------------------------+
-| mapX:ROTATION         | No       | Rotation  of the map 'X'                 |
-+-----------------------+----------+------------------------------------------+
-| mapX:GRID_INTERVAL_X  | No       | Grid interval on x axis of the map 'X'   |
-+-----------------------+----------+------------------------------------------+
-| mapX:GRID_INTERVAL_Y  | No       | Grid interval on y axis of the map 'X'   |
-+-----------------------+----------+------------------------------------------+
+.. csv-table::
+   :header: "Parameter", "Required", "Description"
+   :widths: auto
 
-|
+   "MAP", "Yes", "Specify the QGIS project file"
+   "SERVICE", "Yes", "Name of the service (WMS)"
+   "VERSION", "No", ":ref:`See GetMap <qgisserver-wms-getmap>`"
+   "REQUEST", "Yes", "Name of the request (GetPrint)"
+   "LAYERS", "No", ":ref:`See GetMap <qgisserver-wms-getmap>`"
+   "TEMPLATE", "Yes", "Layout template to use"
+   "SRS / CRS", "Yes", ":ref:`See GetMap <qgisserver-wms-getmap>`"
+   "FORMAT", "Yes", "Output format"
+   "ATLAS_PK", "No", "Atlas features"
+   "STYLES", "No", ":ref:`See GetMap <qgisserver-wms-getmap>`"
+   "TRANSPARENT", "No", ":ref:`See GetMap <qgisserver-wms-getmap>`"
+   "OPACITIES", "No", ":ref:`See GetMap <qgisserver-wms-getmap>`"
+   "SELECTION", "No", ":ref:`See GetMap <qgisserver-wms-getmap>`"
+   "mapX:EXTENT", "No", "Extent of the map 'X'"
+   "mapX:LAYERS", "No", "Layers of the map 'X'"
+   "mapX:STYLES", "No", "Layers' style of the map 'X'"
+   "mapX:SCALE", "No", "Layers' scale of the map 'X'"
+   "mapX:ROTATION", "No", "Rotation  of the map 'X'"
+   "mapX:GRID_INTERVAL_X", "No", "Grid interval on x axis of the map 'X'"
+   "mapX:GRID_INTERVAL_Y", "No", "Grid interval on y axis of the map 'X'"
+
+.. only:: html
+
+   |
 
 URL example:
 
@@ -1008,17 +949,14 @@ Specifications document according to the version number of the service:
 
 Standard requests provided by QGIS Server:
 
-+--------------------+-----------------------------------------------------------+
-| Request            |  Description                                              |
-+====================+===========================================================+
-| GetCapabilities    | Returns XML metadata with information about the server    |
-+--------------------+-----------------------------------------------------------+
-| GetFeature         | Returns a selection of features                           |
-+--------------------+-----------------------------------------------------------+
-| DescribeFeatureType| Returns a description of feature types and properties     |
-+--------------------+-----------------------------------------------------------+
-| Transaction        | Allows features to be inserted, updated or deleted        |
-+--------------------+-----------------------------------------------------------+
+.. csv-table::
+   :header: "Request", "Description"
+   :widths: auto
+
+   "GetCapabilities", "Returns XML metadata with information about the server"
+   "GetFeature", "Returns a selection of features"
+   "DescribeFeatureType", "Returns a description of feature types and properties"
+   "Transaction", "Allows features to be inserted, updated or deleted"
 
 
 .. _`qgisserver-wfs-getfeature`:
@@ -1029,53 +967,40 @@ GetFeature
 Standard parameters for the **GetFeature** request according to the OGC WFS 1.0.0
 and 1.1.0 specifications:
 
-+---------------+----------+-------------------------------------+
-| Parameter     | Required | Description                         |
-+===============+==========+=====================================+
-| SERVICE       | Yes      | Name of the service                 |
-+---------------+----------+-------------------------------------+
-| VERSION       | No       | Version of the service              |
-+---------------+----------+-------------------------------------+
-| REQUEST       | Yes      | Name of the request                 |
-+---------------+----------+-------------------------------------+
-| TYPENAME      | No       | Name of layers                      |
-+---------------+----------+-------------------------------------+
-| OUTPUTFORMAT  | No       | Output Format                       |
-+---------------+----------+-------------------------------------+
-| RESULTTYPE    | No       | Type of the result                  |
-+---------------+----------+-------------------------------------+
-| PROPERTYNAME  | No       | Name of properties to return        |
-+---------------+----------+-------------------------------------+
-| MAXFEATURES   | No       | Maximum number of features to return|
-+---------------+----------+-------------------------------------+
-| SRSNAME       | No       | Coordinate reference system         |
-+---------------+----------+-------------------------------------+
-| FEATUREID     | No       | Filter the features by ids          |
-+---------------+----------+-------------------------------------+
-| FILTER        | No       | OGC Filter Encoding                 |
-+---------------+----------+-------------------------------------+
-| BBOX          | No       | Map Extent                          |
-+---------------+----------+-------------------------------------+
-| SORTBY        | No       | Sort the results                    |
-+---------------+----------+-------------------------------------+
+.. csv-table::
+   :header: "Parameter", "Required", "Description"
+   :widths: auto
 
-|
+   "SERVICE", "Yes", "Name of the service"
+   "VERSION", "No", "Version of the service"
+   "REQUEST", "Yes", "Name of the request"
+   "TYPENAME", "No", "Name of layers"
+   "OUTPUTFORMAT", "No", "Output Format"
+   "RESULTTYPE", "No", "Type of the result"
+   "PROPERTYNAME", "No", "Name of properties to return"
+   "MAXFEATURES", "No", "Maximum number of features to return"
+   "SRSNAME", "No", "Coordinate reference system"
+   "FEATUREID", "No", "Filter the features by ids"
+   "FILTER", "No", "OGC Filter Encoding"
+   "BBOX", "No", "Map Extent"
+   "SORTBY", "No", "Sort the results"
+
+.. only:: html
+
+   |
 
 In addition to the standard ones, QGIS Server supports the following extra
 parameters:
 
 
-+---------------+----------+----------------------------------+
-| Parameter     | Required | Description                      |
-+===============+==========+==================================+
-| MAP           | Yes      | Specify the QGIS project file    |
-+---------------+----------+----------------------------------+
-| STARTINDEX    | No       | Paging                           |
-+---------------+----------+----------------------------------+
-| GEOMETRYNAME  | No       | Type of geometry to return       |
-+---------------+----------+----------------------------------+
-| EXP_FILTER    | No       | Expression filtering             |
-+---------------+----------+----------------------------------+
+.. csv-table::
+   :header: "Parameter", "Required", "Description"
+   :widths: auto
+
+   "MAP", "Yes", "Specify the QGIS project file"
+   "STARTINDEX", "No", "Paging"
+   "GEOMETRYNAME", "No", "Type of geometry to return"
+   "EXP_FILTER", "No", "Expression filtering"
 
 
 SERVICE
@@ -1207,15 +1132,13 @@ Specifications document of the service:
 
 Standard requests provided by QGIS Server:
 
-+--------------------+-----------------------------------------------------------+
-| Request            |  Description                                              |
-+====================+===========================================================+
-| GetCapabilities    | Returns XML metadata with information about the server    |
-+--------------------+-----------------------------------------------------------+
-| GetTile            | Returns a tile                                            |
-+--------------------+-----------------------------------------------------------+
-| GetFeatureInfo     | Retrieves data (geometry and values) for a pixel location |
-+--------------------+-----------------------------------------------------------+
+.. csv-table::
+   :header: "Request", "Description"
+   :widths: auto
+
+   "GetCapabilities", "Returns XML metadata with information about the server"
+   "GetTile", "Returns a tile"
+   "GetFeatureInfo", "Retrieves data (geometry and values) for a pixel location"
 
 
 .. _`qgisserver-wmts-getcapabilities`:
@@ -1226,27 +1149,30 @@ GetCapabilities
 Standard parameters for the **GetCapabilities** request according to the OGC WMTS 1.0.0
 specifications:
 
-+---------------+----------+-----------------------------------------------+
-| Parameter     | Required | Description                                   |
-+===============+==========+===============================================+
-| SERVICE       | Yes      | Name of the service (WMTS)                    |
-+---------------+----------+-----------------------------------------------+
-| REQUEST       | Yes      | Name of the request (GetCapabilities)         |
-+---------------+----------+-----------------------------------------------+
+.. csv-table::
+   :header: "Parameter", "Required", "Description"
+   :widths: auto
 
-|
+   "SERVICE", "Yes", "Name of the service (WMTS)"
+   "REQUEST", "Yes", "Name of the request (GetCapabilities)"
+
+.. only:: html
+
+   |
 
 In addition to the standard ones, QGIS Server supports the following extra
 parameters:
 
 
-+---------------+----------+----------------------------------+
-| Parameter     | Required | Description                      |
-+===============+==========+==================================+
-| MAP           | Yes      | Specify the QGIS project file    |
-+---------------+----------+----------------------------------+
+.. csv-table::
+   :header: "Parameter", "Required", "Description"
+   :widths: auto
 
-|
+   "MAP", "Yes", "Specify the QGIS project file"
+
+.. only:: html
+
+   |
 
 URL example:
 
@@ -1285,39 +1211,36 @@ GetTile
 Standard parameters for the **GetTile** request according to the OGC WMTS 1.0.0
 specifications:
 
-+---------------+----------+----------------------------------+
-| Parameter     | Required | Description                      |
-+===============+==========+==================================+
-| SERVICE       | Yes      | Name of the service (WMTS)       |
-+---------------+----------+----------------------------------+
-| REQUEST       | Yes      | Name of the request (GetTile)    |
-+---------------+----------+----------------------------------+
-| LAYER         | Yes      | Layer identifier                 |
-+---------------+----------+----------------------------------+
-| FORMAT        | Yes      | Output format of the tile        |
-+---------------+----------+----------------------------------+
-| TILEMATRIXSET | Yes      | Name of the pyramid              |
-+---------------+----------+----------------------------------+
-| TILEMATRIX    | Yes      | Meshing                          |
-+---------------+----------+----------------------------------+
-| TILEROW       | Yes      | Row coordinate in the mesh       |
-+---------------+----------+----------------------------------+
-| TILECOL       | Yes      | Column coordinate in the mesh    |
-+---------------+----------+----------------------------------+
+.. csv-table::
+   :header: "Parameter", "Required", "Description"
+   :widths: auto
 
-|
+   "SERVICE", "Yes", "Name of the service (WMTS)"
+   "REQUEST", "Yes", "Name of the request (GetTile)"
+   "LAYER", "Yes", "Layer identifier"
+   "FORMAT", "Yes", "Output format of the tile"
+   "TILEMATRIXSET", "Yes", "Name of the pyramid"
+   "TILEMATRIX", "Yes", "Meshing"
+   "TILEROW", "Yes", "Row coordinate in the mesh"
+   "TILECOL", "Yes", "Column coordinate in the mesh"
+
+.. only:: html
+
+   |
 
 In addition to the standard ones, QGIS Server supports the following extra
 parameters:
 
 
-+---------------+----------+----------------------------------+
-| Parameter     | Required | Description                      |
-+===============+==========+==================================+
-| MAP           | Yes      | Specify the QGIS project file    |
-+---------------+----------+----------------------------------+
+.. csv-table::
+   :header: "Parameter", "Required", "Description"
+   :widths: auto
 
-|
+   "MAP", "Yes", "Specify the QGIS project file"
+
+.. only:: html
+
+   |
 
 URL example:
 
@@ -1446,43 +1369,38 @@ WMTS 1.0.0 specifications:
 
 - `WMS 1.1.0 <https://portal.opengeospatial.org/files/?artifact_id=1081&version=1&format=pdf>`_
 
-+---------------+----------+-----------------------------------------------+
-| Parameter     | Required | Description                                   |
-+===============+==========+===============================================+
-| SERVICE       | Yes      | Name of the service (WMTS)                    |
-+---------------+----------+-----------------------------------------------+
-| REQUEST       | Yes      | Name of the request (GetFeatureInfo)          |
-+---------------+----------+-----------------------------------------------+
-| LAYER         | Yes      | Layer identifier                              |
-+---------------+----------+-----------------------------------------------+
-| INFOFORMAT    | No       | Output format                                 |
-+---------------+----------+-----------------------------------------------+
-| I             | No       | X coordinate of a pixel                       |
-+---------------+----------+-----------------------------------------------+
-| J             | No       | Y coordinate of a pixel                       |
-+---------------+----------+-----------------------------------------------+
-| TILEMATRIXSET | Yes      | :ref:`See GetTile <qgisserver-wmts-gettile>`  |
-+---------------+----------+-----------------------------------------------+
-| TILEMATRIX    | Yes      | :ref:`See GetTile <qgisserver-wmts-gettile>`  |
-+---------------+----------+-----------------------------------------------+
-| TILEROW       | Yes      | :ref:`See GetTile <qgisserver-wmts-gettile>`  |
-+---------------+----------+-----------------------------------------------+
-| TILECOL       | Yes      | :ref:`See GetTile <qgisserver-wmts-gettile>`  |
-+---------------+----------+-----------------------------------------------+
+.. csv-table::
+   :header: "Parameter", "Required", "Description"
+   :widths: auto
 
-|
+   "SERVICE", "Yes", "Name of the service (WMTS)"
+   "REQUEST", "Yes", "Name of the request (GetFeatureInfo)"
+   "LAYER", "Yes", "Layer identifier"
+   "INFOFORMAT", "No", "Output format"
+   "I", "No", "X coordinate of a pixel"
+   "J", "No", "Y coordinate of a pixel"
+   "TILEMATRIXSET", "Yes", ":ref:`See GetTile <qgisserver-wmts-gettile>`"
+   "TILEMATRIX", "Yes", ":ref:`See GetTile <qgisserver-wmts-gettile>`"
+   "TILEROW", "Yes", ":ref:`See GetTile <qgisserver-wmts-gettile>`"
+   "TILECOL", "Yes", ":ref:`See GetTile <qgisserver-wmts-gettile>`"
+
+.. only::html
+
+   |
 
 In addition to the standard ones, QGIS Server supports the following extra
 parameters:
 
 
-+---------------+----------+----------------------------------+
-| Parameter     | Required | Description                      |
-+===============+==========+==================================+
-| MAP           | Yes      | Specify the QGIS project file    |
-+---------------+----------+----------------------------------+
+.. csv-table::
+   :header: "Parameter", "Required", "Description"
+   :widths: auto
 
-|
+   "MAP", "Yes", "Specify the QGIS project file"
+
+.. only:: html
+
+   |
 
 URL example:
 

--- a/source/docs/user_manual/working_with_vector/attribute_table.rst
+++ b/source/docs/user_manual/working_with_vector/attribute_table.rst
@@ -55,9 +55,9 @@ If you prefer shortcuts, :kbd:`F6` will open the attribute table.
 This will open a new window that displays the feature attributes for the
 layer (figure_attributes_table_). According to the setting in
 :menuselection:`Settings --> Options --> Data sources` menu, the attribute table
-will open in a docked window or a regular window. The total number of features in the layer
-and the number of currently selected/filtered features are shown in the
-attribute table title, as well as if the layer is spatially limited.
+will open in a docked window or a regular window. The total number of features
+in the layer and the number of currently selected/filtered features are shown
+in the attribute table title, as well as if the layer is spatially limited.
 
 
 .. _figure_attributes_table:
@@ -72,57 +72,35 @@ following functionality:
 
 .. _table_attribute_1:
 
-+-------------------------+-------------------------------------+--------------------------------------------+---------------------+
-| Icon                    | Label                               | Purpose                                    | Default Shortcut    |
-+=========================+=====================================+============================================+=====================+
-| |toggleEditing|         | Toggle editing mode                 | Enable editing functionalities             | :kbd:`Ctrl+E`       |
-+-------------------------+-------------------------------------+--------------------------------------------+---------------------+
-| |multiEdit|             | Toggle multi edit mode              | Update multiple fields of many features    |                     |
-+-------------------------+-------------------------------------+--------------------------------------------+---------------------+
-| |saveEdits|             | Save Edits                          | Save current modifications                 |                     |
-+-------------------------+-------------------------------------+--------------------------------------------+---------------------+
-| |draw|                  | Reload the table                    |                                            |                     |
-+-------------------------+-------------------------------------+--------------------------------------------+---------------------+
-| |newTableRow|           | Add feature                         | Add new geometryless feature               |                     |
-+-------------------------+-------------------------------------+--------------------------------------------+---------------------+
-| |deleteSelectedFeatures|| Delete selected features            | Remove selected features from the layer    |                     |
-+-------------------------+-------------------------------------+--------------------------------------------+---------------------+
-| |editCut|               | Cut selected features to clipboard  |                                            | :kbd:`Ctrl+X`       |
-+-------------------------+-------------------------------------+--------------------------------------------+---------------------+
-| |copySelected|          | Copy selected features to clipboard |                                            | :kbd:`Ctrl+C`       |
-+-------------------------+-------------------------------------+--------------------------------------------+---------------------+
-| |editPaste|             | Paste features from clipboard       | Insert new features from copied ones       | :kbd:`Ctrl+V`       |
-+-------------------------+-------------------------------------+--------------------------------------------+---------------------+
-| |expressionSelect|      | Select features using an Expression |                                            |                     |
-+-------------------------+-------------------------------------+--------------------------------------------+---------------------+
-| |selectAll|             | Select All                          | Select all features in the layer           | :kbd:`Ctrl+A`       |
-+-------------------------+-------------------------------------+--------------------------------------------+---------------------+
-| |invertSelection|       | Invert selection                    | Invert the current selection in the layer  | :kbd:`Ctrl+R`       |
-+-------------------------+-------------------------------------+--------------------------------------------+---------------------+
-| |deselectAll|           | Deselect all                        | Deselect all features in the current layer | :kbd:`Ctrl+Shift+A` |
-+-------------------------+-------------------------------------+--------------------------------------------+---------------------+
-| |filterMap|             | Filter/Select features using form   |                                            | :kbd:`Ctrl+F`       |
-+-------------------------+-------------------------------------+--------------------------------------------+---------------------+
-| |selectedToTop|         | Move selected to top                | Move selected rows to the top of the table |                     |
-+-------------------------+-------------------------------------+--------------------------------------------+---------------------+
-| |panToSelected|         | Pan map to the selected rows        |                                            | :kbd:`Ctrl+P`       |
-+-------------------------+-------------------------------------+--------------------------------------------+---------------------+
-| |zoomToSelected|        | Zoom map to the selected rows       |                                            | :kbd:`Ctrl+J`       |
-+-------------------------+-------------------------------------+--------------------------------------------+---------------------+
-| |newAttribute|          | New field                           | Add a new field to the data source         | :kbd:`Ctrl+W`       |
-+-------------------------+-------------------------------------+--------------------------------------------+---------------------+
-| |deleteAttribute|       | Delete field                        | Remove a field from the data source        |                     |
-+-------------------------+-------------------------------------+--------------------------------------------+---------------------+
-| |calculateField|        | Open field calculator               | Update field for many features in a row    | :kbd:`Ctrl+I`       |
-+-------------------------+-------------------------------------+--------------------------------------------+---------------------+
-| |conditionalFormatting| | Conditional formatting              | Enable table formatting                    |                     |
-+-------------------------+-------------------------------------+--------------------------------------------+---------------------+
-| |dock|                  | Dock attribute table                | Allows to dock/undock the attribute table  |                     |
-+-------------------------+-------------------------------------+--------------------------------------------+---------------------+
-| |actionRun|             | Actions                             | Lists the actions related to the layer     |                     |
-+-------------------------+-------------------------------------+--------------------------------------------+---------------------+
+.. csv-table:: Available Tools
+   :header: "Icon", "Label", "Purpose", "Default Shortcut"
+   :widths: auto
+   :class: longtable
 
-Table Attribute 1: Available Tools
+   "|toggleEditing|", "Toggle editing mode", "Enable editing functionalities", ":kbd:`Ctrl+E`"
+   "|multiEdit|", "Toggle multi edit mode", "Update multiple fields of many features"
+   "|saveEdits|", "Save Edits", "Save current modifications"
+   "|draw|", "Reload the table"
+   "|newTableRow|", "Add feature", "Add new geometryless feature"
+   "|deleteSelectedFeatures|", "Delete selected features", "Remove selected features from the layer"
+   "|editCut|", "Cut selected features to clipboard", "", ":kbd:`Ctrl+X`"
+   "|copySelected|", "Copy selected features to clipboard", "", ":kbd:`Ctrl+C`"
+   "|editPaste|", "Paste features from clipboard", "Insert new features from copied ones", ":kbd:`Ctrl+V`"
+   "|expressionSelect|", "Select features using an Expression"
+   "|selectAll|", "Select All", "Select all features in the layer", ":kbd:`Ctrl+A`"
+   "|invertSelection|", "Invert selection", "Invert the current selection in the layer", ":kbd:`Ctrl+R`"
+   "|deselectAll|", "Deselect all", "Deselect all features in the current layer", ":kbd:`Ctrl+Shift+A`"
+   "|filterMap|", "Filter/Select features using form", "", ":kbd:`Ctrl+F`"
+   "|selectedToTop|", "Move selected to top", "Move selected rows to the top of the table"
+   "|panToSelected|", "Pan map to the selected rows", "", ":kbd:`Ctrl+P`"
+   "|zoomToSelected|", "Zoom map to the selected rows", "", ":kbd:`Ctrl+J`"
+   "|newAttribute|", "New field", "Add a new field to the data source", ":kbd:`Ctrl+W`"
+   "|deleteAttribute|", "Delete field", "Remove a field from the data source"
+   "|calculateField|", "Open field calculator", "Update field for many features in a row", ":kbd:`Ctrl+I`"
+   "|conditionalFormatting|", "Conditional formatting", "Enable table formatting"
+   "|dock|", "Dock attribute table", "Allows to dock/undock the attribute table"
+   "|actionRun|", "Actions", "Lists the actions related to the layer"
+
 
 .. note:: Depending on the format of the data and the OGR library built with
    your QGIS version, some tools may not be available.

--- a/source/docs/user_manual/working_with_vector/expression.rst
+++ b/source/docs/user_manual/working_with_vector/expression.rst
@@ -185,55 +185,42 @@ Aggregates Functions
 
 This group contains functions which aggregate values over layers and fields.
 
-========================== =======================================================
- Function                   Description
-========================== =======================================================
- aggregate                  Returns an aggregate value calculated using
-                            features from another layer
- array_agg                  Returns an array of aggregated values from a field
-                            or expression
- collect                    Returns the multipart geometry of aggregated
-                            geometries from an expression
- concatenate                Returns all aggregated strings from a field
-                            or expression joined by a delimiter
- concatenate_unique |38|    Returns all unique aggregated strings from a field
-                            or expression joined by a delimiter
- count                      Returns the count of matching features
- count_distinct             Returns the count of distinct values
- count_missing              Returns the count of missing (null) values
- iqr                        Returns the calculated inter quartile range from
-                            a field or expression
- majority                   Returns the aggregate majority of values (most
-                            commonly occurring value) from a field or expression
- max_length                 Returns the maximum length of strings from a field
-                            or expression
- maximum                    Returns the aggregate maximum value from a field
-                            or expression
- mean                       Returns the aggregate mean value from a field
-                            or expression
- median                     Returns the aggregate median value from a field
-                            or expression
- min_length                 Returns the minimum length of strings from a field
-                            or expression
- minimum                    Returns the aggregate minimum value from a field
-                            or expression
- minority                   Returns the aggregate minority of values (least
-                            commonly occurring value) from a field or expression
- q1                         Returns the calculated first quartile from a field
-                            or expression
- q3                         Returns the calculated third quartile from a field
-                            or expression
- range                      Returns the aggregate range of values (maximum -
-                            minimum) from a field or expression
- relation_aggregate         Returns an aggregate value calculated using all
-                            matching child features from a layer relation
- stdev                      Returns the aggregate standard deviation value
-                            from a field or expression
- sum                        Returns the aggregate summed value from a field
-                            or expression
-========================== =======================================================
+.. csv-table::
+   :header: "Function", "Description"
+   :widths: 20, 75
+   :class: longtable
 
-|
+   "aggregate", "Returns an aggregate value calculated using features from another layer"
+   "array_agg", "Returns an array of aggregated values from a field or expression"
+   "collect", "Returns the multipart geometry of aggregated geometries from an expression"
+   "concatenate", "Returns all aggregated strings from a field or expression joined by a delimiter"
+   "concatenate_unique |38|", "Returns all unique aggregated strings from a field
+   or expression joined by a delimiter"
+   "count", "Returns the count of matching features"
+   "count_distinct", "Returns the count of distinct values"
+   "count_missing", "Returns the count of missing (null) values"
+   "iqr", "Returns the calculated inter quartile range from a field or expression"
+   "majority", "Returns the aggregate majority of values (most commonly occurring
+   value) from a field or expression"
+   "max_length", "Returns the maximum length of strings from a field or expression"
+   "maximum", "Returns the aggregate maximum value from a field or expression"
+   "mean", "Returns the aggregate mean value from a field or expression"
+   "median", "Returns the aggregate median value from a field or expression"
+   "min_length", "Returns the minimum length of strings from a field or expression"
+   "minimum", "Returns the aggregate minimum value from a field or expression"
+   "minority", "Returns the aggregate minority of values (least commonly occurring
+   value) from a field or expression"
+   "q1", "Returns the calculated first quartile from a field or expression"
+   "q3", "Returns the calculated third quartile from a field or expression"
+   "range", "Returns the aggregate range of values (maximum - minimum) from a field or expression"
+   "relation_aggregate", "Returns an aggregate value calculated using all matching
+   child features from a layer relation"
+   "stdev", "Returns the aggregate standard deviation value from a field or expression"
+   "sum", "Returns the aggregate summed value from a field or expression"
+
+.. only:: html
+
+   |
 
 **Examples:**
 
@@ -270,45 +257,44 @@ list data structures). The order of values within the array matters, unlike the
 :ref:`'map' data structure <maps_functions>`, where the order of key-value pairs
 is irrelevant and values are identified by their keys.
 
-====================== =======================================================
- Function               Description
-====================== =======================================================
- array                  Returns an array containing all the values passed
-                        as parameter
- array_all |38|         Returns true if an array contains all the values of a given array
- array_append           Returns an array with the given value added at the end
- array_cat              Returns an array containing all the given arrays concatenated
- array_contains         Returns true if an array contains the given value
- array_distinct         Returns an array containing distinct values of the given array
- array_filter           Returns an array with only the items for which an expression
-                        evaluates to true
- array_find             Returns the index (0 for the first one) of a value
-                        within an array. Returns -1 if the value is not found.
- array_first            Returns the first value of an array
- array_foreach          Returns an array with the given expression evaluated on each item
- array_get              Returns the Nth value (0 for the first one) of an array
- array_insert           Returns an array with the given value added at the
-                        given position
- array_intersect        Returns true if any element of array_1 exists in array_2
- array_last             Returns the last element of an array
- array_length           Returns the number of elements of an array
- array_prepend          Returns an array with the given value added at the beginning
- array_remove_all       Returns an array with all the entries of the given
-                        value removed
- array_remove_at        Returns an array with the given index removed
- array_reverse          Returns the given array with array values in reversed order
- array_slice            Returns the values of the array from the start_pos argument up
-                        to and including the end_pos argument
- array_sort |36|        Returns the provided array with its elements sorted
- array_to_string        Concatenates array elements into a string separated by
-                        a delimiter and using optional string for empty values
- generate_series        Creates an array containing a sequence of numbers
- regexp_matches         Returns an array of all strings captured by capturing
-                        groups, in the order the groups themselves appear in
-                        the supplied regular expression against a string
- string_to_array        Splits string into an array using supplied delimiter
-                        and optional string for empty values
-====================== =======================================================
+
+.. csv-table::
+   :header: "Function", "Description"
+   :widths: 20, 75
+   :class: longtable
+
+   "array", "Returns an array containing all the values passed as parameter"
+   "array_all |38|", "Returns true if an array contains all the values of a given array"
+   "array_append", "Returns an array with the given value added at the end"
+   "array_cat", "Returns an array containing all the given arrays concatenated"
+   "array_contains", "Returns true if an array contains the given value"
+   "array_distinct", "Returns an array containing distinct values of the given array"
+   "array_filter", "Returns an array with only the items for which an expression
+   evaluates to true"
+   "array_find", "Returns the index (0 for the first one) of a value within an array.
+   Returns -1 if the value is not found."
+   "array_first", "Returns the first value of an array"
+   "array_foreach", "Returns an array with the given expression evaluated on each item"
+   "array_get", "Returns the Nth value (0 for the first one) of an array"
+   "array_insert", "Returns an array with the given value added at the given position"
+   "array_intersect", "Returns true if any element of array_1 exists in array_2"
+   "array_last", "Returns the last element of an array"
+   "array_length", "Returns the number of elements of an array"
+   "array_prepend", "Returns an array with the given value added at the beginning"
+   "array_remove_all", "Returns an array with all the entries of the given value removed"
+   "array_remove_at", "Returns an array with the given index removed"
+   "array_reverse", "Returns the given array with array values in reversed order"
+   "array_slice", "Returns the values of the array from the start_pos argument
+   up to and including the end_pos argument"
+   "array_sort |36|", "Returns the provided array with its elements sorted"
+   "array_to_string", "Concatenates array elements into a string separated by a
+   delimiter and using optional string for empty values"
+   "generate_series", "Creates an array containing a sequence of numbers"
+   "regexp_matches", "Returns an array of all strings captured by capturing groups,
+   in the order the groups themselves appear in the supplied regular expression
+   against a string"
+   "string_to_array", "Splits string into an array using supplied delimiter and
+   optional string for empty values"
 
 
 Color Functions
@@ -316,43 +302,27 @@ Color Functions
 
 This group contains functions for manipulating colors.
 
-============================== ==========================================================
- Function                       Description
-============================== ==========================================================
- color_cmyk                     Returns a string representation of a color based on
-                                its cyan, magenta, yellow and black components
- color_cmyka                    Returns a string representation of a color based on
-                                its cyan, magenta, yellow, black and alpha (transparency)
-                                components
- color_grayscale_average        Applies a grayscale filter and returns a string
-                                representation from a provided color
- color_hsl                      Returns a string representation of a color based on
-                                its hue, saturation, and lightness attributes
- color_hsla                     Returns a string representation of a color based on its
-                                hue, saturation, lightness and alpha (transparency)
-                                attributes
- color_hsv                      Returns a string representation of a color based on
-                                its hue, saturation, and value attributes
- color_hsva                     Returns a string representation of a color based on
-                                its hue, saturation, value and alpha (transparency)
-                                attributes
- color_mix_rgb                  Returns a string representing a color mixing the red,
-                                green, blue, and alpha values of two provided colors
-                                based on a given ratio
- color_part                     Returns a specific component from a color string,
-                                eg the red component or alpha component
- color_rgb                      Returns a string representation of a color based on
-                                its red, green, and blue components
- color_rgba                     Returns a string representation of a color based on
-                                its red, green, blue, and alpha (transparency) components
- create_ramp                    Returns a gradient ramp from a map of color strings and steps
- darker                         Returns a darker (or lighter) color string
- lighter                        Returns a lighter (or darker) color string
- project_color                  Returns a color from the project's color scheme
- ramp_color                     Returns a string representing a color from a color ramp
- set_color_part                 Sets a specific color component for a color string,
-                                eg the red component or alpha component
-============================== ==========================================================
+.. csv-table::
+   :header: "Function", "Description"
+   :widths: 25, 70
+
+   "color_cmyk", "Returns a string representation of a color based on its cyan, magenta, yellow and black components"
+   "color_cmyka", "Returns a string representation of a color based on its cyan, magenta, yellow, black and alpha (transparency) components"
+   "color_grayscale_average", "Applies a grayscale filter and returns a string representation from a provided color"
+   "color_hsl", "Returns a string representation of a color based on its hue, saturation, and lightness attributes"
+   "color_hsla", "Returns a string representation of a color based on its hue, saturation, lightness and alpha (transparency) attributes"
+   "color_hsv", "Returns a string representation of a color based on its hue, saturation, and value attributes"
+   "color_hsva", "Returns a string representation of a color based on its hue, saturation, value and alpha (transparency) attributes"
+   "color_mix_rgb", "Returns a string representing a color mixing the red, green, blue, and alpha values of two provided colors based on a given ratio"
+   "color_part", "Returns a specific component from a color string, eg the red component or alpha component"
+   "color_rgb", "Returns a string representation of a color based on its red, green, and blue components"
+   "color_rgba", "Returns a string representation of a color based on its red, green, blue, and alpha (transparency) components"
+   "create_ramp", "Returns a gradient ramp from a map of color strings and steps"
+   "darker", "Returns a darker (or lighter) color string"
+   "lighter", "Returns a lighter (or darker) color string"
+   "project_color", "Returns a color from the project's color scheme"
+   "ramp_color", "Returns a string representing a color from a color ramp"
+   "set_color_part", "Sets a specific color component for a color string, eg the red component or alpha component"
 
 
 Conditional Functions
@@ -360,28 +330,20 @@ Conditional Functions
 
 This group contains functions to handle conditional checks in expressions.
 
-===================================== =========================================
- Function                              Description
-===================================== =========================================
- CASE WHEN ... THEN ... END           Evaluates an expression and returns a
-                                      result if true. You can test multiple
-                                      conditions
- CASE WHEN ... THEN ... ELSE ... END  Evaluates an expression and returns a
-                                      different result whether it's true or
-                                      false. You can test multiple conditions
- coalesce                             Returns the first non-NULL value from
-                                      the expression list
- if                                   Tests a condition and returns a
-                                      different result depending on the
-                                      conditional check
- nullif(value1, value2) |36|          Returns a null value if value1 equals value2
-                                      otherwise it returns value1. This can be
-                                      used to conditionally substitute values with NULL.
- try |36|                             Tries an expression and returns its value if error-free,
-                                      an alternative value (if provided) or Null if an error occurs
-===================================== =========================================
+.. csv-table::
+   :header: "Function", "Description"
+   :widths: auto
 
-|
+   "CASE WHEN ... THEN ... END", "Evaluates an expression and returns a result if true. You can test multiple conditions"
+   "CASE WHEN ... THEN ... ELSE ... END", "Evaluates an expression and returns a different result whether it's true or false. You can test multiple conditions"
+   "coalesce", "Returns the first non-NULL value from the expression list"
+   "if", "Tests a condition and returns a different result depending on the conditional check"
+   "nullif(value1, value2) |36|", "Returns a null value if value1 equals value2 otherwise it returns value1. This can be used to conditionally substitute values with NULL."
+   "try |36|", "Tries an expression and returns its value if error-free,an alternative value (if provided) or Null if an error occurs"
+
+.. only:: html
+
+   |
 
 **Some example:**
 
@@ -398,20 +360,19 @@ Conversions Functions
 This group contains functions to convert one data type to another
 (e.g., string to integer, integer to string).
 
-==================  ========================================================
- Function            Description
-==================  ========================================================
- to_date             Converts a string into a date object
- to_datetime         Converts a string into a datetime object
- to_dm               Converts a coordinate to degree, minute
- to_dms              Converts coordinate to degree, minute, second
- to_int              Converts a string to integer number
- to_interval         Converts a string to an interval type (can be used
-                     to take days, hours, months, etc. of a date)
- to_real             Converts a string to a real number
- to_string           Converts number to string
- to_time             Converts a string into a time object
-==================  ========================================================
+.. csv-table::
+   :header: "Function", "Description"
+   :widths: auto
+
+   "to_date", "Converts a string into a date object"
+   "to_datetime", "Converts a string into a datetime object"
+   "to_dm", "Converts a coordinate to degree, minute"
+   "to_dms", "Converts coordinate to degree, minute, second"
+   "to_int", "Converts a string to integer number"
+   "to_interval", "Converts a string to an interval type (can be used to take days, hours, months, etc. of a date)"
+   "to_real", "Converts a string to a real number"
+   "to_string", "Converts number to string"
+   "to_time", "Converts a string into a time object"
 
 
 Custom Functions
@@ -426,33 +387,25 @@ Date and Time Functions
 
 This group contains functions for handling date and time data.
 
-==============  ==============================================================
- Function        Description
-==============  ==============================================================
- age             Returns as an interval the difference between two dates
-                 or datetimes
- day             Extracts the day from a date or datetime, or the number
-                 of days from an interval
- day_of_week     Returns a number corresponding to the day of the week
-                 for a specified date or datetime
- epoch           Returns the interval in milliseconds between the unix
-                 epoch and a given date value
- hour            Extracts the hour from a datetime or time,
-                 or the number of hours from an interval
- minute          Extracts the minute from a datetime or time,
-                 or the number of minutes from an interval
- month           Extracts the month part from a date or datetime, or the
-                 number of months from an interval
- now             Returns current date and time
- second          Extracts the second from a datetime or time,
-                 or the number of seconds from an interval
- week            Extracts the week number from a date or datetime,
-                 or the number of weeks from an interval
- year            Extracts the year part from a date or datetime,
-                 or the number of years from an interval
-==============  ==============================================================
+.. csv-table::
+   :header: "Function", "Description"
+   :widths: auto
 
-|
+   "age", "Returns as an interval the difference between two dates or datetimes"
+   "day", "Extracts the day from a date or datetime, or the number of days from an interval"
+   "day_of_week", "Returns a number corresponding to the day of the week for a specified date or datetime"
+   "epoch", "Returns the interval in milliseconds between the unix epoch and a given date value"
+   "hour", "Extracts the hour from a datetime or time, or the number of hours from an interval"
+   "minute", "Extracts the minute from a datetime or time, or the number of minutes from an interval"
+   "month", "Extracts the month part from a date or datetime, or the number of months from an interval"
+   "now", "Returns current date and time"
+   "second", "Extracts the second from a datetime or time, or the number of seconds from an interval"
+   "week", "Extracts the week number from a date or datetime, or the number of weeks from an interval"
+   "year", "Extracts the year part from a date or datetime,or the number of years from an interval"
+
+.. only:: html
+
+   |
 
 This group also shares several functions with the :ref:`conversion_functions` (
 to_date, to_time, to_datetime, to_interval) and :ref:`string_functions`
@@ -535,21 +488,18 @@ Files and Paths Functions |38|
 
 This group contains functions which manipulate file and path names.
 
-====================  =======================================================
- Function              Description
-====================  =======================================================
- base_file_name        Returns the base name of the file without the directory
-                       or file suffix.
- file_exists           Returns true if a file path exists.
- file_name             Returns the name of a file (including the file extension),
-                       excluding the directory.
- file_path             Returns the directory component of a file path, without
-                       the file name
- file_size             Returns the size (in bytes) of a file.
- file_suffix           Returns the file extension from a file path.
- is_directory          Returns true if a path corresponds to a directory.
- is_file               Returns true if a path corresponds to a file.
-====================  =======================================================
+.. csv-table::
+   :header: "Function", "Description"
+   :widths: auto
+
+   "base_file_name", "Returns the base name of the file without the directory or file suffix."
+   "file_exists", "Returns true if a file path exists."
+   "file_name", "Returns the name of a file (including the file extension), excluding the directory."
+   "file_path", "Returns the directory component of a file path, without the file name"
+   "file_size", "Returns the size (in bytes) of a file."
+   "file_suffix", "Returns the file extension from a file path."
+   "is_directory", "Returns true if a path corresponds to a directory."
+   "is_file", "Returns true if a path corresponds to a file."
 
 
 Fuzzy Matching Functions
@@ -557,20 +507,14 @@ Fuzzy Matching Functions
 
 This group contains functions for fuzzy comparisons between values.
 
-=========================== =================================================
- Function                    Description
-=========================== =================================================
- hamming_distance            Returns the number of characters at
-                             corresponding positions within the input
-                             strings where the characters are different
- levensheim                  Returns the minimum number of character edits
-                             (insertions, deletions or substitutions)
-                             required to change one string to another.
-                             Measure the similarity between two strings
- longest_common_substring    Returns the longest common substring between
-                             two strings
- soundex                     Returns the Soundex representation of a string
-=========================== =================================================
+.. csv-table::
+   :header: "Function", "Description"
+   :widths: 25, 70
+
+   "hamming_distance", "Returns the number of characters at corresponding positions within the input strings where the characters are different"
+   "levensheim", "Returns the minimum number of character edits (insertions, deletions or substitutions) required to change one string to another. Measure the similarity between two strings"
+   "longest_common_substring", "Returns the longest common substring between two strings"
+   "soundex", "Returns the Soundex representation of a string"
 
 
 General Functions
@@ -578,26 +522,16 @@ General Functions
 
 This group contains general assorted functions.
 
-====================  =======================================================
- Function              Description
-====================  =======================================================
- env                   Gets an environment variable and returns its content
-                       as a string. If the variable is not found, ``NULL``
-                       will be returned.
- eval                  Evaluates an expression which is passed in a string.
-                       Useful to expand dynamic parameters passed as context
-                       variables or fields
- is_layer_visible      Returns true if a specified layer is visible
- layer_property        Returns a property of a layer or a value of its
-                       metadata. It can be layer name, crs, geometry type,
-                       feature count...
- var                   Returns the value stored within a specified
-                       variable. See variable functions below
- with_variable         Creates and sets a variable for any expression code
-                       that will be provided as a third argument. Useful to
-                       avoid repetition in expressions where the same value
-                       needs to be used more than once.
-====================  =======================================================
+.. csv-table::
+   :header: "Function", "Description"
+   :widths: 20, 75
+
+   "env", "Gets an environment variable and returns its content as a string. If the variable is not found, ``NULL`` will be returned."
+   "eval", "Evaluates an expression which is passed in a string. Useful to expand dynamic parameters passed as context variables or fields."
+   "is_layer_visible", "Returns true if a specified layer is visible"
+   "layer_property", "Returns a property of a layer or a value of its metadata. It can be layer name, crs, geometry type, feature count..."
+   "var", "Returns the value stored within a specified variable. See variable functions below"
+   "with_variable", "Creates and sets a variable for any expression code that will be provided as a third argument. Useful to avoid repetition in expressions where the same value needs to be used more than once."
 
 
 .. _geometry_functions:
@@ -607,379 +541,199 @@ Geometry Functions
 
 This group contains functions that operate on geometry objects (e.g., length, area).
 
-+------------------------+---------------------------------------------------+
-| Function               | Description                                       |
-+========================+===================================================+
-| $area                  | Returns the area size of the current feature      |
-+------------------------+---------------------------------------------------+
-| $geometry              | Returns the geometry of the current feature (can  |
-|                        | be used for processing with other functions)      |
-+------------------------+---------------------------------------------------+
-| $length                | Returns the length of the current line feature    |
-+------------------------+---------------------------------------------------+
-| $perimeter             | Returns the perimeter of the current polygon      |
-|                        | feature                                           |
-+------------------------+---------------------------------------------------+
-| $x                     | Returns the X coordinate of the current feature   |
-+------------------------+---------------------------------------------------+
-| $x_at(n)               | Returns the X coordinate of the nth node of the   |
-|                        | current feature's geometry                        |
-+------------------------+---------------------------------------------------+
-| $y                     | Returns the Y coordinate of the current feature   |
-+------------------------+---------------------------------------------------+
-| $y_at(n)               | Returns the Y coordinate of the nth node of the   |
-|                        | current feature's geometry                        |
-+------------------------+---------------------------------------------------+
-| angle_at_vertex        | Returns the bisector angle (average angle) to the |
-|                        | geometry for a specified vertex on a linestring   |
-|                        | geometry. Angles are in degrees clockwise from    |
-|                        | north                                             |
-+------------------------+---------------------------------------------------+
-| area                   | Returns the area of a geometry polygon feature.   |
-|                        | Calculations are in the Spatial Reference System  |
-|                        | of this geometry                                  |
-+------------------------+---------------------------------------------------+
-| azimuth                | Returns the north-based azimuth as the angle in   |
-|                        | radians measured clockwise from the vertical on   |
-|                        | point_a to point_b                                |
-+------------------------+---------------------------------------------------+
-| boundary               | Returns the closure of the combinatorial boundary |
-|                        | of the geometry (ie the topological boundary of   |
-|                        | the geometry - see also :ref:`qgisboundary`).     |
-+------------------------+---------------------------------------------------+
-| bounds                 | Returns a geometry which represents the bounding  |
-|                        | box of an input geometry. Calculations are in     |
-|                        | the Spatial Reference System of this geometry     |
-|                        | (see also :ref:`qgisboundingboxes`)               |
-+------------------------+---------------------------------------------------+
-| bounds_height          | Returns the height of the bounding box of a       |
-|                        | geometry. Calculations are in the Spatial         |
-|                        | Reference System of this geometry                 |
-+------------------------+---------------------------------------------------+
-| bounds_width           | Returns the width of the bounding box of a        |
-|                        | geometry. Calculations are in the Spatial         |
-|                        | Reference System of this geometry                 |
-+------------------------+---------------------------------------------------+
-| buffer                 | Returns a geometry that represents all points     |
-|                        | whose distance from this geometry is less than    |
-|                        | or equal to distance. Calculations are in the     |
-|                        | Spatial Reference System of this geometry         |
-|                        | (see also :ref:`qgisbuffer`)                      |
-+------------------------+---------------------------------------------------+
-| buffer_by_m            | Creates a buffer along a line geometry where the  |
-|                        | buffer diameter varies according to the M values  |
-|                        | at the line vertices                              |
-|                        | (see also :ref:`qgisbufferbym`)                   |
-+------------------------+---------------------------------------------------+
-| centroid               | Returns the geometric center of a geometry        |
-|                        | (see also :ref:`qgiscentroids`)                   |
-+------------------------+---------------------------------------------------+
-| closest_point          | Returns the point on a geometry that is closest   |
-|                        | to a second geometry                              |
-+------------------------+---------------------------------------------------+
-| combine                | Returns the combination of two geometries         |
-+------------------------+---------------------------------------------------+
-| contains(a,b)          | Returns 1 (true) if and only if no points of b    |
-|                        | lie in the exterior of a, and at least one point  |
-|                        | of the interior of b lies in the interior of a    |
-+------------------------+---------------------------------------------------+
-| convex_hull            | Returns the convex hull of a geometry (this       |
-|                        | represents the minimum convex geometry that       |
-|                        | encloses all geometries within the set)           |
-|                        | (see also :ref:`qgisconvexhull`)                  |
-+------------------------+---------------------------------------------------+
-| crosses                | Returns 1 (true) if the supplied geometries have  |
-|                        | some, but not all, interior points in common      |
-+------------------------+---------------------------------------------------+
-| difference(a,b)        | Returns a geometry that represents that part of   |
-|                        | geometry a that does not intersect with geometry b|
-|                        | (see also :ref:`qgisdifference`)                  |
-+------------------------+---------------------------------------------------+
-| disjoint               | Returns 1 (true) if the geometries do not share   |
-|                        | any space together                                |
-+------------------------+---------------------------------------------------+
-| distance               | Returns the minimum distance (based on Spatial    |
-|                        | Reference System) between two geometries in       |
-|                        | projected units                                   |
-+------------------------+---------------------------------------------------+
-| distance_to_vertex     | Returns the distance along the geometry to a      |
-|                        | specified vertex                                  |
-+------------------------+---------------------------------------------------+
-| end_point              | Returns the last node from a geometry             |
-|                        | (see also :ref:`qgisextractspecificvertices`)     |
-+------------------------+---------------------------------------------------+
-| extend                 | Extends the start and end of a linestring         |
-|                        | geometry by a specified amount                    |
-|                        | (see also :ref:`qgisextendlines`)                 |
-+------------------------+---------------------------------------------------+
-| exterior_ring          | Returns a line string representing the exterior   |
-|                        | ring of a polygon geometry,                       |
-|                        | or null if the geometry is not a polygon          |
-+------------------------+---------------------------------------------------+
-| extrude(geom,x,y)      | Returns an extruded version of the input (Multi-) |
-|                        | Curve or (Multi-)Linestring geometry with an      |
-|                        | extension specified by X and Y                    |
-+------------------------+---------------------------------------------------+
-| flip_coordinates       | Returns a copy of the geometry with the X and Y   |
-|                        | coordinates swapped (see also :ref:`qgisswapxy`)  |
-+------------------------+---------------------------------------------------+
-| force_rhr |36|         | Forces a geometry to respect the Right-Hand-Rule  |
-+------------------------+---------------------------------------------------+
-| geom_from_gml          | Returns a geometry created from a GML             |
-|                        | representation of geometry                        |
-+------------------------+---------------------------------------------------+
-| geom_from_wkt          | Returns a geometry created from a well-known text |
-|                        | (WKT) representation                              |
-+------------------------+---------------------------------------------------+
-| geom_to_wkt            | Returns the well-known text (WKT) representation  |
-|                        | of the geometry without SRID metadata             |
-+------------------------+---------------------------------------------------+
-| geometry               | Returns a feature's geometry                      |
-+------------------------+---------------------------------------------------+
-| geometry_n             | Returns the nth geometry from a geometry          |
-|                        | collection, or null if the input geometry         |
-|                        | is not a collection                               |
-+------------------------+---------------------------------------------------+
-| hausdorff_distance     | Returns basically a measure of how similar or     |
-|                        | dissimilar 2 geometries are, with a lower         |
-|                        | distance indicating more similar geometries       |
-+------------------------+---------------------------------------------------+
-| inclination            | Returns the inclination measured from the zenith  |
-|                        | (0) to the nadir (180) on point_a to point_b      |
-+------------------------+---------------------------------------------------+
-| interior_ring_n        | Returns the geometry of the nth interior ring     |
-|                        | from a polygon geometry, or null if the geometry  |
-|                        | is not a polygon                                  |
-+------------------------+---------------------------------------------------+
-| intersection           | Returns a geometry that represents the shared     |
-|                        | portion of two geometries                         |
-|                        | (see also  :ref:`qgisintersection`)               |
-+------------------------+---------------------------------------------------+
-| intersects             | Tests whether a geometry intersects another.      |
-|                        | Returns 1 (true) if the geometries spatially      |
-|                        | intersect (share any portion of space)            |
-|                        | and 0 if they don't                               |
-+------------------------+---------------------------------------------------+
-| intersects_bbox        | Tests whether a geometry's bounding box overlaps  |
-|                        | another geometry's bounding box. Returns 1 (true) |
-|                        | if the geometries spatially intersect (share any  |
-|                        | portion of space) their bounding box,             |
-|                        | or 0 if they don't                                |
-+------------------------+---------------------------------------------------+
-| is_closed              | Returns true if a line string is closed           |
-|                        | (start and end points are coincident), false if   |
-|                        | a line string is not closed, or null if the       |
-|                        | geometry is not a line string                     |
-+------------------------+---------------------------------------------------+
-| length                 | Returns length of a line geometry feature         |
-|                        | (or length of a string)                           |
-+------------------------+---------------------------------------------------+
-| line_interpolate_angle | Returns the angle parallel to the geometry at a   |
-|                        | specified distance along a linestring geometry.   |
-|                        | Angles are in degrees clockwise from north.       |
-+------------------------+---------------------------------------------------+
-| line_interpolate_point | Returns the point interpolated by a specified     |
-|                        | distance along a linestring geometry.             |
-|                        | (see also :ref:`qgisinterpolatepoint`)            |
-+------------------------+---------------------------------------------------+
-| line_locate_point      | Returns the distance along a linestring           |
-|                        | corresponding to the closest position the         |
-|                        | linestring comes to a specified point geometry.   |
-+------------------------+---------------------------------------------------+
-| line_substring         | Returns the portion of a line or curve geometry   |
-|                        | falling betweeen specified start and end distances|
-|                        | (measured from the beginning of the line)         |
-|                        | (see also :ref:`qgislinesubstring`)               |
-+------------------------+---------------------------------------------------+
-| line_merge             | Returns a (Multi-)LineString geometry, where any  |
-|                        | connected LineStrings from the input geometry     |
-|                        | have been merged into a single linestring.        |
-+------------------------+---------------------------------------------------+
-| m                      | Returns the M value of a point geometry           |
-+------------------------+---------------------------------------------------+
-| make_circle            | Creates a circular geometry based on center point |
-|                        | and radius                                        |
-+------------------------+---------------------------------------------------+
-| make_ellipse           | Creates an elliptical geometry based on center    |
-|                        | point, axes and azimuth                           |
-+------------------------+---------------------------------------------------+
-| make_line              | Creates a line geometry from a series of point    |
-|                        | geometries                                        |
-+------------------------+---------------------------------------------------+
-| make_point(x,y,z,m)    | Returns a point geometry from X and Y (and        |
-|                        | optional Z or M) values                           |
-+------------------------+---------------------------------------------------+
-| make_point_m(x,y,m)    | Returns a point geometry from X and Y coordinates |
-|                        | and M values                                      |
-+------------------------+---------------------------------------------------+
-| make_polygon           | Creates a polygon geometry from an outer ring and |
-|                        | optional series of inner ring geometries          |
-+------------------------+---------------------------------------------------+
-| make_rectangle_3points | Creates a rectangle from 3 points                 |
-| |36|                   |                                                   | 
-+------------------------+---------------------------------------------------+
-| make_regular_polygon   | Creates a regular polygon                         |
-+------------------------+---------------------------------------------------+
-| make_square |36|       | Creates a square from a diagonal                  |
-+------------------------+---------------------------------------------------+
-| make_triangle          | Creates a triangle polygon                        |
-+------------------------+---------------------------------------------------+
-| minimal_circle         | Returns the minimal enclosing circle of an input  |
-|                        | geometry (see also                                |
-|                        | :ref:`qgisminimumenclosingcircle`)                |
-+------------------------+---------------------------------------------------+
-| nodes_to_points        | Returns a multipoint geometry consisting of every |
-|                        | node in the input geometry                        |
-|                        | (see also :ref:`qgisextractvertices`)             |
-+------------------------+---------------------------------------------------+
-| num_geometries         | Returns the number of geometries in a geometry    |
-|                        | collection, or null if the input geometry is not  |
-|                        | a collection                                      |
-+------------------------+---------------------------------------------------+
-| num_interior_rings     | Returns the number of interior rings in a polygon |
-|                        | or geometry collection, or null if the input      |
-|                        | geometry is not a polygon or collection           |
-+------------------------+---------------------------------------------------+
-| num_points             | Returns the number of vertices in a geometry      |
-+------------------------+---------------------------------------------------+
-| num_rings              | Returns the number of rings (including exterior   |
-|                        | rings) in a polygon or geometry collection, or    |
-|                        | null if the input geometry is not a polygon or    |
-|                        | collection                                        |
-+------------------------+---------------------------------------------------+
-| offset_curve           | Returns a geometry formed by offsetting a         |
-|                        | linestring geometry to the side. Distances are in |
-|                        | the Spatial Reference System of this geometry.    |
-|                        | (see also :ref:`qgisoffsetline`)                  |
-+------------------------+---------------------------------------------------+
-| order_parts            | Orders the parts of a MultiGeometry by a given    |
-|                        | criteria                                          |
-+------------------------+---------------------------------------------------+
-| oriented_bbox          | Returns a geometry representing the minimal       |
-|                        | oriented bounding box of an input geometry        |
-|                        | (see also :ref:`qgisorientedminimumboundingbox`)  |
-+------------------------+---------------------------------------------------+
-| overlaps               | Tests whether a geometry overlaps another.        |
-|                        | Returns 1 (true) if the geometries share space,   |
-|                        | are of the same dimension, but are not completely |
-|                        | contained by each other                           |
-+------------------------+---------------------------------------------------+
-| perimeter              | Returns the perimeter of a geometry polygon       |
-|                        | feature. Calculations are in the Spatial          |
-|                        | Reference System of this geometry                 |
-+------------------------+---------------------------------------------------+
-| point_n                | Returns a specific node from a geometry           |
-|                        | (see also :ref:`qgisextractspecificvertices`)     |
-+------------------------+---------------------------------------------------+
-| point_on_surface       | Returns a point guaranteed to lie on the surface  |
-|                        | of a geometry (see also :ref:`qgispointonsurface`)|
-+------------------------+---------------------------------------------------+
-| pole_of_inaccessibility| Calculates the approximate pole of inaccessibility|
-|                        | for a surface, which is the most distant internal |
-|                        | point from the boundary of the surface (see also  |
-|                        | :ref:`qgispoleofinaccessibility`)                 |
-+------------------------+---------------------------------------------------+
-| project                | Returns a point projected from a start point      |
-|                        | using a distance and bearing (azimuth) in radians |
-|                        | (see also :ref:`qgisprojectpointcartesian`)       |
-+------------------------+---------------------------------------------------+
-| relate                 | Tests or returns the Dimensional Extended 9       |
-|                        | Intersection Model (DE-9IM) representation of the |
-|                        | relationship between two geometries               |
-+------------------------+---------------------------------------------------+
-| reverse                | Reverses the direction of a line string by        |
-|                        | reversing the order of its vertices               |
-|                        | (see also :ref:`qgisreverselinedirection`)        |
-+------------------------+---------------------------------------------------+
-| segments_to_lines      | Returns a multi line geometry consisting of a     |
-|                        | line for every segment in the input geometry      |
-|                        | (see also :ref:`qgisexplodelines`)                |
-+------------------------+---------------------------------------------------+
-| shortest_line          | Returns the shortest line joining two geometries. |
-|                        | The resultant line will start at geometry 1 and   |
-|                        | end at geometry 2                                 |
-+------------------------+---------------------------------------------------+
-| simplify               | Simplifies a geometry by removing nodes using a   |
-|                        | distance based threshold                          |
-|                        | (see also :ref:`qgissimplifygeometries`)          |
-+------------------------+---------------------------------------------------+
-| simplify_vw            | Simplifies a geometry by removing nodes using an  |
-|                        | area based threshold                              |
-|                        | (see also :ref:`qgissimplifygeometries`)          |
-+------------------------+---------------------------------------------------+
-| single_sided_buffer    | Returns a geometry formed by buffering out just   |
-|                        | one side of a linestring geometry. Distances are  |
-|                        | in the Spatial Reference System of this geometry  |
-|                        | (see also :ref:`qgissinglesidedbuffer`)           |
-+------------------------+---------------------------------------------------+
-| smooth                 | Smooths a geometry by adding extra nodes which    |
-|                        | round off corners in the geometry                 |
-|                        | (see also :ref:`qgissmoothgeometry`)              |
-+------------------------+---------------------------------------------------+
-| start_point            | Returns the first node from a geometry            |
-|                        | (see also :ref:`qgisextractspecificvertices`)     |
-+------------------------+---------------------------------------------------+
-| sym_difference         | Returns a geometry that represents the portions   |
-|                        | of two geometries that do not intersect           |
-|                        | (see also :ref:`qgissymmetricaldifference`)       |
-+------------------------+---------------------------------------------------+
-| tapered_buffer         | Creates a buffer along a line geometry where the  |
-|                        | buffer diameter varies evenly over the length of  |
-|                        | the line (see also :ref:`qgistaperedbuffer`)      |
-+------------------------+---------------------------------------------------+
-| touches                | Tests whether a geometry touches another.         |
-|                        | Returns 1 (true) if the geometries have at least  |
-|                        | one point in common, but their interiors do not   |
-|                        | intersect                                         |
-+------------------------+---------------------------------------------------+
-| transform              | Returns the geometry transformed from the source  |
-|                        | CRS to the destination CRS                        |
-|                        | (see also :ref:`qgisreprojectlayer`)              |
-+------------------------+---------------------------------------------------+
-| translate              | Returns a translated version of a geometry.       |
-|                        | Calculations are in the Spatial Reference System  |
-|                        | of the geometry                                   |
-|                        | (see also :ref:`qgistranslategeometry`)           |
-+------------------------+---------------------------------------------------+
-| union                  | Returns a geometry that represents the point set  |
-|                        | union of the geometries                           |
-+------------------------+---------------------------------------------------+
-| wedge_buffer           | Returns a wedge shaped buffer originating from a  |
-|                        | point geometry given an angle and radii           |
-|                        | (see also :ref:`qgiswedgebuffers`)                |
-+------------------------+---------------------------------------------------+
-| within (a,b)           | Tests whether a geometry is within another.       |
-|                        | Returns 1 (true) if geometry a is completely      |
-|                        | inside geometry b                                 |
-+------------------------+---------------------------------------------------+
-| x                      | Returns the X coordinate of a point geometry, or  |
-|                        | the X coordinate of the centroid for a non-point  |
-|                        | geometry                                          |
-+------------------------+---------------------------------------------------+
-| x_min                  | Returns the minimum X coordinate of a geometry.   |
-|                        | Calculations are in the Spatial Reference System  |
-|                        | of this geometry                                  |
-+------------------------+---------------------------------------------------+
-| x_max                  | Returns the maximum X coordinate of a geometry.   |
-|                        | Calculations are in the Spatial Reference System  |
-|                        | of this geometry                                  |
-+------------------------+---------------------------------------------------+
-| y                      | Returns the Y coordinate of a point geometry, or  |
-|                        | the Y coordinate of the centroid for a non-point  |
-|                        | geometry                                          |
-+------------------------+---------------------------------------------------+
-| y_min                  | Returns the minimum Y coordinate of a geometry.   |
-|                        | Calculations are in the Spatial Reference System  |
-|                        | of this geometry                                  |
-+------------------------+---------------------------------------------------+
-| y_max                  | Returns the maximum Y coordinate of a geometry.   |
-|                        | Calculations are in the Spatial Reference System  |
-|                        | of this geometry                                  |
-+------------------------+---------------------------------------------------+
-| z                      | Returns the Z coordinate of a point geometry      |
-+------------------------+---------------------------------------------------+
 
-|
+.. csv-table::
+   :header: "Function", "Description"
+   :widths: 25, 70
+   :class: longtable
+
+   "$area", "Returns the area size of the current feature"
+   "$geometry", "Returns the geometry of the current feature (can be used for
+   processing with other functions)"
+   "$length", "Returns the length of the current line feature"
+   "$perimeter", "Returns the perimeter of the current polygon feature"
+   "$x", "Returns the X coordinate of the current feature"
+   "$x_at(n)", "Returns the X coordinate of the nth node of the current feature's geometry"
+   "$y", "Returns the Y coordinate of the current feature"
+   "$y_at(n)", "Returns the Y coordinate of the nth node of the current feature's geometry"
+   "angle_at_vertex", "Returns the bisector angle (average angle) to the geometry
+   for a specified vertex on a linestring geometry. Angles are in degrees clockwise from north"
+   "area", "Returns the area of a geometry polygon feature. Calculations are in
+   the Spatial Reference System of this geometry"
+   "azimuth", "Returns the north-based azimuth as the angle in radians measured
+   clockwise from the vertical on point_a to point_b"
+   
+   "boundary", "Returns the closure of the combinatorial boundary of the geometry
+   (ie the topological boundary of the geometry - see also :ref:`qgisboundary`)."
+   "bounds", "Returns a geometry which represents the bounding box of an input geometry.
+   Calculations are in the Spatial Reference System of this geometry
+   (see also :ref:`qgisboundingboxes`)"
+   "bounds_height", "Returns the height of the bounding box of a geometry.
+   Calculations are in the Spatial Reference System of this geometry"
+   "bounds_width", "Returns the width of the bounding box of a geometry.
+   Calculations are in the Spatial Reference System of this geometry"
+   "buffer", "Returns a geometry that represents all points whose distance from
+   this geometry is less than or equal to distance. Calculations are in the Spatial
+   Reference System of this geometry (see also :ref:`qgisbuffer`)"
+   "buffer_by_m", "Creates a buffer along a line geometry where the buffer diameter
+   varies according to the M values at the line vertices (see also :ref:`qgisbufferbym`)"
+
+   "centroid", "Returns the geometric center of a geometry (see also :ref:`qgiscentroids`)"
+   "closest_point", "Returns the point on a geometry that is closest to a second geometry"
+   "combine", "Returns the combination of two geometries"
+   "contains(a,b)", "Returns 1 (true) if and only if no points of b lie in the exterior of a,
+   and at least one point of the interior of b lies in the interior of a"
+   "convex_hull", "Returns the convex hull of a geometry (this represents the minimum
+   convex geometry that encloses all geometries within the set) (see also :ref:`qgisconvexhull`)"
+   "crosses", "Returns 1 (true) if the supplied geometries have some, but not all,
+   interior points in common"
+   "difference(a,b)", "Returns a geometry that represents that part of geometry
+   a that does not intersect with geometry b (see also :ref:`qgisdifference`)"
+   "disjoint", "Returns 1 (true) if the geometries do not share any space together"
+   "distance", "Returns the minimum distance (based on Spatial Reference System)
+   between two geometries in projected units"
+   "distance_to_vertex", "Returns the distance along the geometry to a specified vertex"
+
+   "end_point", "Returns the last node from a geometry (see also :ref:`qgisextractspecificvertices`)"
+   "extend", "Extends the start and end of a linestring geometry by a specified amount
+   (see also :ref:`qgisextendlines`)"
+   "exterior_ring", "Returns a line string representing the exterior ring of a polygon geometry,
+   or null if the geometry is not a polygon"
+   "extrude(geom,x,y)", "Returns an extruded version of the input (Multi-) Curve
+   or (Multi-)Linestring geometry with an extension specified by X and Y"
+   "flip_coordinates", "Returns a copy of the geometry with the X and Y coordinates
+   swapped (see also :ref:`qgisswapxy`)"
+   "force_rhr |36|", "Forces a geometry to respect the Right-Hand-Rule"
+   "geom_from_gml", "Returns a geometry created from a GML representation of geometry"
+   "geom_from_wkt", "Returns a geometry created from a well-known text (WKT) representation"
+   "geom_to_wkt", "Returns the well-known text (WKT) representation of the geometry without SRID metadata"
+   "geometry", "Returns a feature's geometry"
+   "geometry_n", "Returns the nth geometry from a geometry collection,
+   or null if the input geometry is not a collection"
+
+   "hausdorff_distance", "Returns basically a measure of how similar or dissimilar
+   two geometries are, with a lower distance indicating more similar geometries"
+   "inclination", "Returns the inclination measured from the zenith (0) to the nadir (180) on point_a to point_b"
+   "interior_ring_n", "Returns the geometry of the nth interior ring from a polygon geometry,
+   or null if the geometry is not a polygon"
+   "intersection", "Returns a geometry that represents the shared portion of two
+   geometries (see also  :ref:`qgisintersection`)"
+   "intersects", "Tests whether a geometry intersects another. Returns 1 (true)
+   if the geometries spatially intersect (share any portion of space) and 0 if they don't"
+   "intersects_bbox", "Tests whether a geometry's bounding box overlaps another geometry's
+   bounding box. Returns 1 (true) if the geometries spatially intersect 
+   (share any portion of space) their bounding box, or 0 if they don't"
+   "is_closed", "Returns true if a line string is closed (start and end points are coincident),
+   false if a line string is not closed, or null if the geometry is not a line string"
+
+   "length", "Returns length of a line geometry feature (or length of a string)"
+   "line_interpolate_angle", "Returns the angle parallel to the geometry at a specified
+   distance along a linestring geometry. Angles are in degrees clockwise from north."
+   "line_interpolate_point", "Returns the point interpolated by a specified
+   distance along a linestring geometry. (see also :ref:`qgisinterpolatepoint`)"
+   "line_locate_point", "Returns the distance along a linestring corresponding
+   to the closest position the linestring comes to a specified point geometry."
+   "line_substring", "Returns the portion of a line or curve geometry falling betweeen
+   specified start and end distances (measured from the beginning of the line)
+   (see also :ref:`qgislinesubstring`)"
+   "line_merge", "Returns a (Multi-)LineString geometry, where any connected LineStrings
+   from the input geometry have been merged into a single linestring."
+
+   "m", "Returns the M value of a point geometry"
+   "make_circle", "Creates a circular geometry based on center point and radius"
+   "make_ellipse", "Creates an elliptical geometry based on center point, axes and azimuth"
+   "make_line", "Creates a line geometry from a series of point geometries"
+   "make_point(x,y,z,m)", "Returns a point geometry from X and Y (and optional Z or M) values"
+   "make_point_m(x,y,m)", "Returns a point geometry from X and Y coordinates and M values"
+   "make_polygon", "Creates a polygon geometry from an outer ring and optional series
+   of inner ring geometries"
+   "make_rectangle_3points |36|", "Creates a rectangle from 3 points" 
+   "make_regular_polygon", "Creates a regular polygon"
+   "make_square |36|", "Creates a square from a diagonal"
+   "make_triangle", "Creates a triangle polygon"
+   "minimal_circle", "Returns the minimal enclosing circle of an input geometry
+   (see also :ref:`qgisminimumenclosingcircle`)"
+   "nodes_to_points", "Returns a multipoint geometry consisting of every node in
+   the input geometry (see also :ref:`qgisextractvertices`)"
+
+   "num_geometries", "Returns the number of geometries in a geometry collection,
+   or null if the input geometry is not a collection"
+   "num_interior_rings", "Returns the number of interior rings in a polygon or
+   geometry collection, or null if the input geometry is not a polygon or collection"
+   "num_points", "Returns the number of vertices in a geometry"
+   "num_rings", "Returns the number of rings (including exterior rings) in a polygon
+   or geometry collection, or null if the input geometry is not a polygon or collection"
+   "offset_curve", "Returns a geometry formed by offsetting a linestring geometry to the side.
+   Distances are in the Spatial Reference System of this geometry. (see also :ref:`qgisoffsetline`)"
+   "order_parts", "Orders the parts of a MultiGeometry by a given criteria"
+   "oriented_bbox", "Returns a geometry representing the minimal oriented
+   bounding box of an input geometry (see also :ref:`qgisorientedminimumboundingbox`)"
+   "overlaps", "Tests whether a geometry overlaps another. Returns 1 (true) if
+   the geometries share space, are of the same dimension, but are not completely contained by each other"
+
+   "perimeter", "Returns the perimeter of a geometry polygon feature.
+   Calculations are in the Spatial Reference System of this geometry"
+   "point_n", "Returns a specific node from a geometry (see also :ref:`qgisextractspecificvertices`)"
+   "point_on_surface", "Returns a point guaranteed to lie on the surface of
+   a geometry (see also :ref:`qgispointonsurface`)"
+   "pole_of_inaccessibility", "Calculates the approximate pole of inaccessibility for
+   a surface, which is the most distant internal point from the boundary of the surface
+   (see also :ref:`qgispoleofinaccessibility`)"
+   "project", "Returns a point projected from a start point using a distance and
+   bearing (azimuth) in radians (see also :ref:`qgisprojectpointcartesian`)"
+   "relate", "Tests or returns the Dimensional Extended 9 Intersection Model (DE-9IM)
+   representation of the relationship between two geometries"
+   "reverse", "Reverses the direction of a line string by reversing the order of its
+   vertices (see also :ref:`qgisreverselinedirection`)"
+
+   "segments_to_lines", "Returns a multi line geometry consisting of a line for
+   every segment in the input geometry (see also :ref:`qgisexplodelines`)"
+   "shortest_line", "Returns the shortest line joining two geometries.
+   The resultant line will start at geometry 1 and end at geometry 2"
+   "simplify", "Simplifies a geometry by removing nodes using a distance based
+   threshold (see also :ref:`qgissimplifygeometries`)"
+   "simplify_vw", "Simplifies a geometry by removing nodes using an area based
+   threshold (see also :ref:`qgissimplifygeometries`)"
+   "single_sided_buffer", "Returns a geometry formed by buffering out just one
+   side of a linestring geometry. Distances are in the Spatial Reference System
+   of this geometry (see also :ref:`qgissinglesidedbuffer`)"
+   "smooth", "Smooths a geometry by adding extra nodes which round off corners
+   in the geometry (see also :ref:`qgissmoothgeometry`)"
+   "start_point", "Returns the first node from a geometry (see also :ref:`qgisextractspecificvertices`)"
+   "sym_difference", "Returns a geometry that represents the portions of two
+   geometries that do not intersect (see also :ref:`qgissymmetricaldifference`)"
+
+   "tapered_buffer", "Creates a buffer along a line geometry where the buffer
+   diameter varies evenly over the length of the line (see also :ref:`qgistaperedbuffer`)"
+   "touches", "Tests whether a geometry touches another. Returns 1 (true) if
+   the geometries have at least one point in common, but their interiors do not intersect"
+   "transform", "Returns the geometry transformed from the source CRS to the 
+   destination CRS (see also :ref:`qgisreprojectlayer`)"
+   "translate", "Returns a translated version of a geometry. Calculations are in
+   the Spatial Reference System of the geometry (see also :ref:`qgistranslategeometry`)"
+   "union", "Returns a geometry that represents the point set union of the geometries"
+   "wedge_buffer", "Returns a wedge shaped buffer originating from a point geometry
+   given an angle and radii (see also :ref:`qgiswedgebuffers`)"
+   "within (a,b)", "Tests whether a geometry is within another. Returns 1 (true)
+   if geometry a is completely inside geometry b"
+
+   "x", "Returns the X coordinate of a point geometry, or the X coordinate of the
+   centroid for a non-point geometry"
+   "x_min", "Returns the minimum X coordinate of a geometry.
+   Calculations are in the Spatial Reference System of this geometry"
+   "x_max", "Returns the maximum X coordinate of a geometry.
+   Calculations are in the Spatial Reference System of this geometry"
+   "y", "Returns the Y coordinate of a point geometry, or the Y coordinate of
+   the centroid for a non-point geometry"
+   "y_min", "Returns the minimum Y coordinate of a geometry.
+   Calculations are in the Spatial Reference System of this geometry"
+   "y_max", "Returns the maximum Y coordinate of a geometry.
+   Calculations are in the Spatial Reference System of this geometry"
+   "z", "Returns the Z coordinate of a point geometry"
+
+.. only:: html
+
+   |
 
 **Some examples:**
 
@@ -1003,14 +757,15 @@ Layout Functions
 
 This group contains functions to manipulate print layout items properties.
 
-==================  ========================================================
- Function            Description
-==================  ========================================================
- item_variables      Returns a map of variables from a layout item inside
-                     this print layout
-==================  ========================================================
+.. csv-table::
+   :header: "Function", "Description"
+   :widths: auto
 
-|
+   "item_variables", "Returns a map of variables from a layout item inside this print layout"
+
+.. only:: html
+
+   |
 
 **Some example:**
 
@@ -1029,13 +784,12 @@ such as when performing :ref:`aggregates <aggregates_function>`, :ref:`attribute
 
 It also provides some convenient functions to manipulate layers.
 
-==================  ========================================================
- Function            Description
-==================  ========================================================
- decode_uri |36|     Takes a layer and decodes the uri of the underliying data
-                     provider. Available information depends on the data provider
-                     type.
-==================  ========================================================
+.. csv-table::
+   :header: "Function", "Description"
+   :widths: auto
+
+   "decode_uri |36|", "Takes a layer and decodes the uri of the underlying data provider.
+   Available information depends on the data provider type."
 
 .. index:: Map data structure, Dictionary, Key-value pairs, Associative arrays
 .. _maps_functions:
@@ -1049,29 +803,24 @@ arrays). Unlike the :ref:`list data structure <array_functions>` where values
 order matters, the order of the key-value pairs in the map object is not relevant
 and values are identified by their keys.
 
-==================== =========================================================
- Function             Description
-==================== =========================================================
- from_json |36|       Loads a json-formatted string
- hstore_to_map        Creates a map from a hstore-formatted string
- json_to_map          Creates a map from a json-formatted string
- map                  Returns a map containing all the keys and values passed
-                      as pair of parameters
- map_akeys            Returns all the keys of a map as an array
- map_avals            Returns all the values of a map as an array
- map_concat           Returns a map containing all the entries of the given
-                      maps. If two maps contain the same key, the value of
-                      the second map is taken.
- map_delete           Returns a map with the given key and its corresponding
-                      value deleted
- map_exist            Returns true if the given key exists in the map
- map_get              Returns the value of a map, given it's key
- map_insert           Returns a map with an added key/value
- map_to_hstore        Merges map elements into a hstore-formatted string
- map_to_json          Merges map elements into a json-formatted string
- to_json |36|         Creates a json-formatted string from a map, an array or
-                      other value
-==================== =========================================================
+.. csv-table::
+   :header: "Function", "Description"
+   :widths: auto
+
+   "from_json |36|", "Loads a json-formatted string"
+   "hstore_to_map", "Creates a map from a hstore-formatted string"
+   "json_to_map", "Creates a map from a json-formatted string"
+   "map", "Returns a map containing all the keys and values passed as pair of parameters"
+   "map_akeys", "Returns all the keys of a map as an array"
+   "map_avals", "Returns all the values of a map as an array"
+   "map_concat", "Returns a map containing all the entries of the given maps. If two maps contain the same key, the value of the second map is taken."
+   "map_delete", "Returns a map with the given key and its corresponding value deleted"
+   "map_exist", "Returns true if the given key exists in the map"
+   "map_get", "Returns the value of a map, given it's key"
+   "map_insert", "Returns a map with an added key/value"
+   "map_to_hstore", "Merges map elements into a hstore-formatted string"
+   "map_to_json", "Merges map elements into a json-formatted string"
+   "to_json |36|", "Creates a json-formatted string from a map, an array or other value"
 
 
 Mathematical Functions
@@ -1079,49 +828,39 @@ Mathematical Functions
 
 This group contains math functions (e.g., square root, sin and cos).
 
-=================  ==========================================================
- Function           Description
-=================  ==========================================================
- abs                Returns the absolute value of a number
- acos               Returns the inverse cosine of a value in radians
- asin               Returns the inverse sine of a value in radians
- atan               Returns the inverse tangent of a value in radians
- atan2(y,x)         Returns the inverse tangent of Y/X by using the signs
-                    of the two arguments to determine the quadrant of the
-                    result
- azimuth(a,b)       Returns the north-based azimuth as the angle in radians
-                    measured clockwise from the vertical on point a
-                    to point b
- ceil               Rounds a number upwards
- clamp              Restricts an input value to a specified range
- cos                Returns the cosine of a value in radians
- degrees            Converts from radians to degrees
- exp                Returns exponential of a value
- floor              Rounds a number downwards
- inclination        Returns the inclination measured from the zenith (0) to
-                    the nadir (180) on point_a to point_b.
- ln                 Returns the natural logarithm of the passed expression
- log                Returns the value of the logarithm of the passed
-                    value and base
- log10              Returns the value of the base 10 logarithm of the
-                    passed expression
- max                Returns the largest not null value in a set of values
- min                Returns the smallest not null value in a set of values
- pi                 Returns the value of pi for calculations
- radians            Converts from degrees to radians
- rand               Returns the random integer within the range specified
-                    by the minimum and maximum argument (inclusive)
- randf              Returns the random float within the range specified
-                    by the minimum and maximum argument (inclusive)
- round              Rounds to number of decimal places
- scale_exp          Transforms a given value from an input domain
-                    to an output range using an exponential curve
- scale_linear       Transforms a given value from an input domain
-                    to an output range using linear interpolation
- sin                Returns the sine of an angle
- sqrt               Returns the square root of a value
- tan                Returns the tangent of an angle
-=================  ==========================================================
+.. csv-table::
+   :header: "Function", "Description"
+   :widths: 15, 80
+   :class: longtable
+
+   "abs", "Returns the absolute value of a number"
+   "acos", "Returns the inverse cosine of a value in radians"
+   "asin", "Returns the inverse sine of a value in radians"
+   "atan", "Returns the inverse tangent of a value in radians"
+   "atan2(y,x)", "Returns the inverse tangent of Y/X by using the signs of the two arguments to determine the quadrant of the result"
+   "azimuth(a,b)", "Returns the north-based azimuth as the angle in radians measured clockwise from the vertical on point a to point b"
+   "ceil", "Rounds a number upwards"
+   "clamp", "Restricts an input value to a specified range"
+   "cos", "Returns the cosine of a value in radians"
+   "degrees", "Converts from radians to degrees"
+   "exp", "Returns exponential of a value"
+   "floor", "Rounds a number downwards"
+   "inclination", "Returns the inclination measured from the zenith (0) to the nadir (180) on point_a to point_b."
+   "ln", "Returns the natural logarithm of the passed expression"
+   "log", "Returns the value of the logarithm of the passed value and base"
+   "log10", "Returns the value of the base 10 logarithm of the passed expression"
+   "max", "Returns the largest not null value in a set of values"
+   "min", "Returns the smallest not null value in a set of values"
+   "pi", "Returns the value of pi for calculations"
+   "radians", "Converts from degrees to radians"
+   "rand", "Returns the random integer within the range specified by the minimum and maximum argument (inclusive)"
+   "randf", "Returns the random float within the range specified by the minimum and maximum argument (inclusive)"
+   "round", "Rounds to number of decimal places"
+   "scale_exp", "Transforms a given value from an input domain to an output range using an exponential curve"
+   "scale_linear", "Transforms a given value from an input domain to an output range using linear interpolation"
+   "sin", "Returns the sine of an angle"
+   "sqrt", "Returns the square root of a value"
+   "tan", "Returns the tangent of an angle"
 
 
 Operators
@@ -1131,62 +870,44 @@ This group contains operators (e.g., +, -, \*).
 Note that for most of the mathematical functions below,
 if one of the inputs is NULL then the result is NULL.
 
-=========================== ===================================================
- Function                    Description
-=========================== ===================================================
- a + b                       Addition of two values (a plus b)
- a - b                       Subtraction of two values (a minus b).
- a * b                       Multiplication of two values (a multiplied by b)
- a / b                       Division of two values (a divided by b)
- a % b                       Remainder of division of a by b
-                             (eg, 7 % 2 = 1, or 2 fits into 7 three times
-                             with remainder 1)
- a ^ b                       Power of two values (for example, 2^2=4 or 2^3=8)
- a < b                       Compares two values and evaluates to 1 if the
-                             left value is less than the right value
-                             (a is smaller than b)
- a <= b                      Compares two values and evaluates to 1 if the
-                             left value isless than or equal to the right
-                             value
- a <> b                      Compares two values and evaluates to 1
-                             if they are not equal
- a = b                       Compares two values and evaluates to 1
-                             if they are equal
- a != b                      a and b are not equal
- a > b                       Compares two values and evaluates to 1
-                             if the left value is greater than the right
-                             value (a is larger than b)
- a >= b                      Compares two values and evaluates to 1
-                             if the left value is greater than or equal to
-                             the right value
- a ~ b                       a matches the regular expression b
- ||                          Joins two values together into a string.
-                             If one of the values is NULL the result will
-                             be NULL
- '\\n'                       Inserts a new line in a string
- LIKE                        Returns 1 if the first parameter matches the
-                             supplied pattern
- ILIKE                       Returns 1 if the first parameter matches
-                             case-insensitive the supplied pattern (ILIKE
-                             can be used instead of LIKE to make the match
-                             case-insensitive)
- a IS b                      Tests whether two values are identical.
-                             Returns 1 if a is the same as b
- a OR b                      Returns 1 when condition a or condition b is true
- a AND b                     Returns 1 when conditions a and b are true
- NOT                         Negates a condition
- column name "column name"   Value of the field column name, take care to
-                             not be confused with simple quote, see below
- 'string'                    a string value, take care to not be confused
-                             with double quote, see above
- NULL                        null value
- a IS NULL                   a has no value
- a IS NOT NULL               a has a value
- a IN (value[,value])        a is below the values listed
- a NOT IN (value[,value])    a is not below the values listed
-=========================== ===================================================
+.. csv-table::
+   :header: "Function", "Description"
+   :widths: 27,68
+   :class: longtable
 
-|
+   "a + b", "Addition of two values (a plus b)"
+   "a - b", "Subtraction of two values (a minus b)."
+   "a * b", "Multiplication of two values (a multiplied by b)"
+   "a / b", "Division of two values (a divided by b)"
+   "a % b", "Remainder of division of a by b (eg, 7 % 2 = 1, or 2 fits into 7 three times with remainder 1)"
+   "a ^ b", "Power of two values (for example, 2^2=4 or 2^3=8)"
+   "a < b", "Compares two values and evaluates to 1 if the left value is less than the right value (a is smaller than b)"
+   "a <= b", "Compares two values and evaluates to 1 if the left value is less than or equal to the right value"
+   "a <> b", "Compares two values and evaluates to 1 if they are not equal"
+   "a = b", "Compares two values and evaluates to 1 if they are equal"
+   "a != b", "a and b are not equal"
+   "a > b", "Compares two values and evaluates to 1 if the left value is greater than the right value (a is larger than b)"
+   "a >= b", "Compares two values and evaluates to 1 if the left value is greater than or equal to the right value"
+   "a ~ b", "a matches the regular expression b"
+   "||", "Joins two values together into a string. If one of the values is NULL the result will be NULL"
+   "'\\n'", "Inserts a new line in a string"
+   "LIKE", "Returns 1 if the first parameter matches the supplied pattern"
+   "ILIKE", "Returns 1 if the first parameter matches case-insensitive the supplied pattern (ILIKE can be used instead of LIKE to make the match case-insensitive)"
+   "a IS b", "Tests whether two values are identical. Returns 1 if a is the same as b"
+   "a OR b", "Returns 1 when condition a or condition b is true"
+   "a AND b", "Returns 1 when conditions a and b are true"
+   "NOT", "Negates a condition"
+   """Column_name""", "Value of the field *Column_name*, take care to not be confused with simple quote, see below"
+   "'string'", "a string value, take care to not be confused with double quote, see above"
+   "NULL", "null value"
+   "a IS NULL", "a has no value"
+   "a IS NOT NULL", "a has a value"
+   "a IN (value[,value])", "a is below the values listed"
+   "a NOT IN (value[,value])", "a is not below the values listed"
+
+.. only:: html
+
+   |
 
 **Some examples:**
 
@@ -1207,11 +928,11 @@ Processing Functions |36|
 
 This group contains functions that operate on processing algorithms.
 
-==================== =========================================================
- Function             Description
-==================== =========================================================
- parameter            Returns the value of a processing algorithm input parameter
-==================== =========================================================
+.. csv-table::
+   :header: "Function", "Description"
+   :widths: auto
+
+   "parameter", "Returns the value of a processing algorithm input parameter"
 
 
 .. _raster_functions:
@@ -1221,12 +942,12 @@ Rasters Functions
 
 This group contains functions to operate on raster layer.
 
-==================== =========================================================
- Function             Description
-==================== =========================================================
- raster_statistic     Returns statistics from a raster layer
- raster_value         Returns the raster band value at the provided point
-==================== =========================================================
+.. csv-table::
+   :header: "Function", "Description"
+   :widths: auto
+
+   "raster_statistic", "Returns statistics from a raster layer"
+   "raster_value", "Returns the raster band value at the provided point"
 
 
 .. _record_attributes:
@@ -1236,32 +957,26 @@ Record and Attributes Functions
 
 This group contains functions that operate on record identifiers.
 
-============================== =========================================================
- Function                       Description
-============================== =========================================================
- $currentfeature                Returns the current feature being evaluated.
-                                This can be used with the 'attribute' function
-                                to evaluate attribute values from the current feature.
- $id                            Returns the feature id of the current row
- attribute                      Returns the value of a specified attribute from a
-                                feature
- attributes |310|               Returns a :ref:`map <maps_functions>` of all attributes
-                                from a feature, with field names as map keys
- get_feature                    Returns the first feature of a layer matching a
-                                given attribute value
- get_feature_by_id              Returns the feature of a layer matching the given
-                                feature ID
- is_selected                    Returns if a feature is selected
- num_selected                   Returns the number of selected features on a given layer
- represent_value                Returns the configured representation value for a
-                                field value (convenient with some :ref:`widget types
-                                <edit_widgets>`)
- sql_fetch_and_increment |36|   Manage autoincrementing values in sqlite databases
- uuid                           Generates a Universally Unique Identifier (UUID)
-                                for each row. Each UUID is 38 characters long.
-============================== =========================================================
+.. csv-table::
+   :header: "Function", "Description"
+   :widths: 25, 70
+   :class: longtable
 
-|
+   "$currentfeature", "Returns the current feature being evaluated. This can be used with the 'attribute' function to evaluate attribute values from the current feature."
+   "$id", "Returns the feature id of the current row"
+   "attribute", "Returns the value of a specified attribute from a feature"
+   "attributes |310|", "Returns a :ref:`map <maps_functions>` of all attributes from a feature, with field names as map keys"
+   "get_feature", "Returns the first feature of a layer matching a given attribute value"
+   "get_feature_by_id", "Returns the feature of a layer matching the given feature ID"
+   "is_selected", "Returns if a feature is selected"
+   "num_selected", "Returns the number of selected features on a given layer"
+   "represent_value", "Returns the configured representation value for a field value (convenient with some :ref:`widget types <edit_widgets>`)"
+   "sql_fetch_and_increment |36|", "Manage autoincrementing values in sqlite databases"
+   "uuid", "Generates a Universally Unique Identifier (UUID) for each row. Each UUID is 38 characters long."
+
+.. only:: html
+
+   |
 
 **Some examples:**
 
@@ -1283,52 +998,36 @@ String Functions
 This group contains functions that operate on strings
 (e.g., that replace, convert to upper case).
 
-=====================  ======================================================
- Function               Description
-=====================  ======================================================
- char                   Returns the character associated with a unicode code
- concat                 Concatenates several strings to one
- format                 Formats a string using supplied arguments
- format_date            Formats a date type or string into a custom
-                        string format
- format_number          Returns a number formatted with the locale
-                        separator for thousands (also truncates the
-                        number to the number of supplied places)
- left(string, n)        Returns a substring that contains the n
-                        leftmost characters of the string
- length                 Returns length of a string
-                        (or length of a line geometry feature)
- lower                  converts a string to lower case
- lpad                   Returns a string padded on the left to the specified
-                        width, using the fill character
- regexp_match           Returns the first matching position matching a regular
-                        expression within a string, or 0 if the substring is
-                        not found
- regexp_replace         Returns a string with the supplied regular
-                        expression replaced
- regexp_substr          Returns the portion of a string which matches
-                        a supplied regular expression
- replace                Returns a string with the supplied string, array, or
-                        map of strings replaced by a string, an array of strings
-                        or paired values
- right(string, n)       Returns a substring that contains the n
-                        rightmost characters of the string
- rpad                   Returns a string padded on the right to the specified
-                        width, using the fill character
- strpos                 Returns the first matching position of a substring within
-                        another string, or 0 if the substring is not found
- substr                 Returns a part of a string
- title                  Converts all words of a string to title
-                        case (all words lower case with leading
-                        capital letter)
- trim                   Removes all leading and trailing white
-                        space (spaces, tabs, etc.) from a string
- upper                  Converts string a to upper case
- wordwrap               Returns a string wrapped to a maximum/
-                        minimum number of characters
-=====================  ======================================================
+.. csv-table::
+   :header: "Function", "Description"
+   :widths: 20, 75
+   :class: longtable
 
-|
+   "char", "Returns the character associated with a unicode code"
+   "concat", "Concatenates several strings to one"
+   "format", "Formats a string using supplied arguments"
+   "format_date", "Formats a date type or string into a custom string format"
+   "format_number", "Returns a number formatted with the locale separator for thousands (also truncates the number to the number of supplied places)"
+   "left(string, n)", "Returns a substring that contains the n leftmost characters of the string"
+   "length", "Returns length of a string (or length of a line geometry feature)"
+   "lower", "converts a string to lower case"
+   "lpad", "Returns a string padded on the left to the specified width, using the fill character"
+   "regexp_match", "Returns the first matching position matching a regular expression within a string, or 0 if the substring is not found"
+   "regexp_replace", "Returns a string with the supplied regular expression replaced"
+   "regexp_substr", "Returns the portion of a string which matches a supplied regular expression"
+   "replace", "Returns a string with the supplied string, array, or map of strings replaced by a string, an array of strings or paired values"
+   "right(string, n)", "Returns a substring that contains the n rightmost characters of the string"
+   "rpad", "Returns a string padded on the right to the specified width, using the fill character"
+   "strpos", "Returns the first matching position of a substring within another string, or 0 if the substring is not found"
+   "substr", "Returns a part of a string"
+   "title", "Converts all words of a string to title case (all words lower case with leading capital letter)"
+   "trim", "Removes all leading and trailing white space (spaces, tabs, etc.) from a string"
+   "upper", "Converts string a to upper case"
+   "wordwrap", "Returns a string wrapped to a maximum/minimum number of characters"
+
+.. only:: html
+
+   |
 
 **About fields concatenation**
 
@@ -1375,127 +1074,128 @@ It means that some functions may not be available according to the context:
 To use these functions in an expression, they should be preceded by @ character
 (e.g, @row_number). Are concerned:
 
-============================ =======================================================
- Function                     Description
-============================ =======================================================
- algorithm_id                 Returns the unique ID of an algorithm
- atlas_feature                Returns the current atlas feature (as feature object)
- atlas_featureid              Returns the current atlas feature ID
- atlas_featurenumber          Returns the current atlas feature number in the layout
- atlas_filename               Returns the current atlas file name
- atlas_geometry               Returns the current atlas feature geometry
- atlas_layerid                Returns the current atlas coverage layer ID
- atlas_layername              Returns the current atlas coverage layer name
- atlas_pagename               Returns the current atlas page name
- atlas_totalfeatures          Returns the total number of features in atlas
- canvas_cursor_point          Returns the last cursor position on the canvas in the
-                              project's geographical coordinates
- cluster_color                Returns the color of symbols within a cluster, or NULL
-                              if symbols have mixed colors
- cluster_size                 Returns the number of symbols contained within a cluster
- current_feature              Returns the feature currently being edited in the
-                              attribute form or table row
- current_geometry             Returns the geometry of the feature currently being edited
-                              in the form or the table row
- fullextent_maxx |38|         Maximum x value from full canvas extent (including all layers)
- fullextent_maxy |38|         Maximum y value from full canvas extent (including all layers)
- fullextent_minx |38|         Minimum x value from full canvas extent (including all layers)
- fullextent_miny |38|         Minimum x value from full canvas extent (including all layers)
- geometry_part_count          Returns the number of parts in rendered feature's geometry
- geometry_part_num            Returns the current geometry part number for feature being rendered
- geometry_point_count         Returns the number of points in the rendered geometry's part
- geometry_point_num           Returns the current point number in the rendered geometry's part
- grid_axis                    Returns the current grid annotation axis
-                              (eg, 'x' for longitude, 'y' for latitude)
- grid_number                  Returns the current grid annotation value
- item_id                      Returns the layout item user ID
-                              (not necessarily unique)
- item_uuid                    Returns the layout item unique ID
- layer                        Returns the current layer
- layer_id                     Returns the ID of current layer
- layer_name                   Returns the name of current layer
- layout_dpi                   Returns the composition resolution (DPI)
- layout_name                  Returns the layout name
- layout_numpages              Returns the number of pages in the layout
- layout_page                  Returns the page number of the current item in the layout
- layout_pageheight            Returns the active page height in the layout (in mm)
- layout_pagewidth             Returns the active page width in the layout (in mm)
- map_crs                      Returns the Coordinate reference system of the current map
- map_crs_acronym |36|         Returns the acronym of the Coordinate reference system of the
-                              current map
- map_crs_definition           Returns the full definition of the Coordinate reference
-                              system of the current map
- map_crs_description |36|     Returns the name of the Coordinate reference system of the
-                              current map
- map_crs_ellipsoid |36|       Returns the acronym of the ellipsoid of the Coordinate reference
-                              system of the current map
- map_crs_proj4 |36|           Returns the Proj4 definition of the Coordinate reference
-                              system of the current map
- map_crs_wkt |36|             Returns the WKT definition of the Coordinate reference system
-                              of the current map
- map_extent                   Returns the geometry representing the current extent of the map
- map_extent_center            Returns the point feature at the center of the map
- map_extent_height            Returns the current height of the map
- map_extent_width             Returns the current width of the map
- map_id                       Returns the ID of current map destination.
-                              This will be 'canvas' for canvas renders, and
-                              the item ID for layout map renders
- map_layer_ids                Returns the list of map layer IDs visible in the map
- map_layers                   Returns the list of map layers visible in the map
- map_rotation                 Returns the current rotation of the map
- map_scale                    Returns the current scale of the map
- map_units                    Returns the units of map measurements
- notification_message         Content of the notification message sent by the provider
-                              (available only for actions triggered by provider notifications).
- parent                       Refers to the current feature in the parent layer,
-                              providing access to its attributes and geometry when filtering
-                              an :ref:`aggregate <aggregates_function>` function
- project_abstract             Returns the project abstract, taken from project metadata
- project_area_units           Returns the area unit for the current project, used when
-                              calculating areas of geometries
- project_author               Returns the project author, taken from project metadata
- project_basename             Returns the basename of current project's filename (without
-                              path and extension)
- project_creation_date        Returns the project creation date, taken from project metadata
- project_crs                  Returns the Coordinate reference system of the project
- project_crs_definition       Returns the full definition of the Coordinate reference
-                              system of the project
- project_distance_units       Returns the distance unit for the current project, used when
-                              calculating lengths of geometries and distances
- project_ellipsoid            Returns the name of the ellipsoid of the current project, used when
-                              calculating geodetic areas or lengths of geometries
- project_filename             Returns the filename of the current project
- project_folder               Returns the folder of the current project
- project_home                 Returns the home path of the current project
- project_identifier           Returns the project identifier, taken from the project's metadata
- project_keywords             Returns the project keywords, taken from the project's metadata
- project_path                 Returns the full path (including file name) of the current project
- project_title                Returns the title of current project
- qgis_locale                  Returns the current language of QGIS
- qgis_os_name                 Returns the current Operating system name,
-                              eg 'windows', 'linux' or 'osx'
- qgis_platform                Returns QGIS platform, eg 'desktop' or 'server'
- qgis_release_name            Returns current QGIS release name
- qgis_short_version           Returns current QGIS version short string
- qgis_version                 Returns current QGIS version string
- qgis_version_no              Returns current QGIS version number
- snapping_results             Gives access to snapping results while digitizing a
-                              feature (only available in add feature)
- symbol_angle                 Returns the angle of the symbol used to render
-                              the feature (valid for marker symbols only)
- symbol_color                 Returns the color of the symbol used to render
-                              the feature
- user_account_name            Returns the current user's operating system
-                              account name
- user_full_name               Returns the current user's operating system
-                              user name
- row_number                   Stores the number of the current row
- value                        Returns the current value
- with_variable                Allows setting a variable for usage within an expression
-                              and avoid recalculating the same value repeatedly
-============================ =======================================================
+.. csv-table::
+   :header: "Function", "Description"
+   :widths: 25, 70
 
-|
+   "algorithm_id", "Returns the unique ID of an algorithm"
+   "atlas_feature", "Returns the current atlas feature (as feature object)"
+   "atlas_featureid", "Returns the current atlas feature ID"
+   "atlas_featurenumber", "Returns the current atlas feature number in the layout"
+   "atlas_filename", "Returns the current atlas file name"
+   "atlas_geometry", "Returns the current atlas feature geometry"
+   "atlas_layerid", "Returns the current atlas coverage layer ID"
+   "atlas_layername", "Returns the current atlas coverage layer name"
+   "atlas_pagename", "Returns the current atlas page name"
+   "atlas_totalfeatures", "Returns the total number of features in atlas"
+
+   "canvas_cursor_point", "Returns the last cursor position on the canvas in the
+   project's geographical coordinates"
+   "cluster_color", "Returns the color of symbols within a cluster, or NULL if
+   symbols have mixed colors"
+   "cluster_size", "Returns the number of symbols contained within a cluster"
+   "current_feature", "Returns the feature currently being edited in the attribute
+   form or table row"
+   "current_geometry", "Returns the geometry of the feature currently being edited
+   in the form or the table row"
+   "fullextent_maxx |38|", "Maximum x value from full canvas extent (including all layers)"
+   "fullextent_maxy |38|", "Maximum y value from full canvas extent (including all layers)"
+   "fullextent_minx |38|", "Minimum x value from full canvas extent (including all layers)"
+   "fullextent_miny |38|", "Minimum x value from full canvas extent (including all layers)"
+
+   "geometry_part_count", "Returns the number of parts in rendered feature's geometry"
+   "geometry_part_num", "Returns the current geometry part number for feature being rendered"
+   "geometry_point_count", "Returns the number of points in the rendered geometry's part"
+   "geometry_point_num", "Returns the current point number in the rendered geometry's part"
+   "grid_axis", "Returns the current grid annotation axis (eg, 'x' for longitude, 'y' for latitude)"
+   "grid_number", "Returns the current grid annotation value"
+   "item_id", "Returns the layout item user ID (not necessarily unique)"
+   "item_uuid", "Returns the layout item unique ID"
+   "layer", "Returns the current layer"
+   "layer_id", "Returns the ID of current layer"
+   "layer_name", "Returns the name of current layer"
+   "layout_dpi", "Returns the composition resolution (DPI)"
+   "layout_name", "Returns the layout name"
+   "layout_numpages", "Returns the number of pages in the layout"
+   "layout_page", "Returns the page number of the current item in the layout"
+   "layout_pageheight", "Returns the active page height in the layout (in mm)"
+   "layout_pagewidth", "Returns the active page width in the layout (in mm)"
+
+   "map_crs", "Returns the Coordinate reference system of the current map"
+   "map_crs_acronym |36|", "Returns the acronym of the Coordinate reference
+   system of the current map"
+   "map_crs_definition", "Returns the full definition of the Coordinate
+   reference system of the current map"
+   "map_crs_description |36|", "Returns the name of the Coordinate reference
+   system of the current map"
+   "map_crs_ellipsoid |36|", "Returns the acronym of the ellipsoid of the
+   Coordinate reference system of the current map"
+   "map_crs_proj4 |36|", "Returns the Proj4 definition of the Coordinate
+   reference system of the current map"
+   "map_crs_wkt |36|", "Returns the WKT definition of the Coordinate reference
+   system of the current map"
+   "map_extent", "Returns the geometry representing the current extent of the map"
+   "map_extent_center", "Returns the point feature at the center of the map"
+   "map_extent_height", "Returns the current height of the map"
+   "map_extent_width", "Returns the current width of the map"
+   "map_id", "Returns the ID of current map destination. This will be 'canvas'
+   for canvas renders, and the item ID for layout map renders"
+   "map_layer_ids", "Returns the list of map layer IDs visible in the map"
+   "map_layers", "Returns the list of map layers visible in the map"
+   "map_rotation", "Returns the current rotation of the map"
+   "map_scale", "Returns the current scale of the map"
+   "map_units", "Returns the units of map measurements"
+   "notification_message", "Content of the notification message sent by the provider
+   (available only for actions triggered by provider notifications)."
+   "parent", "Refers to the current feature in the parent layer, providing access to
+   its attributes and geometry when filtering an :ref:`aggregate <aggregates_function>`
+   function"
+
+   "project_abstract", "Returns the project abstract, taken from project metadata"
+   "project_area_units", "Returns the area unit for the current project, used when
+   calculating areas of geometries"
+   "project_author", "Returns the project author, taken from project metadata"
+   "project_basename", "Returns the basename of current project's filename
+   (without path and extension)"
+   "project_creation_date", "Returns the project creation date, taken from project metadata"
+   "project_crs", "Returns the Coordinate reference system of the project"
+   "project_crs_definition", "Returns the full definition of the Coordinate reference
+   system of the project"
+   "project_distance_units", "Returns the distance unit for the current project,
+   used when calculating lengths of geometries and distances"
+   "project_ellipsoid", "Returns the name of the ellipsoid of the current project,
+   used when calculating geodetic areas or lengths of geometries"
+   "project_filename", "Returns the filename of the current project"
+   "project_folder", "Returns the folder of the current project"
+   "project_home", "Returns the home path of the current project"
+   "project_identifier", "Returns the project identifier, taken from the project's metadata"
+   "project_keywords", "Returns the project keywords, taken from the project's metadata"
+   "project_path", "Returns the full path (including file name) of the current project"
+   "project_title", "Returns the title of current project"
+
+   "qgis_locale", "Returns the current language of QGIS"
+   "qgis_os_name", "Returns the current Operating system name, eg 'windows', 'linux' or 'osx'"
+   "qgis_platform", "Returns QGIS platform, eg 'desktop' or 'server'"
+   "qgis_release_name", "Returns current QGIS release name"
+   "qgis_short_version", "Returns current QGIS version short string"
+   "qgis_version", "Returns current QGIS version string"
+   "qgis_version_no", "Returns current QGIS version number"
+
+   "snapping_results", "Gives access to snapping results while digitizing a
+   feature (only available in add feature)"
+   "symbol_angle", "Returns the angle of the symbol used to render the feature
+   (valid for marker symbols only)"
+   "symbol_color", "Returns the color of the symbol used to renderthe feature"
+   "user_account_name", "Returns the current user's operating system account name"
+   "user_full_name", "Returns the current user's operating system user name"
+   "row_number", "Stores the number of the current row"
+   "value", "Returns the current value"
+   "with_variable", "Allows setting a variable for usage within an expression
+   and avoid recalculating the same value repeatedly"
+
+.. only:: html
+
+   |
 
 **Some examples:**
 

--- a/source/docs/user_manual/working_with_vector/expression.rst
+++ b/source/docs/user_manual/working_with_vector/expression.rst
@@ -306,17 +306,26 @@ This group contains functions for manipulating colors.
    :header: "Function", "Description"
    :widths: 25, 70
 
-   "color_cmyk", "Returns a string representation of a color based on its cyan, magenta, yellow and black components"
-   "color_cmyka", "Returns a string representation of a color based on its cyan, magenta, yellow, black and alpha (transparency) components"
-   "color_grayscale_average", "Applies a grayscale filter and returns a string representation from a provided color"
-   "color_hsl", "Returns a string representation of a color based on its hue, saturation, and lightness attributes"
-   "color_hsla", "Returns a string representation of a color based on its hue, saturation, lightness and alpha (transparency) attributes"
-   "color_hsv", "Returns a string representation of a color based on its hue, saturation, and value attributes"
-   "color_hsva", "Returns a string representation of a color based on its hue, saturation, value and alpha (transparency) attributes"
-   "color_mix_rgb", "Returns a string representing a color mixing the red, green, blue, and alpha values of two provided colors based on a given ratio"
+   "color_cmyk", "Returns a string representation of a color based on its cyan,
+   magenta, yellow and black components"
+   "color_cmyka", "Returns a string representation of a color based on its cyan,
+   magenta, yellow, black and alpha (transparency) components"
+   "color_grayscale_average", "Applies a grayscale filter and returns a string
+   representation from a provided color"
+   "color_hsl", "Returns a string representation of a color based on its hue,
+   saturation, and lightness attributes"
+   "color_hsla", "Returns a string representation of a color based on its hue,
+   saturation, lightness and alpha (transparency) attributes"
+   "color_hsv", "Returns a string representation of a color based on its hue,
+   saturation, and value attributes"
+   "color_hsva", "Returns a string representation of a color based on its hue,
+   saturation, value and alpha (transparency) attributes"
+   "color_mix_rgb", "Returns a string representing a color mixing the red, green,
+   blue, and alpha values of two provided colors based on a given ratio"
    "color_part", "Returns a specific component from a color string, eg the red component or alpha component"
    "color_rgb", "Returns a string representation of a color based on its red, green, and blue components"
-   "color_rgba", "Returns a string representation of a color based on its red, green, blue, and alpha (transparency) components"
+   "color_rgba", "Returns a string representation of a color based on its red,
+   green, blue, and alpha (transparency) components"
    "create_ramp", "Returns a gradient ramp from a map of color strings and steps"
    "darker", "Returns a darker (or lighter) color string"
    "lighter", "Returns a lighter (or darker) color string"
@@ -335,11 +344,14 @@ This group contains functions to handle conditional checks in expressions.
    :widths: auto
 
    "CASE WHEN ... THEN ... END", "Evaluates an expression and returns a result if true. You can test multiple conditions"
-   "CASE WHEN ... THEN ... ELSE ... END", "Evaluates an expression and returns a different result whether it's true or false. You can test multiple conditions"
+   "CASE WHEN ... THEN ... ELSE ... END", "Evaluates an expression and
+   returns a different result whether it's true or false. You can test multiple conditions"
    "coalesce", "Returns the first non-NULL value from the expression list"
    "if", "Tests a condition and returns a different result depending on the conditional check"
-   "nullif(value1, value2) |36|", "Returns a null value if value1 equals value2 otherwise it returns value1. This can be used to conditionally substitute values with NULL."
-   "try |36|", "Tries an expression and returns its value if error-free,an alternative value (if provided) or Null if an error occurs"
+   "nullif(value1, value2) |36|", "Returns a null value if value1 equals value2
+   otherwise it returns value1. This can be used to conditionally substitute values with NULL."
+   "try |36|", "Tries an expression and returns its value if error-free,
+   an alternative value (if provided) or Null if an error occurs"
 
 .. only:: html
 
@@ -369,7 +381,8 @@ This group contains functions to convert one data type to another
    "to_dm", "Converts a coordinate to degree, minute"
    "to_dms", "Converts coordinate to degree, minute, second"
    "to_int", "Converts a string to integer number"
-   "to_interval", "Converts a string to an interval type (can be used to take days, hours, months, etc. of a date)"
+   "to_interval", "Converts a string to an interval type (can be used
+   to take days, hours, months, etc. of a date)"
    "to_real", "Converts a string to a real number"
    "to_string", "Converts number to string"
    "to_time", "Converts a string into a time object"
@@ -511,8 +524,11 @@ This group contains functions for fuzzy comparisons between values.
    :header: "Function", "Description"
    :widths: 25, 70
 
-   "hamming_distance", "Returns the number of characters at corresponding positions within the input strings where the characters are different"
-   "levensheim", "Returns the minimum number of character edits (insertions, deletions or substitutions) required to change one string to another. Measure the similarity between two strings"
+   "hamming_distance", "Returns the number of characters at corresponding
+   positions within the input strings where the characters are different"
+   "levensheim", "Returns the minimum number of character edits (insertions,
+   deletions or substitutions) required to change one string to another.
+   Measure the similarity between two strings"
    "longest_common_substring", "Returns the longest common substring between two strings"
    "soundex", "Returns the Soundex representation of a string"
 
@@ -526,12 +542,17 @@ This group contains general assorted functions.
    :header: "Function", "Description"
    :widths: 20, 75
 
-   "env", "Gets an environment variable and returns its content as a string. If the variable is not found, ``NULL`` will be returned."
-   "eval", "Evaluates an expression which is passed in a string. Useful to expand dynamic parameters passed as context variables or fields."
+   "env", "Gets an environment variable and returns its content as a string.
+   If the variable is not found, ``NULL`` will be returned."
+   "eval", "Evaluates an expression which is passed in a string.
+   Useful to expand dynamic parameters passed as context variables or fields."
    "is_layer_visible", "Returns true if a specified layer is visible"
-   "layer_property", "Returns a property of a layer or a value of its metadata. It can be layer name, crs, geometry type, feature count..."
+   "layer_property", "Returns a property of a layer or a value of its metadata.
+   It can be layer name, crs, geometry type, feature count..."
    "var", "Returns the value stored within a specified variable. See variable functions below"
-   "with_variable", "Creates and sets a variable for any expression code that will be provided as a third argument. Useful to avoid repetition in expressions where the same value needs to be used more than once."
+   "with_variable", "Creates and sets a variable for any expression code that
+   will be provided as a third argument. Useful to avoid repetition in expressions
+   where the same value needs to be used more than once."
 
 
 .. _geometry_functions:
@@ -562,7 +583,6 @@ This group contains functions that operate on geometry objects (e.g., length, ar
    the Spatial Reference System of this geometry"
    "azimuth", "Returns the north-based azimuth as the angle in radians measured
    clockwise from the vertical on point_a to point_b"
-   
    "boundary", "Returns the closure of the combinatorial boundary of the geometry
    (ie the topological boundary of the geometry - see also :ref:`qgisboundary`)."
    "bounds", "Returns a geometry which represents the bounding box of an input geometry.
@@ -577,7 +597,6 @@ This group contains functions that operate on geometry objects (e.g., length, ar
    Reference System of this geometry (see also :ref:`qgisbuffer`)"
    "buffer_by_m", "Creates a buffer along a line geometry where the buffer diameter
    varies according to the M values at the line vertices (see also :ref:`qgisbufferbym`)"
-
    "centroid", "Returns the geometric center of a geometry (see also :ref:`qgiscentroids`)"
    "closest_point", "Returns the point on a geometry that is closest to a second geometry"
    "combine", "Returns the combination of two geometries"
@@ -593,7 +612,6 @@ This group contains functions that operate on geometry objects (e.g., length, ar
    "distance", "Returns the minimum distance (based on Spatial Reference System)
    between two geometries in projected units"
    "distance_to_vertex", "Returns the distance along the geometry to a specified vertex"
-
    "end_point", "Returns the last node from a geometry (see also :ref:`qgisextractspecificvertices`)"
    "extend", "Extends the start and end of a linestring geometry by a specified amount
    (see also :ref:`qgisextendlines`)"
@@ -610,7 +628,6 @@ This group contains functions that operate on geometry objects (e.g., length, ar
    "geometry", "Returns a feature's geometry"
    "geometry_n", "Returns the nth geometry from a geometry collection,
    or null if the input geometry is not a collection"
-
    "hausdorff_distance", "Returns basically a measure of how similar or dissimilar
    two geometries are, with a lower distance indicating more similar geometries"
    "inclination", "Returns the inclination measured from the zenith (0) to the nadir (180) on point_a to point_b"
@@ -625,7 +642,6 @@ This group contains functions that operate on geometry objects (e.g., length, ar
    (share any portion of space) their bounding box, or 0 if they don't"
    "is_closed", "Returns true if a line string is closed (start and end points are coincident),
    false if a line string is not closed, or null if the geometry is not a line string"
-
    "length", "Returns length of a line geometry feature (or length of a string)"
    "line_interpolate_angle", "Returns the angle parallel to the geometry at a specified
    distance along a linestring geometry. Angles are in degrees clockwise from north."
@@ -638,7 +654,6 @@ This group contains functions that operate on geometry objects (e.g., length, ar
    (see also :ref:`qgislinesubstring`)"
    "line_merge", "Returns a (Multi-)LineString geometry, where any connected LineStrings
    from the input geometry have been merged into a single linestring."
-
    "m", "Returns the M value of a point geometry"
    "make_circle", "Creates a circular geometry based on center point and radius"
    "make_ellipse", "Creates an elliptical geometry based on center point, axes and azimuth"
@@ -655,7 +670,6 @@ This group contains functions that operate on geometry objects (e.g., length, ar
    (see also :ref:`qgisminimumenclosingcircle`)"
    "nodes_to_points", "Returns a multipoint geometry consisting of every node in
    the input geometry (see also :ref:`qgisextractvertices`)"
-
    "num_geometries", "Returns the number of geometries in a geometry collection,
    or null if the input geometry is not a collection"
    "num_interior_rings", "Returns the number of interior rings in a polygon or
@@ -670,7 +684,6 @@ This group contains functions that operate on geometry objects (e.g., length, ar
    bounding box of an input geometry (see also :ref:`qgisorientedminimumboundingbox`)"
    "overlaps", "Tests whether a geometry overlaps another. Returns 1 (true) if
    the geometries share space, are of the same dimension, but are not completely contained by each other"
-
    "perimeter", "Returns the perimeter of a geometry polygon feature.
    Calculations are in the Spatial Reference System of this geometry"
    "point_n", "Returns a specific node from a geometry (see also :ref:`qgisextractspecificvertices`)"
@@ -685,7 +698,6 @@ This group contains functions that operate on geometry objects (e.g., length, ar
    representation of the relationship between two geometries"
    "reverse", "Reverses the direction of a line string by reversing the order of its
    vertices (see also :ref:`qgisreverselinedirection`)"
-
    "segments_to_lines", "Returns a multi line geometry consisting of a line for
    every segment in the input geometry (see also :ref:`qgisexplodelines`)"
    "shortest_line", "Returns the shortest line joining two geometries.
@@ -702,7 +714,6 @@ This group contains functions that operate on geometry objects (e.g., length, ar
    "start_point", "Returns the first node from a geometry (see also :ref:`qgisextractspecificvertices`)"
    "sym_difference", "Returns a geometry that represents the portions of two
    geometries that do not intersect (see also :ref:`qgissymmetricaldifference`)"
-
    "tapered_buffer", "Creates a buffer along a line geometry where the buffer
    diameter varies evenly over the length of the line (see also :ref:`qgistaperedbuffer`)"
    "touches", "Tests whether a geometry touches another. Returns 1 (true) if
@@ -716,7 +727,6 @@ This group contains functions that operate on geometry objects (e.g., length, ar
    given an angle and radii (see also :ref:`qgiswedgebuffers`)"
    "within (a,b)", "Tests whether a geometry is within another. Returns 1 (true)
    if geometry a is completely inside geometry b"
-
    "x", "Returns the X coordinate of a point geometry, or the X coordinate of the
    centroid for a non-point geometry"
    "x_min", "Returns the minimum X coordinate of a geometry.
@@ -813,7 +823,8 @@ and values are identified by their keys.
    "map", "Returns a map containing all the keys and values passed as pair of parameters"
    "map_akeys", "Returns all the keys of a map as an array"
    "map_avals", "Returns all the values of a map as an array"
-   "map_concat", "Returns a map containing all the entries of the given maps. If two maps contain the same key, the value of the second map is taken."
+   "map_concat", "Returns a map containing all the entries of the given maps.
+   If two maps contain the same key, the value of the second map is taken."
    "map_delete", "Returns a map with the given key and its corresponding value deleted"
    "map_exist", "Returns true if the given key exists in the map"
    "map_get", "Returns the value of a map, given it's key"
@@ -837,15 +848,18 @@ This group contains math functions (e.g., square root, sin and cos).
    "acos", "Returns the inverse cosine of a value in radians"
    "asin", "Returns the inverse sine of a value in radians"
    "atan", "Returns the inverse tangent of a value in radians"
-   "atan2(y,x)", "Returns the inverse tangent of Y/X by using the signs of the two arguments to determine the quadrant of the result"
-   "azimuth(a,b)", "Returns the north-based azimuth as the angle in radians measured clockwise from the vertical on point a to point b"
+   "atan2(y,x)", "Returns the inverse tangent of Y/X by using the signs of the
+   two arguments to determine the quadrant of the result"
+   "azimuth(a,b)", "Returns the north-based azimuth as the angle in radians
+   measured clockwise from the vertical on point a to point b"
    "ceil", "Rounds a number upwards"
    "clamp", "Restricts an input value to a specified range"
    "cos", "Returns the cosine of a value in radians"
    "degrees", "Converts from radians to degrees"
    "exp", "Returns exponential of a value"
    "floor", "Rounds a number downwards"
-   "inclination", "Returns the inclination measured from the zenith (0) to the nadir (180) on point_a to point_b."
+   "inclination", "Returns the inclination measured from the zenith (0) to the
+   nadir (180) on point_a to point_b."
    "ln", "Returns the natural logarithm of the passed expression"
    "log", "Returns the value of the logarithm of the passed value and base"
    "log10", "Returns the value of the base 10 logarithm of the passed expression"
@@ -853,11 +867,15 @@ This group contains math functions (e.g., square root, sin and cos).
    "min", "Returns the smallest not null value in a set of values"
    "pi", "Returns the value of pi for calculations"
    "radians", "Converts from degrees to radians"
-   "rand", "Returns the random integer within the range specified by the minimum and maximum argument (inclusive)"
-   "randf", "Returns the random float within the range specified by the minimum and maximum argument (inclusive)"
+   "rand", "Returns the random integer within the range specified by the minimum
+   and maximum argument (inclusive)"
+   "randf", "Returns the random float within the range specified by the minimum
+   and maximum argument (inclusive)"
    "round", "Rounds to number of decimal places"
-   "scale_exp", "Transforms a given value from an input domain to an output range using an exponential curve"
-   "scale_linear", "Transforms a given value from an input domain to an output range using linear interpolation"
+   "scale_exp", "Transforms a given value from an input domain to an output
+   range using an exponential curve"
+   "scale_linear", "Transforms a given value from an input domain to an output
+   range using linear interpolation"
    "sin", "Returns the sine of an angle"
    "sqrt", "Returns the square root of a value"
    "tan", "Returns the tangent of an angle"
@@ -892,7 +910,8 @@ if one of the inputs is NULL then the result is NULL.
    "||", "Joins two values together into a string. If one of the values is NULL the result will be NULL"
    "'\\n'", "Inserts a new line in a string"
    "LIKE", "Returns 1 if the first parameter matches the supplied pattern"
-   "ILIKE", "Returns 1 if the first parameter matches case-insensitive the supplied pattern (ILIKE can be used instead of LIKE to make the match case-insensitive)"
+   "ILIKE", "Returns 1 if the first parameter matches case-insensitive the supplied
+   pattern (ILIKE can be used instead of LIKE to make the match case-insensitive)"
    "a IS b", "Tests whether two values are identical. Returns 1 if a is the same as b"
    "a OR b", "Returns 1 when condition a or condition b is true"
    "a AND b", "Returns 1 when conditions a and b are true"
@@ -962,15 +981,18 @@ This group contains functions that operate on record identifiers.
    :widths: 25, 70
    :class: longtable
 
-   "$currentfeature", "Returns the current feature being evaluated. This can be used with the 'attribute' function to evaluate attribute values from the current feature."
+   "$currentfeature", "Returns the current feature being evaluated. This can be used
+   with the 'attribute' function to evaluate attribute values from the current feature."
    "$id", "Returns the feature id of the current row"
    "attribute", "Returns the value of a specified attribute from a feature"
-   "attributes |310|", "Returns a :ref:`map <maps_functions>` of all attributes from a feature, with field names as map keys"
+   "attributes |310|", "Returns a :ref:`map <maps_functions>` of all attributes from
+   a feature, with field names as map keys"
    "get_feature", "Returns the first feature of a layer matching a given attribute value"
    "get_feature_by_id", "Returns the feature of a layer matching the given feature ID"
    "is_selected", "Returns if a feature is selected"
    "num_selected", "Returns the number of selected features on a given layer"
-   "represent_value", "Returns the configured representation value for a field value (convenient with some :ref:`widget types <edit_widgets>`)"
+   "represent_value", "Returns the configured representation value for a field value
+   (convenient with some :ref:`widget types <edit_widgets>`)"
    "sql_fetch_and_increment |36|", "Manage autoincrementing values in sqlite databases"
    "uuid", "Generates a Universally Unique Identifier (UUID) for each row. Each UUID is 38 characters long."
 
@@ -1007,18 +1029,22 @@ This group contains functions that operate on strings
    "concat", "Concatenates several strings to one"
    "format", "Formats a string using supplied arguments"
    "format_date", "Formats a date type or string into a custom string format"
-   "format_number", "Returns a number formatted with the locale separator for thousands (also truncates the number to the number of supplied places)"
+   "format_number", "Returns a number formatted with the locale separator for
+   thousands (also truncates the number to the number of supplied places)"
    "left(string, n)", "Returns a substring that contains the n leftmost characters of the string"
    "length", "Returns length of a string (or length of a line geometry feature)"
    "lower", "converts a string to lower case"
    "lpad", "Returns a string padded on the left to the specified width, using the fill character"
-   "regexp_match", "Returns the first matching position matching a regular expression within a string, or 0 if the substring is not found"
+   "regexp_match", "Returns the first matching position matching a regular expression
+   within a string, or 0 if the substring is not found"
    "regexp_replace", "Returns a string with the supplied regular expression replaced"
    "regexp_substr", "Returns the portion of a string which matches a supplied regular expression"
-   "replace", "Returns a string with the supplied string, array, or map of strings replaced by a string, an array of strings or paired values"
+   "replace", "Returns a string with the supplied string, array, or map of strings replaced
+   by a string, an array of strings or paired values"
    "right(string, n)", "Returns a substring that contains the n rightmost characters of the string"
    "rpad", "Returns a string padded on the right to the specified width, using the fill character"
-   "strpos", "Returns the first matching position of a substring within another string, or 0 if the substring is not found"
+   "strpos", "Returns the first matching position of a substring within another string,
+   or 0 if the substring is not found"
    "substr", "Returns a part of a string"
    "title", "Converts all words of a string to title case (all words lower case with leading capital letter)"
    "trim", "Removes all leading and trailing white space (spaces, tabs, etc.) from a string"
@@ -1088,7 +1114,6 @@ To use these functions in an expression, they should be preceded by @ character
    "atlas_layername", "Returns the current atlas coverage layer name"
    "atlas_pagename", "Returns the current atlas page name"
    "atlas_totalfeatures", "Returns the total number of features in atlas"
-
    "canvas_cursor_point", "Returns the last cursor position on the canvas in the
    project's geographical coordinates"
    "cluster_color", "Returns the color of symbols within a cluster, or NULL if
@@ -1102,7 +1127,6 @@ To use these functions in an expression, they should be preceded by @ character
    "fullextent_maxy |38|", "Maximum y value from full canvas extent (including all layers)"
    "fullextent_minx |38|", "Minimum x value from full canvas extent (including all layers)"
    "fullextent_miny |38|", "Minimum x value from full canvas extent (including all layers)"
-
    "geometry_part_count", "Returns the number of parts in rendered feature's geometry"
    "geometry_part_num", "Returns the current geometry part number for feature being rendered"
    "geometry_point_count", "Returns the number of points in the rendered geometry's part"
@@ -1120,7 +1144,6 @@ To use these functions in an expression, they should be preceded by @ character
    "layout_page", "Returns the page number of the current item in the layout"
    "layout_pageheight", "Returns the active page height in the layout (in mm)"
    "layout_pagewidth", "Returns the active page width in the layout (in mm)"
-
    "map_crs", "Returns the Coordinate reference system of the current map"
    "map_crs_acronym |36|", "Returns the acronym of the Coordinate reference
    system of the current map"
@@ -1150,7 +1173,6 @@ To use these functions in an expression, they should be preceded by @ character
    "parent", "Refers to the current feature in the parent layer, providing access to
    its attributes and geometry when filtering an :ref:`aggregate <aggregates_function>`
    function"
-
    "project_abstract", "Returns the project abstract, taken from project metadata"
    "project_area_units", "Returns the area unit for the current project, used when
    calculating areas of geometries"
@@ -1172,7 +1194,6 @@ To use these functions in an expression, they should be preceded by @ character
    "project_keywords", "Returns the project keywords, taken from the project's metadata"
    "project_path", "Returns the full path (including file name) of the current project"
    "project_title", "Returns the title of current project"
-
    "qgis_locale", "Returns the current language of QGIS"
    "qgis_os_name", "Returns the current Operating system name, eg 'windows', 'linux' or 'osx'"
    "qgis_platform", "Returns QGIS platform, eg 'desktop' or 'server'"
@@ -1180,7 +1201,6 @@ To use these functions in an expression, they should be preceded by @ character
    "qgis_short_version", "Returns current QGIS version short string"
    "qgis_version", "Returns current QGIS version string"
    "qgis_version_no", "Returns current QGIS version number"
-
    "snapping_results", "Gives access to snapping results while digitizing a
    feature (only available in add feature)"
    "symbol_angle", "Returns the angle of the symbol used to render the feature


### PR DESCRIPTION
If you have ever downloaded [our user manual](https://docs.qgis.org/3.4/pdf/), you have probably noticed how awful are some tables in the PDF (check the Expressions chapter). Particularly when they are long or have a column really wider than the others. While the rendering is always good in html, in PDF it's another story.
This PR walks through the user manual and fixes each table, using advanced properties to handle and customize tables in Sphinx/LaTeX. 
* Tables are mainly moved to a csv-table format, because it's the format I managed to work with when I looked at this issue. It also has the advantage to ease update, avoiding the whole table reformatting when the new function to add is too long
* Enable columns width control, using smart latex options, resulting in more useful table in pdf docs
* Remove additional space after the tables: only html output is concerned. By default the PDF already adds the necessary space at the bottom of a page

We'd move from this kind of rendering 
![image](https://user-images.githubusercontent.com/7983394/64641047-a0dbd100-d40b-11e9-911b-754ddec5ce77.png)
to this one 
![image](https://user-images.githubusercontent.com/7983394/64641247-0c25a300-d40c-11e9-8b83-39073169176a.png)

Almost no text change.
Last but not least fixes #1135