### PR TITLE
Move "Delete duplicates by attributes" from QGIS vector selection to QGIS vector general - part 1

### DIFF
--- a/source/docs/user_manual/processing_algs/qgis/vectorgeneral.rst
+++ b/source/docs/user_manual/processing_algs/qgis/vectorgeneral.rst
@@ -156,6 +156,91 @@ Outputs
   The final layer without any duplicated geometries.
 
 
+.. _qgisdeleteduplicatesbyattribute:
+
+Delete duplicates by attribute |36|
+-----------------------------------
+Deletes duplicate rows by only considering the specified field
+/ fields.
+The first matching row will be retained, and duplicates will be
+discarded.
+
+Optionally, these duplicate records can be saved to a separate
+output for analysis.
+
+Parameters
+..........
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 20 20 40
+   :stub-columns: 0
+
+   *  -  Label
+      -  Name
+      -  Type
+      -  Description
+
+   *  -  **Input layer**
+      -   ``INPUT``
+      -  [vector: any]
+      -  The input layer
+
+   *  -  **Fields**
+      -  ``FIELDS``
+      -  [tablefields]
+      -  Fields to match duplicates by
+
+   *  -  **Filtered (no duplicates)**
+      -  ``OUTPUT``
+      -  [feature sink]
+      -  Feature sink containing the remaining features.
+
+   *  -  **Filtered (duplicates)**
+   
+         (Optional)
+      - ``DUPLICATES``
+      -  [feature sink]
+      -  Feature sink containing the removed features.
+         Will not be produced if not specifed (left as ``[Skip output]``).
+
+
+Outputs
+..........
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 20 20 40
+   :stub-columns: 0
+
+   *  -  Label
+      -  Name
+      -  Type
+      -  Description
+
+   *  -  **Count of retained records**
+      -  ``RETAINED_COUNT``
+      -  [Number]
+      -  Count of retained records
+
+   *  -  **Count of discarded duplicate records**
+      -  ``DUPLICATE_COUNT``
+      -  [Number]
+      -  Count of discarded duplicate records
+
+   *  -  **Filtered (no duplicates)**
+      -  ``OUTPUT``
+      -  [String]
+      -  The link to the output (duplicates removed)
+
+   *  -  **Filtered (duplicates)**
+   
+         (Optional)
+      -  ``DUPLICATES``
+      -  [String]
+      -  The link to a vector layer containing the removed duplicates (if defined)
+
+
 .. _qgisdropgeometries:
 
 Drop geometries

--- a/source/docs/user_manual/processing_algs/qgis/vectorgeneral.rst
+++ b/source/docs/user_manual/processing_algs/qgis/vectorgeneral.rst
@@ -884,6 +884,7 @@ Parameters
    please add it also to the substitutions.txt file in the
    source folder.
 
+.. |36| replace:: ``NEW in 3.6``
 .. |38| replace:: ``NEW in 3.8``
 .. |checkbox| image:: /static/common/checkbox.png
    :width: 1.3em

--- a/source/docs/user_manual/processing_algs/qgis/vectorgeneral.rst
+++ b/source/docs/user_manual/processing_algs/qgis/vectorgeneral.rst
@@ -156,7 +156,7 @@ Outputs
   The final layer without any duplicated geometries.
 
 
-.. _qgisdeleteduplicatesbyattribute:
+.. _qgisdeleteduplicatesbyattribute2:
 
 Delete duplicates by attribute |36|
 -----------------------------------


### PR DESCRIPTION
Start with including it in Vector general.
New PR to remove from Vector selection.

<!---
Include a few sentences describing the overall goals for this Pull Request.
 
A list of issues is at https://github.com/qgis/QGIS-Documentation/issues.
Add "fix #issuenumber" for each issue the PR fixes. The ticket(s) will be closed automatically.
If your PR doesn't fix entirely the ticket, only add the ticket(s) reference preceded by # character.
-->
Goal:

Ticket(s): #
<!---
Indicate whether the fix should be backported to previous release.
Replace the space between square brackets by a `x` to make it checked.
-->
- [ ] Backport to LTR documentation is required

<!---
Reviewing is a process done by community members, mostly on a volunteer basis.
We try to keep the overhead as small as possible and appreciate if you help us.
Please read carefully and ensure you comply with our writing guidelines at
https://docs.qgis.org/testing/en/docs/documentation_guidelines/index.html.
Feel free to ask in a comment or the (qgis-community-team mailing list)
[https://lists.osgeo.org/mailman/listinfo/qgis-community-team] if you have troubles with any item.
--->
