### PR TITLE
Revert "Use master branch of backport bot"

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -11,7 +11,7 @@ jobs:
     name: Backport
     steps:
       - name: Backport Bot
-        uses: Gaurav0/backport@master
+        uses: Gaurav0/backport@v1.0.24
         with:
           bot_username: qgis-bot
           bot_token: ddbdec32940df79f1adf2369b4b10f10b5a66f65


### PR DESCRIPTION
Reverts qgis/QGIS-Documentation#4974 because it doesn't fix the issue but it makes PR fail