### PR TITLE
Fix indentation to move together help and field's values

### DIFF
--- a/source/docs/user_manual/working_with_vector/expression.rst
+++ b/source/docs/user_manual/working_with_vector/expression.rst
@@ -155,11 +155,11 @@ using functions, layer's fields and values. It contains following widgets:
    Press :kbd:`Ctrl+Click` when hovering a function name in an expression to
    automatically display its help in the dialog.
 
-* A field's values widget shown when a field is selected in the function selector
+  A field's values widget shown when a field is selected in the function selector
   helps to fetch features attributes. Double-clicking a value adds it to the
   expression editor.
 
-.. tip::
+  .. tip::
 
    The right panel, showing functions help or field values, can be
    collapsed (invisible) in the dialog. Press the :guilabel:`Show Values`


### PR DESCRIPTION
in the right panel (refs changes in #4985)

<!---
Include a few sentences describing the overall goals for this Pull Request.
 
A list of issues is at https://github.com/qgis/QGIS-Documentation/issues.
Add "fix #issuenumber" for each issue the PR fixes. The ticket(s) will be closed automatically.
If your PR doesn't fix entirely the ticket, only add the ticket(s) reference preceded by # character.
-->
Goal:

Ticket(s): #
<!---
Indicate whether the fix should be backported to previous release.
Replace the space between square brackets by a `x` to make it checked.
-->
- [ ] Backport to LTR documentation is required

<!---
Reviewing is a process done by community members, mostly on a volunteer basis.
We try to keep the overhead as small as possible and appreciate if you help us.
Please read carefully and ensure you comply with our writing guidelines at
https://docs.qgis.org/testing/en/docs/documentation_guidelines/index.html.
Feel free to ask in a comment or the (qgis-community-team mailing list)
[https://lists.osgeo.org/mailman/listinfo/qgis-community-team] if you have troubles with any item.
--->
