### PR TITLE
Keep our external links synced with the doc release

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -29,6 +29,7 @@ extensions = [
     'sphinx.ext.imgmath',
     'sphinx.ext.intersphinx',
     'sphinx.ext.doctest',
+    'sphinx.ext.extlinks',
 ]
 
 # Add any paths that contain templates here, relative to this directory.
@@ -109,7 +110,15 @@ pygments_style = 'sphinx'
 # If true, keep warnings as "system message" paragraphs in the built documents.
 #keep_warnings = False
 
-intersphinx_mapping = {'pyqgis_api': ('https://qgis.org/pyqgis/master/', None)}
+intersphinx_mapping = {'pyqgis_api': ('https://qgis.org/pyqgis/{}/'.format(version if version != 'testing' else 'master'), None)}
+
+# This config value must be a dictionary of external sites, mapping unique short
+# alias names to a base URL and a prefix.
+extlinks = {'api': ('https://qgis.org/api/{}%s'.format(''.join([version, '/']) if version != 'testing' else ''), None),
+            'pyqgis': ('https://qgis.org/pyqgis/{}/%s'.format(version if version != 'testing' else 'master'), None),
+            'qgissource': ('https://github.com/qgis/QGIS/blob/{}/%s'.format(
+                ''.join(['release-', version]).replace('.', '_') if version != 'testing' else 'master'), None)
+           }
 
 # -- Options for HTML output ---------------------------------------------------
 

