### PR TITLE
QGIS Vector geometry - tables for alg parameters (part three)

### DIFF
--- a/source/docs/user_manual/processing_algs/qgis/vectorgeometry.rst
+++ b/source/docs/user_manual/processing_algs/qgis/vectorgeometry.rst
@@ -3076,25 +3076,64 @@ will be maintained.
 Parameters
 ..........
 
-``Input layer`` [vector: any]
-  Input vector layer with duplicate vertices.
+.. list-table::
+   :header-rows: 1
+   :widths: 20 20 20 40
+   :stub-columns: 0
 
-``Tolerance`` [number |dataDefined|]
-  Vertices closer than the specified distance are considered duplicates.
+   * - Label
+     - Name
+     - Type
+     - Description
+   * - **Input layer**
+     - ``INPUT``
+     - [vector: any]
+     - Input vector layer
+   * - **Tolerance**
+     - ``TOLERANCE``
+     - [number |dataDefined|]
 
-  Default:*0.000001*
+       Default: 0.000001
+     - Vertices closer than the specified distance are considered
+       duplicates
+   * - **Use Z value**
+     - ``USE_Z_VALUE``
+     - [boolean |dataDefined|]
 
-``Use Z value`` [boolean |dataDefined|]
-  Allows to consider the Z coordinate when detecting duplicate vertices ie two points
-  at the same X,Y coordinate but with different Z value are not set as duplicates.
+       Default: False
+     - Use also the Z coordinate when detecting duplicate vertices
+       (two points that share X and Y coordinates but have different
+       Z values are not considered duplicates).
+   * - **Cleaned**
+     - ``OUTPUT``
+     - [same as input]
 
-  Default: *False*
+       Default: ``[Create temporary layer]``
+     - Specify the output multipart vector layer. One of:
+
+       * Create Temporary Layer (``TEMPORARY_OUTPUT``)
+       * Save to File...
+       * Save to Geopackage...
+       * Save to PostGIS Table
+
+       The file encoding can also be changed here.
 
 Outputs
 .......
 
-``Cleaned`` [vector: any]
-  Vector layer without duplicate vertices.
+.. list-table::
+   :header-rows: 1
+   :widths: 20 20 20 40
+   :stub-columns: 0
+
+   * - Label
+     - Name
+     - Type
+     - Description
+   * - **Cleaned**
+     - ``OUTPUT``
+     - [same as input]
+     - The output vector layer
 
 
 .. _qgisremovenullgeometries:
@@ -3111,17 +3150,70 @@ The features with null geometries can be saved to a separate layer.
 
 Parameters
 ..........
-``Input layer`` [vector: any]
-  Input vector layer with NULL geometries.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 20 20 40
+   :stub-columns: 0
+
+   * - Label
+     - Name
+     - Type
+     - Description
+   * - **Input layer**
+     - ``INPUT``
+     - [vector: any]
+     - Input vector layer
+   * - **Non null geometries**
+     - ``OUTPUT``
+     - [same as input]
+
+       Default: ``[Create temporary layer]``
+     - Specify the output vector layer for the non-NULL geometries.
+       One of:
+
+       * Create Temporary Layer (``TEMPORARY_OUTPUT``)
+       * Save to File...
+       * Save to Geopackage...
+       * Save to PostGIS Table
+
+       The file encoding can also be changed here.
+   * - **Null geometries**
+     - ``NULL_OUTPUT``
+     - [same as input]
+
+       Default: ``[Skip output]``
+     - Specify the output vector layer for the NULL geometries.
+       One of:
+
+       * Skip Output
+       * Create Temporary Layer (``TEMPORARY_OUTPUT``)
+       * Save to File...
+       * Save to Geopackage...
+       * Save to PostGIS Table
+
+       The file encoding can also be changed here.
 
 Outputs
 .......
 
-``Non null geometries`` [vector: any]
-  Vector layer without NULL geometries.
+.. list-table::
+   :header-rows: 1
+   :widths: 20 20 20 40
+   :stub-columns: 0
 
-``Null geometries`` [vector: any]
-  Vector layer with only NULL geometries.
+   * - Label
+     - Name
+     - Type
+     - Description
+   * - **Null geometries**
+     - ``NULL_OUTPUT``
+     - [same as input]
+     - The output vector layer (only NULL geometries)
+   * - **Non null geometries**
+     - ``OUTPUT``
+     - [same as input]
+     - The output vector layer (without NULL geometries)
 
 
 .. _qgisreverselinedirection:
@@ -3140,14 +3232,50 @@ Inverts the direction of a line layer.
 Parameters
 ..........
 
-``Input layer`` [vector: line]
-  Input line vector layer to invert the direction.
+.. list-table::
+   :header-rows: 1
+   :widths: 20 20 20 40
+   :stub-columns: 0
+
+   * - Label
+     - Name
+     - Type
+     - Description
+   * - **Input layer**
+     - ``INPUT``
+     - [vector: line]
+     - Input line vector layer
+   * - **Reversed**
+     - ``OUTPUT``
+     - [vector: line]
+     
+       Default: ``[Create temporary layer]``
+     - Specify the output line vector layer.
+       One of:
+
+       * Create Temporary Layer (``TEMPORARY_OUTPUT``)
+       * Save to File...
+       * Save to Geopackage...
+       * Save to PostGIS Table
+
+       The file encoding can also be changed here.
 
 Outputs
 .......
 
