### PR TITLE
Manual backport GDAL vector extracton tables for parameters to 3.4

### DIFF
--- a/source/docs/user_manual/processing_algs/gdal/vectorconversion.rst
+++ b/source/docs/user_manual/processing_algs/gdal/vectorconversion.rst
@@ -22,51 +22,59 @@ This algorithm is derived from the `ogr2ogr utility <https://www.gdal.org/ogr2og
 Parameters
 ..........
 
-``Input layer`` [vector: any]
-  Input vector layer.
+.. list-table::
+   :header-rows: 1
+   :widths: 20 20 20 40
+   :stub-columns: 0
 
-``Destination Format`` [enumeration]
-  Defines the destination format. By default this is ESRI Shapefile.
+   *  - Label
+      - Name
+      - Type
+      - Description
+   *  - **Input layer**
+      - ``INPUT``
+      - [vector: any]
+      - Input vector layer
+   *  - **Additional creation options**
+        
+        (optional)
+      - ``OPTIONS``
+      - [string]
+        
+        Default: '' (no additional options)
+      - Additional GDAL creation options.
+   *  - **Converted**
+      - ``OUTPUT``
+      - [vector: any]
+      - Specification of the output vector layer.
+        One of:
+        
+        * Save to a Temporary File
+        * Save to File...
+        
+        The file encoding can also be changed here.
 
-  Options:
-
-  * 0 --- ESRI Shapefile
-  * 1 --- GeoJSON
-  * 2 --- GeoRSS
-  * 3 --- SQLite
-  * 4 --- GMT
-  * 5 --- MapInfo File
-  * 6 --- INTERLIS 1
-  * 7 --- INTERLIS 2
-  * 8 --- GML
-  * 9 --- Geoconcept
-  * 10 --- DXF
-  * 11 --- DGN
-  * 12 --- CSV
-  * 13 --- BNA
-  * 14 --- S57
-  * 15 --- KML
-  * 16 --- GPX
-  * 17 --- PGDump
-  * 18 --- GPSTrackMaker
-  * 19 --- ODS
-  * 20 --- XLSX
-  * 21 --- PDF
-
-  Default: *0*
-
-``Creation Options`` [string]
-  Optional
-
-  <put parameter description here>
-
-  Default: *(not set)*
+        For ``Save to File``, the output format has to be specified.
+        All GDAL vector formats are supported.
+        For ``Save to a Temporary File`` the QGIS default vector format
+        will be used.
 
 Outputs
 .......
 
-``Output layer`` [vector: any]
-  Output vector layer.
+.. list-table::
+   :header-rows: 1
+   :widths: 20 20 20 40
+   :stub-columns: 0
+
+   *  - Label
+      - Name
+      - Type
+      - Description
+   *  - **Converted**
+      - ``OUTPUT``
+      - [vector: any]
+      - The output vector layer
 
 
 .. _gdalrasterize:
@@ -82,97 +90,154 @@ This algorithm is derived from the `GDAL rasterize utility <https://www.gdal.org
 Parameters
 ..........
 
-``Input layer`` [vector: any]
-  Input vector layer with point, line or polygon geometries.
+.. list-table::
+   :header-rows: 1
+   :widths: 20 20 20 40
+   :stub-columns: 0
 
