### PR TITLE
Enable a new banner on top of the testing documentation

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -135,7 +135,10 @@ html_theme_options = {
 html_context = {
     # When a QGIS version reaches end of life, set this to True to show an information
     # message on the top of the page.
-    'outdated': False
+    'outdated': False,
+    # When a new QGIS version is released, set this to False to remove the disclaimer
+    # information message on the top of the page.
+    'isTesting': True
 }
 
 # Add any paths that contain custom themes here, relative to this directory.

--- a/themes/qgis-theme/layout.html
+++ b/themes/qgis-theme/layout.html
@@ -30,9 +30,17 @@
     </div>
 {%- endmacro %}
 
+{%- macro isTesting_block() %}
+    <div class="row isTesting">
+    This documentation is a work in progress. For the Long Term Release and translations, please visit the <a href="https://docs.qgis.org/latest/{{ language }}/">latest version</a>.
+    </div>
+{%- endmacro %}
+
 {%- macro relbar() %}
     {%- if outdated %}
       {%- set navigation_classes = "related related-outdated" %}
+    {%- elif isTesting %}
+      {%- set navigation_classes = "related related-isTesting" %}
     {%- else %}
       {%- set navigation_classes = "related" %}
     {%- endif %}

--- a/themes/qgis-theme/page.html
+++ b/themes/qgis-theme/page.html
@@ -147,10 +147,13 @@ http://stackoverflow.com/questions/13209597/override-html-page-template-for-a-sp
         </div>
       </div>
     </div>
+    {%- if isTesting %}
+      {{ isTesting_block() }}
+    {%- endif %}
     {%- if outdated %}
       {{ outdated_block() }}
     {%- endif %}
-  </div>
+    </div>
 {% endmacro %}
 
 {# qgis_bsidebar macro: make sidebar span4 and scroll instead of affix #}

--- a/themes/qgis-theme/page.html
+++ b/themes/qgis-theme/page.html
@@ -153,7 +153,7 @@ http://stackoverflow.com/questions/13209597/override-html-page-template-for-a-sp
     {%- if outdated %}
       {{ outdated_block() }}
     {%- endif %}
-    </div>
+  </div>
 {% endmacro %}
 
 {# qgis_bsidebar macro: make sidebar span4 and scroll instead of affix #}

--- a/themes/qgis-theme/static/qgis-style.css
+++ b/themes/qgis-theme/static/qgis-style.css
@@ -915,14 +915,25 @@ section.menu nav.subnav ul li a:hover {
   padding-right: 3px;
 }
 .outdated {
+  /* only to be visible for outdated releases*/
   background: #ffbaba;
   color: #6a0e0e;
+}
+.isTesting {
+  /* only to be visible in testing*/
+  background: #f3fbfb;
+  color: black;
+}
+.outdated,
+.isTesting {
+  /* top banner for testing and outdated docs*/
   padding-top: 0.5rem;
   margin-left: 0;
   padding-left: 0.5rem;
   padding-bottom: 0.5rem;
   font-size: 0.9rem;
 }
-.related-outdated {
+.related-outdated,
+.related-isTesting {
   margin-top: 2.5rem;
 }

--- a/themes/qgis-theme/static/qgis-style.less
+++ b/themes/qgis-theme/static/qgis-style.less
@@ -916,14 +916,23 @@ section.menu nav.subnav ul li a:hover {
   padding-right: 3px;
 }
 .outdated {
+  /* only to be visible for outdated releases*/
   background: #ffbaba;
   color: #6a0e0e;
+}
+.isTesting {
+  /* only to be visible in testing*/
+  background: #f3fbfb;
+  color: black;
+}
+.outdated, .isTesting {
+  /* top banner for testing and outdated docs*/
   padding-top: 0.5rem;
   margin-left: 0;
   padding-left: 0.5rem;
   padding-bottom: 0.5rem;
   font-size: 0.9rem;
 }
-.related-outdated {
+.related-outdated, .related-isTesting{
   margin-top: 2.5rem;
 }


### PR DESCRIPTION
To replace update disclaimer mention and mimicking the outdated doc banner as suggested in PR #4274 - fixes #4295 
Using a soft blue banner ~(no build around yet for a screenshot or check #f3fbfb color)~

![Capture du 2019-10-19 09-31-10](https://user-images.githubusercontent.com/7983394/67176642-34b99900-f3cb-11e9-9b4d-676834bcab37.png)

