### PR TITLE
Typo's

### DIFF
--- a/docs/user_manual/managing_data_source/opening_data.rst
+++ b/docs/user_manual/managing_data_source/opening_data.rst
@@ -48,7 +48,7 @@ More than 80 vector and 140 raster formats are supported by
    installation of your OS may not have been built to support the format you
    want to use. To see the list of available formats, run the command line
    ``ogrinfo --formats`` (for vector) and ``gdalinfo --formats`` (for raster),
-   or check :menuselection:`settings --> Options --> GDAL` menu (for raster)
+   or check :menuselection:`Settings --> Options --> GDAL` menu (for raster)
    in QGIS.
    
 .. let's use ogrinfo until a list of vector formats is provided in a (GDAL/)OGR tab


### PR DESCRIPTION
Line 51 :  "settings -->"  should be "Settings -->" as it is a selection in a menu

Line 547 : "approriate :guilabel:`Geometry field` " should be "appropriate :guilabel:`Geometry type` " ( 1 typo en wrong name for this field)


Goal: Display correct documentation

- [x] Backport to LTR documentation is required

