### PR TITLE
Removed superfluous space

### DIFF
--- a/source/docs/user_manual/working_with_mesh/mesh_properties.rst
+++ b/source/docs/user_manual/working_with_mesh/mesh_properties.rst
@@ -292,7 +292,7 @@ Rendering
 .........
 
 In the tab |rendering_mesh|,  QGIS offers two possibilities to display the grid,
-as shown in the image :ref:` Mesh rendering <figure_mesh_symbology_grid>`:
+as shown in the image :ref:`Mesh rendering <figure_mesh_symbology_grid>`:
 
 *	``Native Mesh Rendering`` that shows quadrants
 *	``Triangular Mesh Rendering`` that display triangles


### PR DESCRIPTION
Line 295 : superfluous space causes ref to be broken
                ":ref:` Mesh" must be ":ref:`Mesh" for ref to work.  Removed space.

Goal: Make correct documentation

- [x] Backport to LTR documentation is required
