### PR TITLE
Wrong sample dataset or misused "Alaska" ?

### DIFF
--- a/source/docs/training_manual/map_composer/dynamic_layout.rst
+++ b/source/docs/training_manual/map_composer/dynamic_layout.rst
@@ -16,7 +16,8 @@ will adapt dynamically.
    click the |newLayout| :sup:`New Print Layout` icon in the toolbar or
    choose :menuselection:`File --> New Print Layout`. You will be prompted to
    choose a title for the new layer.
-#. We want to create a map layout consisting of a header and a map of the region near Swellendam, South Africa.
+#. We want to create a map layout consisting of a header and a map of the region near
+   Swellendam, South Africa.
    The layout should have a margin of 7.5 mm and the header should be 36mm high.
 #. Create a map item called ``main map`` on the canvas and go to the :guilabel:`Layout` panel.
    Scroll down to the :guilabel:`Variables` section and find the :guilabel:`Layout` part.

--- a/source/docs/training_manual/map_composer/dynamic_layout.rst
+++ b/source/docs/training_manual/map_composer/dynamic_layout.rst
@@ -16,8 +16,8 @@ will adapt dynamically.
    click the |newLayout| :sup:`New Print Layout` icon in the toolbar or
    choose :menuselection:`File --> New Print Layout`. You will be prompted to
    choose a title for the new layer.
-#. We want to create a map layout consisting of a header and a map with the regions of
-   Alaska. The layout should have a margin of 7.5 mm and the header should be 36mm high.
+#. We want to create a map layout consisting of a header and a map of the region near Swellendam, South Africa.
+   The layout should have a margin of 7.5 mm and the header should be 36mm high.
 #. Create a map item called ``main map`` on the canvas and go to the :guilabel:`Layout` panel.
    Scroll down to the :guilabel:`Variables` section and find the :guilabel:`Layout` part.
    Here we set some variables you can use all over the dynamic print layout. Go to the :guilabel:`Layout` panel


### PR DESCRIPTION
Line 19 and 20 : "a map with the regions of  Alaska."

However, we are loading shapefiles from the sample dataset of the region near Swellendam South-Africa.
If I read through it is probably meant to be Swellendam and not Alaska that we are making the dynamic print layout for.

I suppose/suggest therefore that the sentence should be changed to:  "a map of the region near Swellendam, South Africa."

Greetings
DiGro

<!---
Include a few sentences describing the overall goals for this Pull Request.

Goal: Display correct documentation

- [x] Backport to LTR documentation is required
