### PR TITLE
Typo corrected

### DIFF
--- a/docs/user_manual/processing_algs/qgis/vectortable.rst
+++ b/docs/user_manual/processing_algs/qgis/vectortable.rst
@@ -683,7 +683,7 @@ Outputs
    * - **Folder**
      - ``FOLDER``
      - [folder]
-     - The folder that contains the output file.
+     - The folder that contains the output files.
 
 
 .. _qgisfeaturefilter:


### PR DESCRIPTION
Line 686 : "The folder that contains the output file." should probably be plural since the description of the algorithm states: "Extracts contents from a binary field, saving them to individual files."

Therefore corrected to:   "The folder that contains the output files."


Goal: Display correct documentation

- [x] Backport to LTR documentation is required
