### PR TITLE
Open third-party urls of the bottom bar in a new tab

### DIFF
--- a/themes/rtd_qgis/versions.html
+++ b/themes/rtd_qgis/versions.html
@@ -35,12 +35,12 @@
       <dl>
         <dt>{{ _('Contribute to Docs') }}</dt>
           <dd>
-            <a href="{{ github_url }}/{{ pagename }}.rst">{{ _('Edit on GitHub') }}</a>
+            <a href="{{ github_url }}/{{ pagename }}.rst" target="_blank" rel="noopener noreferrer">{{ _('Edit on GitHub') }}</a>
           </dd>
           {# Display the call for translation only for the latest document. #}
           {% if not isTesting %} 
           <dd>
-            <a href="{{ transifex_url }}/#{{ language }}/{{ pagename | replace("/","--") }}">{{ _('Translate Page') }}</a>
+            <a href="{{ transifex_url }}/#{{ language }}/{{ pagename | replace("/","--") }}" target="_blank" rel="noopener noreferrer">{{ _('Translate Page') }}</a>
           </dd>
           {% endif %}
       </dl>
@@ -49,16 +49,16 @@
       <dl>
         <dt>{{ _('On QGIS Project') }}</dt>
           <dd>
-            <a href="https://qgis.org/{{ language }}">{{ _('Home') }}</a>
+            <a href="https://qgis.org/{{ language }}" target="_blank" rel="noopener noreferrer">{{ _('Home') }}</a>
           </dd>
           <dd>
-            <a href="https://qgis.org/api/{{ api_version }}">{{ _('C++ API') }}</a>
+            <a href="https://qgis.org/api/{{ api_version }}" target="_blank" rel="noopener noreferrer">{{ _('C++ API') }}</a>
           </dd>
           <dd>
-            <a href="https://qgis.org/pyqgis/{{ pyqgis_version }}">{{ _('PyQGIS API') }}</a>
+            <a href="https://qgis.org/pyqgis/{{ pyqgis_version }}" target="_blank" rel="noopener noreferrer">{{ _('PyQGIS API') }}</a>
           </dd>
           <dd>
-            <a href="https://github.com/qgis/QGIS/tree/{{ source_version }}">{{ _('Source') }}</a>
+            <a href="https://github.com/qgis/QGIS/tree/{{ source_version }}" target="_blank" rel="noopener noreferrer">{{ _('Source') }}</a>
           </dd>
       </dl>
 


### PR DESCRIPTION
When the user hits api, transifex or github urls in the bottom bar, we should still let the user have an access to the docs' current page and open the requested page in a new tab