### PR TITLE
spawn-fcgi should be the prefered way compare to fcgiwrap

### DIFF
--- a/source/docs/user_manual/working_with_ogc/server/getting_started.rst
+++ b/source/docs/user_manual/working_with_ogc/server/getting_started.rst
@@ -173,53 +173,7 @@ QGIS Server is now available at http://localhost/qgisserver.
     packaged in Debian.
 
 Of course, you can add an init script (like a ``qgis-server.service`` file
-with systemd) to start QGIS Server at boot time or whenever you want. To use an init script with systemd,
-copy/paste this content in :file:`/etc/systemd/system/qgis-server.service`
-
-.. code-block:: bash
-
-   [Unit]
-   Description=QGIS Server Service
-
-   [Service]
-   # Add some environment variable if needed
-   Environment=QGIS_SERVER_LOG_LEVEL=0
-
-   StandardOutput=null
-   StandardError=journal
-   ExecStart=spawn-fcgi -s /var/run/qgisserver.socket -U www-data -G www-data -n /usr/lib/cgi-bin/qgis_mapserv.fcgi
-
-   [Install]
-   WantedBy=multi-user.target
-
-We can enable this init file:
-
-.. code-block:: bash
-
-   sudo systemctl enable /etc/systemd/system/qgis-server.service
-   sudo systemctl start qgis-server
-   sudo systemctl status qgis-server
-
-
-QGIS Server should be available and you can watch the live logs with:
-
-.. code-block:: bash
-
-   sudo journalctl -f -u qgis-server
-
-As mentioned above, we can setup ``multiwatch`` to increase
-the number of processes to 2 for instance:
-
-.. code-block:: bash
-
-   sudo apt install multiwatch
-
-Either in your bash line or in your init file, launch your QGIS Server
-by adding this line before the path to :file:`qgis_mapserv.fcgi`:
-
-.. code-block:: bash
-
-   /usr/bin/multiwatch -f 2
+with systemd) to start QGIS Server at boot time or whenever you want.
 
 fcgiwrap
 ^^^^^^^^

--- a/source/docs/user_manual/working_with_ogc/server/getting_started.rst
+++ b/source/docs/user_manual/working_with_ogc/server/getting_started.rst
@@ -172,7 +172,7 @@ QGIS Server is now available at http://localhost/qgisserver.
     `multiwatch <https://redmine.lighttpd.net/projects/multiwatch/wiki>`_ tool, which is also
     packaged in Debian.
 
