### PR TITLE
Fix links for pages in the bottom bar

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -157,10 +157,12 @@ intersphinx_mapping = {'pyqgis_api': ('https://qgis.org/pyqgis/{}/'.format(pyqgi
 api_version = version if version != 'testing' else ''
 source_version = ''.join(['release-', version]).replace('.', '_') if version != 'testing' else 'master'
 
-extlinks = {'api': ('https://qgis.org/api/{}%s'.format(''.join([version, '/']) if version != 'testing' else ''), None),
-            'pyqgis': ('https://qgis.org/pyqgis/{}/%s'.format(version if version != 'testing' else 'master'), None),
-            'source': ('https://github.com/qgis/QGIS/blob/{}/%s'.format(
-                ''.join(['release-', version]).replace('.', '_') if version != 'testing' else 'master'), None)
+extlinks = {# api website: docs master branch points to '/' while x.y points to x.y
+            'api': ('https://qgis.org/api/{}%s'.format(''.join([version, '/']) if version != 'testing' else ''), None),
+            # pyqgis website: docs master branch points to 'master' and x.y points to x.y
+            'pyqgis': ('https://qgis.org/pyqgis/{}/%s'.format(pyqgis_version), None),
+            # code on github: docs master branch points to 'master' while x.y points to release-x_y
+            'source': ('https://github.com/qgis/QGIS/blob/{}/%s'.format(source_version), None)
            }
 
 context = {

--- a/conf.py
+++ b/conf.py
@@ -150,10 +150,9 @@ version_list = cfg['version_list'].replace(' ','').split(',')
 url = cfg['docs_url']
 if not url.endswith('/'):
   url += '/'
-github_url = cfg['github_url'] + 'tree/master'
-if not github_url.endswith('/'):
-  github_url += '/'
+github_url = cfg['github_url'] + 'edit/master'
 transifex_url = cfg['transifex_url']
+
 
 if version not in version_list:
   raise ValueError('QGIS version is not in version list', version, version_list)

--- a/conf.py
+++ b/conf.py
@@ -147,12 +147,7 @@ html_context = {
 
 supported_languages = cfg['supported_languages'].replace(' ','').split(',')
 version_list = cfg['version_list'].replace(' ','').split(',')
-url = cfg['docs_url']
-if not url.endswith('/'):
-  url += '/'
-github_url = cfg['github_url'] + 'edit/master'
-transifex_url = cfg['transifex_url']
-
+docs_url = 'https://docs.qgis.org/'
 
 if version not in version_list:
   raise ValueError('QGIS version is not in version list', version, version_list)
@@ -178,15 +173,17 @@ extlinks = {'api': ('https://qgis.org/api/{}%s'.format(''.join([version, '/']) i
 context = {
     # 'READTHEDOCS': True,
     'version_downloads': False,
-    'versions': [ [v, url+v] for v in version_list],
-    'supported_languages': [ [l, url+version+'/'+l] for l in supported_languages],
+    'versions': [ [v, docs_url+v] for v in version_list],
+    'supported_languages': [ [l, docs_url+version+'/'+l] for l in supported_languages],
     # 'downloads': [ ['PDF', '/builders.pdf'], ['HTML', '/builders.tgz'] ],
+    
     'display_github': True,
-    'github_url': github_url,
     'github_user': 'qgis',
     'github_repo': 'QGIS-Documentation',
     'github_version': 'master/',
-    'transifex_url': transifex_url,
+    'github_url':'https://github.com/qgis/QGIS-Documentation/edit/master',
+    'transifex_url': 'https://www.transifex.com/qgis/qgis-documentation/translate',
+    
     'pyqgis_version': pyqgis_version,
     'source_version': source_version,
     'api_version': api_version
@@ -197,6 +194,7 @@ if 'html_context' in globals():
 else:
     html_context = context
 
+# -- Settings for Python code samples testing --------------------------------
 
 # adding this because in pycookbook a lot of text is referencing classes, which cannot be found by sphinx
 # eg: Map canvas is implemented as :class:`QgsMapCanvas` ...

--- a/conf.py
+++ b/conf.py
@@ -100,18 +100,11 @@ html_theme_options = {
     'prev_next_buttons_location': 'both',
     # style_external_links': Add an icon next to external links. Default: False,
     'style_external_links': False,
-    # vcs_pageview_mode': Changes how to view files when using display_github, display_gitlab, etc. When using GitHub or GitLab this can be: blob (default), edit, or raw. On Bitbucket, this can be either: view (default) or edit. '',
-    # unsupported ??
-    #'vcs_pageview_mode': 'edit',
     # style_nav_header_background': Changes the background of the search area in the navigation bar. The value can be anything valid in a CSS background property. Default: 'white',
     #'style_nav_header_background': 'Gray',
     # Toc options
     # titles_only: When enabled, page subheadings are not included in the navigation. Default: False
     # 'titles_only': False,
-    # 'github_url' Force the Edit on GitHub button to use the configured URL.
-     'github_url': 'https://github.com/qgis/QGIS-Documentation',
-    # 'gitlab_url' Force the Edit on GitLab button to use the configured URL.
-    # 'gitlab_url': 'xxx',
 }
 
 # Add any paths that contain custom themes here, relative to this directory.

--- a/docs_conf.yml
+++ b/docs_conf.yml
@@ -4,4 +4,4 @@ version_list: testing, latest, 3.10, 3.4, 2.18
 supported_languages: en
 docs_url: https://docs.qgis.org/
 github_url: https://github.com/qgis/QGIS-Documentation/
-transifex_url: https://www.transifex.com/qgis/qgis-documentation/dashboard/
+transifex_url: https://www.transifex.com/qgis/qgis-documentation/translate

--- a/docs_conf.yml
+++ b/docs_conf.yml
@@ -2,6 +2,4 @@
 version_list: testing, latest, 3.10, 3.4, 2.18
 # Fill this list based on languages that are actually pulled from transifex
 supported_languages: en
-docs_url: https://docs.qgis.org/
-github_url: https://github.com/qgis/QGIS-Documentation/
-transifex_url: https://www.transifex.com/qgis/qgis-documentation/translate
+

--- a/themes/rtd_qgis/theme.conf
+++ b/themes/rtd_qgis/theme.conf
@@ -4,4 +4,3 @@ stylesheet = css/qgis_docs.css
 
 [options]
 style_external_links = True
-github_url = https://github.com/qgis/QGIS-Documentation

--- a/themes/rtd_qgis/versions.html
+++ b/themes/rtd_qgis/versions.html
@@ -10,14 +10,14 @@
       <dl>
         <dt>{{ _('Languages') }}</dt>
         {% for slug, url in supported_languages %}
-          <dd><a href="{{ url }}">{{ slug }}</a></dd>
+          <dd><a href="{{ url }}/{{ pagename }}.html">{{ slug }}</a></dd>
         {% endfor %}
       </dl>
 
       <dl>
         <dt>{{ _('Versions') }}</dt>
         {% for slug, url in versions %}
-          <dd><a href="{{ url }}">{{ slug }}</a></dd>
+          <dd><a href="{{ url }}/{{ language }}/{{ pagename }}.html">{{ slug }}</a></dd>
         {% endfor %}
       </dl>
 
@@ -35,7 +35,7 @@
       <dl>
         <dt>{{ _('Contribute to Docs') }}</dt>
           <dd>
-            <a href="{{github_url}}/{{pagename}}.rst">{{ _('Edit on GitHub') }}</a>
+            <a href="{{ github_url }}/{{ pagename }}.rst">{{ _('Edit on GitHub') }}</a>
           </dd>
           {# Display the call for translation only for the latest document. #}
           {% if not isTesting %} 
@@ -49,7 +49,7 @@
       <dl>
         <dt>{{ _('On QGIS Project') }}</dt>
           <dd>
-            <a href="https://qgis.org/">{{ _('Home') }}</a>
+            <a href="https://qgis.org/{{ language }}">{{ _('Home') }}</a>
           </dd>
           <dd>
             <a href="https://qgis.org/api/{{ api_version }}">{{ _('C++ API') }}</a>

--- a/themes/rtd_qgis/versions.html
+++ b/themes/rtd_qgis/versions.html
@@ -40,7 +40,7 @@
           {# Display the call for translation only for the latest document. #}
           {% if not isTesting %} 
           <dd>
-            <a href="{{transifex_url}}">{{ _('Translate Page') }}</a>
+            <a href="{{ transifex_url }}/#{{ language }}/{{ pagename }}">{{ _('Translate Page') }}</a>
           </dd>
           {% endif %}
       </dl>


### PR DESCRIPTION
Currently when switching on items in the bottom bar, regardless where you are in the docs, it opens:
- the main index page if you change language
- the main index page in English if you change version.
Other links are also English-centered.

This PR:
- ensures that it instead keeps the page you are reading and only changes the target language or version (a possible 404 if page does not exist in the other version - need to catch?)
- fixes the "edit on github" buttons (the ones in the bottom bar and at the top of the window) url and make them open the source file in edit mode (like we previously did)
- updates the transifex url--> This still needs a work: replace the pagename with a regex to match transifex file naming (Someone to take this?)
- simplify and aerate the configuration file(s) - first round
