### PR TITLE
Default resampling settings

### DIFF
--- a/source/docs/user_manual/introduction/qgis_configuration.rst
+++ b/source/docs/user_manual/introduction/qgis_configuration.rst
@@ -440,9 +440,14 @@ Rendering Settings
 
 * With :guilabel:`RGB band selection`, you can define the number for the Red,
   Green and Blue band.
-* For newly added rasters you can define the :guilabel:`Zoomed in resampling`
-  and the :guilabel:`Zoomed out resampling`. You can choose between three default
+* The :guilabel:`Zoomed in resampling`
+  and the :guilabel:`Zoomed out resampling` methods can be defined.
+  For :guilabel:`Zoomed in resampling` you can choose between three
   resampling methods: 'Nearest Neighbour', 'Bilinear' and 'Cubic'.
+  For :guilabel:`Zoomed out resampling` you can choose between 'Nearest Neighbour'
+  and 'Average'.
+  You can also set the :guilabel:`Oversampling` value (between 0.0 and 99.99 - a large
+  value means more work for QGIS - the default value is 2.0).
 
 *Contrast enhancement*
 

--- a/source/docs/user_manual/introduction/qgis_configuration.rst
+++ b/source/docs/user_manual/introduction/qgis_configuration.rst
@@ -440,6 +440,9 @@ Rendering Settings
 
 * With :guilabel:`RGB band selection`, you can define the number for the Red,
   Green and Blue band.
+* For newly added rasters you can define the :guilabel:`Zoomed in resampling`
+  and the :guilabel:`Zoomed out resampling`. You can choose between three default
+  resampling methods: 'Nearest Neighbour', 'Bilinear' and 'Cubic'.
 
 *Contrast enhancement*
 


### PR DESCRIPTION

The screenshot about options --> rendering and the description about the default resampling methods were added.
 <!---
A list of issues is at https://github.com/qgis/QGIS-Documentation/issues.
Add "fix #issuenumber" for each issue the PR fixes. The ticket(s) will be closed automatically.
If your PR doesn't fix entirely the ticket, only add the ticket(s) reference preceded by # character.
-->
Goal: Users shall be able to set the default resampling method for newly added rasters.

Ticket(s): fix #3878
<!---
Indicate whether the fix should be backported to previous release.
Replace the space between square brackets by a `x` to make it checked.
-->
- [ ] Backport to LTR documentation is required

<!---
Reviewing is a process done by community members, mostly on a volunteer basis.
We try to keep the overhead as small as possible and appreciate if you help us.
Please read carefully and ensure you comply with our writing guidelines at
https://docs.qgis.org/testing/en/docs/documentation_guidelines/index.html.
Feel free to ask in a comment or the (qgis-community-team mailing list)
[https://lists.osgeo.org/mailman/listinfo/qgis-community-team] if you have troubles with any item.
--->