-``Reversed`` [vector: line]
-  Inverted line vector layer.
+.. list-table::
+   :header-rows: 1
+   :widths: 20 20 20 40
+   :stub-columns: 0
+
+   * - Label
+     - Name
+     - Type
+     - Description
+   * - **Reversed**
+     - ``OUTPUT``
+     - [vector: line]
+     - The output line vector layer (with reversed lines)
 
 
 .. _qgisrotatefeatures:
@@ -3165,25 +3293,67 @@ around a unique preset point.
 Parameters
 ..........
 
-``Input layer`` [vector: any]
-  Vector layer in input.
+.. list-table::
+   :header-rows: 1
+   :widths: 20 20 20 40
+   :stub-columns: 0
 
-``Rotation (degrees clockwise)`` [number |dataDefined|]
-  Angle of the rotation in degrees.
+   * - Label
+     - Name
+     - Type
+     - Description
+   * - **Input layer**
+     - ``INPUT``
+     - [vector: line]
+     - Input line vector layer
+   * - **Rotation (degrees clockwise)**
+     - ``ANGLE``
+     - [number |dataDefined|]
 
-  Default: *0.0*
+       Default: 0.0
+     - Angle of the rotation in degrees
+   * - **Rotation anchor point (x, y)**
 
-``Rotation anchor point (x, y)`` [point]
-  Optional
+       Optional
+     - ``ANCHOR``
+     - [point]
 
-  X,Y coordinates of the point to rotate the features around.
-  If not set the rotation occurs around each feature's centroid.
+       Default: 0.0
+     - X,Y coordinates of the point to rotate the
+       features around.
+       If not set the rotation occurs around each
+       feature's centroid.
+   * - **Rotated**
+     - ``OUTPUT``
+     - [same as input]
+     
+       Default: ``[Create temporary layer]``
+     - Specify the output line vector layer.
+       One of:
+
+       * Create Temporary Layer (``TEMPORARY_OUTPUT``)
+       * Save to File...
+       * Save to Geopackage...
+       * Save to PostGIS Table
+
+       The file encoding can also be changed here.
 
 Outputs
 .......
 
-``Rotated`` [vector: any]
-  Vector layer with rotated geometries.
+.. list-table::
+   :header-rows: 1
+   :widths: 20 20 20 40
+   :stub-columns: 0
+
+   * - Label
+     - Name
+     - Type
+     - Description
+   * - **Rotated**
+     - ``OUTPUT``
+     - [same as input]
+     - The output vector layer with rotated geometries
 
 
 .. _qgissegmentizebymaxangle:
@@ -3204,19 +3374,57 @@ Non-curved geometries will be retained without change.
 Parameters
 ..........
 
-``Input layer`` [vector: line, polygon]
-  Vector layer in input.
+.. list-table::
+   :header-rows: 1
+   :widths: 20 20 20 40
+   :stub-columns: 0
 
-``Maximum angle between vertices (degrees)`` [number |dataDefined|]
-  Maximum allowed radius angle between vertices on the straightened geometry.
+   * - Label
+     - Name
+     - Type
+     - Description
+   * - **Input layer**
+     - ``INPUT``
+     - [vector: line, polygon]
+     - Input line vector layer
+   * - **Maximum angle between vertices (degrees)**
+     - ``ANGLE``
+     - [number |dataDefined|]
 
-  Default: *5.0*
+       Default: 5.0
+     - Maximum allowed radius angle between vertices
+       on the straightened geometry
+   * - **Segmentized**
+     - ``OUTPUT``
+     - [same as input]
+     
+       Default: ``[Create temporary layer]``
+     - Specify the output line vector layer.
+       One of:
+
+       * Create Temporary Layer (``TEMPORARY_OUTPUT``)
+       * Save to File...
+       * Save to Geopackage...
+       * Save to PostGIS Table
+
+       The file encoding can also be changed here.
 
 Outputs
 .......
 
-``Segmentized`` [vector: line, polygon]
-  Vector layer with segmentized geometries.
+.. list-table::
+   :header-rows: 1
+   :widths: 20 20 20 40
+   :stub-columns: 0
+
+   * - Label
+     - Name
+     - Type
+     - Description
+   * - **Segmentized**
+     - ``OUTPUT``
+     - [same as input]
+     - The output vector layer with segmentized geometries
 
 
 .. _qgissegmentizebymaxdistance:
@@ -3234,20 +3442,58 @@ Non-curved geometries will be retained without change.
 Parameters
 ..........
 
-``Input layer`` [vector: line, polygon]
-  Vector layer in input.
+.. list-table::
+   :header-rows: 1
+   :widths: 20 20 20 40
+   :stub-columns: 0
 
