### PR TITLE
Double wording "be be"

### DIFF
--- a/source/docs/user_manual/processing/modeler.rst
+++ b/source/docs/user_manual/processing/modeler.rst
@@ -371,7 +371,7 @@ Toolbox and choose :guilabel:`Export Model as Python Algorithm...`.
 About available algorithms
 --------------------------
 
-You might notice that some algorithms that can be be executed from the
+You might notice that some algorithms that can be executed from the
 toolbox do not appear in the list of available algorithms when you are
 designing a model.
 To be included in a model, an algorithm must have the correct


### PR DESCRIPTION
Line 374 : "can be be executed"  should be "can be executed"
                Removed first occurrence of "be"

Goal: Display correct information

- [x] Backport to LTR documentation is required
