### PR TITLE
Add a separate include for the service area QGIS network algorithms

### DIFF
--- a/source/docs/user_manual/processing_algs/qgis/networkanalysis.rst
+++ b/source/docs/user_manual/processing_algs/qgis/networkanalysis.rst
@@ -55,105 +55,10 @@ Parameters
      - The value is estimated as a distance (in the network
        layer units) when looking for the *Shortest* path and
        as time (in seconds) for the *Fastest* path.
-   * - **Direction field**
-
-       Optional
-     - ``DIRECTION_FIELD``
-     - [tablefield: string]
-
-       Default: None
-     - The field used to specify directions for the network edges.
-       
-       The values used in this field are specified with the three
-       parameters ``Value for forward direction``,
-       ``Value for backward direction`` and
-       ``Value for both directions``.
-       Forward and reverse directions correspond to a one-way edge,
-       "both directions" indicates a two-way edge.
-       If a feature does not have a value in this field, or no field
-       is set then the   default direction setting (provided with
-       the ``Default direction`` parameter) is used.
-   * - **Value for forward direction**
-
-       Optional
-     - ``VALUE_FORWARD``
-     - [string]
-
-       Default: '' (empty string)
-     - Value set in the direction field to identify edges with a
-       forward direction
-   * - **Value for backward direction**
-
-       Optional
-     - ``VALUE_BACKWARD``
-     - [string]
-
-       Default: '' (empty string)
-     - Value set in the direction field to identify edges with a
-       backward direction
-   * - **Value for both directions**
-
-       Optional
-     - ``VALUE_BOTH``
-     - [string]
-
-       Default: '' (empty string)
-     - Value set in the direction field to identify
-       bidirectional edges
-   * - **Default direction**
-
-       Optional
-     - ``DEFAULT_DIRECTION``
-     - [enumeration]
-
-       Default: 2
-     - If a feature has no value set in the direction field or
-       if no direction field is set, then this direction value
-       is used. One of:
-
-       * 0 --- Forward direction
-       * 1 --- Backward direction
-       * 2 --- Both directions
-
-   * - **Speed field**
-
-       Optional
-     - ``SPEED_FIELD``
-     - [tablefield: string]
-
-       Default: None
-     - Field providing the speed value (in ``km/h``) for the
-       edges of the network when looking for the fastest path.
-       
-       If a feature does not have a value in this field, or
-       no field is set then the default speed value (provided
-       with the ``Default speed`` parameter) is used.
-   * - **Default speed (km/h)**
-
-       Optional
-     - ``DEFAULT_SPEED``
-     - [number]
-
-       Default: 50
-     - Value to use to calculate the travel time if no speed
-       field is provided for an edge
-   * - **Topology tolerance**
-
-       Optional
-     - ``TOLERANCE``
-     - [number]
-
-       Default: 0
-     - Two lines with nodes closer than the specified
-       tolerance are considered connected
-   * - **Include upper/lower bound points**
-     - ``INCLUDE_BOUNDS``
-     - [boolean]
-
-       Default: False
-     - Creates a point layer output with two points for each
-       edge at the boundaries of the service area.
-       One point is the start of that edge, the other is the end.
+   * - **Advanced parameters**
+     - GUI only
+     - 
+     - Group of advanced network analysis parameters - se below.
    * - **Service area (lines)**
      - ``OUTPUT_LINES``
      - [vector: line]
@@ -184,6 +89,10 @@ Parameters
        * Save to PostGIS Table
 
        The file encoding can also be changed here.
+
+.. include:: qgis_algs_include.rst
+  :start-after: **network_advanced_parameters_service_area**
+  :end-before: **end_network_advanced_parameters_service_area**
 
 Outputs
 .......
@@ -259,105 +168,10 @@ Parameters
      - The value is estimated as a distance (in the network
        layer units) when looking for the *Shortest* path and
        as time (in seconds) for the *Fastest* path.