-Of course, we can add an init script (like a ``qgis-server.service`` file
+Of course, you can add an init script (like a ``qgis-server.service`` file
 with Systemd) to start QGIS Server at boot time or whenever you want. To use a init script with systemd,
 copy/paste this content in :file:`/etc/systemd/system/qgis-server.service`
 
@@ -203,19 +203,21 @@ We can enable this init file:
 
 QGIS Server should be available and you can watch the live logs with:
 
-.. code-block::bash
+.. code-block:: bash
 
    sudo journalctl -f -u qgis-server
 
-As mentioned above, we can setup `multiwatch` to increase the number of process to 2 for instance:
+As mentioned above, we can setup ``multiwatch`` to increase
+the number of process to 2 for instance:
 
 .. code-block:: bash
 
    sudo apt install multiwatch
 
-Either in your bash line or in your init file, launch your QGIS Server by adding this line before the path to the :file:`qgis_mapserv.fcgi`:
+Either in your bash line or in your init file, launch your QGIS Server
+by adding this line before the path to the :file:`qgis_mapserv.fcgi`:
 
-..code-block:: bash
+.. code-block:: bash
 
    /usr/bin/multiwatch -f 2
 

--- a/source/docs/user_manual/working_with_ogc/server/getting_started.rst
+++ b/source/docs/user_manual/working_with_ogc/server/getting_started.rst
@@ -107,12 +107,12 @@ You can also use QGIS Server with `NGINX <https://nginx.org/>`_. Unlike Apache,
 NGINX does not automatically spawn FastCGI processes. The FastCGI processes are
 to be started by something else.
 
-On Debian-based systems, you may use **fcgiwrap** or **spawn-fcgi** to start
+On Debian-based systems, you can use **spawn-fcgi** or **fcgiwrap** to start
 and manage the QGIS Server processes. Official Debian packages exist for both.
 
-.. note::
+.. warning::
 
-    fcgiwrap is easier to set up than spawn-fcgi, because it's already wrapped
+    **fcgiwrap** is easier to set up than **spawn-fcgi**, because it's already wrapped
     in a Systemd service. But it also leads to a solution that is much slower
     than using spawn-fcgi. With fcgiwrap a new QGIS Server process is created
     on each request, meaning that the QGIS Server initialization process, which
@@ -127,43 +127,11 @@ Install NGINX:
 
  sudo apt install nginx
 
-
-fcgiwrap
-^^^^^^^^
-
-If you want to use `fcgiwrap <https://www.nginx.com/resources/wiki/start/topics/examples/fcgiwrap/>`_
-to run QGIS Server, you first have to install the corresponding package:
-
-.. code-block:: bash
-
- sudo apt install fcgiwrap
-
-Then, introduce the following block in your NGINX server configuration:
-
-.. code-block:: nginx
-   :linenos:
-
-     location /qgisserver {
-         gzip           off;
-         include        fastcgi_params;
-         fastcgi_pass   unix:/var/run/fcgiwrap.socket;
-         fastcgi_param  SCRIPT_FILENAME /usr/lib/cgi-bin/qgis_mapserv.fcgi;
-     }
-
-Finally, restart NGINX and fcgiwrap to take into account the new configuration:
-
-.. code-block:: bash
-
- sudo service nginx restart
- sudo service fcgiwrap restart
-
-QGIS Server is now available at http://localhost/qgisserver.
-
 spawn-fcgi
 ^^^^^^^^^^
 
-If you prefer to use `spawn-fcgi <https://redmine.lighttpd.net/projects/spawn-fcgi/wiki>`_ instead
-of fcgiwrap, the first step is to install the package:
+If you want to use `spawn-fcgi <https://redmine.lighttpd.net/projects/spawn-fcgi/wiki>`_,
+the first step is to install the package:
 
 .. code-block:: bash
 
@@ -195,9 +163,6 @@ have to manually start QGIS Server in your terminal:
                  -U www-data -G www-data -n \
                  /usr/lib/bin/cgi-bin/qgis_mapserv.fcgi
 
-Of course, you may write an init script (like a ``qgisserver.service`` file
-with Systemd) to start QGIS Server at boot time or whenever you want.
-
 QGIS Server is now available at http://localhost/qgisserver.
 
 .. note::
@@ -206,6 +171,85 @@ QGIS Server is now available at http://localhost/qgisserver.
     Server process you can combine spawn-fcgi with the
     `multiwatch <https://redmine.lighttpd.net/projects/multiwatch/wiki>`_ tool, which is also
     packaged in Debian.
+
+Of course, we can add an init script (like a ``qgis-server.service`` file
+with Systemd) to start QGIS Server at boot time or whenever you want. To use a init script with systemd,
+copy/paste this content in :file:`/etc/systemd/system/qgis-server.service`
+
+.. code-block:: bash
+
+   [Unit]
+   Description=QGIS Server Service
+
+   [Service]
+   # Add some environment variable if needed
+   Environment=QGIS_SERVER_LOG_LEVEL=0
+
+   StandardOutput=null
+   StandardError=journal
+   ExecStart=spawn-fcgi -s /var/run/qgisserver.socket -U www-data -G www-data -n /usr/lib/cgi-bin/qgis_mapserv.fcgi
+
+   [Install]
+   WantedBy=multi-user.target
+
+We can enable this init file:
+
+.. code-block:: bash
+
+   sudo systemctl enable /etc/systemd/system/qgis-server.service
+   sudo systemctl start qgis-server
+   sudo systemctl status qgis-server
+
+
+QGIS Server should be available and you can watch the live logs with:
+
+.. code-block::bash
+
+   sudo journalctl -f -u qgis-server
+
+As mentioned above, we can setup `multiwatch` to increase the number of process to 2 for instance:
+
+.. code-block:: bash
+
+   sudo apt install multiwatch
+
+Either in your bash line or in your init file, launch your QGIS Server by adding this line before the path to the :file:`qgis_mapserv.fcgi`:
+
+..code-block:: bash
+
+   /usr/bin/multiwatch -f 2
+
+fcgiwrap
+^^^^^^^^
+
+Using `fcgiwrap <https://www.nginx.com/resources/wiki/start/topics/examples/fcgiwrap/>`_
+is much easier to setup than `spawn-fcgi` but it's much slower.
+You first have to install the corresponding package:
+
+.. code-block:: bash
+
+ sudo apt install fcgiwrap
+
+Then, introduce the following block in your NGINX server configuration:
+
+.. code-block:: nginx
+   :linenos:
+
+     location /qgisserver {
+         gzip           off;
+         include        fastcgi_params;
+         fastcgi_pass   unix:/var/run/fcgiwrap.socket;
+         fastcgi_param  SCRIPT_FILENAME /usr/lib/cgi-bin/qgis_mapserv.fcgi;
+     }
+
+Finally, restart NGINX and fcgiwrap to take into account the new configuration:
+
+.. code-block:: bash
+
+ sudo service nginx restart
+ sudo service fcgiwrap restart
+
+QGIS Server is now available at http://localhost/qgisserver.
 
 Configuration
 ^^^^^^^^^^^^^

--- a/source/docs/user_manual/working_with_ogc/server/getting_started.rst
+++ b/source/docs/user_manual/working_with_ogc/server/getting_started.rst
@@ -173,7 +173,7 @@ QGIS Server is now available at http://localhost/qgisserver.
     packaged in Debian.
 
 Of course, you can add an init script (like a ``qgis-server.service`` file
-with Systemd) to start QGIS Server at boot time or whenever you want. To use a init script with systemd,
+with systemd) to start QGIS Server at boot time or whenever you want. To use an init script with systemd,
 copy/paste this content in :file:`/etc/systemd/system/qgis-server.service`
 
 .. code-block:: bash