-``Maximum offset distance`` [number |dataDefined|]
-  Maximum allowed offset distance between the original curve and the segmentized
-  representation, in the layer units.
+   * - Label
+     - Name
+     - Type
+     - Description
+   * - **Input layer**
+     - ``INPUT``
+     - [vector: line, polygon]
+     - Input line vector layer
+   * - **Maximum offset distance**
+     - ``DISTANCE``
+     - [number |dataDefined|]
 
-  Default: *1.0*
+       Default: 1.0
+     - Maximum allowed offset distance between the
+       original curve and the segmentized representation,
+       in the layer units.
+   * - **Segmentized**
+     - ``OUTPUT``
+     - [same as input]
+     
+       Default: ``[Create temporary layer]``
+     - Specify the output line vector layer.
+       One of:
+
+       * Create Temporary Layer (``TEMPORARY_OUTPUT``)
+       * Save to File...
+       * Save to Geopackage...
+       * Save to PostGIS Table
+
+       The file encoding can also be changed here.
 
 Outputs
 .......
 
-``Segmentized`` [vector: line, polygon]
-  Vector layer with segmentized geometries.
+.. list-table::
+   :header-rows: 1
+   :widths: 20 20 20 40
+   :stub-columns: 0
+
+   * - Label
+     - Name
+     - Type
+     - Description
+   * - **Segmentized**
+     - ``OUTPUT``
+     - [same as input]
+     - The output vector layer with segmentized geometries
 
 
 .. _qgissetmvalue:
@@ -3268,19 +3514,56 @@ specified value used as the initial M value for all geometries.
 Parameters
 ..........
 
-``Input layer`` [vector: any]
-  Input vector layer.
+.. list-table::
+   :header-rows: 1
+   :widths: 20 20 20 40
+   :stub-columns: 0
 
-``M Value`` [number |dataDefined|]
-  New M value to assign to the features.
+   * - Label
+     - Name
+     - Type
+     - Description
+   * - **Input layer**
+     - ``INPUT``
+     - [vector: any]
+     - Input vector layer
+   * - **M Value**
+     - ``M_VALUE``
+     - [number |dataDefined|]
 
-  Default: *0.0*
+       Default: 0.0
+     - M value to assign to the feature geometries
+   * - **M Added**
+     - ``OUTPUT``
+     - [same as input]
+     
+       Default: ``[Create temporary layer]``
+     - Specify the output line vector layer.
+       One of:
+
+       * Create Temporary Layer (``TEMPORARY_OUTPUT``)
+       * Save to File...
+       * Save to Geopackage...
+       * Save to PostGIS Table
+
+       The file encoding can also be changed here.
 
 Outputs
 .......
 
-``M Added`` [vector: any]
-  Vector layer in output with M value.
+.. list-table::
+   :header-rows: 1
+   :widths: 20 20 20 40
+   :stub-columns: 0
+
+   * - Label
+     - Name
+     - Type
+     - Description
+   * - **M Added**
+     - ``OUTPUT``
+     - [same as input]
+     - The output vector layer
 
 
 .. _qgissetmfromraster:
@@ -3299,30 +3582,76 @@ If no M values exist, the geometry will be upgraded to include M values.
 
 Parameters
 ..........
-``Input layer`` [vector: any]
-  Input vector layer to set the M values to.
 
-``Raster layer`` [raster]
-  Raster layer to take the M values from.
+.. list-table::
+   :header-rows: 1
+   :widths: 20 20 20 40
+   :stub-columns: 0
 
-``Band number`` [raster band]
-  The raster band to take the M values from if the raster is multiband.
+   * - Label
+     - Name
+     - Type
+     - Description
+   * - **Input layer**
+     - ``INPUT``
+     - [vector: any]
+     - Input vector layer
+   * - **Raster layer**
+     - ``RASTER``
+     - [raster]
 
-``Value for nodata or non-intersecting vertices`` [number |dataDefined|]
-  Value to use in case the vertex does not intersect (a valid pixel of) the raster.
+       Default: []
+     - Raster layer with M values
+   * - **Band number**
+     - ``BAND``
+     - [raster band]
 
-  Default: *0.0*
+       Default: 1
+     - The raster band with the M values
+   * - **Value for nodata or non-intersecting vertices**
+     - ``NODATA``
+     - [number |dataDefined|]
+       Default: 0.0
+     - Value to use in case the vertex does not intersect
+       (a valid pixel of) the raster
+   * - **Scale factor**
+     - ``SCALE``
+     - [number |dataDefined|]
 
-``Scale factor`` [number |dataDefined|]
-  Scaling value: the band values are multiplied by this value.
+       Default: 1.0
+     - Scaling value: the band values are multiplied
+       by this value.
+   * - **Updated**
+     - ``OUTPUT``
+     - [same as input]
+     
+       Default: ``[Create temporary layer]``
+     - Specify the output line vector layer.
+       One of:
 
-  Default: *1.0*
+       * Create Temporary Layer (``TEMPORARY_OUTPUT``)
+       * Save to File...
+       * Save to Geopackage...
+       * Save to PostGIS Table
+
+       The file encoding can also be changed here.
 
 Outputs
 .......
 
