### PR TITLE
Update location of Toolbars menu in Training Manual

### DIFF
--- a/source/docs/training_manual/introduction/overview.rst
+++ b/source/docs/training_manual/introduction/overview.rst
@@ -78,7 +78,7 @@ Your most often used sets of tools can be turned into toolbars for basic access.
 For example, the File toolbar allows you to save, load, print, and start a new
 project. You can easily customize the interface to see only the tools you use
 most often, adding or removing toolbars as necessary via the
-:menuselection:`Settings --> Toolbars` menu.
+:menuselection:`View --> Toolbars` menu.
 
 Even if they are not visible in a toolbar, all of your tools will remain
 accessible via the menus. For example, if you remove the :guilabel:`File`


### PR DESCRIPTION
Goal: Section 2.2.1.3 says the Toolbars menu is under the Settings menu when it has moved to the View menu.

- [ ] Backport to LTR documentation is required