### PR TITLE
Update interpolation.rst

### DIFF
--- a/source/docs/user_manual/processing_algs/qgis/interpolation.rst
+++ b/source/docs/user_manual/processing_algs/qgis/interpolation.rst
@@ -261,7 +261,7 @@ Parameters
      - Type
      - Description
 
-   * - **Input layers(s)**
+   * - **Input layer(s)**
      - ``INTERPOLATION_DATA``
      - [string]
      - Vector layer(s) and field(s) to use for the interpolation, coded
@@ -379,7 +379,7 @@ Parameters
      - Type
      - Description
 
-   * - **Input layers(s)**
+   * - **Input layer(s)**
      - ``INTERPOLATION_DATA``
      - [string]
      - Vector layer(s) and field(s) to use for the interpolation, coded


### PR DESCRIPTION
Line 374 : "can be be executed"  should be "can be executed"
                Removed first occurrence of "be"

Goal: Display correct information

- [x] Backport to LTR documentation is required
