### PR TITLE
Hopefully nicer version bar

### DIFF
--- a/themes/rtd_qgis/breadcrumbs.html
+++ b/themes/rtd_qgis/breadcrumbs.html
@@ -1,0 +1,69 @@
+{% extends "sphinx_rtd_theme/breadcrumbs.html" %}
+
+{##
+This is just a stupid copy of the breadcrumbs block from the original theme,
+with the 'release_status_topbar' squeezed in.
+So feel free to updat his part if the orginal breadcrumbs is updated...
+##}
+
+    {% block breadcrumbs %}
+      <li><a href="{{ pathto(master_doc) }}">{{ _('Docs') }}</a> &raquo;</li>
+        {% for doc in parents %}
+          <li><a href="{{ doc.link|e }}">{{ doc.title }}</a> &raquo;</li>
+        {% endfor %}
+      <li>{{ title }}</li>
+    {% endblock %}
+    {% block breadcrumbs_aside %}
+      <li class="wy-breadcrumbs-aside">
+        {% if hasdoc(pagename) %}
+            {% if display_github %}
+            {% if check_meta and 'github_url' in meta %}
+              <!-- User defined GitHub URL -->
+              <a href="{{ meta['github_url'] }}" class="fa fa-github"> {{ _('Edit on GitHub') }}</a>
+            {% else %}
+              <a href="https://{{ github_host|default("github.com") }}/{{ github_user }}/{{ github_repo }}/{{ theme_vcs_pageview_mode|default("blob") }}/{{ github_version }}{{ conf_py_path }}{{ pagename }}{{ suffix }}" class="fa fa-github"> {{ _('Edit on GitHub') }}</a>
+            {% endif %}
+          {% elif display_bitbucket %}
+            {% if check_meta and 'bitbucket_url' in meta %}
+              <!-- User defined Bitbucket URL -->
+              <a href="{{ meta['bitbucket_url'] }}" class="fa fa-bitbucket"> {{ _('Edit on Bitbucket') }}</a>
+            {% else %}
+              <a href="https://bitbucket.org/{{ bitbucket_user }}/{{ bitbucket_repo }}/src/{{ bitbucket_version}}{{ conf_py_path }}{{ pagename }}{{ suffix }}?mode={{ theme_vcs_pageview_mode|default("view") }}" class="fa fa-bitbucket"> {{ _('Edit on Bitbucket') }}</a>
+            {% endif %}
+          {% elif display_gitlab %}
+            {% if check_meta and 'gitlab_url' in meta %}
+              <!-- User defined GitLab URL -->
+              <a href="{{ meta['gitlab_url'] }}" class="fa fa-gitlab"> {{ _('Edit on GitLab') }}</a>
+            {% else %}
+              <a href="https://{{ gitlab_host|default("gitlab.com") }}/{{ gitlab_user }}/{{ gitlab_repo }}/{{ theme_vcs_pageview_mode|default("blob") }}/{{ gitlab_version }}{{ conf_py_path }}{{ pagename }}{{ suffix }}" class="fa fa-gitlab"> {{ _('Edit on GitLab') }}</a>
+            {% endif %}
+          {% elif show_source and source_url_prefix %}
+            <a href="{{ source_url_prefix }}{{ pagename }}{{ suffix }}">{{ _('View page source') }}</a>
+          {% elif show_source and has_source and sourcename %}
+            <a href="{{ pathto('_sources/' + sourcename, true)|e }}" rel="nofollow"> {{ _('View page source') }}</a>
+          {% endif %}
+        {% endif %}
+      </li>
+
+     {# THIS PART IS INSERTED #}
+     {%- if isTesting %}
+     <nav class="release_status_topbar">
+      <div class="row isTesting">
+       This is a work in progress. For the Long Term Release and translations, please visit the <a href="https://docs.qgis.org/latest/{{ language }}/">latest version</a>.
+      </div>
+     </nav>
+     {%- endif %}
+     {%- if outdated %}
+     <nav class="release_status_topbar">
+      <div class="row outdated">
+       This documentation is for a QGIS version which has reached end of life. Visit the <a href="https://docs.qgis.org/latest/{{ language }}/">latest version</a> instead.
+      </div>
+     </nav>
+     {%- endif %}
+     {#TILL HERE#}
+
+
+    {% endblock %}
+
+
+

--- a/themes/rtd_qgis/layout.html
+++ b/themes/rtd_qgis/layout.html
@@ -2,20 +2,6 @@
 
  {%block extrabody %}
 
-  <nav class="release_status_topbar">
-   {%- if isTesting %}
-    <div class="row isTesting">
-     This documentation is a work in progress. For the Long Term Release and translations, please visit the <a href="https://docs.qgis.org/latest/{{ language }}/">latest version</a>.
-    </div>
-   {%- endif %}
-
-   {%- if outdated %}
-    <div class="row outdated">
-     This documentation is for a QGIS version which has reached end of life. Visit the <a href="https://docs.qgis.org/latest/{{ language }}/">latest version</a> instead.
-    </div>
-   {%- endif %}
-  </nav>
-
   {{ super() }}
 
  {% endblock extrabody %}

--- a/themes/rtd_qgis/static/css/qgis_docs.css
+++ b/themes/rtd_qgis/static/css/qgis_docs.css
@@ -26,7 +26,7 @@
 }
 .isTesting {
   /* only to be visible in testing*/
-  background: #f3fbfb;
+  background: #f3fbff;
   color: black;
 }
 .outdated,
@@ -34,12 +34,13 @@
   /* top banner for testing and outdated docs*/
   padding-top: 0.5rem;
   margin-left: 0;
-  padding-left: 0.5rem;
+  padding-left: 0.3rem;
   padding-bottom: 0.5rem;
   font-size: 0.9rem;
   z-index: 300;
-  width: 100%;
-  position: fixed
+  margin-right: 0.1rem;
+  /*width: 100%;*/
+  /*position: fixed*/
 }
 
 /* override table width restrictions 


### PR DESCRIPTION
I think current 'in progress warning bar' is not behaving very nice on different screens. It hides the title or is over the left bar.

![Screenshot-20200319105623-813x126](https://user-images.githubusercontent.com/731673/77054739-619cc700-69d0-11ea-94f9-54818aafe818.png)

![Screenshot-20200319105558-590x147](https://user-images.githubusercontent.com/731673/77054751-62cdf400-69d0-11ea-8f5c-b66838b3b6a6.png)

(See also current master build)

I've experimented and extended the breadcrumbs to include our current bar. Also tweaked css.
To me it looks better. now

![Screenshot-20200319105942-1137x186](https://user-images.githubusercontent.com/731673/77055227-d112b680-69d0-11ea-973e-34e80d4dcc09.png)

![Screenshot-20200319110006-494x331](https://user-images.githubusercontent.com/731673/77055237-d40da700-69d0-11ea-94c4-141d63d894b5.png)