--- a/source/conf.py
+++ b/source/conf.py
@@ -116,7 +116,7 @@ intersphinx_mapping = {'pyqgis_api': ('https://qgis.org/pyqgis/{}/'.format(versi
 # alias names to a base URL and a prefix.
 extlinks = {'api': ('https://qgis.org/api/{}%s'.format(''.join([version, '/']) if version != 'testing' else ''), None),
             'pyqgis': ('https://qgis.org/pyqgis/{}/%s'.format(version if version != 'testing' else 'master'), None),
-            'qgissource': ('https://github.com/qgis/QGIS/blob/{}/%s'.format(
+            'source': ('https://github.com/qgis/QGIS/blob/{}/%s'.format(
                 ''.join(['release-', version]).replace('.', '_') if version != 'testing' else 'master'), None)
            }
 

--- a/source/docs/developers_guide/codingstandards.rst
+++ b/source/docs/developers_guide/codingstandards.rst
@@ -369,7 +369,7 @@ Braces should start on the line following the expression:
 API Compatibility
 ==================
 
-There is `API documentation <https://qgis.org/api/>`_ for C++.
+There is :api:`API documentation <>` for C++.
 
 We try to keep the API stable and backwards compatible. Cleanups to the API
 should be done in a manner similar to the Qt sourcecode e.g.
@@ -608,6 +608,6 @@ contribution by:
   and add it to the QGIS planet https://plugins.qgis.org/planet/
 * adding their name to:
 
-  * https://github.com/qgis/QGIS/blob/master/doc/CONTRIBUTORS
-  * https://github.com/qgis/QGIS/blob/master/doc/AUTHORS  
+  * :qgissource:`doc/CONTRIBUTORS`
+  * :qgissource:`doc/AUTHORS`
 

--- a/source/docs/developers_guide/codingstandards.rst
+++ b/source/docs/developers_guide/codingstandards.rst
@@ -608,6 +608,6 @@ contribution by:
   and add it to the QGIS planet https://plugins.qgis.org/planet/
 * adding their name to:
 
-  * :qgissource:`doc/CONTRIBUTORS`
-  * :qgissource:`doc/AUTHORS`
+  * :source:`doc/CONTRIBUTORS`
+  * :source:`doc/AUTHORS`
 

--- a/source/docs/developers_guide/ogcconformancetesting.rst
+++ b/source/docs/developers_guide/ogcconformancetesting.rst
@@ -60,8 +60,7 @@ For the WMS tests, data can be downloaded and loaded into a QGIS project:
   wget https://cite.opengeospatial.org/teamengine/about/wms/1.3.0/site/data-wms-1.3.0.zip
   unzip data-wms-1.3.0.zip
 
-Then create a `QGIS project
-<https://github.com/qgis/QGIS/blob/master/tests/testdata/qgis_server/ets-wms13/project.qgs>`_
+Then create a :qgissource:`QGIS project <tests/testdata/qgis_server/ets-wms13/project.qgs>`
 according to the description in
 https://cite.opengeospatial.org/teamengine/about/wms/1.3.0/site/.
 To run the tests, we need to provide the GetCapabilities URL of the service later.

--- a/source/docs/developers_guide/ogcconformancetesting.rst
+++ b/source/docs/developers_guide/ogcconformancetesting.rst
@@ -60,7 +60,7 @@ For the WMS tests, data can be downloaded and loaded into a QGIS project:
   wget https://cite.opengeospatial.org/teamengine/about/wms/1.3.0/site/data-wms-1.3.0.zip
   unzip data-wms-1.3.0.zip
 
-Then create a :qgissource:`QGIS project <tests/testdata/qgis_server/ets-wms13/project.qgs>`
+Then create a :source:`QGIS project <tests/testdata/qgis_server/ets-wms13/project.qgs>`
 according to the description in
 https://cite.opengeospatial.org/teamengine/about/wms/1.3.0/site/.
 To run the tests, we need to provide the GetCapabilities URL of the service later.

--- a/source/docs/developers_guide/processingtesting.rst
+++ b/source/docs/developers_guide/processingtesting.rst
@@ -11,7 +11,7 @@ Algorithm tests
 ===============
 
 .. note:: The original version of these instructions is available at
-  :qgissource:`python/plugins/processing/tests/README.md`
+  :source:`python/plugins/processing/tests/README.md`
 
 QGIS provides several algorithms under the Processing framework.
 You can extend this list with algorithms of your own and, like any new feature,
@@ -261,5 +261,5 @@ Running tests locally
 
  ctest -V -R ProcessingQgisAlgorithmsTest
 
-or one of the following values listed in the :qgissource:`CMakelists.txt
+or one of the following values listed in the :source:`CMakelists.txt
 <python/plugins/processing/tests/CMakeLists.txt>`

--- a/source/docs/developers_guide/processingtesting.rst
+++ b/source/docs/developers_guide/processingtesting.rst
@@ -11,7 +11,7 @@ Algorithm tests
 ===============
 
 .. note:: The original version of these instructions is available at
-  https://github.com/qgis/QGIS/blob/master/python/plugins/processing/tests/README.md
+  :qgissource:`python/plugins/processing/tests/README.md`
 
 QGIS provides several algorithms under the Processing framework.
 You can extend this list with algorithms of your own and, like any new feature,
@@ -261,5 +261,5 @@ Running tests locally
 
  ctest -V -R ProcessingQgisAlgorithmsTest
 
-or one of the following values listed in the `CMakelists.txt
-<https://github.com/qgis/QGIS/blob/master/python/plugins/processing/tests/CMakeLists.txt>`_
+or one of the following values listed in the :qgissource:`CMakelists.txt
+<python/plugins/processing/tests/CMakeLists.txt>`

--- a/source/docs/documentation_guidelines/substitutions.rst
+++ b/source/docs/documentation_guidelines/substitutions.rst
@@ -22,7 +22,7 @@ If no replacement exists:
 #. check the documentation repository whether the icon is available in
    :file:`/static/common` folder. If no image, then you need to find and
    copy the icon image file from `QGIS repository <https://github.com/qgis/QGIS>`_
-   (often under https://github.com/qgis/QGIS/tree/master/images/themes/default folder)
+   (often under :qgissource:`images/themes/default` folder)
    and paste (in ``.png`` format) under :file:`/static/common` folder.
    For convenience and update, it's advised to keep filename when possible.
 #. create the reference to the substitution in the :file:`/source/substitutions.txt`

--- a/source/docs/documentation_guidelines/substitutions.rst
+++ b/source/docs/documentation_guidelines/substitutions.rst
@@ -22,7 +22,7 @@ If no replacement exists:
 #. check the documentation repository whether the icon is available in
    :file:`/static/common` folder. If no image, then you need to find and
    copy the icon image file from `QGIS repository <https://github.com/qgis/QGIS>`_
-   (often under :qgissource:`images/themes/default` folder)
+   (often under :source:`images/themes/default` folder)
    and paste (in ``.png`` format) under :file:`/static/common` folder.
    For convenience and update, it's advised to keep filename when possible.
 #. create the reference to the substitution in the :file:`/source/substitutions.txt`

--- a/source/docs/pyqgis_developer_cookbook/authentication.rst
+++ b/source/docs/pyqgis_developer_cookbook/authentication.rst
@@ -33,7 +33,7 @@ plugin and its tests. This is the first plugin that used Authentication
 infrastructure. The plugin code and its tests can be found at this
 `link <https://github.com/boundlessgeo/qgis-geoserver-plugin>`_.
 Other good code reference can be read from the authentication infrastructure
-:qgissource:`tests code <tests/src/python/test_qgsauthsystem.py>`.
+:source:`tests code <tests/src/python/test_qgsauthsystem.py>`.
 
 
 .. _Authentication_manager_glossary:
@@ -309,8 +309,8 @@ PKI examples with other data providers
 ......................................
 
 Other example can be read directly in the QGIS tests upstream as in
-:qgissource:`test_authmanager_pki_ows <tests/src/python/test_authmanager_pki_ows.py>` or
-:qgissource:`test_authmanager_pki_postgres <tests/src/python/test_authmanager_pki_postgres.py>`.
+:source:`test_authmanager_pki_ows <tests/src/python/test_authmanager_pki_ows.py>` or
+:source:`test_authmanager_pki_postgres <tests/src/python/test_authmanager_pki_postgres.py>`.
 
 
 .. _Adapt_plugins_to_use_Auth_infrastructure:
@@ -367,7 +367,7 @@ and can be used as in the following snippet:
   # GUI has to be integrated
   tabGui.insertTab( 1, gui, "Configurations" )
 
-The above example is taken from the QGIS source :qgissource:`code
+The above example is taken from the QGIS source :source:`code
 <src/providers/postgres/qgspgnewconnection.cpp#L42>`
 The second parameter of the GUI constructor refers to data provider type. The
 parameter is used to restrict the compatible :term:`Authentication Method`\s with
@@ -394,7 +394,7 @@ and can be used as in the following snippet:
  gui = QgsAuthConfigSelect( parent )
  gui.show()
 
-an integrated example can be found in the related :qgissource:`test
+an integrated example can be found in the related :source:`test
 <tests/src/python/test_qgsauthsystem.py#L80>`.
 
 .. _Authorities_Editor_GUI:

--- a/source/docs/pyqgis_developer_cookbook/authentication.rst
+++ b/source/docs/pyqgis_developer_cookbook/authentication.rst
@@ -33,7 +33,7 @@ plugin and its tests. This is the first plugin that used Authentication
 infrastructure. The plugin code and its tests can be found at this
 `link <https://github.com/boundlessgeo/qgis-geoserver-plugin>`_.
 Other good code reference can be read from the authentication infrastructure
-`tests code <https://github.com/qgis/QGIS/blob/master/tests/src/python/test_qgsauthsystem.py>`_
+:qgissource:`tests code <tests/src/python/test_qgsauthsystem.py>`.
 
 
 .. _Authentication_manager_glossary:
@@ -309,11 +309,8 @@ PKI examples with other data providers
 ......................................
 
 Other example can be read directly in the QGIS tests upstream as in
-test_authmanager_pki_ows_ or test_authmanager_pki_postgres_.
-
-.. _test_authmanager_pki_ows: https://github.com/qgis/QGIS/blob/master/tests/src/python/test_authmanager_pki_ows.py
-.. _test_authmanager_pki_postgres: https://github.com/qgis/QGIS/blob/master/tests/src/python/test_authmanager_pki_postgres.py
-
+:qgissource:`test_authmanager_pki_ows <tests/src/python/test_authmanager_pki_ows.py>` or
+:qgissource:`test_authmanager_pki_postgres <tests/src/python/test_authmanager_pki_postgres.py>`.
 
 
 .. _Adapt_plugins_to_use_Auth_infrastructure:
@@ -370,8 +367,8 @@ and can be used as in the following snippet:
   # GUI has to be integrated
   tabGui.insertTab( 1, gui, "Configurations" )
 
-The above example is taken from the QGIS source `code
-<https://github.com/qgis/QGIS/blob/master/src/providers/postgres/qgspgnewconnection.cpp#L42>`_
+The above example is taken from the QGIS source :qgissource:`code
+<src/providers/postgres/qgspgnewconnection.cpp#L42>`
 The second parameter of the GUI constructor refers to data provider type. The
 parameter is used to restrict the compatible :term:`Authentication Method`\s with
 the specified provider.
@@ -397,7 +394,8 @@ and can be used as in the following snippet:
  gui = QgsAuthConfigSelect( parent )
  gui.show()
 
-an integrated example can be found in the related `test <https://github.com/qgis/QGIS/blob/master/tests/src/python/test_qgsauthsystem.py#L80>`_
+an integrated example can be found in the related :qgissource:`test
+<tests/src/python/test_qgsauthsystem.py#L80>`.
 
 .. _Authorities_Editor_GUI:
 

--- a/source/docs/pyqgis_developer_cookbook/cheat_sheet.rst
+++ b/source/docs/pyqgis_developer_cookbook/cheat_sheet.rst
@@ -804,8 +804,8 @@ Composer
 Sources
 =======
 
-* `QGIS Python (PyQGIS) API <https://qgis.org/pyqgis/>`_
-* `QGIS C++ API <https://qgis.org/api/>`_
+* :pyqgis:`QGIS Python (PyQGIS) API <>`
+* :api:`QGIS C++ API <>`
 * `StackOverFlow QGIS questions <https://stackoverflow.com/questions/tagged/qgis>`_
 * `Script by Klas Karlsson <https://raw.githubusercontent.com/klakar/QGIS_resources/master/collections/Geosupportsystem/python/qgis_basemaps.py>`_
 * `Boundless lib-qgis-common repository <https://github.com/boundlessgeo/lib-qgis-commons>`_

--- a/source/docs/pyqgis_developer_cookbook/geometry.rst
+++ b/source/docs/pyqgis_developer_cookbook/geometry.rst
@@ -290,8 +290,8 @@ methods to analyze and transform vector data. Here are some links to the code
 of a few of them.
 
 * Distance and area using the :class:`QgsDistanceArea <qgis.core.QgsDistanceArea>` class:
-  :qgissource:`Distance matrix algorithm <python/plugins/processing/algs/qgis/PointDistance.py>`
-* :qgissource:`Lines to polygons algorithm <python/plugins/processing/algs/qgis/LinesToPolygons.py>`
+  :source:`Distance matrix algorithm <python/plugins/processing/algs/qgis/PointDistance.py>`
+* :source:`Lines to polygons algorithm <python/plugins/processing/algs/qgis/LinesToPolygons.py>`
 
 .. Substitutions definitions - AVOID EDITING PAST THIS LINE
    This will be automatically updated by the find_set_subst.py script.

--- a/source/docs/pyqgis_developer_cookbook/geometry.rst
+++ b/source/docs/pyqgis_developer_cookbook/geometry.rst
@@ -290,8 +290,8 @@ methods to analyze and transform vector data. Here are some links to the code
 of a few of them.
 
 * Distance and area using the :class:`QgsDistanceArea <qgis.core.QgsDistanceArea>` class:
-  `Distance matrix algorithm <https://github.com/qgis/QGIS/blob/master/python/plugins/processing/algs/qgis/PointDistance.py>`_
-* `Lines to polygons algorithm <https://github.com/qgis/QGIS/blob/master/python/plugins/processing/algs/qgis/LinesToPolygons.py>`_
+  :qgissource:`Distance matrix algorithm <python/plugins/processing/algs/qgis/PointDistance.py>`
+* :qgissource:`Lines to polygons algorithm <python/plugins/processing/algs/qgis/LinesToPolygons.py>`
 
 .. Substitutions definitions - AVOID EDITING PAST THIS LINE
    This will be automatically updated by the find_set_subst.py script.

--- a/source/docs/pyqgis_developer_cookbook/intro.rst
+++ b/source/docs/pyqgis_developer_cookbook/intro.rst
@@ -31,9 +31,9 @@ Python application.
 
 .. index:: API
 
-There is a `complete QGIS API <https://qgis.org/api/>`_ reference that
-documents the classes from the QGIS libraries. `The Pythonic QGIS API
-(pyqgis) <https://qgis.org/pyqgis>`_ is nearly identical to the C++ API.
+There is a :api:`complete QGIS API <>` reference that
+documents the classes from the QGIS libraries. :pyqgis:`The Pythonic QGIS API
+(pyqgis) <>` is nearly identical to the C++ API.
 
 A good resource for learning how to perform common tasks is to
 download existing plugins from the

--- a/source/docs/pyqgis_developer_cookbook/network_analysis.rst
+++ b/source/docs/pyqgis_developer_cookbook/network_analysis.rst
@@ -56,7 +56,8 @@ of an edge.
 
 Converting from a vector layer to the graph is done using the `Builder <https://en.wikipedia.org/wiki/Builder_pattern>`_
 programming pattern. A graph is constructed using a so-called Director.
-There is only one Director for now: `QgsLineVectorLayerDirector <https://qgis.org/api/classQgsLineVectorLayerDirector.html>`_.
+There is only one Director for now: :api:`QgsLineVectorLayerDirector
+<classQgsLineVectorLayerDirector.html>`.
 The director sets the basic settings that will be used to construct a graph
 from a line vector layer, used by the builder to create the graph. Currently, as
 in the case with the director, only one builder exists: :class:`QgsGraphBuilder <qgis.analysis.QgsGraphBuilder>`,
@@ -66,7 +67,7 @@ with such libraries as `BGL <https://www.boost.org/doc/libs/1_48_0/libs/graph/do
 or `NetworkX <https://networkx.lanl.gov/>`_.
 
 To calculate edge properties the programming pattern `strategy <https://en.wikipedia.org/wiki/Strategy_pattern>`_
-is used. For now only `QgsDistanceArcProperter <https://qgis.org/api/classQgsDistanceArcProperter.html>`_
+is used. For now only :api:`QgsDistanceArcProperter <classQgsDistanceArcProperter.html>`
 strategy is available, that takes into account the length of the route. You
 can implement your own strategy that will use all necessary parameters.
 For example, RoadGraph plugin uses a strategy that computes travel time

--- a/source/docs/pyqgis_developer_cookbook/processing.rst
+++ b/source/docs/pyqgis_developer_cookbook/processing.rst
@@ -109,7 +109,7 @@ You can create a folder :file:`processing_provider` with three files in it:
 
 * :file:`example_processing_algorithm.py` which contains the example algorithm file.
   Copy/paste the content of the script template:
-  :qgissource:`python/plugins/processing/script/ScriptTemplate.py`
+  :source:`python/plugins/processing/script/ScriptTemplate.py`
 
 Now you can reload your plugin in QGIS and you should see your example script in
 the Processing toolbox and modeler.

--- a/source/docs/pyqgis_developer_cookbook/processing.rst
+++ b/source/docs/pyqgis_developer_cookbook/processing.rst
@@ -109,7 +109,7 @@ You can create a folder :file:`processing_provider` with three files in it:
 
 * :file:`example_processing_algorithm.py` which contains the example algorithm file.
   Copy/paste the content of the script template:
-  https://github.com/qgis/QGIS/blob/master/python/plugins/processing/script/ScriptTemplate.py
+  :qgissource:`python/plugins/processing/script/ScriptTemplate.py`
 
 Now you can reload your plugin in QGIS and you should see your example script in
 the Processing toolbox and modeler.

--- a/source/docs/pyqgis_developer_cookbook/server.rst
+++ b/source/docs/pyqgis_developer_cookbook/server.rst
@@ -29,9 +29,10 @@ Server Filter Plugins architecture
 ==================================
 
 Server python plugins are loaded once when the FCGI application starts. They
-register one or more :class:`QgsServerFilter <qgis.server.QgsServerFilter>` (from this point, you might
-find useful a quick look to the `server plugins API docs <https://qgis.org/api/group__server.html>`_).
-Each filter should implement at least one of three callbacks:
+register one or more :class:`QgsServerFilter <qgis.server.QgsServerFilter>`
+(from this point, you might find useful a quick look to the :api:`server plugins
+API docs <group__server.html>`). Each filter should implement at least one of
+three callbacks:
 
 * :meth:`requestReady() <qgis.server.QgsServerFilter.requestReady>`
 * :meth:`responseComplete() <qgis.server.QgsServerFilter.responseComplete>`

--- a/source/docs/user_manual/plugins/python_console.rst
+++ b/source/docs/user_manual/plugins/python_console.rst
@@ -76,8 +76,8 @@ The console main features are:
   accessed from context menu of input area;
 * Save and clear the command history. The history will be saved into the file
   :file:`~/.qgis2/console_history.txt`;
-* Open `QGIS C++ API <https://qgis.org/api>`_ documentation by typing ``_api``;
-* Open `QGIS Python API <https://qgis.org/pyqgis>`_ documentation by typing ``_pyqgis``.
+* Open :api:`QGIS C++ API <>` documentation by typing ``_api``;
+* Open :pyqgis:`QGIS Python API <>` documentation by typing ``_pyqgis``.
 * Open :ref:`PyQGIS Cookbook <PyQGIS-Developer-Cookbook>` by typing ``_cookbook``.
 
 

--- a/source/docs/user_manual/processing/history.rst
+++ b/source/docs/user_manual/processing/history.rst
@@ -48,7 +48,7 @@ The :guilabel:`History` dialog also provides a convenient way to contribute to
 the consolidation of the testing infrastructure of QGIS Processing algorithms
 and scripts. Right-click on a command you previously executed and you can
 :guilabel:`Create Test...` for the concerned algorithm, following instructions at
-https://github.com/qgis/QGIS/blob/master/python/plugins/processing/tests/README.md.
+:qgissource:`python/plugins/processing/tests/README.md`.
 
 
 The processing log

--- a/source/docs/user_manual/processing/history.rst
+++ b/source/docs/user_manual/processing/history.rst
@@ -48,7 +48,7 @@ The :guilabel:`History` dialog also provides a convenient way to contribute to
 the consolidation of the testing infrastructure of QGIS Processing algorithms
 and scripts. Right-click on a command you previously executed and you can
 :guilabel:`Create Test...` for the concerned algorithm, following instructions at
-:qgissource:`python/plugins/processing/tests/README.md`.
+:source:`python/plugins/processing/tests/README.md`.
 
 
 The processing log

--- a/source/docs/user_manual/processing/scripts.rst
+++ b/source/docs/user_manual/processing/scripts.rst
@@ -657,7 +657,7 @@ interface.
   throw a :class:`QgsProcessingException <qgis.core.QgsProcessingException>`.
 
 There are already many processing algorithms available in QGIS.
-You can find code on :qgissource:`python/plugins/processing/algs/qgis`.
+You can find code on :source:`python/plugins/processing/algs/qgis`.
 
 .. Substitutions definitions - AVOID EDITING PAST THIS LINE
    This will be automatically updated by the find_set_subst.py script.

--- a/source/docs/user_manual/processing/scripts.rst
+++ b/source/docs/user_manual/processing/scripts.rst
@@ -657,8 +657,7 @@ interface.
   throw a :class:`QgsProcessingException <qgis.core.QgsProcessingException>`.
 
 There are already many processing algorithms available in QGIS.
-You can find code on
-https://github.com/qgis/QGIS/tree/master/python/plugins/processing/algs/qgis.
+You can find code on :qgissource:`python/plugins/processing/algs/qgis`.
 
 .. Substitutions definitions - AVOID EDITING PAST THIS LINE
    This will be automatically updated by the find_set_subst.py script.


### PR DESCRIPTION
When browsing 3.4 document, it's better to point to  pages in code repository, c++ api or pyqgis that are of the same release than master. And when 3.10 is out, the same should apply, as well as when browsing testing --> master.
To avoid manual tracking of these links in the doc, this PR configures and applies an automatic redirection based on the doc version using the [extlinks sphinx extension](https://www.sphinx-doc.org/en/1.6/ext/extlinks.html).
Also applies the same logic to the intersphinx link replacement.
@Gustry it should cover the particular case of https://github.com/qgis/QGIS-Documentation/pull/4237#issuecomment-530794557