### PR TITLE
Backport to 3.4 of #4443 (add geometry less type when we create memory layer)

### DIFF
--- a/source/docs/pyqgis_developer_cookbook/vector.rst
+++ b/source/docs/pyqgis_developer_cookbook/vector.rst
@@ -721,7 +721,7 @@ the :class:`QgsVectorLayer <qgis.core.QgsVectorLayer>` constructor.
 
 The constructor also takes a URI defining the geometry type of the layer,
 one of: ``"Point"``, ``"LineString"``, ``"Polygon"``, ``"MultiPoint"``,
-``"MultiLineString"``, or ``"MultiPolygon"``.
+``"MultiLineString"``, ``"MultiPolygon"`` or ``"None"``.
 
 The URI can also specify the coordinate reference system, fields, and indexing
 of the memory provider in the URI. The syntax is:


### PR DESCRIPTION
<!---
Include a few sentences describing the overall goals for this Pull Request.
 
A list of issues is at https://github.com/qgis/QGIS-Documentation/issues.
Add "fix #issuenumber" for each issue the PR fixes. The ticket(s) will be closed automatically.
If your PR doesn't fix entirely the ticket, only add the ticket(s) reference preceded by # character.
-->
Goal:

Ticket(s): #4443, #746
<!---
Indicate whether the fix should be backported to previous release.
Replace the space between square brackets by a `x` to make it checked.
-->
- [ ] Backport to LTR documentation is required

<!---
Reviewing is a process done by community members, mostly on a volunteer basis.
We try to keep the overhead as small as possible and appreciate if you help us.
Please read carefully and ensure you comply with our writing guidelines at
https://docs.qgis.org/testing/en/docs/documentation_guidelines/index.html.
Feel free to ask in a comment or the (qgis-community-team mailing list)
[https://lists.osgeo.org/mailman/listinfo/qgis-community-team] if you have troubles with any item.
--->
