### PR TITLE
Document contextual menu for changing symbol properties for paletted and singleband pseudocolor

### DIFF
--- a/source/docs/user_manual/working_with_raster/raster_properties.rst
+++ b/source/docs/user_manual/working_with_raster/raster_properties.rst
@@ -169,13 +169,22 @@ Paletted/Unique values
 This is the standard render option for singleband files that include
 a color table, where a certain color is assigned to each pixel value.
 In that case, the palette is rendered automatically.
+
+It can be used for all kinds of raster bands, assigning a
+color to each unique raster value.
+
 If you want to change a color, just double-click on the color and
 the :guilabel:`Select color` dialog appears.
+
 It is also possible to assign a label to the each color value.
 The label will then appear in the legend of the raster layer.
 
-This option can be used for all kinds of raster bands, assigning a
-color to each unique raster value.
+Right-clicking over selected rows in the color table shows a
+contextual menu to:
+
+* Change Color. . . of the selected symbol(s)
+* Change Opacity. . . of the selected symbol(s)
+* Change Label. . . of the selected symbol(s)
 
 .. _figure_raster_paletted_unique:
 
@@ -262,6 +271,12 @@ Double clicking in the :guilabel:`Color` column opens the dialog
 that value.
 Further, you can also add labels for each color, but this value won't
 be displayed when you use the identify feature tool.
+
+Right-clicking over selected rows in the color table shows a
+contextual menu to:
+
+* Change Color. . . of the selected symbol(s)
+* Change Opacity. . . of the selected symbol(s)
 
 You can use the buttons |fileOpen| :sup:`Load color map from file`
 or |fileSaveAs| :sup:`Export color map to file` to load an existing

--- a/source/docs/user_manual/working_with_raster/raster_properties.rst
+++ b/source/docs/user_manual/working_with_raster/raster_properties.rst
@@ -176,15 +176,15 @@ color to each unique raster value.
 If you want to change a color, just double-click on the color and
 the :guilabel:`Select color` dialog appears.
 
-It is also possible to assign a label to the each color value.
+It is also possible to assign labels to the colors.
 The label will then appear in the legend of the raster layer.
 
 Right-clicking over selected rows in the color table shows a
 contextual menu to:
 
-* :guilabel:`Change Color...` of the selected symbol(s)
-* :guilabel:`Change Opacity...` of the selected symbol(s)
-* :guilabel:`Change Label...` of the selected symbol(s)
+* :guilabel:`Change Color...` for the selection
+* :guilabel:`Change Opacity...` for the selection
+* :guilabel:`Change Label...` for the selection
 
 .. _figure_raster_paletted_unique:
 

--- a/source/docs/user_manual/working_with_raster/raster_properties.rst
+++ b/source/docs/user_manual/working_with_raster/raster_properties.rst
@@ -182,9 +182,9 @@ The label will then appear in the legend of the raster layer.
 Right-clicking over selected rows in the color table shows a
 contextual menu to:
 
-* Change Color. . . of the selected symbol(s)
-* Change Opacity. . . of the selected symbol(s)
-* Change Label. . . of the selected symbol(s)
+* :guilabel:`Change Color...` of the selected symbol(s)
+* :guilabel:`Change Opacity...` of the selected symbol(s)
+* :guilabel:`Change Label...` of the selected symbol(s)
 
 .. _figure_raster_paletted_unique:
 
@@ -275,8 +275,8 @@ be displayed when you use the identify feature tool.
 Right-clicking over selected rows in the color table shows a
 contextual menu to:
 
-* Change Color. . . of the selected symbol(s)
-* Change Opacity. . . of the selected symbol(s)
+* :guilabel:`Change Color...` of the selected symbol(s)
+* :guilabel:`Change Opacity...` of the selected symbol(s)
 
 You can use the buttons |fileOpen| :sup:`Load color map from file`
 or |fileSaveAs| :sup:`Export color map to file` to load an existing


### PR DESCRIPTION
<!---
Include a few sentences describing the overall goals for this Pull Request.
 
A list of issues is at https://github.com/qgis/QGIS-Documentation/issues.
Add "fix #issuenumber" for each issue the PR fixes. The ticket(s) will be closed automatically.
If your PR doesn't fix entirely the ticket, only add the ticket(s) reference preceded by # character.
-->
Goal: Document the contextual menus for changing opacity, colour, ... of selected entries
in the "colour table" for the "singleband pseudocolor" and "paletted/unique values" raster
rendering types.

Ticket(s):
Fixes: #1571
Fixes: #1572
Fixes: #1578
<!---
Indicate whether the fix should be backported to previous release.
Replace the space between square brackets by a `x` to make it checked.
-->
- [x] Backport to LTR documentation is required

<!---
Reviewing is a process done by community members, mostly on a volunteer basis.
We try to keep the overhead as small as possible and appreciate if you help us.
Please read carefully and ensure you comply with our writing guidelines at
https://docs.qgis.org/testing/en/docs/documentation_guidelines/index.html.
Feel free to ask in a comment or the (qgis-community-team mailing list)
[https://lists.osgeo.org/mailman/listinfo/qgis-community-team] if you have troubles with any item.
--->
