### PR TITLE
Configurable end of life notice

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -124,6 +124,8 @@ html_theme_options = {
 }
 
 html_context = {
+    # When a QGIS version reaches end of life, set this to True to show an information
+    # message on the top of the page.message on top from now on.
     'outdated': False
 }
 

--- a/source/conf.py
+++ b/source/conf.py
@@ -125,7 +125,7 @@ html_theme_options = {
 
 html_context = {
     # When a QGIS version reaches end of life, set this to True to show an information
-    # message on the top of the page.message on top from now on.
+    # message on the top of the page.
     'outdated': False
 }
 

--- a/source/conf.py
+++ b/source/conf.py
@@ -123,6 +123,10 @@ html_theme = 'basic'
 html_theme_options = {
 }
 
+html_context = {
+    'outdated': False
+}
+
 # Add any paths that contain custom themes here, relative to this directory.
 #html_theme_path = []
 

--- a/themes/qgis-theme/layout.html
+++ b/themes/qgis-theme/layout.html
@@ -26,7 +26,7 @@
 
 {%- macro outdated_block() %}
     <div class="row outdated">
-      This documentation is for a QGIS version which has reached end of life. Visit the <a href="https://docs.qgis.org/latest/">latest version</a> instead.
+    This documentation is for a QGIS version which has reached end of life. Visit the <a href="https://docs.qgis.org/latest/{{ language }}/">latest version</a> instead.
     </div>
 {%- endmacro %}
 

--- a/themes/qgis-theme/layout.html
+++ b/themes/qgis-theme/layout.html
@@ -24,7 +24,7 @@
   {%- set titlesuffix = "" %}
 {%- endif %}
 
-{%- macro outdated() %}
+{%- macro outdated_block() %}
     <div class="row outdated">
       This documentation is for a QGIS version which has reached end of life. Visit the <a href="https://www.qgis.org/en/docs/index.html">latest version</a> instead.
     </div>

--- a/themes/qgis-theme/layout.html
+++ b/themes/qgis-theme/layout.html
@@ -31,7 +31,12 @@
 {%- endmacro %}
 
 {%- macro relbar() %}
-    <div class="related">
+    {%- if outdated %}
+      {%- set navigation_classes = "related related-outdated" %}
+    {%- else %}
+      {%- set navigation_classes = "related" %}
+    {%- endif %}
+    <div class="{{ navigation_classes }}">
       {# QGIS hide this # navigation h3 #} 
       {#<h3>{{ _('Navigation') }}</h3>#}
       <ul>

--- a/themes/qgis-theme/layout.html
+++ b/themes/qgis-theme/layout.html
@@ -26,7 +26,7 @@
 
 {%- macro outdated_block() %}
     <div class="row outdated">
-      This documentation is for a QGIS version which has reached end of life. Visit the <a href="https://www.qgis.org/en/docs/index.html">latest version</a> instead.
+      This documentation is for a QGIS version which has reached end of life. Visit the <a href="https://docs.qgis.org/latest/">latest version</a> instead.
     </div>
 {%- endmacro %}
 

--- a/themes/qgis-theme/layout.html
+++ b/themes/qgis-theme/layout.html
@@ -24,6 +24,12 @@
   {%- set titlesuffix = "" %}
 {%- endif %}
 
+{%- macro outdated() %}
+    <div class="row outdated">
+      This documentation is for a QGIS version which has reached end of life. Visit the <a href="https://www.qgis.org/en/docs/index.html">latest version</a> instead.
+    </div>
+{%- endmacro %}
+
 {%- macro relbar() %}
     <div class="related">
       {# QGIS hide this # navigation h3 #} 

--- a/themes/qgis-theme/page.html
+++ b/themes/qgis-theme/page.html
@@ -147,7 +147,9 @@ http://stackoverflow.com/questions/13209597/override-html-page-template-for-a-sp
         </div>
       </div>
     </div>
-    {{ outdated() }}
+    {%- if outdated %}
+      {{ outdated_block() }}
+    {%- endif %}
   </div>
 {% endmacro %}
 

--- a/themes/qgis-theme/page.html
+++ b/themes/qgis-theme/page.html
@@ -147,6 +147,7 @@ http://stackoverflow.com/questions/13209597/override-html-page-template-for-a-sp
         </div>
       </div>
     </div>
+    {{ outdated() }}
   </div>
 {% endmacro %}
 

--- a/themes/qgis-theme/static/qgis-style.css
+++ b/themes/qgis-theme/static/qgis-style.css
@@ -908,3 +908,12 @@ section.menu nav.subnav ul li a:hover {
   padding-left: 3px;
   padding-right: 3px;
 }
+.outdated {
+  background: #ffbaba;
+  color: #6a0e0e;
+  padding-top: 10px;
+  margin-left: 0;
+  padding-left: 10px;
+  padding-bottom: 3px;
+  font-size: 0.9rem;
+}

--- a/themes/qgis-theme/static/qgis-style.css
+++ b/themes/qgis-theme/static/qgis-style.css
@@ -911,9 +911,12 @@ section.menu nav.subnav ul li a:hover {
 .outdated {
   background: #ffbaba;
   color: #6a0e0e;
-  padding-top: 10px;
+  padding-top: 0.5rem;
   margin-left: 0;
-  padding-left: 10px;
-  padding-bottom: 3px;
+  padding-left: 0.5rem;
+  padding-bottom: 0.5rem;
   font-size: 0.9rem;
+}
+.related-outdated {
+  margin-top: 2.5rem;
 }

--- a/themes/qgis-theme/static/qgis-style.less
+++ b/themes/qgis-theme/static/qgis-style.less
@@ -909,3 +909,12 @@ section.menu nav.subnav ul li a:hover {
   padding-left: 3px;
   padding-right: 3px;
 }
+.outdated {
+  background: #ffbaba;
+  color: #6a0e0e;
+  padding-top: 10px;
+  margin-left: 0;
+  padding-left: 10px;
+  padding-bottom: 3px;
+  font-size: 0.9rem;
+}

--- a/themes/qgis-theme/static/qgis-style.less
+++ b/themes/qgis-theme/static/qgis-style.less
@@ -912,9 +912,12 @@ section.menu nav.subnav ul li a:hover {
 .outdated {
   background: #ffbaba;
   color: #6a0e0e;
-  padding-top: 10px;
+  padding-top: 0.5rem;
   margin-left: 0;
-  padding-left: 10px;
-  padding-bottom: 3px;
+  padding-left: 0.5rem;
+  padding-bottom: 0.5rem;
   font-size: 0.9rem;
+}
+.related-outdated {
+  margin-top: 2.5rem;
 }


### PR DESCRIPTION
Future proof version of https://github.com/qgis/QGIS-Documentation/pull/4273

Adds a new "outdated" option source/conf.py -> html_context
Set that whenever docs are put to the archive to get a nice header bar sending people to the newer version.

![image](https://user-images.githubusercontent.com/588407/66271900-a4744380-e863-11e9-874a-15553d3722f6.png)
