### PR TITLE
Add fit segement size explanation 

### DIFF
--- a/source/docs/user_manual/print_composer/composer_items/composer_map.rst
+++ b/source/docs/user_manual/print_composer/composer_items/composer_map.rst
@@ -209,7 +209,7 @@ As grid type, you can specify to use a:
   intersection;
 * or *Frame and annotations only*.
 
-Other than the grid type, you can define:
+Other than the grid type, you can define: 
 
 * the :guilabel:`CRS` which could not be the same as the map item's;
 * the :guilabel:`Interval` between two consecutive grid references in ``X``

--- a/source/docs/user_manual/print_composer/composer_items/composer_map.rst
+++ b/source/docs/user_manual/print_composer/composer_items/composer_map.rst
@@ -216,9 +216,9 @@ Other than the grid type, you can define:
   and ``Y`` directions;
 * the :guilabel:`Interval Units` to use for the grid references, in ``Map  
   Unit``, ``Fit Segment Width``, ``Millimeter`` or ``Centimeter``;
-* *``Fix Segment Width`` will dynamically select the grid interval based 
+* choosing ``Fix Segment Width`` will dynamically select the grid interval based 
   on the map extent to a "pretty" interval. When selected, the ``Minimum`` and 
-  ``Maximum`` intervals can be set*;
+  ``Maximum`` intervals can be set;
 * an :guilabel:`Offset` from the map item edges, in ``X`` and ``Y`` directions;
 * and the :guilabel:`Blend mode` of the grid (see :ref:`blend-modes`) when
   compatible.

--- a/source/docs/user_manual/print_composer/composer_items/composer_map.rst
+++ b/source/docs/user_manual/print_composer/composer_items/composer_map.rst
@@ -215,7 +215,8 @@ Other than the grid type, you can define:
 * the :guilabel:`Interval` between two consecutive grid references in ``X``
   and ``Y`` directions;
 * the :guilabel:`Interval Units` to use for the grid references, in ``Map
-  units``, ``Fit Segement Width``, ``Millimeters`` or ``Centimeters`` *(`Fix Segement Width` will dynamically select the grid interval based on the map extent to a "pretty" interval)*;
+  Unit``, ``Fit Segment Width``, ``Millimeter`` or ``Centimeter``;
+* *``Fix Segment Width`` will dynamically select the grid interval based on the map extent to a "pretty" interval. When selected, the Minimum and Maximum intervals can be set*;
 * an :guilabel:`Offset` from the map item edges, in ``X`` and ``Y`` directions;
 * and the :guilabel:`Blend mode` of the grid (see :ref:`blend-modes`) when
   compatible.

--- a/source/docs/user_manual/print_composer/composer_items/composer_map.rst
+++ b/source/docs/user_manual/print_composer/composer_items/composer_map.rst
@@ -214,12 +214,11 @@ Other than the grid type, you can define:
 * the :guilabel:`CRS` which could not be the same as the map item's;
 * the :guilabel:`Interval` between two consecutive grid references in ``X``
   and ``Y`` directions;
-* the :guilabel:`Interval Units` to use for the grid references, in ``Map
-* the :guilabel:`Interval Units` to use for the grid references, in ``Map
+* the :guilabel:`Interval Units` to use for the grid references, in ``Map  
   Unit``, ``Fit Segment Width``, ``Millimeter`` or ``Centimeter``;
 * *``Fix Segment Width`` will dynamically select the grid interval based 
-on the map extent to a "pretty" interval. When selected, the ``Minimum`` and 
-``Maximum`` intervals can be set*;
+  on the map extent to a "pretty" interval. When selected, the ``Minimum`` and 
+  ``Maximum`` intervals can be set*;
 * an :guilabel:`Offset` from the map item edges, in ``X`` and ``Y`` directions;
 * and the :guilabel:`Blend mode` of the grid (see :ref:`blend-modes`) when
   compatible.

--- a/source/docs/user_manual/print_composer/composer_items/composer_map.rst
+++ b/source/docs/user_manual/print_composer/composer_items/composer_map.rst
@@ -215,7 +215,7 @@ Other than the grid type, you can define:
 * the :guilabel:`Interval` between two consecutive grid references in ``X``
   and ``Y`` directions;
 * the :guilabel:`Interval Units` to use for the grid references, in ``Map
-  units``, ``Millimeters`` or ``Centimeters``;
+  units``, ``Fit Segement Width``, ``Millimeters`` or ``Centimeters`` *(`Fix Segement Width` will dynamically select the grid interval based on the map extent to a "pretty" interval)*;
 * an :guilabel:`Offset` from the map item edges, in ``X`` and ``Y`` directions;
 * and the :guilabel:`Blend mode` of the grid (see :ref:`blend-modes`) when
   compatible.


### PR DESCRIPTION
to address https://github.com/qgis/QGIS-Documentation/issues/4166
fix #4166 

Adding new option for resizing the legend. 

Ticket(s): #4020 
- [ ] Backport to LTR documentation is required
