### PR TITLE
gpkg is no more the single and hard-coded output format

### DIFF
--- a/source/docs/user_manual/processing_algs/qgis/vectorgeneral.rst
+++ b/source/docs/user_manual/processing_algs/qgis/vectorgeneral.rst
@@ -283,9 +283,9 @@ Parameters
   The area that the layer covers.
   The options for specifying the extent are:
 
-    * Use Canvas Extent
-    * Select Extent on Canvas
-    * Use Layer Extent
+  * Use Canvas Extent
+  * Select Extent on Canvas
+  * Use Layer Extent
 
   It is also possible to provide the extent coordinates directly
   (xmin, xmax, ymin, ymax).
@@ -743,7 +743,7 @@ Creates a set of vectors in an output folder based on an input layer and an attr
 The output folder will contain as many layers as the unique values found in the
 desired field.
 
-The number of geopackage files generated is equal to the number of different values found
+The number of files generated is equal to the number of different values found
 for the specified attribute.
 
 It is the opposite operation of *merging*.


### PR DESCRIPTION
for split vector (fixes #4260)

<!---
Include a few sentences describing the overall goals for this Pull Request.
 
A list of issues is at https://github.com/qgis/QGIS-Documentation/issues.
Add "fix #issuenumber" for each issue the PR fixes. The ticket(s) will be closed automatically.
If your PR doesn't fix entirely the ticket, only add the ticket(s) reference preceded by # character.
-->
Goal:

Ticket(s): #
<!---
Indicate whether the fix should be backported to previous release.
Replace the space between square brackets by a `x` to make it checked.
-->
- [ ] Backport to LTR documentation is required

<!---
Reviewing is a process done by community members, mostly on a volunteer basis.
We try to keep the overhead as small as possible and appreciate if you help us.
Please read carefully and ensure you comply with our writing guidelines at
https://docs.qgis.org/testing/en/docs/documentation_guidelines/index.html.
Feel free to ask in a comment or the (qgis-community-team mailing list)
[https://lists.osgeo.org/mailman/listinfo/qgis-community-team] if you have troubles with any item.
--->
