### PR TITLE
Flipped pictures (what was upper is now lower and vice versa)

### DIFF
--- a/docs/user_manual/working_with_vector/attribute_table.rst
+++ b/docs/user_manual/working_with_vector/attribute_table.rst
@@ -141,7 +141,7 @@ It can be 'Remember last view', 'Table view' or 'Form view'.
 .. figure:: img/attribute_table_views.png
    :align: center
 
-   Attribute table in form view (top) vs table view (bottom)
+   Attribute table in table view (top) vs form view (bottom)
 
 
 .. index:: Sort columns, Add actions


### PR DESCRIPTION
Line 144 :  Was " Attribute table in form view (top) vs table view (bottom)", but the two pictures have             
                 been flipped.
So, should be " Attribute table in table view (top) vs form view (bottom) "

Goal: Display correct documentation

- [x] Backport to LTR documentation is required
