### PR TITLE
 Reintroduce the geometric predicates examples 

### DIFF
--- a/source/docs/user_manual/processing_algs/qgis/qgis_algs_include.rst
+++ b/source/docs/user_manual/processing_algs/qgis/qgis_algs_include.rst
@@ -343,52 +343,48 @@ Advanced parameters
    vector layer*) consists of the green circles, the orange rectangle is the
    dataset that it is being compared to (the *intersection vector layer*).
 
-``Where the features (geometric predicate)`` [enumeration] [list]
-  The spatial condition for the selection is defined by choosing one or more
-  geometric predicates.
+Available geometric predicates are:
 
-  *Intersect*
-    Tests whether a geometry intersects another. Returns 1 (true) if the
-    geometries spatially intersect (share any portion of space - overlap or touch) and 0 if they
-    don’t. In the picture above, this will select circles 1, 2 and 3.
+*Intersect*
+  Tests whether a geometry intersects another. Returns 1 (true) if the
+  geometries spatially intersect (share any portion of space - overlap or touch) and 0 if they
+  don’t. In the picture above, this will select circles 1, 2 and 3.
 
-  *Contain*
-    Returns 1 (true) if and only if no points of b lie in the exterior of a,
-    and at least one point of the interior of b lies in the interior of a.
-    In the picture, no circle is selected, but the rectangle would be if you
-    would select it the other way around, as it contains a circle completely.
-    This is the opposite of *are within*.
-    
-  *Disjoint*
-    Returns 1 (true) if the geometries do not share any portion of space (no overlap, not touching).
-    Only circle 4 is selected.
-    
-  *Equal*
-    Returns 1 (true) if and only if geometries are exactly the same.
-    No circles will be selected.
-    
-  *Touch*
-    Tests whether a geometry touches another. Returns 1 (true) if the geometries
-    have at least one point in common, but their interiors do not intersect.
-    Only circle 3 is selected.
-      
-  *Overlap*
-    Tests whether a geometry overlaps another. Returns 1 (true) if the geometries
-    share space, are of the same dimension, but are not completely contained by
-    each other. Only circle 2 is selected.
-    
-  *Are within*
-    Tests whether a geometry is within another. Returns 1 (true) if geometry a
-    is completely inside geometry b. Only circle 1 is selected.
-    
-  *Cross*
-    Returns 1 (true) if the supplied geometries have some, but not all, interior
-    points in common and the actual crossing is of a lower dimension than the
-    highest supplied geometry. For example, a line crossing a polygon will cross
-    as a line (selected). Two lines crossing will cross as a point (selected).
-    Two polygons cross as a polygon (not selected).
+*Contain*
+  Returns 1 (true) if and only if no points of b lie in the exterior of a,
+  and at least one point of the interior of b lies in the interior of a.
+  In the picture, no circle is selected, but the rectangle would be if you
+  would select it the other way around, as it contains a circle completely.
+  This is the opposite of *are within*.
 
-  Default: *Intersect*
+*Disjoint*
+  Returns 1 (true) if the geometries do not share any portion of space (no overlap, not touching).
+  Only circle 4 is selected.
+
+*Equal*
+  Returns 1 (true) if and only if geometries are exactly the same.
+  No circles will be selected.
+
+*Touch*
+  Tests whether a geometry touches another. Returns 1 (true) if the geometries
+  have at least one point in common, but their interiors do not intersect.
+  Only circle 3 is selected.
+
+*Overlap*
+  Tests whether a geometry overlaps another. Returns 1 (true) if the geometries
+  share space, are of the same dimension, but are not completely contained by
+  each other. Only circle 2 is selected.
+
+*Are within*
+  Tests whether a geometry is within another. Returns 1 (true) if geometry a
+  is completely inside geometry b. Only circle 1 is selected.
+
+*Cross*
+  Returns 1 (true) if the supplied geometries have some, but not all, interior
+  points in common and the actual crossing is of a lower dimension than the
+  highest supplied geometry. For example, a line crossing a polygon will cross
+  as a line (selected). Two lines crossing will cross as a point (selected).
+  Two polygons cross as a polygon (not selected).
 
 **end_geometric_predicates**
 

--- a/source/docs/user_manual/processing_algs/qgis/vectorselection.rst
+++ b/source/docs/user_manual/processing_algs/qgis/vectorselection.rst
@@ -15,7 +15,7 @@ Extract by attribute
 Creates two vector layers from an input layer: one will contain only matching
 features while the second will contain all the non-matching features.
 
-The criteria for adding features to the resulting layer is defined based on the
+The criteria for adding features to the resulting layer is based on the
 values of an attribute from the input layer.
 
 .. seealso:: :ref:`qgisselectbyattribute`
@@ -126,7 +126,6 @@ Creates two vector layers from an input layer: one will contain only matching
 features while the second will contain all the non-matching features.
 
 The criteria for adding features to the resulting layer is based on a QGIS expression.
-
 For more information about expressions see the :ref:`vector_expressions`.
 
 .. seealso:: :ref:`qgisselectbyexpression`
@@ -210,8 +209,12 @@ Extract by location
 -------------------
 Creates a new vector layer that only contains matching features from an input layer.
 
-The criteria for adding features to the resulting layer is defined based on the
+The criteria for adding features to the resulting layer is based on the
 spatial relationship between each feature and the features in an additional layer.
+
+.. include:: qgis_algs_include.rst
+   :start-after: **geometric_predicates**
+   :end-before: **end_geometric_predicates**
 
 .. seealso:: :ref:`qgisselectbylocation`
 
@@ -602,10 +605,8 @@ Select by attribute
 -------------------
 Creates a selection in a vector layer.
 
-The criteria for selected features is defined based on the values of an attribute
+The criteria for selecting features is based on the values of an attribute
 from the input layer.
-
-No new outputs are created.
 
 .. seealso:: :ref:`qgisextractbyattribute`
 
@@ -689,11 +690,10 @@ Outputs
 
 Select by expression
 --------------------
-Creates a selection in a vector layer. The criteria for selecting
-features is based on a QGIS expression. For more information about expressions
-see the :ref:`vector_expressions`.
+Creates a selection in a vector layer.
 
-No new outputs are created.
+The criteria for selecting features is based on a QGIS expression.
+For more information about expressions see the :ref:`vector_expressions`.
 
 .. seealso:: :ref:`qgisextractbyexpression`
 
@@ -752,11 +752,14 @@ Outputs
 
 Select by location
 ------------------
-Creates a selection in a vector layer. The criteria for selecting
-features is based on the spatial relationship between each feature and
-the features in an additional layer.
+Creates a selection in a vector layer.
 
-No new outputs are created.
+The criteria for selecting features is based on the spatial
+relationship between each feature and the features in an additional layer.
+
+.. include:: qgis_algs_include.rst
+   :start-after: **geometric_predicates**
+   :end-before: **end_geometric_predicates**
 
 ``Default menu``: :menuselection:`Vector --> Research Tools`
 


### PR DESCRIPTION
that were added to the extract/select by location algorithms in #4134 
I think it's too much to be included as part of the `Where the features (geometric predicate)` tiny cell so they are moved to the alg description section.