### PR TITLE
Added two periods after end of sentence

### DIFF
--- a/docs/user_manual/processing_algs/qgis/cartography.rst
+++ b/docs/user_manual/processing_algs/qgis/cartography.rst
@@ -49,7 +49,7 @@ Parameters
      - [file]
        
        Default: ``[Save to temporary file]``
-     - Output :file:`.XML` file combining the selected style items
+     - Output :file:`.XML` file combining the selected style items.
        One of:
 
        * Save to a Temporary Layer (``TEMPORARY_OUTPUT``)
@@ -262,7 +262,7 @@ Parameters
      - [file]
 
        Default: ``[Save to temporary file]``
-     - Specify the output :file:`.XML` file for the selected style items
+     - Specify the output :file:`.XML` file for the selected style items.
        One of:
 
        * Save to a Temporary Layer (``TEMPORARY_OUTPUT``)


### PR DESCRIPTION
Line 52    :  " style items"  should be " style items." since "One of: " is on the same line in display
Line 265  :  " style items"  should be " style items." since "One of: " is on the same line in display

Goal: Display correct information

- [x] Backport to LTR documentation is required