-   * - **Direction field**
-
-       Optional
-     - ``DIRECTION_FIELD``
-     - [tablefield: string]
-
-       Default: None
-     - The field used to specify directions for the network edges.
-       
-       The values used in this field are specified with the three
-       parameters ``Value for forward direction``,
-       ``Value for backward direction`` and
-       ``Value for both directions``.
-       Forward and reverse directions correspond to a one-way edge,
-       "both directions" indicates a two-way edge.
-       If a feature does not have a value in this field, or no field
-       is set then the   default direction setting (provided with
-       the ``Default direction`` parameter) is used.
-   * - **Value for forward direction**
-
-       Optional
-     - ``VALUE_FORWARD``
-     - [string]
-
-       Default: '' (empty string)
-     - Value set in the direction field to identify edges with a
-       forward direction
-   * - **Value for backward direction**
-
-       Optional
-     - ``VALUE_BACKWARD``
-     - [string]
-
-       Default: '' (empty string)
-     - Value set in the direction field to identify edges with a
-       backward direction
-   * - **Value for both directions**
-
-       Optional
-     - ``VALUE_BOTH``
-     - [string]
-
-       Default: '' (empty string)
-     - Value set in the direction field to identify
-       bidirectional edges
-   * - **Default direction**
-
-       Optional
-     - ``DEFAULT_DIRECTION``
-     - [enumeration]
-
-       Default: 2
-     - If a feature has no value set in the direction field or
-       if no direction field is set, then this direction value
-       is used. One of:
-
-       * 0 --- Forward direction
-       * 1 --- Backward direction
-       * 2 --- Both directions
-
-   * - **Speed field**
-
-       Optional
-     - ``SPEED_FIELD``
-     - [tablefield: string]
-
-       Default: None
-     - Field providing the speed value (in ``km/h``) for the
-       edges of the network when looking for the fastest path.
-       
-       If a feature does not have a value in this field, or
-       no field is set then the default speed value (provided
-       with the ``Default speed`` parameter) is used.
-   * - **Default speed (km/h)**
-
-       Optional
-     - ``DEFAULT_SPEED``
-     - [number]
-
-       Default: 50
-     - Value to use to calculate the travel time if no speed
-       field is provided for an edge
-   * - **Topology tolerance**
-
-       Optional
-     - ``TOLERANCE``
-     - [number]
-
-       Default: 0
-     - Two lines with nodes closer than the specified
-       tolerance are considered connected
-   * - **Include upper/lower bound points**
-     - ``INCLUDE_BOUNDS``
-     - [boolean]
-
-       Default: False
-     - Creates a point layer output with two points for each
-       edge at the boundaries of the service area.
-       One point is the start of that edge, the other is the end.
+   * - **Advanced parameters**
+     - GUI only
+     - 
+     - Group of advanced network analysis parameters - se below.
    * - **Service area (lines)**
      - ``OUTPUT_LINES``
      - [vector: line]
@@ -388,6 +202,10 @@ Parameters
        * Save to PostGIS Table
 
        The file encoding can also be changed here.
+
+.. include:: qgis_algs_include.rst
+  :start-after: **network_advanced_parameters**
+  :end-before: **end_network_advanced_parameters**
 
 Outputs
 .......
@@ -457,97 +275,10 @@ Parameters
      - ``END_POINT``
      - [coordinates]
      - Point feature representing the end point of the routes
-   * - **Direction field**
-
-       Optional
-     - ``DIRECTION_FIELD``
-     - [tablefield: string]
-
-       Default: None
-     - The field used to specify directions for the network edges.
-       
-       The values used in this field are specified with the three
-       parameters ``Value for forward direction``,
-       ``Value for backward direction`` and
-       ``Value for both directions``.
-       Forward and reverse directions correspond to a one-way edge,
-       "both directions" indicates a two-way edge.
-       If a feature does not have a value in this field, or no field
-       is set then the   default direction setting (provided with
-       the ``Default direction`` parameter) is used.
-   * - **Value for forward direction**
-
-       Optional
-     - ``VALUE_FORWARD``
-     - [string]
-
-       Default: '' (empty string)
-     - Value set in the direction field to identify edges with a
-       forward direction
-   * - **Value for backward direction**
-
-       Optional
-     - ``VALUE_BACKWARD``
-     - [string]
-
-       Default: '' (empty string)
-     - Value set in the direction field to identify edges with a
-       backward direction
-   * - **Value for both directions**
-
-       Optional
-     - ``VALUE_BOTH``
-     - [string]
-
-       Default: '' (empty string)
-     - Value set in the direction field to identify
-       bidirectional edges
-   * - **Default direction**
-
-       Optional
-     - ``DEFAULT_DIRECTION``
-     - [enumeration]
-
-       Default: 2
-     - If a feature has no value set in the direction field or
-       if no direction field is set, then this direction value
-       is used. One of:
-
-       * 0 --- Forward direction
-       * 1 --- Backward direction
-       * 2 --- Both directions
-
-   * - **Speed field**
-
-       Optional
-     - ``SPEED_FIELD``
-     - [tablefield: string]
-
-       Default: None
-     - Field providing the speed value (in ``km/h``) for the
-       edges of the network when looking for the fastest path.
-       
-       If a feature does not have a value in this field, or
-       no field is set then the default speed value (provided
-       with the ``Default speed`` parameter) is used.
-   * - **Default speed (km/h)**
-
-       Optional
-     - ``DEFAULT_SPEED``
-     - [number]
-
-       Default: 50
-     - Value to use to calculate the travel time if no speed
-       field is provided for an edge
-   * - **Topology tolerance**
-
-       Optional
-     - ``TOLERANCE``
-     - [number]
-
-       Default: 0
-     - Two lines with nodes closer than the specified
-       tolerance are considered connected
+   * - **Advanced parameters**
+     - GUI only
+     - 
+     - Group of advanced network analysis parameters - se below.
    * - **Shortest path**
      - ``OUTPUT``
      - [vector: line]
