### PR TITLE
Update file extension to reflect defaults in v3.10.1

### DIFF
--- a/source/docs/training_manual/introduction/preparation.rst
+++ b/source/docs/training_manual/introduction/preparation.rst
@@ -75,7 +75,7 @@ your work.
 
 #. Click on the :guilabel:`Save As` button: |fileSaveAs|
 #. Save the map under a :file:`solution` folder next to :file:`exercise_data`
-   and call it :file:`basic_map.qgs`.
+   and call it :file:`basic_map.qgz`.
 
 .. _backlink-interface-preparation-1:
 


### PR DESCRIPTION
Goal: In the training manual, at the end of section 2.1.1, you are instructed to save the map as `basic_map.qgs` but the dialogue defaults to `.qgz` (at least on Windows). This raises unnecessary questions for a beginner tutorial.

- [ ] Backport to LTR documentation is required
