### PR TITLE
Remove the 'Last updated' sentence in the left column

### DIFF
--- a/themes/rtd_qgis/layout.html
+++ b/themes/rtd_qgis/layout.html
@@ -20,31 +20,3 @@
 
  {% endblock extrabody %}
 
-          {% block menu %}
-            {#
-              The singlehtml builder doesn't handle this toctree call when the
-              toctree is empty. Skip building this for now.
-            #}
-            {% if 'singlehtml' not in builder %}
-              {% set global_toc = toctree(maxdepth=theme_navigation_depth|int,
-                                          collapse=theme_collapse_navigation|tobool,
-                                          includehidden=theme_includehidden|tobool,
-                                          titles_only=theme_titles_only|tobool) %}
-            {% endif %}
-            {% if global_toc %}
-              {{ global_toc }}
-            {% else %}
-              <!-- Local TOC -->
-              <div class="local-toc">{{ toc }}</div>
-            {% endif %}
-
-            {% if pagename == 'docs/index' and last_updated %}
-            <ul>
-              <li>&nbsp;</li>
-              <li class="toctree-l1" style="padding:1.5em; font-size:small;">
-                {% trans last_updated=last_updated|e %}Last updated on {{ last_updated }}{% endtrans %}
-              </li>
-            </ul>
-            {% endif %}
-
-          {% endblock %}


### PR DESCRIPTION
It seemed that after setting the html_last_updated_fmt param in
conf.py automagically there is a 'last updated' string in the footer
of every page.

Though my aim was also to minimize the number of pages changed
(by only putting it on the frontpage index), I'm fine with this.

<!---
Include a few sentences describing the overall goals for this Pull Request.
 
A list of issues is at https://github.com/qgis/QGIS-Documentation/issues.
Add "fix #issuenumber" for each issue the PR fixes. The ticket(s) will be closed automatically.
If your PR doesn't fix entirely the ticket, only add the ticket(s) reference preceded by # character.
-->
Goal:

Ticket(s): #
<!---
Indicate whether the fix should be backported to previous release.
Replace the space between square brackets by a `x` to make it checked.
-->
- [x] Backport to LTR documentation is required

<!---
Reviewing is a process done by community members, mostly on a volunteer basis.
We try to keep the overhead as small as possible and appreciate if you help us.
Please read carefully and ensure you comply with our writing guidelines at
https://docs.qgis.org/testing/en/docs/documentation_guidelines/index.html.
Feel free to ask in a comment or the (qgis-community-team mailing list)
[https://lists.osgeo.org/mailman/listinfo/qgis-community-team] if you have troubles with any item.
--->
