### PR TITLE
Training Manual 7.4.6: Fix radio button substitution

### DIFF
--- a/source/docs/training_manual/vector_analysis/spatial_statistics.rst
+++ b/source/docs/training_manual/vector_analysis/spatial_statistics.rst
@@ -271,7 +271,7 @@ of them, compared to the abundance of pixels with values below the mean. That's
 also why the histogram extends so far to the right, even though there is no
 visible red line marking the frequency of values higher than about ``250``.
 
-.. note:: If the mean and maxmimum values are not the same as those of the example,
+.. note:: If the mean and maximum values are not the same as those of the example,
     it can be due to the min/max value calculation. Open the :guilabel:`Symbology`
     tab and expand the :guilabel:`Min / Max Value Settings` menu. Choose
     |radioButtonOn|:guilabel:`Min / max` and click on :guilabel:`Apply`.

--- a/source/docs/training_manual/vector_analysis/spatial_statistics.rst
+++ b/source/docs/training_manual/vector_analysis/spatial_statistics.rst
@@ -274,7 +274,7 @@ visible red line marking the frequency of values higher than about ``250``.
 .. note:: If the mean and maxmimum values are not the same as those of the example,
     it can be due to the min/max value calculation. Open the :guilabel:`Symbology`
     tab and expand the :guilabel:`Min / Max Value Settings` menu. Choose
-    ``|radioButtonOn| Min / max`` and click on :guilabel:`Apply`.
+    |radioButtonOn|:guilabel:`Min / max` and click on :guilabel:`Apply`.
 
 Therefore, keep in mind that a histogram shows you the distribution of values,
 and not all values are necessarily visible on the graph.


### PR DESCRIPTION
Goal: Radio button substitution was contained in a code block, preventing the substitution from occurring.
Also changed the code block to a `guilabel` block.

It doesn't look right because there's a 15px right margin applied to `<img>` tags within notes (`.admonition` class), but that's a separate issue.

<!---
Include a few sentences describing the overall goals for this Pull Request.
 
A list of issues is at https://github.com/qgis/QGIS-Documentation/issues.
Add "fix #issuenumber" for each issue the PR fixes. The ticket(s) will be closed automatically.
If your PR doesn't fix entirely the ticket, only add the ticket(s) reference preceded by # character.
-->


Ticket(s): None
<!---
Indicate whether the fix should be backported to previous release.
Replace the space between square brackets by a `x` to make it checked.
-->
- [x] Backport to LTR documentation is required

<!---
Reviewing is a process done by community members, mostly on a volunteer basis.
We try to keep the overhead as small as possible and appreciate if you help us.
Please read carefully and ensure you comply with our writing guidelines at
https://docs.qgis.org/testing/en/docs/documentation_guidelines/index.html.
Feel free to ask in a comment or the (qgis-community-team mailing list)
[https://lists.osgeo.org/mailman/listinfo/qgis-community-team] if you have troubles with any item.
--->
