### PR TITLE
Probable typo  so -> do

### DIFF
--- a/source/docs/user_manual/processing_algs/qgis/vectoroverlay.rst
+++ b/source/docs/user_manual/processing_algs/qgis/vectoroverlay.rst
@@ -583,7 +583,7 @@ Parameters
        
        Default: ``[Create temporary layer]``
      - Specify the layer to contain (the parts of) the features from
-       the input and overlay layers that so not overlap features from the
+       the input and overlay layers that do not overlap features from the
        other layer.
        One of:
 


### PR DESCRIPTION
Line 586:  " that so not "  should probably be " that do not " given the rest of the sentence

<!---
Include a few sentences describing the overall goals for this Pull Request.

Goal: Display correct documentation

- [x] Backport to LTR documentation is required
