### PR TITLE
Missing asterisk, messes up formatting

### DIFF
--- a/source/docs/user_manual/processing_algs/qgis/cartography.rst
+++ b/source/docs/user_manual/processing_algs/qgis/cartography.rst
@@ -454,7 +454,7 @@ Parameters
      - Prevent nearby (but non-touching) features from
        being assigned equal colors.
        Minimum 0.0.
-   * - *Balance color assignment**
+   * - **Balance color assignment**
      - ``BALANCE``
      - [enumeration]
 


### PR DESCRIPTION
Line 457 :  " *Balance color assignment**" should be " **Balance color assignment** "

The missing asterisk messes up the formatting of the sentence.
Placing the missing asterisk fixes it.

<!---
Include a few sentences describing the overall goals for this Pull Request.

Goal: Display correct documentation

- [x] Backport to LTR documentation is required
