### PR TITLE
Updated reference and local substitutions

### DIFF
--- a/docs/user_manual/introduction/qgis_gui.rst
+++ b/docs/user_manual/introduction/qgis_gui.rst
@@ -704,7 +704,7 @@ actions like:
        :guilabel:`Image...`
      -
      -
-     - :ref:`decorations`
+     - :ref:`image_decorations`
    * - :menuselection:`-->`
        :guilabel:`North Arrow...`
      -
@@ -2576,8 +2576,6 @@ Click the icon to open the Plugin Manager dialog.
    :width: 1.5em
 .. |circularStringRadius| image:: /static/common/mActionCircularStringRadius.png
    :width: 1.5em
-.. |coordinateCapture| image:: /static/common/coordinate_capture.png
-   :width: 1.5em
 .. |customProjection| image:: /static/common/mActionCustomProjection.png
    :width: 1.5em
 .. |dataSourceManager| image:: /static/common/mActionDataSourceManager.png
@@ -2614,9 +2612,9 @@ Click the icon to open the Plugin Manager dialog.
    :width: 1.5em
 .. |eventId| image:: /static/common/event_id.png
    :width: 1.5em
-.. |expressionSelect| image:: /static/common/mIconExpressionSelect.png
-   :width: 1.5em
 .. |evisConnect| image:: /static/common/evis_connect.png
+   :width: 1.5em
+.. |expressionSelect| image:: /static/common/mIconExpressionSelect.png
    :width: 1.5em
 .. |extents| image:: /static/common/extents.png
    :width: 1.5em
@@ -2633,11 +2631,7 @@ Click the icon to open the Plugin Manager dialog.
    :width: 1.5em
 .. |formSelect| image:: /static/common/mIconFormSelect.png
    :width: 1.5em
-.. |geometryChecker| image:: /static/common/geometrychecker.png
-   :width: 1.5em
 .. |georefRun| image:: /static/common/mGeorefRun.png
-   :width: 1.5em
-.. |gpsImporter| image:: /static/common/gps_importer.png
    :width: 1.5em
 .. |helpContents| image:: /static/common/mActionHelpContents.png
    :width: 1.5em
@@ -2812,8 +2806,6 @@ Click the icon to open the Plugin Manager dialog.
 .. |sum| image:: /static/common/mActionSum.png
    :width: 1.2em
 .. |toggleEditing| image:: /static/common/mActionToggleEditing.png
-   :width: 1.5em
-.. |topologyChecker| image:: /static/common/mActionTopologyChecker.png
    :width: 1.5em
 .. |tracking| image:: /static/common/tracking.png
    :width: 1.5em


### PR DESCRIPTION
reference to image decoration is now OK.
Several substitions have been removed from text but not from local substitions.
Next time you run find_set_subs.py, qgis_gui.rst is complete and will not change!
<!---
Include a few sentences describing the overall goals for this Pull Request.
 
A list of issues is at https://github.com/qgis/QGIS-Documentation/issues.
Add "fix #issuenumber" for each issue the PR fixes. The ticket(s) will be closed automatically.
If your PR doesn't fix entirely the ticket, only add the ticket(s) reference preceded by # character.
-->
Goal:

Ticket(s): fix#5140
<!---
Indicate whether the fix should be backported to previous release.
Replace the space between square brackets by a `x` to make it checked.
-->
- [x] Backport to LTR documentation is required

<!---
Reviewing is a process done by community members, mostly on a volunteer basis.
We try to keep the overhead as small as possible and appreciate if you help us.
Please read carefully and ensure you comply with our writing guidelines at
https://docs.qgis.org/testing/en/docs/documentation_guidelines/index.html.
Feel free to ask in a comment or the (qgis-community-team mailing list)
[https://lists.osgeo.org/mailman/listinfo/qgis-community-team] if you have troubles with any item.
--->