-``Updated`` [vector: any]
-  A vector layer with M values extracted from the provided raster layer.
+.. list-table::
+   :header-rows: 1
+   :widths: 20 20 20 40
+   :stub-columns: 0
+
+   * - Label
+     - Name
+     - Type
+     - Description
+   * - **Updated**
+     - ``OUTPUT``
+     - [same as input]
+     - The output vector layer
 
 
 .. _qgissetzvalue:
@@ -3343,19 +3672,56 @@ specified value used as the initial Z value for all geometries.
 Parameters
 ..........
 
-``Input layer`` [vector: any]
-  Input vector layer.
+.. list-table::
+   :header-rows: 1
+   :widths: 20 20 20 40
+   :stub-columns: 0
 
-``Z Value`` [number |dataDefined|]
-  New Z value to assign to the features.
+   * - Label
+     - Name
+     - Type
+     - Description
+   * - **Input layer**
+     - ``INPUT``
+     - [vector: any]
+     - Input vector layer
+   * - **Z Value**
+     - ``Z_VALUE``
+     - [number |dataDefined|]
 
-  Default: *0.0*
+       Default: 0.0
+     - Z value to assign to the feature geometries
+   * - **Z Added**
+     - ``OUTPUT``
+     - [same as input]
+     
+       Default: ``[Create temporary layer]``
+     - Specify the output line vector layer.
+       One of:
+
+       * Create Temporary Layer (``TEMPORARY_OUTPUT``)
+       * Save to File...
+       * Save to Geopackage...
+       * Save to PostGIS Table
+
+       The file encoding can also be changed here.
 
 Outputs
 .......
 
-``Z Added`` [vector: any]
-  Vector layer in output with Z value.
+.. list-table::
+   :header-rows: 1
+   :widths: 20 20 20 40
+   :stub-columns: 0
+
+   * - Label
+     - Name
+     - Type
+     - Description
+   * - **Z Added**
+     - ``OUTPUT``
+     - [same as input]
+     - The output vector layer
 
 
 .. _qgissimplifygeometries:
@@ -3385,31 +3751,72 @@ snapping geometries to grid.
 Parameters
 ..........
 
-``Input layer`` [vector: line, polygon]
-  Polygon or line vector to simplify.
 
-``Simplification method`` [enumeration]
-  Method of the simplification.
 
-  Options:
+.. list-table::
+   :header-rows: 1
+   :widths: 20 20 20 40
+   :stub-columns: 0
 
-  * 0 --- Distance (Douglas-Peucker)
-  * 1 --- Snap to grid
-  * 2 --- Area (Visvalingam)
+   * - Label
+     - Name
+     - Type
+     - Description
+   * - **Input layer**
+     - ``INPUT``
+     - [vector: line, polygon]
+     - Input line or polygon vector layer
+   * - **Simplification method**
+     - ``METHOD``
+     - [enumeration]
 
-  Default: *0*
+       Default: 0
+     - Simplification method. One of:
 
-``Tolerance`` [number |dataDefined|]
-  Threshold tolerance (in units of the layer): if the distance between two nodes is smaller than the
-  tolerance value, the segment will be simplified and vertices will be removed.
+       * 0 --- Distance (Douglas-Peucker)
+       * 1 --- Snap to grid
+       * 2 --- Area (Visvalingam)
 
-  Default: *1.0*
+   * - **Tolerance**
+     - ``TOLERANCE``
+     - [number |dataDefined|]
+
+       Default: 1.0
+     - Threshold tolerance (in units of the layer):
+       if the distance between two nodes is smaller than
+       the tolerance value, the segment will be simplified
+       and vertices will be removed.
+   * - **Simplified**
+     - ``OUTPUT``
+     - [same as input]
+     
+       Default: ``[Create temporary layer]``
+     - Specify the output line vector layer.
+       One of:
+
+       * Create Temporary Layer (``TEMPORARY_OUTPUT``)
+       * Save to File...
+       * Save to Geopackage...
+       * Save to PostGIS Table
+
+       The file encoding can also be changed here.
 
 Outputs
 .......
 
-``Simplified`` [vector: line, polygon]
-  Simplified vector layers in output.
+.. list-table::
+   :header-rows: 1
+   :widths: 20 20 20 40
+   :stub-columns: 0
+
+   * - Label
+     - Name
+     - Type
+     - Description
+   * - **Simplified**
+     - ``OUTPUT``
+     - [same as input]
+     - The output (simplified) vector layer
 
 
 .. _qgissinglesidedbuffer:

--- a/source/docs/user_manual/processing_algs/qgis/vectorgeometry.rst
+++ b/source/docs/user_manual/processing_algs/qgis/vectorgeometry.rst
@@ -2889,7 +2889,7 @@ Parameters
 
        * 0 --- Rectangles
        * 1 --- Ovals
-       * 2 --- DiamondsInput vector layer
+       * 2 --- Diamonds
 
    * - **Width**
      - ``WIDTH``
@@ -2922,7 +2922,7 @@ Parameters
      - [vector: polygon]
 
        Default: ``[Create temporary layer]``
