### PR TITLE
Comment out classes that not available in master pyQGIS API

### DIFF
--- a/source/docs/user_manual/processing/console.rst
+++ b/source/docs/user_manual/processing/console.rst
@@ -451,7 +451,8 @@ input and output. Below is an alphabetically sorted list:
 
 * :class:`QgsProcessingParameterBand <qgis.core.QgsProcessingParameterBand>`
 * :class:`QgsProcessingParameterBoolean <qgis.core.QgsProcessingParameterBoolean>`
-* :class:`QgsProcessingParameterColor <qgis.core.QgsProcessingParameterColor>`
+
+  .. * :class:`QgsProcessingParameterColor <qgis.core.QgsProcessingParameterColor>`
 * :class:`QgsProcessingParameterCrs <qgis.core.QgsProcessingParameterCrs>`
 * :class:`QgsProcessingParameterDistance <qgis.core.QgsProcessingParameterDistance>`
 * :class:`QgsProcessingParameterEnum <qgis.core.QgsProcessingParameterEnum>`

--- a/source/docs/user_manual/processing/scripts.rst
+++ b/source/docs/user_manual/processing/scripts.rst
@@ -422,9 +422,10 @@ Sorted on class name.
    * - :class:`QgsProcessingParameterBoolean <qgis.core.QgsProcessingParameterBoolean>`
      - ``alg.BOOL``
      - A boolean value
-   * - :class:`QgsProcessingParameterColor <qgis.core.QgsProcessingParameterColor>`
-     - ``alg.COLOR``
-     - A color
+     
+       .. * - :class:`QgsProcessingParameterColor <qgis.core.QgsProcessingParameterColor>`
+            - ``alg.COLOR``
+            - A color
    * - :class:`QgsProcessingParameterCrs <qgis.core.QgsProcessingParameterCrs>`
      - ``alg.CRS``
      - A Coordinate Reference System
@@ -516,9 +517,10 @@ Sorted on class name.
    * - Class
      - Alg constant
      - Description
-   * - :class:`QgsProcessingOutputBoolean <qgis.core.QgsProcessingOutputBoolean>`
-     - ``alg.BOOL``
-     - A boolean value
+
+       .. * - :class:`QgsProcessingOutputBoolean <qgis.core.QgsProcessingOutputBoolean>`
+          - ``alg.BOOL``
+          - A boolean value
    * - :class:`QgsProcessingOutputNumber <qgis.core.QgsProcessingOutputNumber>`
      - ``alg.DISTANCE``
      - A double numeric parameter for distance values


### PR DESCRIPTION
For some reason, some processing parameters (QgsProcessingOutputBoolean and QgsProcessingParameterColor) have disappeared from the master branch of PyQGIS doc, leading our build to fail.
We have two alternative: 
1. hide these parameters until the issue is fixed in master branch
2. or set the docs to instead use the 3.10 pyqgis docs (on which this branch will finally rely on and in which the parameters are still present)

Here's option 1