-``Field to use for a burn-in value`` [tablefield: numeric]
-  Optional
-
-  Defines the attribute field from which the attributes for the pixels
-  should be chosen.
-
-``A fixed value to burn`` [number]
-  Optional
-
-  A fixed value to burn into a band for all features.
-
-  Default: *0.0*
-
-``Output raster size units`` [enumeration]
-  Units to use when defining the output raster size/resolution.
-
-  Options:
-
-  * 0 --- Pixels
-  * 1 --- Georeferenced units
-
-  Default: *0*
-
-``Width/Horizontal resolution`` [number]
-  Sets the width (if size units is "Pixels") or horizontal resolution
-  (if size units is "Georeferenced units") of the output raster.
-
-  Default: *0.0*
-
-``Height/Vertical resolution`` [number]
-  Sets the height (if size units is "Pixels") or vertical resolution
-  (if size units is "Georeferenced units") of the output raster.
-
-  Default: *0.0*
-
-``Output extent (xmin, xmax, ymin, ymax)`` [extent]
-  Extent of the output raster layer. If the extent is not specified, the minimum
-  extent that covers the selected reference layer(s) will be used.
-
-``Assign a specified nodata value to output bands`` [number]
-  Optional
-
-  Assigns a specified nodata value to output bands
-
-  Default: *0.0*
-
-``Additional creation options``
-  Optional
-
-  Allows to add one or more creation options that can be used to control
-  particulars (colorimetry, block size, file compression...) about the file to be
-  created. For convenience, you can rely on predefined profiles (see
-  :ref:`GDAL driver options section <gdal_createoptions>`).
-
-``Output data type`` [enumeration]
-  Defines the type of the resulting raster image.
-
-  Options:
-
-  * 0 --- Byte
-  * 1 --- Int16
-  * 2 --- UInt16
-  * 3 --- UInt32
-  * 4 --- Int32
-  * 5 --- Float32
-  * 6 --- Float64
-  * 7 --- CInt16
-  * 8 --- CInt32
-  * 9 --- CFloat32
-  * 10 --- CFloat64
-
-  Default: *5*
-
-``Pre-initialize the output image with value`` [number]
-  Optional
-
-  Pre-initializes the output image bands with this value.
-  Not marked as the nodata value in the output file.
-  The same value is used in all the bands.
-
-``Invert rasterization`` [boolean]
-  Burns the fixed burn value, or the burn value associated with the first feature
-  into all parts of the image not inside the provided polygon.
-
-  Default: *False*
+   *  - Label
+      - Name
+      - Type
+      - Description
+   *  - **Input layer**
+      - ``INPUT``
+      - [vector: any]
+      - Input vector layer
+   *  - **Field to use for a burn-in value**
+        
+        Optional
+      - ``FIELD``
+      - [tablefield: numeric]
+      - Defines the attribute field from which the attributes for
+        the pixels should be chosen
+   *  - **A fixed value to burn**
+        
+        Optional
+      - ``BURN``
+      - [number]
+        
+        Default: 0.0
+      - A fixed value to burn into a band for all features.
+   *  - **Output raster size units**
+      - ``UNITS``
+      - [enumeration]
+        
+        Default: 0
+      - Units to use when defining the output raster size/resolution. One of:
+        
+        * 0 --- Pixels
+        * 1 --- Georeferenced units
+        
+   *  - **Width/Horizontal resolution**
+      - ``WIDTH``
+      - [number]
+        
+        Default: 0.0
+      - Sets the width (if size units is "Pixels") or horizontal
+        resolution (if size units is "Georeferenced units") of the
+        output raster.  Minimum value: 0.0.
+   *  - **Height/Vertical resolution**
+      - ``HEIGHT``
+      - [number]
+        
+        Default: 0.0
+      - Sets the height (if size units is "Pixels") or vertical
+        resolution (if size units is "Georeferenced units") of the
+        output raster.
+   *  - **Output extent**
+      - ``EXTENT``
+      - [extent]
+      - Extent of the output raster layer. If the extent is not specified,
+        the minimum extent that covers the selected reference layer(s)
+        will be used.
+   *  - **Assign a specified nodata value to output bands**
+        
+        Optional
+      - ``NODATA``
+      - [number]
+        
+        Default: 0.0
+      - Assigns a specified nodata value to output bands
+   *  - **Additional creation options**
+        
+        Optional
+      - ``OPTIONS``
+      - [string]
+        
+        Default: ''
+      - For adding one or more creation options that control the
+        raster to be created (colors, block size, file
+        compression...).
+        For convenience, you can rely on predefined profiles (see
+        :ref:`GDAL driver options section <gdal_createoptions>`).
+   *  - **Output data type**
+      - ``DATA_TYPE``
+      - [enumeration]
+        
+        Default: 5
+      - Defines the format of the output raster file.
+        
+        Options:
+        
+        * 0 --- Use input layer data type
+        * 1 --- Byte
+        * 2 --- Int16
+        * 3 --- UInt16
+        * 4 --- UInt32
+        * 5 --- Int32
+        * 6 --- Float32
+        * 7 --- Float64
+        * 8 --- CInt16
+        * 9 --- CInt32
+        * 10 --- CFloat32
+        * 11 --- CFloat64
+  
+   *  - **Pre-initialize the output image with value**
+        
+        Optional
+      - ``INIT``
+      - [number]
+      - Pre-initializes the output image bands with this value.
+        Not marked as the nodata value in the output file.
+        The same value is used in all the bands.
+   *  - **Invert rasterization**
+      - ``INVERT``
+      - [boolean]
+        
+        Default: False
+      - Burns the fixed burn value, or the burn value associated
+        with the first feature into all parts of the image not
+        inside the provided polygon.
+   *  - **Rasterized**
+      - ``OUTPUT``
+      - [raster]
+        
+        Default: '[Save to temporary file]'
+      - Specification of the output raster layer.
+        One of:
+        
+        * Save to a Temporary File
+        * Save to File...
+        
+        The file encoding can also be changed here
+        For ``Save to File``, the output format has to be specified.
+        All GDAL raster formats are supported.
+        For ``Save to a Temporary File`` the QGIS default raster format
+        will be used.
 
 Outputs
 .......
 
-``Rasterized`` [raster]
-  Output raster layer.
+.. list-table::
+   :header-rows: 1
+   :widths: 20 20 20 40
+   :stub-columns: 0
+
+   *  - Label
+      - Name
+      - Type
+      - Description
+   *  - **Rasterized**
+      - ``OUTPUT``
+      - [raster]
+      - Output raster layer


### PR DESCRIPTION
<!---
Include a few sentences describing the overall goals for this Pull Request.
 
A list of issues is at https://github.com/qgis/QGIS-Documentation/issues.
Add "fix #issuenumber" for each issue the PR fixes. The ticket(s) will be closed automatically.
If your PR doesn't fix entirely the ticket, only add the ticket(s) reference preceded by # character.
-->
Goal:

Ticket(s): #4467
<!---
Indicate whether the fix should be backported to previous release.
Replace the space between square brackets by a `x` to make it checked.
-->
- [ ] Backport to LTR documentation is required

<!---
Reviewing is a process done by community members, mostly on a volunteer basis.
We try to keep the overhead as small as possible and appreciate if you help us.
Please read carefully and ensure you comply with our writing guidelines at
https://docs.qgis.org/testing/en/docs/documentation_guidelines/index.html.
Feel free to ask in a comment or the (qgis-community-team mailing list)
[https://lists.osgeo.org/mailman/listinfo/qgis-community-team] if you have troubles with any item.
--->
