### PR TITLE
Typo in name functie  stddev

### DIFF
--- a/source/docs/user_manual/processing_algs/lidartools/lastools.rst
+++ b/source/docs/user_manual/processing_algs/lidartools/lastools.rst
@@ -2025,7 +2025,7 @@ Parameters
        * 0 --- lowest
        * 1 --- heighest
        * 2 --- average
-       * 3 --- stdeev
+       * 3 --- stddev
 
    * - **use tile bounding box (after tiling with buffer)**
      - ``USE_TILE_BB``


### PR DESCRIPTION
line 2028  : "* 3 --- stdeev" should probably be "* 3 --- stddev"
                stdeev is not the right abbreviation for the function standard deviation, it is stddev


Goal: Display correct documentation

- [x] Backport to LTR documentation is required