@@ -561,6 +292,10 @@ Parameters
        * Save to PostGIS Table
 
        The file encoding can also be changed here.
+
+.. include:: qgis_algs_include.rst
+  :start-after: **network_advanced_parameters**
+  :end-before: **end_network_advanced_parameters**
 
 Outputs
 .......
@@ -624,97 +359,10 @@ Parameters
      - [vector: point]
      - Point vector layer whose features are used as end
        points of the routes
-   * - **Direction field**
-
-       Optional
-     - ``DIRECTION_FIELD``
-     - [tablefield: string]
-
-       Default: None
-     - The field used to specify directions for the network edges.
-       
-       The values used in this field are specified with the three
-       parameters ``Value for forward direction``,
-       ``Value for backward direction`` and
-       ``Value for both directions``.
-       Forward and reverse directions correspond to a one-way edge,
-       "both directions" indicates a two-way edge.
-       If a feature does not have a value in this field, or no field
-       is set then the   default direction setting (provided with
-       the ``Default direction`` parameter) is used.
-   * - **Value for forward direction**
-
-       Optional
-     - ``VALUE_FORWARD``
-     - [string]
-
-       Default: '' (empty string)
-     - Value set in the direction field to identify edges with a
-       forward direction
-   * - **Value for backward direction**
-
-       Optional
-     - ``VALUE_BACKWARD``
-     - [string]
-
-       Default: '' (empty string)
-     - Value set in the direction field to identify edges with a
-       backward direction
-   * - **Value for both directions**
-
-       Optional
-     - ``VALUE_BOTH``
-     - [string]
-
-       Default: '' (empty string)
-     - Value set in the direction field to identify
-       bidirectional edges
-   * - **Default direction**
-
-       Optional
-     - ``DEFAULT_DIRECTION``
-     - [enumeration]
-
-       Default: 2
-     - If a feature has no value set in the direction field or
-       if no direction field is set, then this direction value
-       is used. One of:
-
-       * 0 --- Forward direction
-       * 1 --- Backward direction
-       * 2 --- Both directions
-
-   * - **Speed field**
-
-       Optional
-     - ``SPEED_FIELD``
-     - [tablefield: string]
-
-       Default: None
-     - Field providing the speed value (in ``km/h``) for the
-       edges of the network when looking for the fastest path.
-       
-       If a feature does not have a value in this field, or
-       no field is set then the default speed value (provided
-       with the ``Default speed`` parameter) is used.
-   * - **Default speed (km/h)**
-
-       Optional
-     - ``DEFAULT_SPEED``
-     - [number]
-
-       Default: 50
-     - Value to use to calculate the travel time if no speed
-       field is provided for an edge
-   * - **Topology tolerance**
-
-       Optional
-     - ``TOLERANCE``
-     - [number]
-
-       Default: 0
-     - Two lines with nodes closer than the specified
-       tolerance are considered connected
+   * - **Advanced parameters**
+     - GUI only
+     - 
+     - Group of advanced network analysis parameters - se below.
    * - **Shortest path**
      - ``OUTPUT``
      - [vector: line]
@@ -727,6 +375,10 @@ Parameters
        * Save to PostGIS Table
 
        The file encoding can also be changed here.
+
+.. include:: qgis_algs_include.rst
+  :start-after: **network_advanced_parameters**
+  :end-before: **end_network_advanced_parameters**
 
 Outputs
 .......
@@ -808,10 +460,6 @@ Parameters
 .. include:: qgis_algs_include.rst
   :start-after: **network_advanced_parameters**
   :end-before: **end_network_advanced_parameters**
-
-.. note:: The **Include upper/lower bound points** advanced
-   parameter is not available for this algorithm (it is
-   used for the *Service area* algorithms).
 
 Outputs
 .......

--- a/source/docs/user_manual/processing_algs/qgis/qgis_algs_include.rst
+++ b/source/docs/user_manual/processing_algs/qgis/qgis_algs_include.rst
@@ -107,6 +107,116 @@ Advanced parameters
        Default: 0.0
      - Two lines with nodes closer than the specified
        tolerance are considered connected