-     - Specify the output multipart vector layer. One of:
+     - Specify the output vector layer. One of:
 
        * Create Temporary Layer (``TEMPORARY_OUTPUT``)
        * Save to File...
@@ -2991,7 +2991,7 @@ Parameters
 
        * 0 --- Rectangles
        * 1 --- Ovals
-       * 2 --- DiamondsInput vector layer
+       * 2 --- Diamonds
 
    * - **Width field**
      - ``WIDTH``
@@ -3022,7 +3022,7 @@ Parameters
      - [vector: polygon]
 
        Default: ``[Create temporary layer]``
-     - Specify the output multipart vector layer. One of:
+     - Specify the output vector layer. One of:
 
        * Create Temporary Layer (``TEMPORARY_OUTPUT``)
        * Save to File...
@@ -3063,7 +3063,7 @@ By default, Z values are not considered when detecting duplicate
 vertices.
 E.g. two vertices with the same X and Y coordinate but different Z
 values will still be considered duplicate and one will be removed.
-If the Use Z Value parameter is true, then the Z values are also
+If the :guilabel;`Use Z Value` parameter is true, then the Z values are also
 tested and vertices with the same X and Y but different Z will be
 maintained.
 
@@ -3113,7 +3113,7 @@ Parameters
      - [same as input]
 
        Default: ``[Create temporary layer]``
-     - Specify the output multipart vector layer. One of:
+     - Specify the output vector layer. One of:
 
        * Create Temporary Layer (``TEMPORARY_OUTPUT``)
        * Save to File...
@@ -3137,7 +3137,7 @@ Outputs
    * - **Cleaned**
      - ``OUTPUT``
      - [same as input]
-     - The output vector layer
+     - The output vector layer (without duplicate vertices)
 
 
 .. _qgisremovenullgeometries:
@@ -3167,7 +3167,7 @@ Parameters
    * - **Input layer**
      - ``INPUT``
      - [vector: any]
-     - Input vector layer
+     - Input vector layer (with non-NULL geometries)
    * - **Non null geometries**
      - ``OUTPUT``
      - [same as input]
@@ -3309,8 +3309,8 @@ Parameters
      - Description
    * - **Input layer**
      - ``INPUT``
-     - [vector: line]
-     - Input line vector layer
+     - [vector: any]
+     - Input vector layer
    * - **Rotation (degrees clockwise)**
      - ``ANGLE``
      - [number |dataDefined|]
@@ -3323,7 +3323,7 @@ Parameters
      - ``ANCHOR``
      - [point]
 
-       Default: 0.0
+       Default: None
      - X,Y coordinates of the point to rotate the
        features around.
        If not set the rotation occurs around each
@@ -3333,7 +3333,7 @@ Parameters
      - [same as input]
      
        Default: ``[Create temporary layer]``
-     - Specify the output line vector layer.
+     - Specify the output vector layer (with rotated geometries).
        One of:
 
        * Create Temporary Layer (``TEMPORARY_OUTPUT``)
@@ -3392,7 +3392,7 @@ Parameters
    * - **Input layer**
      - ``INPUT``
      - [vector: line, polygon]
-     - Input line vector layer
+     - Input line or polygon vector layer
    * - **Maximum angle between vertices (degrees)**
      - ``ANGLE``
      - [number |dataDefined|]
@@ -3405,7 +3405,7 @@ Parameters
      - [same as input]
      
        Default: ``[Create temporary layer]``
-     - Specify the output line vector layer.
+     - Specify the output vector layer (with segmentized geometries).
        One of:
 
        * Create Temporary Layer (``TEMPORARY_OUTPUT``)
@@ -3477,7 +3477,7 @@ Parameters
      - [same as input]
      
        Default: ``[Create temporary layer]``
-     - Specify the output line vector layer.
+     - Specify the output vector layer (with segmentized geometries).
        One of:
 
        * Create Temporary Layer (``TEMPORARY_OUTPUT``)
@@ -3547,7 +3547,7 @@ Parameters
      - [same as input]
      
        Default: ``[Create temporary layer]``
-     - Specify the output line vector layer.
+     - Specify the output vector layer.
        One of:
 
        * Create Temporary Layer (``TEMPORARY_OUTPUT``)
@@ -3572,7 +3572,7 @@ Outputs
    * - **M Added**
      - ``OUTPUT``
      - [same as input]
-     - The output vector layer
+     - The output vector layer (with M values assigned to the geometries)
 
 
 .. _qgissetmfromraster:
@@ -3616,7 +3616,7 @@ Parameters
      - [raster band]
 
        Default: 1
-     - The raster band with the M values
+     - The raster band from which the M values are taken
    * - **Value for nodata or non-intersecting vertices**
      - ``NODATA``
      - [number |dataDefined|]
@@ -3635,7 +3635,7 @@ Parameters
      - [same as input]
      
        Default: ``[Create temporary layer]``
-     - Specify the output line vector layer.
+     - Specify the output vector layer (with updated M values).
        One of:
 
        * Create Temporary Layer (``TEMPORARY_OUTPUT``)
