### PR TITLE
Missing punctuation (dot) at end of sentence

### DIFF
--- a/source/docs/pyqgis_developer_cookbook/authentication.rst
+++ b/source/docs/pyqgis_developer_cookbook/authentication.rst
@@ -364,7 +364,7 @@ and can be used as in the following snippet:
   tabGui.insertTab( 1, gui, "Configurations" )
 
 The above example is taken from the QGIS source :source:`code
-<src/providers/postgres/qgspgnewconnection.cpp#L42>`
+<src/providers/postgres/qgspgnewconnection.cpp#L42>`.
 The second parameter of the GUI constructor refers to data provider type. The
 parameter is used to restrict the compatible :term:`Authentication Method`\s with
 the specified provider.


### PR DESCRIPTION
Line 367 <src/providers/postgres/qgspgnewconnection.cpp#L42>`  should probably have a dot at the end,
Next sentence starts with a capital letter.

So; "<src/providers/postgres/qgspgnewconnection.cpp#L42>`"  should probably be:
      "<src/providers/postgres/qgspgnewconnection.cpp#L42>`."

<!---
Include a few sentences describing the overall goals for this Pull Request.

Goal: Display correct documentation

- [x] Backport to LTR documentation is required
