### PR TITLE
Add the remaining algorithms in the GDAL Vector geoprocessing group

### DIFF
--- a/source/docs/user_manual/processing_algs/gdal/vectorgeoprocessing.rst
+++ b/source/docs/user_manual/processing_algs/gdal/vectorgeoprocessing.rst
@@ -133,11 +133,11 @@ Parameters
         output vector file.
         It has to be defined in target CRS coordinates.
    *  - **Additional creation options**
-        
+
         (optional)
       - ``OPTIONS``
       - [string]
-        
+
         Default: '' (no additional options)
       - Additional GDAL creation options.
    *  - **Clipped (extent)**
@@ -201,11 +201,11 @@ Parameters
       - [vector: polygon]
       - Layer to be used as clipping extent for the input vector layer.
    *  - **Additional creation options**
-        
+
         (optional)
       - ``OPTIONS``
       - [string]
-        
+
         Default: '' (no additional options)
       - Additional GDAL creation options.
    *  - **Clipped (mask)**
@@ -265,7 +265,7 @@ Parameters
       - [vector: any]
       - The input layer to dissolve
    *  - **Dissolve field**
-        
+
         (optional)
       - ``FIELD``
       - [tablefield: any]
@@ -273,7 +273,7 @@ Parameters
    *  - **Geometry column name**
       - ``GEOMETRY``
       - [string]
-        
+
         Default: 'geometry'
       - The name of the input layer geometry column to use
         for dissolving.
@@ -281,49 +281,49 @@ Parameters
         geometry collection in the source file**
       - ``EXPLODE_COLLECTIONS``
       - [boolean]
-        
+
         Default: False
       - Produce one feature for each geometry in any kind of geometry
         collection in the source file
    *  - **Keep input attributes**
       - ``KEEP_ATTRIBUTES``
       - [boolean]
-        
+
         Default: False
       - Keep all attributes from the input layer
    *  - **Count dissolved features**
       - ``COUNT_FEATURES``
       - [boolean]
-        
+
         Default: False
       - Count the dissolved features and include it in the output
         layer.
    *  - **Compute area and perimeter of dissolved features**
       - ``COMPUTE_AREA``
       - [boolean]
-        
+
         Default: False
       - Compute the area and perimeter of dissolved features and include
         them in the output layer
    *  - **Compute min/max/sum/mean for attribute**
       - ``COMPUTE_STATISTICS``
       - [boolean]
-        
+
         Default: False
       - Calculate statistics (min, max, sum and mean) for the numeric
         attribute specified and include them in the output layer
    *  - **Numeric attribute to calculate statistics on**
-        
+
         (optional)
       - ``STATISTICS_ATTRIBUTE``
       - [tablefield: numeric]
       - The numeric attribute to calculate statistics on
    *  - **Additional creation options**
-        
+
         (optional)
       - ``OPTIONS``
       - [string]
-        
+
         Default: '' (no additional options)
       - Additional GDAL creation options.
    *  - **Dissolved**
@@ -354,8 +354,8 @@ Outputs
       - ``OUTPUT``
       - [same as input]
       - The output multipart geometry layer (with dissolved geometries)
-      
-      
+
+
 .. _gdaloffsetcurve:
 
 Offset curve
@@ -383,21 +383,21 @@ Parameters
    *  - **Geometry column name**
       - ``GEOMETRY``
       - [string]
-        
+
         Default: 'geometry'
       - The name of the input layer geometry column to use
    *  - **Offset distance (left-sided: positive, right-sided: negative)**
       - ``DISTANCE``
       - [number]
-        
+
         Default: 10.0
       - 
    *  - **Additional creation options**
-        
+
         (optional)
       - ``OPTIONS``
       - [string]
-        
+
         Default: '' (no additional options)
       - Additional GDAL creation options.
    *  - **Offset curve**
@@ -490,10 +490,6 @@ Parameters
         Default: False
       - If set, the result is dissolved. If no field is set for dissolving,
         all the buffers are dissolved into one feature.
---
-
-
-
    *  - **Produce one feature for each geometry in any kind of
         geometry collection in the source file**
       - ``EXPLODE_COLLECTIONS``
@@ -537,8 +533,8 @@ Outputs
       - ``OUTPUT``
       - [vector: polygon]
       - The output buffer layer
-      
-      
+
+
 .. _gdalpointsalonglines:
 
 Points along lines
@@ -565,22 +561,22 @@ Parameters
    *  - **Geometry column name**
       - ``GEOMETRY``
       - [string]
-        
+
         Default: 'geometry'
       - The name of the input layer geometry column to use
    *  - **Distance from line start represented as a fraction of line
         length**
       - ``DISTANCE``
       - [number]
-        
+
         Default: 0.5 (middle of the line)
       - 
    *  - **Additional creation options**
