### PR TITLE
strings are now unicode by default with Python3

### DIFF
--- a/source/docs/pyqgis_developer_cookbook/authentication.rst
+++ b/source/docs/pyqgis_developer_cookbook/authentication.rst
@@ -262,7 +262,7 @@ enabled service like a WMS or WFS or to a DB connection.
 
     In [19]: authM = QgsApplication.authManager()
     In [20]: authM.authMethod("Identity-Cert").supportedDataProviders()
-    Out[20]: [u'ows', u'wfs', u'wcs', u'wms', u'postgres']
+    Out[20]: ['ows', 'wfs', 'wcs', 'wms', 'postgres']
 
 For example, to access a WMS service using stored credentials identified with
 ``authcfg = 'fm1s770'``, we just have to use the ``authcfg`` in the data source

--- a/source/docs/pyqgis_developer_cookbook/tasks.rst
+++ b/source/docs/pyqgis_developer_cookbook/tasks.rst
@@ -41,14 +41,14 @@ There are several ways to create a QGIS task:
 
   .. code-block:: python
 
-    QgsTask.fromFunction(u'heavy function', heavyFunction,
+    QgsTask.fromFunction('heavy function', heavyFunction,
                          onfinished=workdone)
 
 * Create a task from a processing algorithm
 
   .. code-block:: python
 
-    QgsProcessingAlgRunnerTask(u'native:buffer', params, context,
+    QgsProcessingAlgRunnerTask('native:buffer', params, context,
                                feedback)
 
 .. warning::
@@ -290,9 +290,9 @@ parameter ``wait_time``.
           raise exception
 
   # Creae a few tasks
-  task1 = QgsTask.fromFunction(u'Waste cpu 1', doSomething,
+  task1 = QgsTask.fromFunction('Waste cpu 1', doSomething,
                                on_finished=completed, wait_time=4)
-  task2 = QgsTask.fromFunction(u'Waste cpu 2', dosomething,
+  task2 = QgsTask.fromFunction('Waste cpu 2', dosomething,
                                on_finished=completed, wait_time=3)
   QgsApplication.taskManager().addTask(task1)
   QgsApplication.taskManager().addTask(task2)
@@ -330,7 +330,7 @@ added to the project in a safe way.
                context.takeResultLayer(output_layer.id()))
 
   alg = QgsApplication.processingRegistry().algorithmById(
-                                        u'qgis:randompointsinextent')
+                                        'qgis:randompointsinextent')
   context = QgsProcessingContext()
   feedback = QgsProcessingFeedback()
   params = {


### PR DESCRIPTION
<!---
Include a few sentences describing the overall goals for this Pull Request.
 
A list of issues is at https://github.com/qgis/QGIS-Documentation/issues.
Add "fix #issuenumber" for each issue the PR fixes. The ticket(s) will be closed automatically.
If your PR doesn't fix entirely the ticket, only add the ticket(s) reference preceded by # character.
-->
Goal: strings are now unicode by default with Python3

<!---
Indicate whether the fix should be backported to previous release.
Replace the space between square brackets by a `x` to make it checked.
-->
- [x] Backport to LTR documentation is ~required~ *possible* ;-)

<!---
Reviewing is a process done by community members, mostly on a volunteer basis.
We try to keep the overhead as small as possible and appreciate if you help us.
Please read carefully and ensure you comply with our writing guidelines at
https://docs.qgis.org/testing/en/docs/documentation_guidelines/index.html.
Feel free to ask in a comment or the (qgis-community-team mailing list)
[https://lists.osgeo.org/mailman/listinfo/qgis-community-team] if you have troubles with any item.
--->
