### PR TITLE
Two typo's corrected

### DIFF
--- a/docs/user_manual/processing_algs/qgis/vectorgeometry.rst
+++ b/docs/user_manual/processing_algs/qgis/vectorgeometry.rst
@@ -3733,7 +3733,7 @@ Multipart to singleparts
 Splits multipart features in the input layer into singlepart
 features.
 
-The attributes of the output layer is the same of the original ones
+The attributes of the output layer are the same of the original ones
 but divided into single features.
 
 .. figure:: img/multipart.png
@@ -6630,7 +6630,7 @@ Parameters
      - [vector: polygon]
 
        Default: ``[Create temporary layer]``
-     - Specify the output (buffer) layer
+     - Specify the output (buffer) layer.
        One of:
 
        * Create Temporary Layer (``TEMPORARY_OUTPUT``)

--- a/docs/user_manual/processing_algs/qgis/vectorgeometry.rst
+++ b/docs/user_manual/processing_algs/qgis/vectorgeometry.rst
@@ -3733,7 +3733,7 @@ Multipart to singleparts
 Splits multipart features in the input layer into singlepart
 features.
 
-The attributes of the output layer are the same of the original ones
+The attributes of the output layer are the same as the original ones
 but divided into single features.
 
 .. figure:: img/multipart.png


### PR DESCRIPTION
Line 3636  : "layer is the same" should be plural. Calls back on "attributes" not on "layer";  therefore "layer are the same"
Line 6633  : "(buffer) layer One of:" added point (.) after "layer". End of sentence. "(buffer) layer. One of:"


Goal: Display correct documentation
- [x] Backport to LTR documentation is required
