### PR TITLE
 Move up the Browser panel toolbar description

### DIFF
--- a/source/docs/user_manual/managing_data_source/opening_data.rst
+++ b/source/docs/user_manual/managing_data_source/opening_data.rst
@@ -112,6 +112,27 @@ In both cases, the :guilabel:`Browser` helps you navigate in your file system
 and manage geodata, regardless the type of layer (raster, vector, table),
 or the datasource format (plain or compressed files, databases, web services).
 
+At the top of the Browser panel, you find some buttons that help you to:
+
+* |addLayer| :sup:`Add Selected Layers`: you can also add data to the map
+  canvas by selecting **Add selected layer(s)** from the layer's context menu;
+* |draw| :sup:`Refresh` the browser tree;
+* |filterMap| :sup:`Filter Browser` to search for specific data. Enter a search
+  word or wildcard and the browser will filter the tree to only show paths to
+  matching DB tables, filenames or folders -- other data or folders won't be
+  displayed. See the Browser Panel(2) example in figure_browser_panels_.
+  The comparison can be case-sensitive or not. It can also be set to:
+
+  * :guilabel:`Normal`: show items containing the search text
+  * :guilabel:`Wildcard(s)`: fine tune the search using the ``?`` and/or ``*``
+    characters to specify the position of the search text
+  * :guilabel:`Regular expression`
+
+* |collapseTree| :sup:`Collapse All` the whole tree;
+* |metadata| :sup:`Enable/disable properties widget`: when toggled on,
+  a new widget is added at the bottom of the panel showing, if applicable,
+  metadata for the selected item.
+
 The entries in the :guilabel:`Browser` panel are organised
 hierarchically, and there are several top level entries.
 First comes :guilabel:`Favorites` (where you can place shortcuts to
@@ -218,27 +239,6 @@ legend and choosing :menuselection:`Properties` from the context menu. See
 section :ref:`vector_style_menu` for more information on setting symbology for
 vector layers.
 
-
-At the top of the Browser panel, you find some buttons that help you to:
-
-* |addLayer| :sup:`Add Selected Layers`: you can also add data to the map
-  canvas by selecting **Add selected layer(s)** from the layer's context menu;
-* |draw| :sup:`Refresh` the browser tree;
-* |filterMap| :sup:`Filter Browser` to search for specific data. Enter a search
-  word or wildcard and the browser will filter the tree to only show paths to
-  matching DB tables, filenames or folders -- other data or folders won't be
-  displayed. See the Browser Panel(2) example in figure_browser_panels_.
-  The comparison can be case-sensitive or not. It can also be set to:
-
-  * :guilabel:`Normal`: show items containing the search text
-  * :guilabel:`Wildcard(s)`: fine tune the search using the ``?`` and/or ``*``
-    characters to specify the position of the search text
-  * :guilabel:`Regular expression`
-
-* |collapseTree| :sup:`Collapse All` the whole tree;
-* |metadata| :sup:`Enable/disable properties widget`: when toggled on,
-  a new widget is added at the bottom of the panel showing, if applicable,
-  metadata for the selected item.
 
 Right-clicking an item in the browser tree helps you to:
 

--- a/source/docs/user_manual/managing_data_source/opening_data.rst
+++ b/source/docs/user_manual/managing_data_source/opening_data.rst
@@ -155,6 +155,9 @@ Then comes a number of container / database types and service protocols
 :guilabel:`ArcGISMapServer`, :guilabel:`ArcGISFeatureServer` and
 :guilabel:`GeoNode`.
 
+Interacting with the Browser items
+----------------------------------
+
 The browser supports drag and drop within the browser, from the browser to
 the canvas and :guilabel:`Layers` panel, and from the :guilabel:`Layers` panel
 to layer containers (e.g. GeoPackage) in the browser.
@@ -165,9 +168,6 @@ Project items are treated the same way as any other item in the browser,
 so they can be dragged and dropped within the browser (for example to
 copy a layer item to a geopackage file) or added to the current project
 through drag and drop or double click.
-
-Interacting with the Browser items
-----------------------------------
 
 The context menu for an element in the :guilabel:`Browser` panel is opened
 by right-clicking on it.

--- a/source/docs/user_manual/managing_data_source/opening_data.rst
+++ b/source/docs/user_manual/managing_data_source/opening_data.rst
@@ -112,6 +112,9 @@ In both cases, the :guilabel:`Browser` helps you navigate in your file system
 and manage geodata, regardless the type of layer (raster, vector, table),
 or the datasource format (plain or compressed files, databases, web services).
 
+Exploring the Interface
+-----------------------
+
 At the top of the Browser panel, you find some buttons that help you to:
 
 * |addLayer| :sup:`Add Selected Layers`: you can also add data to the map
@@ -162,6 +165,9 @@ Project items are treated the same way as any other item in the browser,
 so they can be dragged and dropped within the browser (for example to
 copy a layer item to a geopackage file) or added to the current project
 through drag and drop or double click.
+
+Interacting with the Browser items
+----------------------------------
 
 The context menu for an element in the :guilabel:`Browser` panel is opened
 by right-clicking on it.


### PR DESCRIPTION
in order to describe the panel from top to bottom (toolbar then panel items)
Also add subsections to aerate a bit the section, help readers to identify contents and avoid a big chunk of text