### PR TITLE
Misplaced "Optional" i GDAL vectorconversion parameter table

### DIFF
--- a/source/docs/user_manual/processing_algs/gdal/vectorconversion.rst
+++ b/source/docs/user_manual/processing_algs/gdal/vectorconversion.rst
@@ -108,9 +108,9 @@ Parameters
       - Defines the attribute field from which the attributes for
         the pixels should be chosen
    *  - **A fixed value to burn**
-      - ``BURN``
         
         Optional
+      - ``BURN``
       - [number]
         
         Default: 0.0


### PR DESCRIPTION
<!---
Include a few sentences describing the overall goals for this Pull Request.
 
A list of issues is at https://github.com/qgis/QGIS-Documentation/issues.
Add "fix #issuenumber" for each issue the PR fixes. The ticket(s) will be closed automatically.
If your PR doesn't fix entirely the ticket, only add the ticket(s) reference preceded by # character.
-->
Goal: Move Optional to its correct position in a parameter table

Ticket(s): #
<!---
Indicate whether the fix should be backported to previous release.
Replace the space between square brackets by a `x` to make it checked.
-->
- [ ] Backport to LTR documentation is required

<!---
Reviewing is a process done by community members, mostly on a volunteer basis.
We try to keep the overhead as small as possible and appreciate if you help us.
Please read carefully and ensure you comply with our writing guidelines at
https://docs.qgis.org/testing/en/docs/documentation_guidelines/index.html.
Feel free to ask in a comment or the (qgis-community-team mailing list)
[https://lists.osgeo.org/mailman/listinfo/qgis-community-team] if you have troubles with any item.
--->
