### PR TITLE
Tweak the text rendering option in placement engine

### DIFF
--- a/source/docs/user_manual/introduction/project_files.rst
+++ b/source/docs/user_manual/introduction/project_files.rst
@@ -143,6 +143,9 @@ Other ways to produce output files are:
   vector layers you want to export to DXF. Through the 'Symbology mode' symbols
   from the original QGIS Symbology can be exported with high fidelity
   (see section :ref:`create_dxf_files`).
+
+.. _`output_canvas_pdf`:
+
 * Exporting to PDF files: :menuselection:`Project --> Import/Export --> Export
   Map to PDF...` opens a dialog where you can define the part
   (:guilabel:`Extent`) of the map to be exported, the :guilabel:`Scale`,

--- a/source/docs/user_manual/working_with_vector/vector_properties.rst
+++ b/source/docs/user_manual/working_with_vector/vector_properties.rst
@@ -1231,7 +1231,7 @@ options:
   generated, the better the labeling will be - but at a cost of rendering
   speed. Smaller number of candidates results in less labels placed but faster
   redraws.
-* :guilabel:`Text rendering`: sets the default value for labels rendering
+* :guilabel:`Text rendering`: sets the default value for label rendering
   widgets when :ref:`exporting a map canvas <output_canvas_pdf>` or
   :ref:`a layout <create-output>` to PDF or SVG. 
   If :guilabel:`Always render labels as text` is selected then labels can be

--- a/source/docs/user_manual/working_with_vector/vector_properties.rst
+++ b/source/docs/user_manual/working_with_vector/vector_properties.rst
@@ -1226,23 +1226,20 @@ options:
 
    The labels automated placement engine
 
-* The :guilabel:`Number of candidates` controls set how many label placement
+* The :guilabel:`Number of candidates` controls how many label placement
   candidates should be generated for each feature type. The more candidates
   generated, the better the labeling will be - but at a cost of rendering
   speed. Smaller number of candidates results in less labels placed but faster
   redraws.
-* :guilabel:`Text rendering`: controls whether text labels are
-  drawn (and exported) as either proper text objects
-  (:guilabel:`Always Render Labels as Text`)
-  OR as paths only (:guilabel:`Always Render Labels as Paths (recommended)`). 
-  If they are exported as text objects then they can be edited
-  in external applications (e.g. Inkscape) as normal text. BUT the side effect is that
-  the rendering quality is decreased, and there are issues with rendering when
-  certain text settings like buffers are in place. That's why rendering as paths
-  is recommended. Note that when :ref:`exporting a layout to svg <export_layout_svg>`,
-  there's an override for this setting.
-  So you can have `Always Render Labels as Paths` for the project, and choose 
-  `Always Render Labels as Text` for :file:`.svg` export.
+* :guilabel:`Text rendering`: sets the default value for labels rendering
+  widgets when :ref:`exporting a map canvas <output_canvas_pdf>` or
+  :ref:`a layout <create-output>` to PDF or SVG. 
+  If :guilabel:`Always render labels as text` is selected then labels can be
+  edited in external applications (e.g. Inkscape) as normal text. BUT the side
+  effect is that the rendering quality is decreased, and there are issues with
+  rendering when certain text settings like buffers are in place. That's why
+  :guilabel:`Always render labels as paths (recommended)` which exports labels
+  as outlines, is recommended.
 * |checkbox| :guilabel:`Allow truncated labels on edges of map`: controls
   whether labels which fall partially outside of the map extent should be
   rendered. If checked, these labels will be shown (when there's no way to


### PR DESCRIPTION
According to https://github.com/qgis/QGIS-Documentation/pull/4579#discussion_r355279346 this option has no influence on exports since export dialogs have their own setting. What it does is only to set the default item of the export dialogs widgets.
Also not only SVG is concerned now.

<!---
Include a few sentences describing the overall goals for this Pull Request.
 
A list of issues is at https://github.com/qgis/QGIS-Documentation/issues.
Add "fix #issuenumber" for each issue the PR fixes. The ticket(s) will be closed automatically.
If your PR doesn't fix entirely the ticket, only add the ticket(s) reference preceded by # character.
-->
Goal:

Ticket(s): #
<!---
Indicate whether the fix should be backported to previous release.
Replace the space between square brackets by a `x` to make it checked.
-->
- [ ] Backport to LTR documentation is required

<!---
Reviewing is a process done by community members, mostly on a volunteer basis.
We try to keep the overhead as small as possible and appreciate if you help us.
Please read carefully and ensure you comply with our writing guidelines at
https://docs.qgis.org/testing/en/docs/documentation_guidelines/index.html.
Feel free to ask in a comment or the (qgis-community-team mailing list)
[https://lists.osgeo.org/mailman/listinfo/qgis-community-team] if you have troubles with any item.
--->
