### PR TITLE
Describe options depend on geometry

### DIFF
--- a/docs/user_manual/working_with_vector/vector_properties.rst
+++ b/docs/user_manual/working_with_vector/vector_properties.rst
@@ -418,7 +418,7 @@ Further tweaks can be done to the default classification:
 Right-clicking over selected item(s) shows a contextual menu to:
 
 * :guilabel:`Copy Symbol` and :guilabel:`Paste Symbol`, a convenient way
-  to apply a category's representation to others
+  to apply the item's representation to others
 * :guilabel:`Change Color...` of the selected symbol(s)
 * :guilabel:`Change Opacity...` of the selected symbol(s)
 * :guilabel:`Change Output Unit...` of the selected symbol(s)
@@ -509,15 +509,16 @@ classes can be disabled unchecking the checkbox at the left of the class name.
 To change symbol, value and/or label of the class, just double click
 on the item you want to change.
 
-Right-clicking over selected item(s) shows a contextual menu to
-**Copy/Paste Symbol**, **Change Color**, **Change Opacity**,
-**Change Output Unit**, **Change Width / Size**, **Change Angle**.
+Right-clicking over selected item(s) shows a contextual menu to:
 
-  Provided options of right-click menu depend on type of geometry:
-
-  * Line layers have **Change Width**  
-  * Point layers have **Change Size** and **Change Angle**
-  * Polygon layers do not have **Change Width / Size**
+* :guilabel:`Copy Symbol` and :guilabel:`Paste Symbol`, a convenient way
+  to apply the item's representation to others
+* :guilabel:`Change Color...` of the selected symbol(s)
+* :guilabel:`Change Opacity...` of the selected symbol(s)
+* :guilabel:`Change Output Unit...` of the selected symbol(s)
+* :guilabel:`Change Width...` of the selected line symbol(s)
+* :guilabel:`Change Size...` of the selected point symbol(s)
+* :guilabel:`Change Angle...` of the selected point symbol(s)
 
 The example in figure_graduated_symbology_ shows the graduated rendering dialog for
 the major_rivers layer of the QGIS sample dataset.
@@ -671,15 +672,19 @@ features that do not match any of the other rules, at the same level. This
 can also be achieved by writing ``Else`` in the *Rule* column of the
 :menuselection:`Layer Properties --> Symbology --> Rule-based` dialog.
 
-Right-clicking over selected rule(s) shows a contextual menu to **Copy/Paste**,
-**Copy/Paste Symbol**, **Change Color**, **Change Opacity**,
-**Change Output Unit**, **Change Width/Size**, **Change Angle** and **Refine Current Rule**.
+Right-clicking over selected item(s) shows a contextual menu to:
 
-  Provided options of right-click menu depend on type of geometry:
-   
-  * Line layers have **Change Width**  
-  * Point layers have **Change Size** and **Change Angle**
-  * Polygon layers do not have **Change Width / Size**
+* :guilabel:`Copy Symbol` and :guilabel:`Paste Symbol`, a convenient way
+  to apply a category's representation to others
+* :guilabel:`Change Color...` of the selected symbol(s)
+* :guilabel:`Change Opacity...` of the selected symbol(s)
+* :guilabel:`Change Output Unit...` of the selected symbol(s)
+* :guilabel:`Change Width...` of the selected line symbol(s)
+* :guilabel:`Change Size...` of the selected point symbol(s)
+* :guilabel:`Change Angle...` of the selected point symbol(s)
+* :guilabel:`Refine Current Rule`: open a submenu that allows to
+  refine the current rule with **scales**, **categories** (categorized renderer)
+  or **Ranges** (graduated renderer).
 
 The created rules also appear in a tree hierarchy in the map legend.
 Double-click the rules in the map legend and the Symbology tab of the layer

--- a/docs/user_manual/working_with_vector/vector_properties.rst
+++ b/docs/user_manual/working_with_vector/vector_properties.rst
@@ -675,7 +675,7 @@ can also be achieved by writing ``Else`` in the *Rule* column of the
 Right-clicking over selected item(s) shows a contextual menu to:
 
 * :guilabel:`Copy Symbol` and :guilabel:`Paste Symbol`, a convenient way
