### PR TITLE
Fix#4056

### DIFF
--- a/docs/user_manual/working_with_vector/vector_properties.rst
+++ b/docs/user_manual/working_with_vector/vector_properties.rst
@@ -509,7 +509,7 @@ on the item you want to change.
 
 Right-clicking over selected item(s) shows a contextual menu to
 **Copy/Paste Symbol**, **Change Color**, **Change Opacity**,
-**Change Output Unit**, **Change Width**.
+**Change Output Unit**, **Change Width / Size**, **Change Angle**.
 
 The example in figure_graduated_symbology_ shows the graduated rendering dialog for
 the major_rivers layer of the QGIS sample dataset.
@@ -665,7 +665,7 @@ can also be achieved by writing ``Else`` in the *Rule* column of the
 
 Right-clicking over selected rule(s) shows a contextual menu to **Copy/Paste**,
 **Copy/Paste Symbol**, **Change Color**, **Change Opacity**,
-**Change Output Unit**, **Change Width** and **Refine Current Rule**.
+**Change Output Unit**, **Change Width/Size**, **Change Angle** and **Refine Current Rule**.
 
 The created rules also appear in a tree hierarchy in the map legend.
 Double-click the rules in the map legend and the Symbology tab of the layer

--- a/docs/user_manual/working_with_vector/vector_properties.rst
+++ b/docs/user_manual/working_with_vector/vector_properties.rst
@@ -421,7 +421,7 @@ Right-clicking over selected item(s) shows a contextual menu to:
   to apply a category's representation to others
 * :guilabel:`Change Color...` of the selected symbol(s)
 * :guilabel:`Change Opacity...` of the selected symbol(s)
-* :guilabel:`Change output Unit...` of the selected symbol(s)
+* :guilabel:`Change Output Unit...` of the selected symbol(s)
 * :guilabel:`Change Width...` of the selected line symbol(s)
 * :guilabel:`Merge Categories`: Groups multiple selected categories into a single
   one. This allows simpler styling of layers with a large number of categories,
@@ -507,8 +507,9 @@ classes can be disabled unchecking the checkbox at the left of the class name.
 To change symbol, value and/or label of the class, just double click
 on the item you want to change.
 
-Right-click shows a contextual menu to **Copy/Paste**, **Change color**, **Change
-transparency**, **Change output unit**, **Change symbol width**.
+Right-clicking over selected item(s) shows a contextual menu to
+**Copy/Paste Symbol**, **Change Color**, **Change Opacity**,
+**Change Output Unit**, **Change Width**.
 
 The example in figure_graduated_symbology_ shows the graduated rendering dialog for
 the major_rivers layer of the QGIS sample dataset.
@@ -661,6 +662,10 @@ make use of the |radioButtonOff| :guilabel:`Else` option to catch all the
 features that do not match any of the other rules, at the same level. This
 can also be achieved by writing ``Else`` in the *Rule* column of the
 :menuselection:`Layer Properties --> Symbology --> Rule-based` dialog.
+
+Right-clicking over selected rule(s) shows a contextual menu to **Copy/Paste**,
+**Copy/Paste Symbol**, **Change Color**, **Change Opacity**,
+**Change Output Unit**, **Change Width** and **Refine Current Rule**.
 
 The created rules also appear in a tree hierarchy in the map legend.
 Double-click the rules in the map legend and the Symbology tab of the layer


### PR DESCRIPTION
describe new feature Copy/Paste Symbol for Right-Click menu for three renderers
Includes some other minor improvements like replace Change Transparancy with Change Opacity

<!---
Include a few sentences describing the overall goals for this Pull Request.
 
A list of issues is at https://github.com/qgis/QGIS-Documentation/issues.
Add "fix #issuenumber" for each issue the PR fixes. The ticket(s) will be closed automatically.
If your PR doesn't fix entirely the ticket, only add the ticket(s) reference preceded by # character.
-->
Goal: Describe new functionality for three style renderers in a consistent way.  

Ticket(s): fixes #4056 
<!---
Indicate whether the fix should be backported to previous release.
Replace the space between square brackets by a `x` to make it checked.
-->
- [ x] Backport to LTR documentation is required
<!---
Reviewing is a process done by community members, mostly on a volunteer basis.
We try to keep the overhead as small as possible and appreciate if you help us.
Please read carefully and ensure you comply with our writing guidelines at
https://docs.qgis.org/testing/en/docs/documentation_guidelines/index.html.
Feel free to ask in a comment or the (qgis-community-team mailing list)
[https://lists.osgeo.org/mailman/listinfo/qgis-community-team] if you have troubles with any item.
--->
