### PR TITLE
use correct script template version in QGIS 3.4

### DIFF
--- a/source/docs/pyqgis_developer_cookbook/processing.rst
+++ b/source/docs/pyqgis_developer_cookbook/processing.rst
@@ -108,7 +108,7 @@ You can create a folder :file:`processing_provider` with three files in it:
 
 * :file:`example_processing_algorithm.py` which contains the example algorithm file.
   Copy/paste the content of the script template:
-  https://github.com/qgis/QGIS/blob/master/python/plugins/processing/script/ScriptTemplate.py
+  https://github.com/qgis/QGIS/blob/release-3_4/python/plugins/processing/script/ScriptTemplate.py
 
 Now you can reload your plugin in QGIS and you should see your example script in
 the Processing toolbox and modeler.


### PR DESCRIPTION
### Description
Goal: PR against the 3.4 branch of the documentation.
The link must target the 3.4 branch of QGIS.

The template in master is not compatible with 3.4.

<!---
Indicate whether the fix should be backported to previous release.
Replace the space between square brackets by a `x` to make it checked.
-->
- [ ] Backport to LTR documentation is required

### Minimal requirements for merging *(for maintainers)*
<!---
Reviewing is a process done by community members, mostly on a volunteer basis.
We try to keep the overhead as small as possible and appreciate if you help us.
In order for your PR to get merged it should satisfy some minimal requirements:
--->

- [ ] The description of this PR is coherent with the manual and does not provide wrong information.
- [ ] This PR passes the checks. <!---The results will be reported by travis-ci **after** opening the PR.-->

<!---
Please read carefully our writing guidelines at https://docs.qgis.org/testing/en/docs/documentation_guidelines/index.html
to help you fulfill these requirements. Feel free to ask in a comment if you have troubles with any of them.
--->
