### PR TITLE
Typo corrected

### DIFF
--- a/source/docs/training_manual/processing/r_intro.rst
+++ b/source/docs/training_manual/processing/r_intro.rst
@@ -185,7 +185,7 @@ As before we have to set some parameters before the script body:
    this case *Point pattern analysis*::
 
     ##Point pattern analysis=group
-#. Define an input parameter (a vector layer) that will contstrain the
+#. Define an input parameter (a vector layer) that will constrain the
    placement of the random points::
 
     ##Layer=vector


### PR DESCRIPTION
Line 188 : "contstrain the" should probably be "constrain the"  (contstrain must be constrain)

Goal: Display correct documentation

- [x] Backport to LTR documentation is required
