### PR TITLE
Remove the note to make the parameters table more compact

### DIFF
--- a/source/docs/user_manual/processing_algs/qgis/vectorgeometry.rst
+++ b/source/docs/user_manual/processing_algs/qgis/vectorgeometry.rst
@@ -1148,9 +1148,9 @@ Convert geometry type
 Generates a new layer based on an existing one, with a different type
 of geometry.
 
-Not all conversions are possible. For instance, a line layer can be
-converted to a point layer, but a point layer cannot be converted to a
-line layer.
+Not all conversions are possible. For instance, a line feature can be
+converted to a point, but a point feature cannot be converted to a
+line. A line feature can also be converted to polygon.
 
 .. seealso:: :ref:`qgispolygonize`, :ref:`qgislinestopolygons`
 
@@ -1183,10 +1183,6 @@ Parameters
        * 2 --- Linestrings
        * 3 --- Multilinestrings
        * 4 --- Polygons
-
-       .. note:: The available conversion types depend on
-          the input layer and the conversion chosen:
-          e.g. it is not possible to convert a point to a line.
 
    * - **Converted**
      - ``OUTPUT``

--- a/source/docs/user_manual/processing_algs/qgis/vectorgeometry.rst
+++ b/source/docs/user_manual/processing_algs/qgis/vectorgeometry.rst
@@ -1148,9 +1148,9 @@ Convert geometry type
 Generates a new layer based on an existing one, with a different type
 of geometry.
 
-Not all conversions are possible. For instance, a line feature can be
-converted to a point, but a point feature cannot be converted to a
-line. A line feature can also be converted to polygon.
+Not all conversions are possible. For instance, a line can be
+converted to a point, but a point cannot be converted to a
+line. A line can also be converted to a polygon.
 
 .. seealso:: :ref:`qgispolygonize`, :ref:`qgislinestopolygons`
 


### PR DESCRIPTION
and because that note is already stated in description few lines above (https://docs.qgis.org/3.4/en/docs/user_manual/processing_algs/qgis/vectorgeometry.html#convert-geometry-type)