### PR TITLE
Typo corrected

### DIFF
--- a/docs/pyqgis_developer_cookbook/legend.rst
+++ b/docs/pyqgis_developer_cookbook/legend.rst
@@ -27,7 +27,7 @@ The QgsProject class
 ====================
 
 You can use :class:`QgsProject <qgis.core.QgsProject>` to retrieve information
-about the TOC and all the layer loaded.
+about the TOC and all the layers loaded.
 
 You have to create an ``instance`` of :class:`QgsProject <qgis.core.QgsProject>`
 and use its methods to get the loaded layers.


### PR DESCRIPTION
Line 30 : "all the layer loaded"  should probably be plural and therefore should be "all the layers loaded"

Goal: Display correct documentation

- [x] Backport to LTR documentation is required

