### PR TITLE
Fix redirection link to the latest docs

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -63,6 +63,7 @@ exclude_patterns = [
 
 # -- Internationalisation ----------------------------------------------------
 
+language = 'en'
 locale_dirs = ['locale/']   # path is example but recommended.
 gettext_compact = False     # optional.
 

--- a/themes/rtd_qgis/layout.html
+++ b/themes/rtd_qgis/layout.html
@@ -5,13 +5,13 @@
   <nav class="release_status_topbar">
    {%- if isTesting %}
     <div class="row isTesting">
-     This documentation is a work in progress. For the Long Term Release and translations, please visit the <a href="https://docs.qgis.org/latest/{{ language }}/">latest version</a>.
+     This documentation is a work in progress. For the Long Term Release and translations, please visit the <a href="https://docs.qgis.org/latest/{{ language }}/{{ pagename }}.html">latest version</a>.
     </div>
    {%- endif %}
 
    {%- if outdated %}
     <div class="row outdated">
-     This documentation is for a QGIS version which has reached end of life. Visit the <a href="https://docs.qgis.org/latest/{{ language }}/">latest version</a> instead.
+     This documentation is for a QGIS version which has reached end of life. Visit the <a href="https://docs.qgis.org/latest/{{ language }}/{{ pagename }}.html">latest version</a> instead.
     </div>
    {%- endif %}
   </nav>


### PR DESCRIPTION
The redirection keeps:
- the language (if not available in latest, we already have a redirection to English in use)
- and the page (if the page does not exist in latest, it will return a 404; we should probably consider setting a redirection ?)
follow-up #5035 