-        
+
         (optional)
       - ``OPTIONS``
       - [string]
-        
+
         Default: '' (no additional options)
       - Additional GDAL creation options.
    *  - **Points along line**

--- a/source/docs/user_manual/processing_algs/gdal/vectorgeoprocessing.rst
+++ b/source/docs/user_manual/processing_algs/gdal/vectorgeoprocessing.rst
@@ -55,7 +55,8 @@ Parameters
       - [boolean]
 
         Default: False
-      - 
+      - If set, the result is dissolved. If no field is set for dissolving,
+        all the buffers are dissolved into one feature.
    *  - **Produce one feature for each geometry in any kind of
         geometry collection in the source file**
       - ``EXPLODE_COLLECTIONS``
@@ -359,6 +360,9 @@ Outputs
 
 Offset curve
 ------------
+Offsets lines by a specified distance.
+Positive distances will offset lines to the left, and negative distances will
+offset them to the right.
 
 Parameters
 ..........
@@ -484,7 +488,12 @@ Parameters
       - [boolean]
 
         Default: False
-      - 
+      - If set, the result is dissolved. If no field is set for dissolving,
+        all the buffers are dissolved into one feature.
+--
+
+
+
    *  - **Produce one feature for each geometry in any kind of
         geometry collection in the source file**
       - ``EXPLODE_COLLECTIONS``

--- a/source/docs/user_manual/processing_algs/gdal/vectorgeoprocessing.rst
+++ b/source/docs/user_manual/processing_algs/gdal/vectorgeoprocessing.rst
@@ -28,7 +28,7 @@ Parameters
       - Description
    *  - **Input layer**
       - ``INPUT``
-      - [vector: line]
+      - [vector: any]
       - The input vector layer
    *  - **Geometry column name**
       - ``GEOMETRY``
@@ -382,7 +382,7 @@ Parameters
         
         Default: 'geometry'
       - The name of the input layer geometry column to use
