### PR TITLE
Removes commented sections about extend trim feature in 3.4

### DIFF
--- a/source/docs/user_manual/working_with_vector/editing_geometry_attributes.rst
+++ b/source/docs/user_manual/working_with_vector/editing_geometry_attributes.rst
@@ -743,10 +743,6 @@ Advanced digitizing
 | |rotatePointSymbols|      | Rotate Point Symbols                    | |offsetPointSymbols|   | Offset Point Symbols    |
 +---------------------------+-----------------------------------------+------------------------+-------------------------+
 
-..
- The next feature belongs to QGIS > 3.4 so should be uncommented when the 3.4 is branched away.
- | |trimExtend|              | Trim or Extend Feature                  |                        |                         |
- +---------------------------+-----------------------------------------+------------------------+-------------------------+
 
 Table Advanced Editing: Vector layer advanced editing toolbar
 
@@ -1199,31 +1195,6 @@ coordinates while moving the symbol in the map canvas.
    :sup:`Vertex Tool (Current Layer)` or |moveFeaturePoint| :sup:`Move Feature`
    tool for this purpose.
 
-..
- The next feature belongs to QGIS > 3.4 so should be uncommented when the 3.4 is branched away.
- Trim/Extend Feature
- -------------------
-
- When a digitized line is too short or too long to snap to another line (missing or
- crossing the line), it is necessary to be able to extend or shorten the segment.
-
- The |trimExtend| :sup:`Trim/Extend` tool allows you to also modify (multi)lines AND
- (multi)polygons. Moreover, it is not necessarily the end
- of the lines that is concerned; any segment of a geometry can be modified.
-
- .. note:: This can lead to invalid geometries.
-
- .. note:: You must activate segment snapping for this tool to work
- 
- The tool asks you to select a limit (a segment) with respect to which another
- segment will be extended or trimmed. Unlike the node tool, a check is performed to
- modify only the layer being edited.
-
- When both segments are in 3D, the tool performs an interpolation on the limit segment
- to get the Z value.
-
- In the case of a trim, you must select the part that will be shortened by clicking on it.
-
 .. _shape_edit:
 
 Shape digitizing
@@ -1664,8 +1635,6 @@ To edit features in-place:
 .. |toggleEditing| image:: /static/common/mActionToggleEditing.png
    :width: 1.5em
 .. |tracing| image:: /static/common/mActionTracing.png
-   :width: 1.5em
-.. |trimExtend| image:: /static/common/mActionTrimExtend.png
    :width: 1.5em
 .. |unchecked| image:: /static/common/checkbox_unchecked.png
    :width: 1.3em


### PR DESCRIPTION
<!---
Include a few sentences describing the overall goals for this Pull Request.
 
A list of issues is at https://github.com/qgis/QGIS-Documentation/issues.
Add "fix #issuenumber" for each issue the PR fixes. The ticket(s) will be closed automatically.
If your PR doesn't fix entirely the ticket, only add the ticket(s) reference preceded by # character.
-->
Goal:

There were some commented sections about the extend trim tools that would be only available on 3.4>

Makes no sense to keep them in 3.4 docs, it's just polluting the code.

Ticket(s): #
<!---
Indicate whether the fix should be backported to previous release.
Replace the space between square brackets by a `x` to make it checked.
-->
- [ ] Backport to LTR documentation is required

<!---
Reviewing is a process done by community members, mostly on a volunteer basis.
We try to keep the overhead as small as possible and appreciate if you help us.
Please read carefully and ensure you comply with our writing guidelines at
https://docs.qgis.org/testing/en/docs/documentation_guidelines/index.html.
Feel free to ask in a comment or the (qgis-community-team mailing list)
[https://lists.osgeo.org/mailman/listinfo/qgis-community-team] if you have troubles with any item.
--->
