### PR TITLE
Add details and anchor to the layout reference map

### DIFF
--- a/source/docs/user_manual/print_composer/overview_composer.rst
+++ b/source/docs/user_manual/print_composer/overview_composer.rst
@@ -493,14 +493,21 @@ print layout.
 
    Layout Settings in the Print Layout
 
+.. _reference_map:
+
 General settings
 ................
 
 In a print layout, you can use more than one map item.
-The :guilabel:`Reference map` selects the map item to be used as the layout's
-master map. The layout will use this map in any
-properties and variable calculating units or scale. This includes exporting
-the print layout to georeferenced formats.
+The :guilabel:`Reference map` represents the map item to use as the layout's
+master map. It's assigned as long as there's a map item in the layout.
+The layout will use this map in any of their properties and variables
+calculating units or scale. This includes exporting the print layout to
+georeferenced formats.
+
+Likewise, the other layout items (scale bar, legend, north arrow...) are
+by default associated and bound to the reference map settings (orientation,
+layers displayed, scale...). 
 
 .. _grid_guides:
 


### PR DESCRIPTION
because it's a central piece in a layout and many features rely on it.

Ticket(s): #
<!---
Indicate whether the fix should be backported to previous release.
Replace the space between square brackets by a `x` to make it checked.
-->
- [ ] Backport to LTR documentation is required

<!---
Reviewing is a process done by community members, mostly on a volunteer basis.
We try to keep the overhead as small as possible and appreciate if you help us.
Please read carefully and ensure you comply with our writing guidelines at
https://docs.qgis.org/testing/en/docs/documentation_guidelines/index.html.
Feel free to ask in a comment or the (qgis-community-team mailing list)
[https://lists.osgeo.org/mailman/listinfo/qgis-community-team] if you have troubles with any item.
--->