@@ -3660,7 +3660,7 @@ Outputs
    * - **Updated**
      - ``OUTPUT``
      - [same as input]
-     - The output vector layer
+     - The output vector layer (with updated M values)
 
 
 .. _qgissetzvalue:
@@ -3705,7 +3705,7 @@ Parameters
      - [same as input]
      
        Default: ``[Create temporary layer]``
-     - Specify the output line vector layer.
+     - Specify the output vector layer.
        One of:
 
        * Create Temporary Layer (``TEMPORARY_OUTPUT``)
@@ -3730,7 +3730,7 @@ Outputs
    * - **Z Added**
      - ``OUTPUT``
      - [same as input]
-     - The output vector layer
+     - The output vector layer (with Z values assigned)
 
 
 .. _qgissimplifygeometries:
@@ -3798,7 +3798,7 @@ Parameters
      - [same as input]
      
        Default: ``[Create temporary layer]``
-     - Specify the output line vector layer.
+     - Specify the output (simplified) vector layer.
        One of:
 
        * Create Temporary Layer (``TEMPORARY_OUTPUT``)

--- a/source/docs/user_manual/processing_algs/qgis/vectorgeometry.rst
+++ b/source/docs/user_manual/processing_algs/qgis/vectorgeometry.rst
@@ -2854,8 +2854,8 @@ Outputs
 
 Rectangles, ovals, diamonds (fixed)
 -----------------------------------
-Creates a buffer area for all the features in an input layer with different shape
-choice.
+Creates a buffer area for all the features in an input layer with
+different shape choice.
 
 Parameters can vary depending on the shape chosen.
 
@@ -2953,10 +2953,11 @@ Outputs
 
 Rectangles, ovals, diamonds (variable)
 --------------------------------------
-Creates a buffer area for all the features in an input layer with different shape
-choice.
+Creates a buffer area for all the features in an input layer with
+different shape choice.
 
-Buffer shape parameters are specified through attribute of the input layer.
+Buffer shape parameters are specified through attribute of the input
+layer.
 
 .. figure:: img/rectangles_ovals_diamond_variable.png
    :align: center
@@ -3052,26 +3053,29 @@ Outputs
 
 Remove duplicate vertices
 -------------------------
-Removes duplicate vertices from features, wherever removing the vertices does not
-result in a degenerate geometry.
+Removes duplicate vertices from features, wherever removing the
+vertices does not result in a degenerate geometry.
 
-The tolerance parameter specifies the tolerance for coordinates when determining
-whether vertices are identical.
+The tolerance parameter specifies the tolerance for coordinates when
+determining whether vertices are identical.
 
-By default, Z values are not considered when detecting duplicate vertices.
-E.g. two vertices with the same X and Y coordinate but different Z values will still
-be considered duplicate and one will be removed. If the Use Z Value parameter is true,
-then the Z values are also tested and vertices with the same X and Y but different Z
-will be maintained.
+By default, Z values are not considered when detecting duplicate
+vertices.
+E.g. two vertices with the same X and Y coordinate but different Z
+values will still be considered duplicate and one will be removed.
+If the Use Z Value parameter is true, then the Z values are also
+tested and vertices with the same X and Y but different Z will be
+maintained.
 
-.. note:: Duplicate vertices are not tested between different parts of a multipart
-  geometry, e.g. a multipoint geometry with overlapping points will not be changed by
-  this method.
+.. note:: Duplicate vertices are not tested between different parts of
+   a multipart geometry, e.g. a multipoint geometry with overlapping
+   points will not be changed by this method.
 
 |checkbox| Allows :ref:`features in-place modification <processing_inplace_edit>`
 
-.. seealso:: :ref:`qgisextractvertices`, :ref:`qgisextractspecificvertices`,
- :ref:`qgisdeleteduplicategeometries`
+.. seealso:: :ref:`qgisextractvertices`,
+   :ref:`qgisextractspecificvertices`,
+   :ref:`qgisdeleteduplicategeometries`
 
 Parameters
 ..........
@@ -3286,7 +3290,8 @@ Rotates feature geometries by the specified angle clockwise.
 The rotation occurs around each feature's centroid, or optionally
 around a unique preset point.
 
-|checkbox| Allows :ref:`features in-place modification <processing_inplace_edit>`
+|checkbox| Allows
+:ref:`features in-place modification <processing_inplace_edit>`
 
 .. seealso:: :ref:`qgistranslategeometry`, :ref:`qgisswapxy`
 
@@ -3360,16 +3365,17 @@ Outputs
 
 Segmentize by maximum angle
 ---------------------------
-Segmentizes a geometry by converting curved sections to linear sections.
+Segmentizes a geometry by converting curved sections to linear
+sections.
 
-The segmentization is performed by specifying the maximum allowed radius angle
-between vertices on the straightened geometry (e.g the angle of the arc created
-from the original arc center to consecutive output vertices on the linearized
-geometry).
+The segmentization is performed by specifying the maximum allowed
+radius angle between vertices on the straightened geometry (e.g the
+angle of the arc created from the original arc center to consecutive
+output vertices on the linearized geometry).
 Non-curved geometries will be retained without change.
 
