### PR TITLE
Typo * - **Smothing**

### DIFF
--- a/source/docs/user_manual/processing_algs/gdal/rasteranalysis.rst
+++ b/source/docs/user_manual/processing_algs/gdal/rasteranalysis.rst
@@ -552,7 +552,7 @@ Parameters
 
        Default: 2.0
      - Weighting power
-   * - **Smothing**
+   * - **Smoothing**
      - ``SMOOTHING``
      - [number]
 


### PR DESCRIPTION
Line 555 :  "* - **Smothing**"  should probably be " * - **Smoothing** "
                Missing letter "o" added

Goal:  Display correct information
- [x] Backport to LTR documentation is required
