### PR TITLE
Fix list formatting on Introducing GIS page

### DIFF
--- a/docs/gentle_gis_introduction/introducing_gis.rst
+++ b/docs/gentle_gis_introduction/introducing_gis.rst
@@ -19,7 +19,7 @@ on a computer. GIS stands for **'Geographical Information System'**.
 A GIS consists of:
 
 * **Digital Data** –-- the geographical information that you will view and
-   analyse using computer hardware and software.
+  analyse using computer hardware and software.
 * **Computer Hardware** –-- computers used for storing data, displaying graphics
   and processing data.
 * **Computer Software** –-- computer programs that run on the computer hardware


### PR DESCRIPTION
Goal:
---
Align the second line of the **Digital Data** list item in the
list at the top of the "Introducing GIS" page so that it correctly
shows up as a list of three items, rather than a list with a
partial block quote.

- [ ] Backport to LTR documentation is required

[Before](https://docs.qgis.org/3.10/en/docs/gentle_gis_introduction/introducing_gis.html#overview):
---
![before](https://user-images.githubusercontent.com/34431661/80341106-ac52ff80-8816-11ea-8f64-92cef91b6c7b.png)

After:
---
![after](https://user-images.githubusercontent.com/34431661/80341100-a9f0a580-8816-11ea-838b-11d374082b76.png)


