### PR TITLE
Update rintro (online collection of R scripts not available)

### DIFF
--- a/source/docs/training_manual/processing/r_intro.rst
+++ b/source/docs/training_manual/processing/r_intro.rst
@@ -164,7 +164,7 @@ into QGIS.
 
 The following example has been taken from the ``Random sampling grid``
 script that can be found in the online collection of R scripts
-(the scripts in this on-line collection can be found in
+(the scripts in this online collection can be found in
 https://github.com/qgis/QGIS-Processing/tree/master/rscripts).
 
 The aim of this exercise is to create a random point vector layer

--- a/source/docs/training_manual/processing/r_intro.rst
+++ b/source/docs/training_manual/processing/r_intro.rst
@@ -163,7 +163,7 @@ You can also create a vector layer and have it automatically loaded
 into QGIS.
 
 The following example has been taken from the ``Random sampling grid``
-script that you can be found in the on-line collection of R scripts
+script that can be found in the online collection of R scripts
 (the scripts in this on-line collection can be found in
 https://github.com/qgis/QGIS-Processing/tree/master/rscripts).
 

--- a/source/docs/training_manual/processing/r_intro.rst
+++ b/source/docs/training_manual/processing/r_intro.rst
@@ -163,9 +163,8 @@ You can also create a vector layer and have it automatically loaded
 into QGIS.
 
 The following example has been taken from the ``Random sampling grid``
-script that you can download from the online collection
-:menuselection:`R --> Tools --> Download R scripts from the on-line collection`
-(the scripts in the on-line collection can be found on
+script that you can be found in the on-line collection of R scripts
+(the scripts in this on-line collection can be found in
 https://github.com/qgis/QGIS-Processing/tree/master/rscripts).
 
 The aim of this exercise is to create a random point vector layer


### PR DESCRIPTION
Update to reflect that the online collection of R scripts is not available with QGIS 3 and the Processing R Provider plugin.

<!---
Include a few sentences describing the overall goals for this Pull Request.
 
A list of issues is at https://github.com/qgis/QGIS-Documentation/issues.
Add "fix #issuenumber" for each issue the PR fixes. The ticket(s) will be closed automatically.
If your PR doesn't fix entirely the ticket, only add the ticket(s) reference preceded by # character.
-->
Goal:

Ticket(s): #
<!---
Indicate whether the fix should be backported to previous release.
Replace the space between square brackets by a `x` to make it checked.
-->
- [ ] Backport to LTR documentation is required

<!---
Reviewing is a process done by community members, mostly on a volunteer basis.
We try to keep the overhead as small as possible and appreciate if you help us.
Please read carefully and ensure you comply with our writing guidelines at
https://docs.qgis.org/testing/en/docs/documentation_guidelines/index.html.
Feel free to ask in a comment or the (qgis-community-team mailing list)
[https://lists.osgeo.org/mailman/listinfo/qgis-community-team] if you have troubles with any item.
--->