-   *  - **Offset distance (left-sided: positive, right-sided: negative**
+   *  - **Offset distance (left-sided: positive, right-sided: negative)**
       - ``DISTANCE``
       - [number]
         
@@ -423,14 +423,14 @@ Outputs
    *  - **Offset curve**
       - ``OUTPUT``
       - [vector: line]
-      - The output offset curve
+      - The output offset curve layer
 
 
 .. _gdalonesidebuffer:
 
 One side buffer
 ---------------
-Create a buffer on one side (right or left) of the lines in a line
+Creates a buffer on one side (right or left) of the lines in a line
 vector layer.
 
 Parameters
@@ -479,7 +479,7 @@ Parameters
 
         Default: None
       - Field to use for dissolving
-   *  - **Dissolve results**
+   *  - **Dissolve all results**
       - ``DISSOLVE``
       - [boolean]
 
@@ -534,7 +534,8 @@ Outputs
 
 Points along lines
 ------------------
-Generate a point on each line of a line vector layer.
+Generates a point on each line of a line vector layer at a distance from start.
+The distance is provided as a fraction of the line length.
 
 Parameters
 ..........

--- a/source/docs/user_manual/processing_algs/gdal/vectorgeoprocessing.rst
+++ b/source/docs/user_manual/processing_algs/gdal/vectorgeoprocessing.rst
@@ -8,6 +8,99 @@ Vector geoprocessing
       :depth: 1
 
 
+.. _gdalbuffervectors:
+
+Buffer vectors
+--------------
+Create buffers around the features of a vector layer.
+
+Parameters
+..........
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 20 20 40
+   :stub-columns: 0
+
+   *  - Label
+      - Name
+      - Type
+      - Description
+   *  - **Input layer**
+      - ``INPUT``
+      - [vector: line]
+      - The input vector layer
+   *  - **Geometry column name**
+      - ``GEOMETRY``
+      - [string]
+
+        Default: 'geometry'
+      - The name of the input layer geometry column to use
+   *  - **Buffer distance**
+      - ``DISTANCE``
+      - [number]
+
+        Default: 10.0
+      - Minimum: 0.0
+   *  - **Dissolve by attribute**
+
+        Optional
+      - ``FIELD``
+      - [tablefield: any]
+
+        Default: None
+      - Field to use for dissolving
+   *  - **Dissolve results**
+      - ``DISSOLVE``
+      - [boolean]
+
+        Default: False
+      - 
+   *  - **Produce one feature for each geometry in any kind of
+        geometry collection in the source file**
+      - ``EXPLODE_COLLECTIONS``
+      - [boolean]
+
+        Default: False
+      - 
+   *  - **Additional creation options**
+
+        (optional)
+      - ``OPTIONS``
+      - [string]
+
+        Default: '' (no additional options)
+      - Additional GDAL creation options.
+   *  - **Buffer**
+      - ``OUTPUT``
+      - [vector: polygon]
+
+        Default: ``[Save to temporary file]``
+      - Specify the output buffer layer. One of:
+
+        * Save to a Temporary File
+        * Save to File...
+
+        The file encoding can also be changed here.
+
+Outputs
+.......
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 20 20 40
+   :stub-columns: 0
+
+   *  - Label
+      - Name
+      - Type
+      - Description
+   *  - **Buffer**
+      - ``OUTPUT``
+      - [vector: polygon]
+      - The output buffer layer
+
+
 .. _gdalclipvectorbyextent:
 
 Clip vector by extent
@@ -44,12 +137,19 @@ Parameters
       - ``OPTIONS``
       - [string]
         
-        Default: "" (no additional options)
+        Default: '' (no additional options)
       - Additional GDAL creation options.
    *  - **Clipped (extent)**
       - ``OUTPUT``
       - [same as input]
-      - The output (clipped) layer
+
+        Default: ``[Save to temporary file]``
+      - Specify the output (clipped) layer. One of:
+
+        * Save to a Temporary File
+        * Save to File...
+
+        The file encoding can also be changed here.
 
 Outputs
 .......
@@ -63,7 +163,7 @@ Outputs
       - Name
       - Type
       - Description
-   *  - **Output layer**
+   *  - **Clipped (extent)**
       - ``OUTPUT``
       - [same as input]
       - The output (clipped) layer.
@@ -105,12 +205,19 @@ Parameters
       - ``OPTIONS``
       - [string]
         
-        Default: "" (no additional options)
+        Default: '' (no additional options)
       - Additional GDAL creation options.
    *  - **Clipped (mask)**
       - ``OUTPUT``
       - [same as input]
-      - The output (masked) layer
+
+        Default: ``[Save to temporary file]``
+      - The output (masked) layer. One of:
+
+        * Save to a Temporary File
+        * Save to File...
+
+        The file encoding can also be changed here.
 
 Outputs
 .......
@@ -124,7 +231,7 @@ Outputs
       - Name
       - Type
       - Description
-   *  - **Output layer**
+   *  - **Clipped (mask)**
       - ``OUTPUT``
       - [same as input]
       - The output (masked) layer.
@@ -166,8 +273,8 @@ Parameters
       - ``GEOMETRY``
       - [string]
         
-        Default: "geometry"
-      - The name of the geometry column of the input layer to use
+        Default: 'geometry'
+      - The name of the input layer geometry column to use
         for dissolving.
    *  - **Produce one feature for each geometry in any kind of
         geometry collection in the source file**
@@ -216,12 +323,19 @@ Parameters
       - ``OPTIONS``
       - [string]
         
-        Default: ""
+        Default: '' (no additional options)
       - Additional GDAL creation options.
    *  - **Dissolved**
       - ``OUTPUT``
-      -  [same as input]
-      - The output layer
+      - [same as input]
+
+        Default: ``[Save to temporary file]``
+      - Specify the output layer. One of:
+
+        * Save to a Temporary File
+        * Save to File...
+
+        The file encoding can also be changed here.
 
 Outputs
 .......
@@ -239,4 +353,252 @@ Outputs
       - ``OUTPUT``
       - [same as input]
       - The output multipart geometry layer (with dissolved geometries)
+      
+      
+.. _gdaloffsetcurve:
 
+Offset curve
+------------
+
+Parameters
+..........
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 20 20 40
+   :stub-columns: 0
+
+   *  - Label
+      - Name
+      - Type
+      - Description
+   *  - **Input layer**
+      - ``INPUT``
+      - [vector: line]
+      - The input line layer
+   *  - **Geometry column name**
+      - ``GEOMETRY``
+      - [string]
+        
+        Default: 'geometry'
+      - The name of the input layer geometry column to use
+   *  - **Offset distance (left-sided: positive, right-sided: negative**
+      - ``DISTANCE``
+      - [number]
+        
+        Default: 10.0
+      - 
+   *  - **Additional creation options**
+        
+        (optional)
+      - ``OPTIONS``
+      - [string]
+        
+        Default: '' (no additional options)
+      - Additional GDAL creation options.
+   *  - **Offset curve**
+      - ``OUTPUT``
+      - [vector: line]
+
+        Default: ``[Save to temporary file]``
+      - Specify the output line layer. One of:
+
+        * Save to a Temporary File
+        * Save to File...
+
+        The file encoding can also be changed here.
+
+Outputs
+.......
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 20 20 40
+   :stub-columns: 0
+
+   *  - Label
+      - Name
+      - Type
+      - Description
+   *  - **Offset curve**
+      - ``OUTPUT``
+      - [vector: line]
+      - The output offset curve
+
+
+.. _gdalonesidebuffer:
+
+One side buffer
+---------------
+Create a buffer on one side (right or left) of the lines in a line
+vector layer.
+
+Parameters
+..........
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 20 20 40
+   :stub-columns: 0
+
+   *  - Label
+      - Name
+      - Type
+      - Description
+   *  - **Input layer**
+      - ``INPUT``
+      - [vector: line]
+      - The input line layer
+   *  - **Geometry column name**
+      - ``GEOMETRY``
+      - [string]
+
+        Default: 'geometry'
+      - The name of the input layer geometry column to use
+   *  - **Buffer distance**
+      - ``DISTANCE``
+      - [number]
+
+        Default: 10.0
+      - 
+   *  - **Buffer side**
+      - ``BUFFER_SIDE``
+      - [enumeration]
+
+        Default: 0
+      - One of:
+
+        * 0 --- Right
+        * 1 --- Left
+
+   *  - **Dissolve by attribute**
+
+        Optional
+      - ``FIELD``
+      - [tablefield: any]
+
+        Default: None
+      - Field to use for dissolving
+   *  - **Dissolve results**
+      - ``DISSOLVE``
+      - [boolean]
+
+        Default: False
+      - 
+   *  - **Produce one feature for each geometry in any kind of
+        geometry collection in the source file**
+      - ``EXPLODE_COLLECTIONS``
+      - [boolean]
+
+        Default: False
+      - 
+   *  - **Additional creation options**
+
+        (optional)
+      - ``OPTIONS``
+      - [string]
+
+        Default: '' (no additional options)
+      - Additional GDAL creation options.
+   *  - **One-sided buffer**
+      - ``OUTPUT``
+      - [vector: polygon]
+
+        Default: ``[Save to temporary file]``
+      - Specify the output buffer layer. One of:
+
+        * Save to a Temporary File
+        * Save to File...
+
+        The file encoding can also be changed here.
+
+Outputs
+.......
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 20 20 40
+   :stub-columns: 0
+
+   *  - Label
+      - Name
+      - Type
+      - Description
+   *  - **One-sided buffer**
+      - ``OUTPUT``
+      - [vector: polygon]
+      - The output buffer layer
+      
+      
+.. _gdalpointsalonglines:
+
+Points along lines
+------------------
+Generate a point on each line of a line vector layer.
+
+Parameters
+..........
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 20 20 40
+   :stub-columns: 0
+
+   *  - Label
+      - Name
+      - Type
+      - Description
+   *  - **Input layer**
+      - ``INPUT``
+      - [vector: line]
+      - The input line layer
+   *  - **Geometry column name**
+      - ``GEOMETRY``
+      - [string]
+        
+        Default: 'geometry'
+      - The name of the input layer geometry column to use
+   *  - **Distance from line start represented as a fraction of line
+        length**
+      - ``DISTANCE``
+      - [number]
+        
+        Default: 0.5 (middle of the line)
+      - 
+   *  - **Additional creation options**
+        
+        (optional)
+      - ``OPTIONS``
+      - [string]
+        
+        Default: '' (no additional options)
+      - Additional GDAL creation options.
+   *  - **Points along line**
+      - ``OUTPUT``
+      - [vector: point]
+
+        Default: ``[Save to temporary file]``
+      - Specify the output point layer.
+        One of:
+
+        * Save to a Temporary File
+        * Save to File...
+
+        The file encoding can also be changed here.
+
+Outputs
+.......
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 20 20 40
+   :stub-columns: 0
+
+   *  - Label
+      - Name
+      - Type
+      - Description
+   *  - **Points along line**
+      - ``OUTPUT``
+      - [vector: point]
+      - The output point layer


### PR DESCRIPTION
<!---
Include a few sentences describing the overall goals for this Pull Request.
 
A list of issues is at https://github.com/qgis/QGIS-Documentation/issues.
Add "fix #issuenumber" for each issue the PR fixes. The ticket(s) will be closed automatically.
If your PR doesn't fix entirely the ticket, only add the ticket(s) reference preceded by # character.
-->
Goal: Add documentation for the remaining algorithms in the GDAL Vector geoprocessing group:
"Buffer vectors", "Offset curve", "One side buffer" and "Points along lines".

Ticket(s): #
<!---
Indicate whether the fix should be backported to previous release.
Replace the space between square brackets by a `x` to make it checked.
-->
- [x] Backport to LTR documentation is required

<!---
Reviewing is a process done by community members, mostly on a volunteer basis.
We try to keep the overhead as small as possible and appreciate if you help us.
Please read carefully and ensure you comply with our writing guidelines at
https://docs.qgis.org/testing/en/docs/documentation_guidelines/index.html.
Feel free to ask in a comment or the (qgis-community-team mailing list)
[https://lists.osgeo.org/mailman/listinfo/qgis-community-team] if you have troubles with any item.
--->
