### PR TITLE
Remove the "minimal requirements for merging" section in pr template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -18,17 +18,11 @@ Replace the space between square brackets by a `x` to make it checked.
 -->
 - [ ] Backport to LTR documentation is required
 
-### Minimal requirements for merging *(for maintainers)*
 <!---
 Reviewing is a process done by community members, mostly on a volunteer basis.
 We try to keep the overhead as small as possible and appreciate if you help us.
-In order for your PR to get merged it should satisfy some minimal requirements:
---->
-
-- [ ] The description of this PR is coherent with the manual and does not provide wrong information.
-- [ ] This PR passes the checks. <!---The results will be reported by travis-ci **after** opening the PR.-->
-
-<!---
-Please read carefully our writing guidelines at https://docs.qgis.org/testing/en/docs/documentation_guidelines/index.html
-to help you fulfill these requirements. Feel free to ask in a comment if you have troubles with any of them.
+Please read carefully and ensure you comply with our writing guidelines at
+https://docs.qgis.org/testing/en/docs/documentation_guidelines/index.html.
+Feel free to ask in a comment or the (qgis-community-team mailing list)
+[https://lists.osgeo.org/mailman/listinfo/qgis-community-team] if you have troubles with any item.
 --->


### PR DESCRIPTION
Over six months, I can count on the fingers of one hand the numbre of times i saw any of these buttons checked. And it was not necessarily by maintainers (as the label supposed to). They are unused, and imho do not add much to the process: one is already covered by the approved/request changes system of github, the other is in guidelines, managed by travis, post-submission.
So, how about replace these with information that could help provide a better communication with submitters?

Ticket: #

<!---
Indicate whether the fix should be backported to previous release.
Replace the space between square brackets by a `x` to make it checked.
-->
- [ ] Backport to LTR documentation is required

### Minimal requirements for merging *(for maintainers)*
<!---
Reviewing is a process done by community members, mostly on a volunteer basis.
We try to keep the overhead as small as possible and appreciate if you help us.
In order for your PR to get merged it should satisfy some minimal requirements:
--->

- [ ] The description of this PR is coherent with the manual and does not provide wrong information.
- [ ] This PR passes the checks. <!---The results will be reported by travis-ci **after** opening the PR.-->

<!---
Please read carefully our writing guidelines at https://docs.qgis.org/testing/en/docs/documentation_guidelines/index.html
to help you fulfill these requirements. Feel free to ask in a comment if you have troubles with any of them.
--->
