### PR TITLE
Wrong name variable

### DIFF
--- a/source/docs/training_manual/map_composer/dynamic_layout.rst
+++ b/source/docs/training_manual/map_composer/dynamic_layout.rst
@@ -64,7 +64,7 @@ will adapt dynamically.
    In the :guilabel:`Items` panel enter the name ``header``.
 #. Again, go to the :guilabel:`Item Properties` and open the :guilabel:`Position and Size` section.
    Using |dataDefineExpressionOn| :sup:`Data defined override`,
-   choose the ``@rg_layout_margin`` variable for :guilabel:`X` as well as for :guilabel:`Y`.
+   choose the ``@sw_layout_margin`` variable for :guilabel:`X` as well as for :guilabel:`Y`.
    :guilabel:`Width` shall be defined by the expression
    
    ::


### PR DESCRIPTION
Line 67 : "choose the ``@rg_layout_margin`` variable",  however there is no such variable.
 
Should probably be the variable @sw_layout_margin which was previously defined

<!---
Include a few sentences describing the overall goals for this Pull Request.
 
A list of issues is at https://github.com/qgis/QGIS-Documentation/issues.
Add "fix #issuenumber" for each issue the PR fixes. The ticket(s) will be closed automatically.
If your PR doesn't fix entirely the ticket, only add the ticket(s) reference preceded by # character.
-->
Goal: Display correct documentation

- [x] Backport to LTR documentation is required

