### PR TITLE
Removed provider_options transform_context

### DIFF
--- a/docs/pyqgis_developer_cookbook/loadlayer.rst
+++ b/docs/pyqgis_developer_cookbook/loadlayer.rst
@@ -136,12 +136,9 @@ providers:
     uri = QgsDataSourceUri()
     # set host name, port, database name, username and password
     uri.setConnection("localhost", "5432", "dbname", "johny", "xxx")
-    provider_options = QgsDataProvider.ProviderOptions()
-    # Use project's transform context
-    provider_options.transformContext = QgsProject.instance().transformContext()
     # set database schema, table name, geometry column and optionally
     # subset (WHERE clause)
-    uri.setDataSource("public", "roads", "the_geom", "cityid = 2643", provider_options)
+    uri.setDataSource("public", "roads", "the_geom", "cityid = 2643", "primary_key_field")
 
     vlayer = QgsVectorLayer(uri.uri(False), "layer name you like", "postgres")
 


### PR DESCRIPTION
The provider_options transform_context is passed as the last parameter to uri.setDataSource(), I have checked both in the python console and in the source code and what I find is that the last parameter is for the primary_key of the database table. I only find one overload of this method, so unless there is another on the way, I think this is a mistake in the documentation.

<!---
Include a few sentences describing the overall goals for this Pull Request.
 
A list of issues is at https://github.com/qgis/QGIS-Documentation/issues.
Add "fix #issuenumber" for each issue the PR fixes. The ticket(s) will be closed automatically.
If your PR doesn't fix entirely the ticket, only add the ticket(s) reference preceded by # character.
-->
Goal:

Ticket(s): #
<!---
Indicate whether the fix should be backported to previous release.
Replace the space between square brackets by a `x` to make it checked.
-->
- [ ] Backport to LTR documentation is required

<!---
Reviewing is a process done by community members, mostly on a volunteer basis.
We try to keep the overhead as small as possible and appreciate if you help us.
Please read carefully and ensure you comply with our writing guidelines at
https://docs.qgis.org/testing/en/docs/documentation_guidelines/index.html.
Feel free to ask in a comment or the (qgis-community-team mailing list)
[https://lists.osgeo.org/mailman/listinfo/qgis-community-team] if you have troubles with any item.
--->
