### PR TITLE
Show only the relevant options in the bottom bar

### DIFF
--- a/themes/rtd_qgis/versions.html
+++ b/themes/rtd_qgis/versions.html
@@ -30,15 +30,21 @@
       </dl>
       {% endif %}
 
+      {# Hide contribute to docs fields for obsolete documents. #}
+      {% if not outdated %} 
       <dl>
         <dt>{{ _('Contribute to Docs') }}</dt>
           <dd>
             <a href="{{github_url}}/{{pagename}}.rst">{{ _('Edit on GitHub') }}</a>
           </dd>
+          {# Display the call for translation only for the latest document. #}
+          {% if not isTesting %} 
           <dd>
             <a href="{{transifex_url}}">{{ _('Translate Page') }}</a>
           </dd>
+          {% endif %}
       </dl>
+      {% endif %}
 
       <dl>
         <dt>{{ _('On QGIS Project') }}</dt>


### PR DESCRIPTION
ie, hide "Contribute to docs" section for outdated versions and only display the transifex url for the actually translated version (latest) - like in the previous structure
![image](https://user-images.githubusercontent.com/7983394/77247732-171b8480-6c34-11ea-999f-212e3aba247c.png)

![image](https://user-images.githubusercontent.com/7983394/77247642-4d0c3900-6c33-11ea-8167-b57738c9d2dd.png)
