### PR TITLE
Clarify text explaining changing to a different CRS for a grid

### DIFF
--- a/source/docs/user_manual/print_composer/composer_items/composer_map.rst
+++ b/source/docs/user_manual/print_composer/composer_items/composer_map.rst
@@ -211,7 +211,7 @@ As grid type, you can specify to use a:
 
 Other than the grid type, you can define: 
 
-* the :guilabel:`CRS` which could be set differently to the project CRS;
+* the :guilabel:`CRS` which could be different from the project CRS;
 * the :guilabel:`Interval` between two consecutive grid references in ``X``
   and ``Y`` directions;
 * the :guilabel:`Interval Units` to use for the grid references, in ``Map

--- a/source/docs/user_manual/print_composer/composer_items/composer_map.rst
+++ b/source/docs/user_manual/print_composer/composer_items/composer_map.rst
@@ -215,7 +215,8 @@ Other than the grid type, you can define:
 * the :guilabel:`Interval` between two consecutive grid references in ``X``
   and ``Y`` directions;
 * the :guilabel:`Interval Units` to use for the grid references, in ``Map
-  units``, ``Fit Segement Width``, ``Millimeters`` or ``Centimeters`` *(`Fix Segement Width` will dynamically select the grid interval based on the map extent to a "pretty" interval)*;
+  Unit``, ``Fit Segment Width``, ``Millimeter`` or ``Centimeter``;
+* *``Fix Segment Width`` will dynamically select the grid interval based on the map extent to a "pretty" interval. When selected, the Minimum and Maximum intervals can be set*;
 * an :guilabel:`Offset` from the map item edges, in ``X`` and ``Y`` directions;
 * and the :guilabel:`Blend mode` of the grid (see :ref:`blend-modes`) when
   compatible.

--- a/source/docs/user_manual/print_composer/composer_items/composer_map.rst
+++ b/source/docs/user_manual/print_composer/composer_items/composer_map.rst
@@ -216,9 +216,9 @@ Other than the grid type, you can define:
   and ``Y`` directions;
 * the :guilabel:`Interval Units` to use for the grid references, in ``Map
   Unit``, ``Fit Segment Width``, ``Millimeter`` or ``Centimeter``;
-* *``Fix Segment Width`` will dynamically select the grid interval based 
-on the map extent to a "pretty" interval. When selected, the ``Minimum`` and 
-``Maximum`` intervals can be set*;
+* choosing ``Fix Segment Width`` will dynamically select the grid interval based 
+  on the map extent to a "pretty" interval. When selected, the ``Minimum`` and 
+  ``Maximum`` intervals can be set;
 * an :guilabel:`Offset` from the map item edges, in ``X`` and ``Y`` directions;
 * and the :guilabel:`Blend mode` of the grid (see :ref:`blend-modes`) when
   compatible.

--- a/source/docs/user_manual/print_composer/composer_items/composer_map.rst
+++ b/source/docs/user_manual/print_composer/composer_items/composer_map.rst
@@ -219,7 +219,7 @@ Other than the grid type, you can define:
 * choosing ``Fix Segment Width`` will dynamically select the grid interval based 
   on the map extent to a "pretty" interval. When selected, the ``Minimum`` and 
   ``Maximum`` intervals can be set;
-* an :guilabel:`Offset` from the map item edges, in ``X`` and ``Y`` directions;
+* the :guilabel:`Offset` from the map item edges, in the ``X`` and/or the ``Y`` direction;
 * and the :guilabel:`Blend mode` of the grid (see :ref:`blend-modes`) when
   compatible.
 

--- a/source/docs/user_manual/print_composer/composer_items/composer_map.rst
+++ b/source/docs/user_manual/print_composer/composer_items/composer_map.rst
@@ -209,7 +209,7 @@ As grid type, you can specify to use a:
   intersection;
 * or *Frame and annotations only*.
 
-Other than the grid type, you can define:
+Other than the grid type, you can define: 
 
 * the :guilabel:`CRS` which could be set differently to the project CRS;
 * the :guilabel:`Interval` between two consecutive grid references in ``X``

--- a/source/docs/user_manual/print_composer/composer_items/composer_map.rst
+++ b/source/docs/user_manual/print_composer/composer_items/composer_map.rst
@@ -216,7 +216,7 @@ Other than the grid type, you can define:
   Unit``, ``Fit Segment Width``, ``Millimeter`` or ``Centimeter``;
 * the :guilabel:`Interval` between two consecutive grid references in ``X``
   and ``Y`` directions;
