### PR TITLE
Remove link to pdf build

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -13,7 +13,6 @@ Please have a look into one of the documents below.
    A Gentle Introduction to GIS <gentle_gis_introduction/index>
    Training Manual <training_manual/index>
    User Guide/Manual (QGIS Testing) <user_manual/index>
-   User Guide/Manual PDF's <https://docs.qgis.org/testing/pdf/>
    PyQGIS Cookbook (QGIS Testing) <pyqgis_developer_cookbook/index>
    Developers Guide <developers_guide/index>
    Documentation Guidelines <documentation_guidelines/index>


### PR DESCRIPTION
no more generated (yet!) and already obsolete.
No need to backport since this is already done in 3.10, and 3.4 pdf are likely still relevant since that doc is EOL (we could keep links to pdf)