### PR TITLE
Reduce depth of the "General tools" local TOC as it becomes too long

### DIFF
--- a/source/docs/user_manual/introduction/general_tools.rst
+++ b/source/docs/user_manual/introduction/general_tools.rst
@@ -11,6 +11,7 @@ General Tools
 
    .. contents::
       :local:
+      :depth: 2
 
 .. _`context_help`:
 


### PR DESCRIPTION
I find the TOC at https://docs.qgis.org/testing/en/docs/user_manual/introduction/general_tools.html is too long and detailed