@@ -208,14 +208,14 @@ QGIS Server should be available and you can watch the live logs with:
    sudo journalctl -f -u qgis-server
 
 As mentioned above, we can setup ``multiwatch`` to increase
-the number of process to 2 for instance:
+the number of processes to 2 for instance:
 
 .. code-block:: bash
 
    sudo apt install multiwatch
 
 Either in your bash line or in your init file, launch your QGIS Server
-by adding this line before the path to the :file:`qgis_mapserv.fcgi`:
+by adding this line before the path to :file:`qgis_mapserv.fcgi`:
 
 .. code-block:: bash
 
@@ -225,7 +225,7 @@ fcgiwrap
 ^^^^^^^^
 
 Using `fcgiwrap <https://www.nginx.com/resources/wiki/start/topics/examples/fcgiwrap/>`_
-is much easier to setup than `spawn-fcgi` but it's much slower.
+is much easier to setup than **spawn-fcgi** but it's much slower.
 You first have to install the corresponding package:
 
 .. code-block:: bash
@@ -244,7 +244,7 @@ Then, introduce the following block in your NGINX server configuration:
          fastcgi_param  SCRIPT_FILENAME /usr/lib/cgi-bin/qgis_mapserv.fcgi;
      }
 
-Finally, restart NGINX and fcgiwrap to take into account the new configuration:
+Finally, restart NGINX and **fcgiwrap** to take into account the new configuration:
 
 .. code-block:: bash
 


### PR DESCRIPTION
<!---
Include a few sentences describing the overall goals for this Pull Request.
 
A list of issues is at https://github.com/qgis/QGIS-Documentation/issues.
Add "fix #issuenumber" for each issue the PR fixes. The ticket(s) will be closed automatically.
If your PR doesn't fix entirely the ticket, only add the ticket(s) reference preceded by # character.
-->
Goal:

A few days ago, I quickly followed the documentation with NGINX and I installed `fcgiwrap`. I didn't see the previous note made by @elemoine. The performance is catastrophic :) according to me. It's indeed very slow. So I think we should move `spawn-fcgi` before `fcgiwrap` in the documentation.

fcgiwrap is easy to setup, but very slow.

I also tried to add a systemd file for starting qgis server.

@elemoine I'm clearly not an expert in this area, a review is welcome.

Ticket(s): #
<!---
Indicate whether the fix should be backported to previous release.
Replace the space between square brackets by a `x` to make it checked.
-->
- [x] Backport to LTR documentation is required

<!---
Reviewing is a process done by community members, mostly on a volunteer basis.
We try to keep the overhead as small as possible and appreciate if you help us.
Please read carefully and ensure you comply with our writing guidelines at
https://docs.qgis.org/testing/en/docs/documentation_guidelines/index.html.
Feel free to ask in a comment or the (qgis-community-team mailing list)
[https://lists.osgeo.org/mailman/listinfo/qgis-community-team] if you have troubles with any item.
--->