-* choosing ``Fix Segment Width`` will dynamically select the grid interval based 
+* choosing ``Fit Segment Width`` will dynamically select the grid interval based 
   on the map extent to a "pretty" interval. When selected, the ``Minimum`` and 
   ``Maximum`` intervals can be set;
 * the :guilabel:`Offset` from the map item edges, in the ``X`` and/or the ``Y`` direction;

--- a/source/docs/user_manual/print_composer/composer_items/composer_map.rst
+++ b/source/docs/user_manual/print_composer/composer_items/composer_map.rst
@@ -211,7 +211,7 @@ As grid type, you can specify to use a:
 
 Other than the grid type, you can define:
 
-* the :guilabel:`CRS` which could not be the same as the map item's;
+* the :guilabel:`CRS` which could be set differently to the project CRS;
 * the :guilabel:`Interval` between two consecutive grid references in ``X``
   and ``Y`` directions;
 * the :guilabel:`Interval Units` to use for the grid references, in ``Map

--- a/source/docs/user_manual/print_composer/composer_items/composer_map.rst
+++ b/source/docs/user_manual/print_composer/composer_items/composer_map.rst
@@ -215,7 +215,6 @@ Other than the grid type, you can define:
 * the :guilabel:`Interval` between two consecutive grid references in ``X``
   and ``Y`` directions;
 * the :guilabel:`Interval Units` to use for the grid references, in ``Map
-* the :guilabel:`Interval Units` to use for the grid references, in ``Map
   Unit``, ``Fit Segment Width``, ``Millimeter`` or ``Centimeter``;
 * *``Fix Segment Width`` will dynamically select the grid interval based 
 on the map extent to a "pretty" interval. When selected, the ``Minimum`` and 

--- a/source/docs/user_manual/print_composer/composer_items/composer_map.rst
+++ b/source/docs/user_manual/print_composer/composer_items/composer_map.rst
@@ -215,7 +215,7 @@ Other than the grid type, you can define:
 * the :guilabel:`Interval` between two consecutive grid references in ``X``
   and ``Y`` directions;
 * the :guilabel:`Interval Units` to use for the grid references, in ``Map
-  units``, ``Millimeters`` or ``Centimeters``;
+  units``, ``Fit Segement Width``, ``Millimeters`` or ``Centimeters`` *(`Fix Segement Width` will dynamically select the grid interval based on the map extent to a "pretty" interval)*;
 * an :guilabel:`Offset` from the map item edges, in ``X`` and ``Y`` directions;
 * and the :guilabel:`Blend mode` of the grid (see :ref:`blend-modes`) when
   compatible.

--- a/source/docs/user_manual/print_composer/composer_items/composer_map.rst
+++ b/source/docs/user_manual/print_composer/composer_items/composer_map.rst
@@ -212,10 +212,10 @@ As grid type, you can specify to use a:
 Other than the grid type, you can define: 
 
 * the :guilabel:`CRS` which could be different from the project CRS;
+* the :guilabel:`Interval units` to use for the grid references, in ``Map
+  Unit``, ``Fit Segment Width``, ``Millimeter`` or ``Centimeter``;
 * the :guilabel:`Interval` between two consecutive grid references in ``X``
   and ``Y`` directions;
-* the :guilabel:`Interval Units` to use for the grid references, in ``Map
-  Unit``, ``Fit Segment Width``, ``Millimeter`` or ``Centimeter``;
 * choosing ``Fix Segment Width`` will dynamically select the grid interval based 
   on the map extent to a "pretty" interval. When selected, the ``Minimum`` and 
   ``Maximum`` intervals can be set;


### PR DESCRIPTION
Since I was working in this file, I have also updated the text explaining how to change the grid to a different CRS to the project CRS. 

Goal:

Ticket(s): #
<!---
Indicate whether the fix should be backported to previous release.
Replace the space between square brackets by a `x` to make it checked.
-->
- [x] Backport to LTR documentation is required

<!---
Reviewing is a process done by community members, mostly on a volunteer basis.
We try to keep the overhead as small as possible and appreciate if you help us.
Please read carefully and ensure you comply with our writing guidelines at
https://docs.qgis.org/testing/en/docs/documentation_guidelines/index.html.
Feel free to ask in a comment or the (qgis-community-team mailing list)
[https://lists.osgeo.org/mailman/listinfo/qgis-community-team] if you have troubles with any item.
--->