-.. seealso:: :ref:`qgissegmentizebymaxdistance`, :ref:`qgissimplifygeometries`,
- :ref:`qgissmoothgeometry`
+.. seealso:: :ref:`qgissegmentizebymaxdistance`,
+   :ref:`qgissimplifygeometries`, :ref:`qgissmoothgeometry`
 
 Parameters
 ..........
@@ -3431,13 +3437,16 @@ Outputs
 
 Segmentize by maximum distance
 ------------------------------
-Segmentizes a geometry by converting curved sections to linear sections.
+Segmentizes a geometry by converting curved sections to linear
+sections.
 
-The segmentization is performed by specifying the maximum allowed offset
-distance between the original curve and the segmentized representation.
+The segmentization is performed by specifying the maximum allowed
+offset distance between the original curve and the segmentized
+representation.
 Non-curved geometries will be retained without change.
 
-.. seealso:: :ref:`qgissegmentizebymaxangle`, :ref:`qgissimplifygeometries`, :ref:`qgissmoothgeometry`
+.. seealso:: :ref:`qgissegmentizebymaxangle`,
+   :ref:`qgissimplifygeometries`, :ref:`qgissmoothgeometry`
 
 Parameters
 ..........
@@ -3750,8 +3759,6 @@ snapping geometries to grid.
 
 Parameters
 ..........
-
-
 
 .. list-table::
    :header-rows: 1

--- a/source/docs/user_manual/processing_algs/qgis/vectorgeometry.rst
+++ b/source/docs/user_manual/processing_algs/qgis/vectorgeometry.rst
@@ -2869,45 +2869,84 @@ Parameters can vary depending on the shape chosen.
 Parameters
 ..........
 
-``Input layer`` [vector: point]
-  Input point vector layer.
+.. list-table::
+   :header-rows: 1
+   :widths: 20 20 20 40
+   :stub-columns: 0
 
-``Buffer shape`` [enumeration]
-  Different shapes available:
+   * - Label
+     - Name
+     - Type
+     - Description
+   * - **Input layer**
+     - ``INPUT``
+     - [vector: point]
+     - Input point vector layer
+   * - **Buffer shape**
+     - ``SHAPE``
+     - [enumeration]
+     - The shape to use. One of:
 
-  * 0 --- Rectangles
-  * 1 --- Ovals
-  * 2 --- Diamonds
+       * 0 --- Rectangles
+       * 1 --- Ovals
+       * 2 --- DiamondsInput vector layer
 
-  Default: *0*
+   * - **Width**
+     - ``WIDTH``
+     - [number]
 
-``Width`` [number]
-  Width of the buffer shape.
+       Default: 1.0
+     - Width of the buffer shape
+   * - **Height**
+     - ``HEIGHT``
+     - [number]
 
-  Default: *1.0*
+       Default: 1.0
+     - Height of the buffer shape
+   * - **Rotation**
 
-``Height`` [number]
-  Height of the buffer shape.
+       Optional
+     - ``ROTATION``
+     - [number]
 
-  Default: *1.0*
+       Default: None
+     - Rotation of the buffer shape
+   * - **Number of segment**
+     - ``SEGMENTS``
+     - [number]
 
-``Rotation`` [number]
-  Optional
+       Default: 36
+     - Number of segments for a full circle (*Ovals* shape)
+   * - **Output**
+     - ``OUTPUT``
+     - [vector: polygon]
 
-  Rotation of the buffer shape.
+       Default: ``[Create temporary layer]``
+     - Specify the output multipart vector layer. One of:
 
-  Default: *0.0*
+       * Create Temporary Layer (``TEMPORARY_OUTPUT``)
+       * Save to File...
+       * Save to Geopackage...
+       * Save to PostGIS Table
 
-``Number of segment`` [number]
-  How many segment should have the buffer shape.
-
-  Default: *36*
+       The file encoding can also be changed here.
 
 Outputs
 .......
 
-``Output`` [vector: polygon]
-  Buffer shape in output.
+.. list-table::
+   :header-rows: 1
+   :widths: 20 20 20 40
+   :stub-columns: 0
+
+   * - Label
+     - Name
+     - Type
+     - Description
+   * - **Output**
+     - ``OUTPUT``
+     - [vector: polygon]
+     - The output vector layer
 
 
 .. _qgisrectanglesovalsdiamondsvariable:
@@ -2929,45 +2968,84 @@ Buffer shape parameters are specified through attribute of the input layer.
 Parameters
 ..........
 
-``Input layer`` [vector: point]
-  Input point vector layer.
+.. list-table::
+   :header-rows: 1
+   :widths: 20 20 20 40
+   :stub-columns: 0
 
-``Buffer shape`` [enumeration]
-  Different shape available:
+   * - Label
+     - Name
+     - Type
+     - Description
+   * - **Input layer**
+     - ``INPUT``
+     - [vector: point]
+     - Input point vector layer
+   * - **Buffer shape**
+     - ``SHAPE``
+     - [enumeration]
 
-  * 0 --- Rectangles
-  * 1 --- Ovals
-  * 2 --- Diamonds
+       Default: 0
+     - The shape to use. One of:
 
