### PR TITLE
Add seealso to database algs and make the sample codes reusable

### DIFF
--- a/source/docs/user_manual/processing_algs/qgis/database.rst
+++ b/source/docs/user_manual/processing_algs/qgis/database.rst
@@ -267,6 +267,9 @@ feature:
 
   UPDATE my_table SET area=ST_AREA(geom);
 
+.. seealso:: :ref:`qgispostgisexecutesql`, :ref:`qgisexecutesql`,
+ :ref:`qgisspatialiteexecutesql`
+
 Parameters
 ..........
 
@@ -307,6 +310,9 @@ the layer itself.
 .. seealso:: For some SQL query examples see :ref:`PostGIS SQL Query Examples
  <qgis_postgis_execute_sql_example>`.
  
+.. seealso:: :ref:`qgispostgisexecuteandloadsql`, :ref:`qgisexecutesql`,
+ :ref:`qgisspatialiteexecutesql`
+
 Parameters
 ..........
 
@@ -331,6 +337,8 @@ SpatiaLite execute SQL
 Allows a SQL database query to be performed on a SpatiaLite database connected to QGIS.
 The algorithm **won't** create any new layer: it is designed to run queries on
 the layer itself.
+
+.. seealso:: :ref:`qgispostgisexecutesql`, :ref:`qgisexecutesql`
 
 Parameters
 ..........

--- a/source/docs/user_manual/processing_algs/qgis/database.rst
+++ b/source/docs/user_manual/processing_algs/qgis/database.rst
@@ -239,33 +239,9 @@ run queries on the layer itself.
 
 .. _qgis_postgis_execute_sql_example:
 
-Example
-.......
-1. Set all the values of an existing field to a fixed value. The SQL query string
-will be:
-
-.. code-block:: sql
-
-  UPDATE your_table SET field_to_update=20;
-
-in the example above, the values of the field ``field_to_update`` of the table
-``your_table`` will be all set to ``20``.
-
-2. Create a new ``area`` column and calculate the area of each feature with the
-``ST_AREA`` PostGIS function.
-
-Run the first query and create the new column ``area`` on the table ``my_table``:
-
-.. code-block:: sql
-
-  ALTER TABLE my_table ADD COLUMN area double precision;
-
-Run the second query and update the ``area`` column and calculate the area of each
-feature:
-
-.. code-block:: sql
-
-  UPDATE my_table SET area=ST_AREA(geom);
+.. include:: qgis_algs_include.rst
+   :start-after: **postgisexecutesqlexample**
+   :end-before: **end_postgisexecutesqlexample**
 
 .. seealso:: :ref:`qgispostgisexecutesql`, :ref:`qgisexecutesql`,
  :ref:`qgisspatialiteexecutesql`
@@ -307,9 +283,10 @@ Allows a SQL database query to be performed on a PostgreSQL database connected t
 The algorithm **won't** create any new layer: it is designed to run queries on
 the layer itself.
 
-.. seealso:: For some SQL query examples see :ref:`PostGIS SQL Query Examples
- <qgis_postgis_execute_sql_example>`.
- 
+.. include:: qgis_algs_include.rst
+   :start-after: **postgisexecutesqlexample**
+   :end-before: **end_postgisexecutesqlexample**
+
 .. seealso:: :ref:`qgispostgisexecuteandloadsql`, :ref:`qgisexecutesql`,
  :ref:`qgisspatialiteexecutesql`
 
@@ -340,6 +317,9 @@ the layer itself.
 
 .. seealso:: :ref:`qgispostgisexecutesql`, :ref:`qgisexecutesql`
 
+ For some SQL query examples see :ref:`PostGIS SQL Query Examples
+ <qgis_postgis_execute_sql_example>`.
+
 Parameters
 ..........
 
@@ -356,9 +336,6 @@ Parameters
 Outputs
 .......
 No new layer is created. The SQL query is executed in place on the layer.
-
-.. seealso:: For some SQL query examples see :ref:`PostGIS SQL Query Examples
- <qgis_postgis_execute_sql_example>`.
 
 
 .. Substitutions definitions - AVOID EDITING PAST THIS LINE

--- a/source/docs/user_manual/processing_algs/qgis/qgis_algs_include.rst
+++ b/source/docs/user_manual/processing_algs/qgis/qgis_algs_include.rst
@@ -128,3 +128,32 @@
   Default: *Intersect*
 
 **end_geometric_predicates**
+
+.. The following section is included in database algorithms such as
+ qgispostgisexecutesql, qgispostgisexecuteandloadsql
+ 
+**postgisexecutesqlexample**
+
+**Example**
+
+#. Set all the values of an existing field to a fixed value. The SQL query string
+   will be:
+
+   .. code-block:: sql
+
+    UPDATE your_table SET field_to_update=20;
+
+   In the example above, the values of the field ``field_to_update`` of the table
+   ``your_table`` will be all set to ``20``.
+
+#. Create a new ``area`` column and calculate the area of each feature with the
+   ``ST_AREA`` PostGIS function.
+
+   .. code-block:: sql
+
+    -- Create the new column "area" on the table your_table"
+    ALTER TABLE your_table ADD COLUMN area double precision;
+    -- Update the "area" column and calculate the area of each feature:
+    UPDATE your_table SET area=ST_AREA(geom);
+
+**end_postgisexecutesqlexample**


### PR DESCRIPTION
next: instead of adding link to postgis queries in the "spatialite execute sql" alg description, it would be better someone used to that provider provides corresponding examples for spatialite