### PR TITLE
Add primary key warning for Oracle spatial layers

### DIFF
--- a/source/docs/user_manual/managing_data_source/opening_data.rst
+++ b/source/docs/user_manual/managing_data_source/opening_data.rst
@@ -802,6 +802,9 @@ Optionally, you can activate following checkboxes:
 
    Normally, an Oracle Spatial layer is defined by an entry in the
    **USER_SDO_METADATA** table.
+   
+   To ensure selection tools work correctly it is recommended your
+   datasets have a **primary key**.
 
 
 .. _create_db2_connection:

--- a/source/docs/user_manual/managing_data_source/opening_data.rst
+++ b/source/docs/user_manual/managing_data_source/opening_data.rst
@@ -803,7 +803,7 @@ Optionally, you can activate following checkboxes:
    Normally, an Oracle Spatial layer is defined by an entry in the
    **USER_SDO_METADATA** table.
    
-   To ensure selection tools work correctly it is recommended your
+   To ensure selection tools work correctly it is recommended that your
    datasets have a **primary key**.
 
 


### PR DESCRIPTION
Following on from discussion https://github.com/qgis/QGIS/issues/32648 it seems wise to warn users that primary keys are needed to avoid unexpected results when selecting features. I've proposed a sentence be added to the documentation to help others avoid issues.

<!---
Include a few sentences describing the overall goals for this Pull Request.
 
A list of issues is at https://github.com/qgis/QGIS-Documentation/issues.
Add "fix #issuenumber" for each issue the PR fixes. The ticket(s) will be closed automatically.
If your PR doesn't fix entirely the ticket, only add the ticket(s) reference preceded by # character.
-->
Goal:

Ticket(s): #
<!---
Indicate whether the fix should be backported to previous release.
Replace the space between square brackets by a `x` to make it checked.
-->
- [x] Backport to LTR documentation is required

<!---
Reviewing is a process done by community members, mostly on a volunteer basis.
We try to keep the overhead as small as possible and appreciate if you help us.
Please read carefully and ensure you comply with our writing guidelines at
https://docs.qgis.org/testing/en/docs/documentation_guidelines/index.html.
Feel free to ask in a comment or the (qgis-community-team mailing list)
[https://lists.osgeo.org/mailman/listinfo/qgis-community-team] if you have troubles with any item.
--->
