### PR TITLE
Add CODEC to DXF parameters for QGIS server GetDxf

### DIFF
--- a/source/docs/user_manual/working_with_ogc/server/services.rst
+++ b/source/docs/user_manual/working_with_ogc/server/services.rst
@@ -120,6 +120,8 @@ extra parameters:
      not specified, the original QGIS layer names are used.
    * USE_TITLE_AS_LAYERNAME: if enabled, the title of the layer will
      be used as layer name.
+   * CODEC: specify a codec to be used for encoding. Default is ``ISO-8859-1``
+     check the QGIS desktop DXF export dialog for valid values.
    "
    "TILED", "No", "Working in *tiled mode*"
 


### PR DESCRIPTION
Missing parameter.
Available since QGIS 3.8.