### PR TITLE
Avoid an "Uncaught TypeError: a.indexOf is not a function"

### DIFF
--- a/themes/qgis-theme/static/qgis-site.js
+++ b/themes/qgis-theme/static/qgis-site.js
@@ -67,7 +67,7 @@ $(document).ready(function(){
         .attr("border", 0);
     };
 
-    $(window).load(function () {
+    $(window).on('load', function () {
         /*
         * Scroll the window to avoid the topnav bar
         * https://github.com/twitter/bootstrap/issues/1768


### PR DESCRIPTION
Goal:
Substitute a deprecated $(window).load(function(){...}); with $(window).on('load', function(){ ...});
See qgis/QGIS-Website@06d668abc57c56a92582308642d7e3984b2b7b44 (PR qgis/QGIS-Website#579)
Ticket(s): qgis/QGIS-Website#718
<!---
Indicate whether the fix should be backported to previous release.
Replace the space between square brackets by a `x` to make it checked.
-->
- [x] Backport to LTR documentation is required

<!---
Reviewing is a process done by community members, mostly on a volunteer basis.
We try to keep the overhead as small as possible and appreciate if you help us.
Please read carefully and ensure you comply with our writing guidelines at
https://docs.qgis.org/testing/en/docs/documentation_guidelines/index.html.
Feel free to ask in a comment or the (qgis-community-team mailing list)
[https://lists.osgeo.org/mailman/listinfo/qgis-community-team] if you have troubles with any item.
--->
