### PR TITLE
Adds hasProcessingProvider option to metadata list

### DIFF
--- a/source/docs/pyqgis_developer_cookbook/plugins/plugins.rst
+++ b/source/docs/pyqgis_developer_cookbook/plugins/plugins.rst
@@ -134,6 +134,7 @@ icon                   False     a file name or a relative path (relative to
                                  package) of a web friendly image (PNG, JPEG)
 category               False     one of `Raster`, `Vector`, `Database` and `Web`
 plugin_dependencies    False     PIP-like comma separated list of other plugins to install
+hasProcessingProvider  False     boolean flag, `True` or `False`, determines if the plugin provides processing algorithms
 =====================  ========  =======================================
 
 |


### PR DESCRIPTION
<!---
Include a few sentences describing the overall goals for this Pull Request.
 
A list of issues is at https://github.com/qgis/QGIS-Documentation/issues.
Add "fix #issuenumber" for each issue the PR fixes. The ticket(s) will be closed automatically.
If your PR doesn't fix entirely the ticket, only add the ticket(s) reference preceded by # character.
-->
Goal:

Adds the hasProcessingProvider option to the metadata list.

This option is explained later in here:
https://docs.qgis.org/testing/en/docs/pyqgis_developer_cookbook/processing.html#

Ticket(s): #
<!---
Indicate whether the fix should be backported to previous release.
Replace the space between square brackets by a `x` to make it checked.
-->
- [ ] Backport to LTR documentation is required

<!---
Reviewing is a process done by community members, mostly on a volunteer basis.
We try to keep the overhead as small as possible and appreciate if you help us.
Please read carefully and ensure you comply with our writing guidelines at
https://docs.qgis.org/testing/en/docs/documentation_guidelines/index.html.
Feel free to ask in a comment or the (qgis-community-team mailing list)
[https://lists.osgeo.org/mailman/listinfo/qgis-community-team] if you have troubles with any item.
--->
