### PR TITLE
Fix syntax and grammar in Gentle Introduction to GIS

### DIFF
--- a/docs/developers_guide/unittesting.rst
+++ b/docs/developers_guide/unittesting.rst
@@ -70,7 +70,7 @@ Creating a unit test
 ====================
 
 Creating a unit test is easy - typically you will do this by just creating a
-single :file:`.cpp` file (not :file:`.h` file is used) and implement all your
+single :file:`.cpp` file (no :file:`.h` file is used) and implement all your
 test methods as public methods that return void. We'll use a simple test class for
 ``QgsRasterLayer`` throughout the section that follows to illustrate. By convention
 we will name our test with the same name as the class they are testing but

--- a/docs/gentle_gis_introduction/topology.rst
+++ b/docs/gentle_gis_introduction/topology.rst
@@ -162,7 +162,7 @@ Common problems / things to be aware of
 =======================================
 
 Mainly designed for simplicity and for fast rendering but not for data analysis
-that require topology (such as finding routes across a network). Many GIS
+that requires topology (such as finding routes across a network), many GIS
 applications are able to show topological and simple feature data together and
 some can also create, edit and analyse both.
 

--- a/docs/gentle_gis_introduction/vector_spatial_analysis_buffers.rst
+++ b/docs/gentle_gis_introduction/vector_spatial_analysis_buffers.rst
@@ -74,7 +74,7 @@ figure_point_buffer_, figure_line_buffer_, ).
    :align: center
    :width: 30em
 
-   A buffer zone around vector polylines.
+   A buffer zone around vector polygons.
 
 Variations in buffering
 =======================


### PR DESCRIPTION
Fix Sentence Fragment in Topology

The previous section began with a sentence fragment, not a complete sentence. Add a comma to turn this into a compound sentence.

----

Update image caption to correctly say polygon

The image that shows a buffer zone around polygons was incorrectly labeled "A buffer zone around vector polylines." Update it to say polygons.

----

Switch not to no for proper grammar

The previous sentence didn't flow or sound right as is: "not .h file is used"

----

- [x] Backport to LTR documentation is required