### PR TITLE
Missing quote

### DIFF
--- a/source/docs/user_manual/processing_algs/lidartools/lastools.rst
+++ b/source/docs/user_manual/processing_algs/lidartools/lastools.rst
@@ -2340,7 +2340,7 @@ Parameters
        Optional
      - ``FILE4``
      - [file]
-     - The fouth file to merge
+     - The fourth file to merge
    * - **5th file**
 
        Optional
@@ -2741,7 +2741,7 @@ Parameters
      - ``PARSE``
      - [string]
 
-       Default: 'xyz
+       Default: 'xyz'
      - 
    * - **skip the first n lines**
      - ``SKIP``


### PR DESCRIPTION
line 2744  : "       Default: 'xyz " should probably be "       Default: 'xyz' " as in line 1787
Last quote missing

Goal: Display correct documentation

- [x] Backport to LTR documentation is required