-  to apply a category's representation to others
+  to apply the item's representation to others
 * :guilabel:`Change Color...` of the selected symbol(s)
 * :guilabel:`Change Opacity...` of the selected symbol(s)
 * :guilabel:`Change Output Unit...` of the selected symbol(s)

--- a/docs/user_manual/working_with_vector/vector_properties.rst
+++ b/docs/user_manual/working_with_vector/vector_properties.rst
@@ -423,6 +423,8 @@ Right-clicking over selected item(s) shows a contextual menu to:
 * :guilabel:`Change Opacity...` of the selected symbol(s)
 * :guilabel:`Change Output Unit...` of the selected symbol(s)
 * :guilabel:`Change Width...` of the selected line symbol(s)
+* :guilabel:`Change Size...` of the selected point symbol(s)
+* :guilabel:`Change Angle...` of the selected point symbol(s)
 * :guilabel:`Merge Categories`: Groups multiple selected categories into a single
   one. This allows simpler styling of layers with a large number of categories,
   where it may be possible to group numerous distinct categories into a smaller
@@ -510,6 +512,12 @@ on the item you want to change.
 Right-clicking over selected item(s) shows a contextual menu to
 **Copy/Paste Symbol**, **Change Color**, **Change Opacity**,
 **Change Output Unit**, **Change Width / Size**, **Change Angle**.
+
+  Provided options of right-click menu depend on type of geometry:
+
+  * Line layers have **Change Width**  
+  * Point layers have **Change Size** and **Change Angle**
+  * Polygon layers do not have **Change Width / Size**
 
 The example in figure_graduated_symbology_ shows the graduated rendering dialog for
 the major_rivers layer of the QGIS sample dataset.
@@ -666,6 +674,12 @@ can also be achieved by writing ``Else`` in the *Rule* column of the
 Right-clicking over selected rule(s) shows a contextual menu to **Copy/Paste**,
 **Copy/Paste Symbol**, **Change Color**, **Change Opacity**,
 **Change Output Unit**, **Change Width/Size**, **Change Angle** and **Refine Current Rule**.
+
+  Provided options of right-click menu depend on type of geometry:
+   
+  * Line layers have **Change Width**  
+  * Point layers have **Change Size** and **Change Angle**
+  * Polygon layers do not have **Change Width / Size**
 
 The created rules also appear in a tree hierarchy in the map legend.
 Double-click the rules in the map legend and the Symbology tab of the layer

--- a/docs/user_manual/working_with_vector/vector_properties.rst
+++ b/docs/user_manual/working_with_vector/vector_properties.rst
@@ -674,6 +674,8 @@ can also be achieved by writing ``Else`` in the *Rule* column of the
 
 Right-clicking over selected item(s) shows a contextual menu to:
 
+* :guilabel:`Copy` and :guilabel:`Paste`, a convenient way to create new
+  item(s) based on existing item(s)
 * :guilabel:`Copy Symbol` and :guilabel:`Paste Symbol`, a convenient way
   to apply the item's representation to others
 * :guilabel:`Change Color...` of the selected symbol(s)


### PR DESCRIPTION
Described which right-click options are available when point, line or polygon is selected in one of three style renderers.
This was a suggested change by @havatv in pull request 5261, which I decided to include.
This is included in the description for three renderers.
<!---
Include a few sentences describing the overall goals for this Pull Request.
 
A list of issues is at https://github.com/qgis/QGIS-Documentation/issues.
Add "fix #issuenumber" for each issue the PR fixes. The ticket(s) will be closed automatically.
If your PR doesn't fix entirely the ticket, only add the ticket(s) reference preceded by # character.
-->
Goal:

Ticket(s): #4056
<!---
Indicate whether the fix should be backported to previous release.
Replace the space between square brackets by a `x` to make it checked.
-->
- [x] Backport to LTR documentation is required

<!---
Reviewing is a process done by community members, mostly on a volunteer basis.
We try to keep the overhead as small as possible and appreciate if you help us.
Please read carefully and ensure you comply with our writing guidelines at
https://docs.qgis.org/testing/en/docs/documentation_guidelines/index.html.
Feel free to ask in a comment or the (qgis-community-team mailing list)
[https://lists.osgeo.org/mailman/listinfo/qgis-community-team] if you have troubles with any item.
--->
