### PR TITLE
Missing letter in "fouth" = "fourth"

### DIFF
--- a/source/docs/user_manual/processing_algs/lidartools/lastools.rst
+++ b/source/docs/user_manual/processing_algs/lidartools/lastools.rst
@@ -2340,7 +2340,7 @@ Parameters
        Optional
      - ``FILE4``
      - [file]
-     - The fouth file to merge
+     - The fourth file to merge
    * - **5th file**
 
        Optional


### PR DESCRIPTION
line 2343  : "- The fouth file to merge"should be "- The fourth file to merge"

Goal: Display correct documentation

- [x] Backport to LTR documentation is required
