### PR TITLE
Add generation timestamp ONLY on frontpage

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -31,6 +31,9 @@ master_doc = 'docs/index'
 # of the sidebar.
 html_logo = 'static/common/logo.png'
 
+html_last_updated_fmt = '%b %d, %Y %H:%M'
+
+
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
 # built documents.

--- a/themes/rtd_qgis/layout.html
+++ b/themes/rtd_qgis/layout.html
@@ -19,3 +19,32 @@
   {{ super() }}
 
  {% endblock extrabody %}
+
+          {% block menu %}
+            {#
+              The singlehtml builder doesn't handle this toctree call when the
+              toctree is empty. Skip building this for now.
+            #}
+            {% if 'singlehtml' not in builder %}
+              {% set global_toc = toctree(maxdepth=theme_navigation_depth|int,
+                                          collapse=theme_collapse_navigation|tobool,
+                                          includehidden=theme_includehidden|tobool,
+                                          titles_only=theme_titles_only|tobool) %}
+            {% endif %}
+            {% if global_toc %}
+              {{ global_toc }}
+            {% else %}
+              <!-- Local TOC -->
+              <div class="local-toc">{{ toc }}</div>
+            {% endif %}
+
+            {% if pagename == 'docs/index' and last_updated %}
+            <ul>
+              <li>&nbsp;</li>
+              <li class="toctree-l1" style="padding:1.5em; font-size:small;">
+                {% trans last_updated=last_updated|e %}Last updated on {{ last_updated }}{% endtrans %}
+              </li>
+            </ul>
+            {% endif %}
+
+          {% endblock %}


### PR DESCRIPTION
This change adds a 'Last updated + timestamp' sentence ONLY on the frontpage, like we did in the old sites.
This way if some language,rsync or build breaks, it will at least be visible on the frontpage.
I choose to only show it on the frontpage, to minimalize the rsync jobs (else EVERY page will be updated)

![Screenshot-20200319121329-477x443](https://user-images.githubusercontent.com/731673/77061768-10460500-69db-11ea-84ac-7686e0120d0a.png)

