### PR TITLE
Constrain the docs to rely on 3.10 PyQGIS API

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -110,7 +110,7 @@ pygments_style = 'sphinx'
 # If true, keep warnings as "system message" paragraphs in the built documents.
 #keep_warnings = False
 
-intersphinx_mapping = {'pyqgis_api': ('https://qgis.org/pyqgis/{}/'.format(version if version != 'testing' else 'master'), None)}
+intersphinx_mapping = {'pyqgis_api': ('https://qgis.org/pyqgis/{}/'.format(version if version != 'testing' else '3.10'), None)}
 
 # This config value must be a dictionary of external sites, mapping unique short
 # alias names to a base URL and a prefix.


### PR DESCRIPTION
For some reason, some processing parameters (QgsProcessingOutputBoolean and QgsProcessingParameterColor) have disappeared from the master branch of PyQGIS doc, leading our build to fail.
We have two alternative: 
1. hide these parameters until the issue is fixed in master branch
2. or set the docs to instead use the 3.10 pyqgis docs (on which this branch will finally rely on and in which the parameters are still present)

Here's option 2