### PR TITLE
Double wording "the the"

### DIFF
--- a/docs/user_manual/processing_algs/gdal/rasterprojections.rst
+++ b/docs/user_manual/processing_algs/gdal/rasterprojections.rst
@@ -14,7 +14,7 @@ Assign projection
 -----------------
 Applies a coordinate system to a raster dataset.
 
-This algorithm is derived from the the `GDAL edit utility <https://gdal.org/gdal_edit.html>`_ .
+This algorithm is derived from the `GDAL edit utility <https://gdal.org/gdal_edit.html>`_ .
 
 ``Default menu``: :menuselection:`Raster --> Projections`
 


### PR DESCRIPTION
Line 17 : Double "the"  in sentence. Removed one instance

Goal: Display correct documentation

- [x] Backport to LTR documentation is required