-  Default: *0*
+       * 0 --- Rectangles
+       * 1 --- Ovals
+       * 2 --- DiamondsInput vector layer
 
-``Width`` [tablefield: numeric]
-  Width of the buffer shape.
+   * - **Width field**
+     - ``WIDTH``
+     - [tablefield: numeric]
 
-  Default: *1.0*
+       Default: First
+     - Width of the buffer shape
+   * - **Height field**
+     - ``HEIGHT``
+     - [tablefield: numeric]
 
-``Height`` [tablefield: numeric]
-  Height of the buffer shape.
+       Default: First
+     - Height of the buffer shape
+   * - **Rotation field**
 
-  Default: *1.0*
+       Optional
+     - ``ROTATION``
+     - [tablefield: numeric]
+     - Rotation of the buffer shape
+   * - **Number of segment**
+     - ``SEGMENTS``
+     - [number]
 
-``Rotation`` [tablefield: numeric]
-  Optional
+       Default: 36
+     - Number of segments for a full circle (*Ovals* shape)
+   * - **Output**
+     - ``OUTPUT``
+     - [vector: polygon]
 
-  Rotation of the buffer shape.
+       Default: ``[Create temporary layer]``
+     - Specify the output multipart vector layer. One of:
 
-  Default: *0.0*
+       * Create Temporary Layer (``TEMPORARY_OUTPUT``)
+       * Save to File...
+       * Save to Geopackage...
+       * Save to PostGIS Table
 
-``Number of segment`` [number]
-  How many segment should have the buffer shape.
-
-  Default: *36*
+       The file encoding can also be changed here.
 
 Outputs
 .......
 
-``Output`` [vector: polygon]
-  Buffer shape in output.
+.. list-table::
+   :header-rows: 1
+   :widths: 20 20 20 40
+   :stub-columns: 0
+
+   * - Label
+     - Name
+     - Type
+     - Description
+   * - **Output**
+     - ``OUTPUT``
+     - [vector: polygon]
+     - The output vector layer
 
 
 .. _qgisremoveduplicatevertices:

--- a/source/docs/user_manual/processing_algs/qgis/vectorgeometry.rst
+++ b/source/docs/user_manual/processing_algs/qgis/vectorgeometry.rst
@@ -2946,7 +2946,7 @@ Outputs
    * - **Output**
      - ``OUTPUT``
      - [vector: polygon]
-     - The output vector layer
+     - The output vector layer (with the buffer shapes)
 
 
 .. _qgisrectanglesovalsdiamondsvariable:
@@ -3046,7 +3046,7 @@ Outputs
    * - **Output**
      - ``OUTPUT``
      - [vector: polygon]
-     - The output vector layer
+     - The output vector layer (with the buffer shapes)
 
 
 .. _qgisremoveduplicatevertices:
@@ -3105,9 +3105,9 @@ Parameters
      - [boolean |dataDefined|]
 
        Default: False
-     - Use also the Z coordinate when detecting duplicate vertices
-       (two points that share X and Y coordinates but have different
-       Z values are not considered duplicates).
+     - If the :guilabel;`Use Z Value` parameter is true, then the Z values are also
+       tested and vertices with the same X and Y but different Z will be
+       maintained.
    * - **Cleaned**
      - ``OUTPUT``
      - [same as input]
@@ -3463,7 +3463,7 @@ Parameters
    * - **Input layer**
      - ``INPUT``
      - [vector: line, polygon]
-     - Input line vector layer
+     - Input line or polygon vector layer
    * - **Maximum offset distance**
      - ``DISTANCE``
      - [number |dataDefined|]
@@ -3608,8 +3608,6 @@ Parameters
    * - **Raster layer**
      - ``RASTER``
      - [raster]
-
-       Default: []
      - Raster layer with M values
    * - **Band number**
      - ``BAND``


### PR DESCRIPTION
<!---
Include a few sentences describing the overall goals for this Pull Request.
 
A list of issues is at https://github.com/qgis/QGIS-Documentation/issues.
Add "fix #issuenumber" for each issue the PR fixes. The ticket(s) will be closed automatically.
If your PR doesn't fix entirely the ticket, only add the ticket(s) reference preceded by # character.
-->
Goal: Use tables for algorithm parameters.
The QGIS Vector geometry algorithms from "Rectangles, Ovals, Diamonds (Fixed)" until (and including) "Simplify".

Ticket(s): #4429.   Following up #4629.
<!---
Indicate whether the fix should be backported to previous release.
Replace the space between square brackets by a `x` to make it checked.
-->
- [x] Backport to LTR documentation is required

<!---
Reviewing is a process done by community members, mostly on a volunteer basis.
We try to keep the overhead as small as possible and appreciate if you help us.
Please read carefully and ensure you comply with our writing guidelines at
https://docs.qgis.org/testing/en/docs/documentation_guidelines/index.html.
Feel free to ask in a comment or the (qgis-community-team mailing list)
[https://lists.osgeo.org/mailman/listinfo/qgis-community-team] if you have troubles with any item.
--->
