### PR TITLE
Add missing import for debugging with command line

### DIFF
--- a/source/docs/pyqgis_developer_cookbook/plugins/ide_debugging.rst
+++ b/source/docs/pyqgis_developer_cookbook/plugins/ide_debugging.rst
@@ -300,7 +300,7 @@ following these steps.
     # Use pdb for debugging
     import pdb
     # also import pyqtRemoveInputHook
-    from PyQt5.QtCore import pyqtRemoveInputHook
+    from qgis.PyQt.QtCore import pyqtRemoveInputHook
     # These lines allow you to set a breakpoint in the app
     pyqtRemoveInputHook()
     pdb.set_trace()

--- a/source/docs/pyqgis_developer_cookbook/plugins/ide_debugging.rst
+++ b/source/docs/pyqgis_developer_cookbook/plugins/ide_debugging.rst
@@ -299,6 +299,8 @@ following these steps.
 
     # Use pdb for debugging
     import pdb
+    # also import pyqtRemoveInputHook
+    from PyQt5.QtCore import pyqtRemoveInputHook
     # These lines allow you to set a breakpoint in the app
     pyqtRemoveInputHook()
     pdb.set_trace()


### PR DESCRIPTION
It is necessary to also import pyqtRemoveInputHook

<!---
Include a few sentences describing the overall goals for this Pull Request.
 
A list of issues is at https://github.com/qgis/QGIS-Documentation/issues.
Add "fix #issuenumber" for each issue the PR fixes. The ticket(s) will be closed automatically.
If your PR doesn't fix entirely the ticket, only add the ticket(s) reference preceded by # character.
-->
Goal:

Ticket(s): #
<!---
Indicate whether the fix should be backported to previous release.
Replace the space between square brackets by a `x` to make it checked.
-->
- [ ] Backport to LTR documentation is required

<!---
Reviewing is a process done by community members, mostly on a volunteer basis.
We try to keep the overhead as small as possible and appreciate if you help us.
Please read carefully and ensure you comply with our writing guidelines at
https://docs.qgis.org/testing/en/docs/documentation_guidelines/index.html.
Feel free to ask in a comment or the (qgis-community-team mailing list)
[https://lists.osgeo.org/mailman/listinfo/qgis-community-team] if you have troubles with any item.
--->
