### PR TITLE
Cp paste style in qgis

### DIFF
--- a/source/docs/user_manual/style_library/style_manager.rst
+++ b/source/docs/user_manual/style_library/style_manager.rst
@@ -144,7 +144,8 @@ Right-clicking over a selection of items also allows you to:
 * :guilabel:`Remove Item(s)`;
 * :guilabel:`Edit Item`: applies to the item you right-click over;
 * :guilabel:`Copy Item`;
-* :guilabel:`Paste Item ...`;
+* :guilabel:`Paste Item ...`: pasting to one of the categories of the style manager
+  or elsewhere in QGIS (symbol or color buttons) 
 * :guilabel:`Export Selected Symbol(s) as PNG...` (only available with symbols);
 * :guilabel:`Export Selected Symbol(s) as SVG...` (only available with symbols);
 


### PR DESCRIPTION
<!---
Copy and paste for style items is possible.
 
A list of issues is at https://github.com/qgis/QGIS-Documentation/issues.
Add "fix #issuenumber" for each issue the PR fixes. The ticket(s) will be closed automatically.
If your PR doesn't fix entirely the ticket, only add the ticket(s) reference preceded by # character.
-->
Goal: Users shall be able to copy and paste style items in the tabs of the style manager and also elsewhere in QGIS (symbol and color buttons).

Ticket(s): fix #4032 
<!---
Indicate whether the fix should be backported to previous release.
Replace the space between square brackets by a `x` to make it checked.
-->
- [ ] Backport to LTR documentation is required

<!---
Reviewing is a process done by community members, mostly on a volunteer basis.
We try to keep the overhead as small as possible and appreciate if you help us.
Please read carefully and ensure you comply with our writing guidelines at
https://docs.qgis.org/testing/en/docs/documentation_guidelines/index.html.
Feel free to ask in a comment or the (qgis-community-team mailing list)
[https://lists.osgeo.org/mailman/listinfo/qgis-community-team] if you have troubles with any item.
--->
