### PR TITLE
Fix shortest path (point to point) algorithm build

### DIFF
--- a/source/docs/user_manual/processing_algs/qgis/networkanalysis.rst
+++ b/source/docs/user_manual/processing_algs/qgis/networkanalysis.rst
@@ -789,9 +789,13 @@ Parameters
      - [coordinates]
      - Point feature representing the end point of the routes
 
-       .. include:: qgis_algs_include.rst
-         :start-after: **network_advanced_parameters**
-         :end-before: **end_network_advanced_parameters**
+.. include:: qgis_algs_include.rst
+   :start-after: **network_advanced_parameters**
+   :end-before: **end_network_advanced_parameters**
+
+.. list-table::
+   :widths: 20 20 20 40
+   :stub-columns: 0
 
    * - **Shortest path**
      - ``OUTPUT``

--- a/source/docs/user_manual/processing_algs/qgis/qgis_algs_include.rst
+++ b/source/docs/user_manual/processing_algs/qgis/qgis_algs_include.rst
@@ -99,14 +99,6 @@
        Default: 0.0
      - Two lines with nodes closer than the specified
        tolerance are considered connected
-   * - **Include upper/lower bound points**
-     - ``INCLUDE_BOUNDS``
-     - [boolean]
-
-       Default: False
-     - Creates a point layer output with two points for each
-       edge at the boundaries of the service area.
-       One point is the start of that edge, the other is the end.
 
 **end_network_advanced_parameters**
 

--- a/source/docs/user_manual/processing_algs/qgis/qgis_algs_include.rst
+++ b/source/docs/user_manual/processing_algs/qgis/qgis_algs_include.rst
@@ -6,6 +6,10 @@
  qgisserviceareafrompoint, qgisserviceareafromlayer, qgisshortestpathlayertopoint,
  qgisshortestpathpointtolayer and qgisshortestpathpointtopoint
 
+.. list-table::
+   :widths: 20 20 20 40
+   :stub-columns: 0
+
    * - **Direction field**
 
        Optional


### PR DESCRIPTION
https://docs.qgis.org/testing/en/docs/user_manual/processing_algs/qgis/networkanalysis.html#shortest-path-point-to-point is not nice so we split the table in three of same widths (only the first table has headers) and concatenate them