### PR TITLE
Inserted reverse line tool

### DIFF
--- a/source/docs/user_manual/working_with_vector/editing_geometry_attributes.rst
+++ b/source/docs/user_manual/working_with_vector/editing_geometry_attributes.rst
@@ -1035,7 +1035,7 @@ input widget. Your changes may then be saved with the |saveEdits| :sup:`Save Lay
 
 QGIS options dialog (Digitizing tab then **Curve offset tools** section) allows
 you to configure some parameters like **Join style**, **Quadrant segments**,
-**Miter lim-it**.
+**Miter limit**.
 
 .. index::
    single: Digitizing tools; Reverse Line

--- a/source/docs/user_manual/working_with_vector/editing_geometry_attributes.rst
+++ b/source/docs/user_manual/working_with_vector/editing_geometry_attributes.rst
@@ -733,7 +733,7 @@ Advanced digitizing
 +---------------------------+-----------------------------------------+------------------------+-------------------------+
 | |addRing|                 | Add Ring                                | |addPart|              | Add Part                |
 +---------------------------+-----------------------------------------+------------------------+-------------------------+
-| |fillRing|                | Fill Ring                               |                        |                         |
+| |fillRing|                | Fill Ring                               | |reverseLine|          | Swap direction          |
 +---------------------------+-----------------------------------------+------------------------+-------------------------+
 | |deleteRing|              | Delete Ring                             | |deletePart|           | Delete Part             |
 +---------------------------+-----------------------------------------+------------------------+-------------------------+
@@ -1035,7 +1035,18 @@ input widget. Your changes may then be saved with the |saveEdits| :sup:`Save Lay
 
 QGIS options dialog (Digitizing tab then **Curve offset tools** section) allows
 you to configure some parameters like **Join style**, **Quadrant segments**,
-**Miter limit**.
+**Miter lim-it**.
+
+.. index::
+   single: Digitizing tools; Reverse Line
+.. _reverse_line:
+
+Reverse Line
+------------
+
+You can change the direction of a line feature for digitizing purposes. 
+Activate the reverse line tool by clicking |reverseLine| :sup:`Reverse line`. 
+Select the line with the cursor to change the direction of the line.
 
 
 .. index::
@@ -1551,7 +1562,8 @@ To edit features in-place:
    If you need to create a new substitution manually,
    please add it also to the substitutions.txt file in the
    source folder.
-
+.. |reverseLine| image:: /static/common/mActionReverseLine.png
+   :width: 1.5em
 .. |addPart| image:: /static/common/mActionAddPart.png
    :width: 1.5em
 .. |addRing| image:: /static/common/mActionAddRing.png

--- a/source/docs/user_manual/working_with_vector/editing_geometry_attributes.rst
+++ b/source/docs/user_manual/working_with_vector/editing_geometry_attributes.rst
@@ -1044,7 +1044,7 @@ you to configure some parameters like **Join style**, **Quadrant segments**,
 Reverse Line
 ------------
 
-You can change the direction of a line feature for digitizing purposes. 
+You can change the direction of a line feature. 
 Activate the reverse line tool by clicking |reverseLine| :sup:`Reverse line`. 
 Select the line with the cursor to change the direction of the line.
 

--- a/source/docs/user_manual/working_with_vector/editing_geometry_attributes.rst
+++ b/source/docs/user_manual/working_with_vector/editing_geometry_attributes.rst
@@ -1044,9 +1044,10 @@ you to configure some parameters like **Join style**, **Quadrant segments**,
 Reverse Line
 ------------
 
-You can change the direction of a line feature. 
-Activate the reverse line tool by clicking |reverseLine| :sup:`Reverse line`. 
-Select the line with the cursor to change the direction of the line.
+To improve the labeling or to use your data for network analysis you can swap the
+direction of a line feature. Activate the reverse line tool by clicking
+|reverseLine| :sup:`Reverse line`. Select the line with the cursor to change the direction
+of the line.
 
 
 .. index::


### PR DESCRIPTION
A description about the reverse line tool.

<!---
Users shall be able to use the reverse line tool in the Advanced Digitizing Toolbar.
 
A list of issues is at https://github.com/qgis/QGIS-Documentation/issues.
Add "fix #issuenumber" for each issue the PR fixes. The ticket(s) will be closed automatically.
If your PR doesn't fix entirely the ticket, only add the ticket(s) reference preceded by # character.
-->
Goal:

Ticket(s): #2957
<!---
Indicate whether the fix should be backported to previous release.
Replace the space between square brackets by a `x` to make it checked.
-->
- [x] Backport to LTR documentation is required

<!---
Reviewing is a process done by community members, mostly on a volunteer basis.
We try to keep the overhead as small as possible and appreciate if you help us.
Please read carefully and ensure you comply with our writing guidelines at
https://docs.qgis.org/testing/en/docs/documentation_guidelines/index.html.
Feel free to ask in a comment or the (qgis-community-team mailing list)
[https://lists.osgeo.org/mailman/listinfo/qgis-community-team] if you have troubles with any item.
--->
