### PR TITLE
Update r_intro.rst

### DIFF
--- a/source/docs/training_manual/processing/r_intro.rst
+++ b/source/docs/training_manual/processing/r_intro.rst
@@ -11,7 +11,7 @@ Processing (with the ``Processing R Provider`` plugin) makes it possible to writ
 and run R scripts inside QGIS.
 
 .. warning::
-   R has to be installed on your computer and the PATH has to correctly
+   R has to be installed on your computer and the PATH has to be correctly
    set up. Moreover Processing just calls the external R packages, it is not able
    to install them. So be sure to install external packages directly in R.
    See the related :ref:`chapter <creating_r_scripts>` in the user manual.
@@ -25,6 +25,10 @@ Adding scripts
 
 Adding a script is very simple. Open the Processing toolbox and just click on
 the :menuselection:`R --> Tools --> Create new R script`.
+In case this tool is not available, you have to create the script in for
+instance a text editor and save it in your R scripts folder - when it has
+been saved, it will be available for editing by right-clicking on the script
+name in the processing toolbox and then choose :menuselection:`Edit Script...`).
 
 .. image:: img/r_intro/r_intro_1.png
 


### PR DESCRIPTION
I have not found the ``Tools`` menu under R in the Processing toolbox (I know that I have seen it with QGIS 2, but I have not found it with QGIS 3), so I added a sentence about what to do if ``Tools`` (and ``Create new R script``) is not available.

<!---
Include a few sentences describing the overall goals for this Pull Request.
 
A list of issues is at https://github.com/qgis/QGIS-Documentation/issues.
Add "fix #issuenumber" for each issue the PR fixes. The ticket(s) will be closed automatically.
If your PR doesn't fix entirely the ticket, only add the ticket(s) reference preceded by # character.
-->
Goal:

Ticket(s): #
<!---
Indicate whether the fix should be backported to previous release.
Replace the space between square brackets by a `x` to make it checked.
-->
- [ ] Backport to LTR documentation is required

<!---
Reviewing is a process done by community members, mostly on a volunteer basis.
We try to keep the overhead as small as possible and appreciate if you help us.
Please read carefully and ensure you comply with our writing guidelines at
https://docs.qgis.org/testing/en/docs/documentation_guidelines/index.html.
Feel free to ask in a comment or the (qgis-community-team mailing list)
[https://lists.osgeo.org/mailman/listinfo/qgis-community-team] if you have troubles with any item.
--->
