### PR TITLE
Typo corrected

### DIFF
--- a/docs/user_manual/working_with_vector/vector_properties.rst
+++ b/docs/user_manual/working_with_vector/vector_properties.rst
@@ -2287,7 +2287,7 @@ To create a join:
    layer
 #. Specify the :guilabel:`Join field` and the :guilabel:`Target field` that are
    common to both the join layer and the target layer
-#. Press :guilabel:`OK` and a summary of selected parametersis added to the
+#. Press :guilabel:`OK` and a summary of selected parameters is added to the
    :guilabel:`Join` panel.
 
 .. _figure_joins:


### PR DESCRIPTION
Line 2290 : "parametersis" should be "parameters is"


Goal:Display correct documentation

- [x] Backport to LTR documentation is required