+
+**end_network_advanced_parameters**
+
+**end_network_advanced_parameters_service_area**
+
+.. The following section is included in network analysis algorithms, ie
+ qgisserviceareafrompoint, qgisserviceareafromlayer, qgisshortestpathlayertopoint,
+ qgisshortestpathpointtolayer and qgisshortestpathpointtopoint
+
+Advanced parameters
+...................
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 20 20 40
+   :stub-columns: 0
+
+   * - Label
+     - Name
+     - Type
+     - Description
+   * - **Direction field**
+
+       Optional
+     - ``DIRECTION_FIELD``
+     - [tablefield: string]
+
+       Default: 0.0
+     - The field used to specify directions for the network edges.
+       
+       The values used in this field are specified with the three
+       parameters ``Value for forward direction``,
+       ``Value for backward direction`` and
+       ``Value for both directions``.
+       Forward and reverse directions correspond to a one-way edge,
+       "both directions" indicates a two-way edge.
+       If a feature does not have a value in this field, or no field
+       is set then the   default direction setting (provided with
+       the ``Default direction`` parameter) is used.
+   * - **Value for forward direction**
+
+       Optional
+     - ``VALUE_FORWARD``
+     - [string]
+
+       Default: '' (empty string)
+     - Value set in the direction field to identify edges with a
+       forward direction
+   * - **Value for backward direction**
+
+       Optional
+     - ``VALUE_BACKWARD``
+     - [string]
+
+       Default: '' (empty string)
+     - Value set in the direction field to identify edges with a
+       backward direction
+   * - **Value for both directions**
+
+       Optional
+     - ``VALUE_BOTH``
+     - [string]
+
+       Default: '' (empty string)
+     - Value set in the direction field to identify
+       bidirectional edges
+   * - **Default direction**
+
+       Optional
+     - ``DEFAULT_DIRECTION``
+     - [enumeration]
+
+       Default: 2
+     - If a feature has no value set in the direction field or
+       if no direction field is set, then this direction value
+       is used. One of:
+
+       * 0 --- Forward direction
+       * 1 --- Backward direction
+       * 2 --- Both directions
+
+   * - **Speed field**
+
+       Optional
+     - ``SPEED_FIELD``
+     - [tablefield: string]
+     - Field providing the speed value (in ``km/h``) for the
+       edges of the network when looking for the fastest path.
+       
+       If a feature does not have a value in this field, or
+       no field is set then the default speed value (provided
+       with the ``Default speed`` parameter) is used.
+   * - **Default speed (km/h)**
+
+       Optional
+     - ``DEFAULT_SPEED``
+     - [number]
+
+       Default: 50.0
+     - Value to use to calculate the travel time if no speed
+       field is provided for an edge
+   * - **Topology tolerance**
+
+       Optional
+     - ``TOLERANCE``
+     - [number]
+
+       Default: 0.0
+     - Two lines with nodes closer than the specified
+       tolerance are considered connected
    * - **Include upper/lower bound points**
      - ``INCLUDE_BOUNDS``
      - [boolean]
@@ -116,7 +226,7 @@ Advanced parameters
        edge at the boundaries of the service area.
        One point is the start of that edge, the other is the end.
 
-**end_network_advanced_parameters**
+**end_network_advanced_parameters_service_area**
 
 **geometric_predicates**
 

--- a/source/docs/user_manual/processing_algs/qgis/qgis_algs_include.rst
+++ b/source/docs/user_manual/processing_algs/qgis/qgis_algs_include.rst
@@ -110,7 +110,7 @@ Advanced parameters
 
 **end_network_advanced_parameters**
 
-**end_network_advanced_parameters_service_area**
+**network_advanced_parameters_service_area**
 
 .. The following section is included in network analysis algorithms, ie
  qgisserviceareafrompoint, qgisserviceareafromlayer, qgisshortestpathlayertopoint,


### PR DESCRIPTION
<!---
Include a few sentences describing the overall goals for this Pull Request.
 
A list of issues is at https://github.com/qgis/QGIS-Documentation/issues.
Add "fix #issuenumber" for each issue the PR fixes. The ticket(s) will be closed automatically.
If your PR doesn't fix entirely the ticket, only add the ticket(s) reference preceded by # character.
-->
Goal: Handle the difference in the advanced parameters for the service area
algorithms and the other QGIS network algorithms. The service area algs have
the additional parameter "Include upper/lower bounds points".

Ticket(s): Discussed in #4604
<!---
Indicate whether the fix should be backported to previous release.
Replace the space between square brackets by a `x` to make it checked.
-->
- [ ] Backport to LTR documentation is required

<!---
Reviewing is a process done by community members, mostly on a volunteer basis.
We try to keep the overhead as small as possible and appreciate if you help us.
Please read carefully and ensure you comply with our writing guidelines at
https://docs.qgis.org/testing/en/docs/documentation_guidelines/index.html.
Feel free to ask in a comment or the (qgis-community-team mailing list)
[https://lists.osgeo.org/mailman/listinfo/qgis-community-team] if you have troubles with any item.
--->
