### PR TITLE
Double wording "polygon"

### DIFF
--- a/source/docs/user_manual/processing_algs/qgis/vectorcreation.rst
+++ b/source/docs/user_manual/processing_algs/qgis/vectorcreation.rst
@@ -998,7 +998,7 @@ Parameters
    * - **Input layer**
      - ``INPUT``
      - [vector: polygon]
-     - Input polygon polygon vector layer
+     - Input polygon vector layer
    * - **Sampling strategy**
      - ``STRATEGY``
      - [enumeration]


### PR DESCRIPTION
Line 1001 : "Input polygon polygon vector layer" should probably be "Input polygon vector layer"
Removed first occurrence of "polygon"

Goal: Display correct documentation

- [x] Backport to LTR documentation is required
