### PR TITLE
Load PostGIS raster using manual URI string.

### DIFF
--- a/docs/pyqgis_developer_cookbook/loadlayer.rst
+++ b/docs/pyqgis_developer_cookbook/loadlayer.rst
@@ -305,62 +305,42 @@ in the layer list) in one step.
 To load a PostGIS raster:
 
 PostGIS rasters, similar to PostGIS vectors, can be added to a project using a URI string.
-It is efficient to create a dictionary of strings for the database connection parameters.
+It is efficient to keep a reusable dictionary of strings for the database connection parameters. 
+Editing those strings for the applicable connection.
 The dictionary is then loaded into an empty URI, before adding the raster.
-Note that None should be used when it is desired to leave the parameter blank: 
 
-.. code-block:: python
+.. testcode:: loadlayer
 
- uri_config = {#
- # database parameters
- 'dbname':'gis_db', # The PostgreSQL database to connect to.
- 'host':'localhost',     # The host IP address or localhost.
- 'port':'5432',          # The port to connect on.
- # SSL/TLS mode, comment/uncomment for your pyQgis version
- 'sslmode':QgsDataSourceUri.SslDisable, # pyQgis 3.13+ SslAllow, SslDisable, SslPrefer, SslRequire, SslVerifyCa, SslVerifyFull
- #'sslmode':'disable',    # pyQgis 3.12 allow, disable, prefer, require, verify-ca, verify-full
- # user and password are not needed if stored in the authcfg or service
- 'user':None,            # pyQgis 3.12 The PostgreSQL user name, also accepts the new WFS provider naming.
- 'username':None,        # pyQgis 3.13+ user name
- 'password':None,        # The PostgreSQL password for the user.
- 'service':None,         # The PostgreSQL service to be used for connection to the database.
- 'authcfg':'QconfigId',  # The QGIS athentication database ID holding connection details.
- # table and raster column details
- 'schema':'public',      # The database schema that the table is located in.
- 'table':'my_rasters',   # The database table to be loaded.
- 'geometrycolumn':'rast',# pyQgis 3.13+ raster column in PostGIS table
- 'column':'rast',        # pyQgis 3.12  raster column in PostGIS table
- 'mode':'2',             # GDAL 'mode' parameter, 2 unions raster tiles, 1 adds tiles separately (may require user input)
- 'sql':None,             # An SQL WHERE clause. It should be placed at the end of the string.
- 'key':None,             # A key column from the table.
- 'srid':None,            # A string designating the SRID of the coordinate reference system.
- 'estimatedmetadata':'False', # A boolean value telling if the metadata is estimated.
- 'type':None,            # A WKT string designating the WKB Type.
- 'selectatid':None,      # Set to True to disable selection by feature ID.
- 'options':None,         # other PostgreSQL connection options not in this list.
- # pyQgis 3.12 parameters
- #   These must must be manually added in 3.13: uri.setParam(key, value)
- 'connect_timeout':None, # The connection timeout time.
- 'hostaddr':None,
- 'driver':None,
- 'tty':None,
- 'requiressl':None,
- 'krbsrvname':None,
- 'gsslib':None,
- # Added in pyQgis 3.13+
- 'enableTime': None,
- 'temporalDefaultTime': None,
- 'temporalFieldIndex': None,
+ uri_config = {
+     # database parameters
+     'dbname':'gis_db',      # The PostgreSQL database to connect to.
+     'host':'localhost',     # The host IP address or localhost.
+     'port':'5432',          # The port to connect on.
+     'sslmode':QgsDataSourceUri.SslDisable, # SslAllow, SslPrefer, SslRequire, SslVerifyCa, SslVerifyFull
+     # user and password are not needed if stored in the authcfg or service
+     'authcfg':'QconfigId',  # The QGIS athentication database ID holding connection details.
+     'service':NULL,         # The PostgreSQL service to be used for connection to the database.
+     'username':NULL,        # The PostgreSQL user name.
+     'password':NULL,        # The PostgreSQL password for the user.
+     # table and raster column details
+     'schema':'public',      # The database schema that the table is located in.
+     'table':'my_rasters',   # The database table to be loaded.
+     'geometrycolumn':'rast',# raster column in PostGIS table
+     'where':'rid > 5',      # An SQL WHERE clause. It should be placed at the end of the string.
+     'key':NULL,             # A key column from the table.
+     'srid':NULL,            # A string designating the SRID of the coordinate reference system.
+     'estimatedmetadata':'False', # A boolean value telling if the metadata is estimated.
+     'type':NULL,            # A WKT string designating the WKB Type.
+     'selectatid':NULL,      # Set to True to disable selection by feature ID.
+     'options':NULL,         # other PostgreSQL connection options not in this list.
+     'enableTime': NULL,
+     'temporalDefaultTime': NULL,
+     'temporalFieldIndex': NULL,     
+     'mode':'2',             # GDAL 'mode' parameter, 2 unions raster tiles, 1 adds tiles separately (may require user input) 
  }
- ### For pyQgis 3.13+ use this syntax:
+ # get the metadata for the raster provider and configure the URI
  md = QgsProviderRegistry.instance().providerMetadata('postgresraster')
  uri = QgsDataSourceUri(md.encodeUri(uri_config))
- 
- ### For pyQgis 3.12 use this syntax: 
- uri = QgsDataSourceUri()
- for param in uri_config:
-     if (uri_config[param] != None):
-         uri.setParam(param, uri_config[param]) # this command can be used to manually add parameters to the URI
  
  # the raster can then be loaded into the project
  rlayer = iface.addRasterLayer(uri.uri(False), "raster layer name", "postgresraster")

--- a/docs/pyqgis_developer_cookbook/loadlayer.rst
+++ b/docs/pyqgis_developer_cookbook/loadlayer.rst
@@ -339,6 +339,8 @@ After that the raster can be added to the project.
      'temporalFieldIndex': NULL,     
      'mode':'2',             # GDAL 'mode' parameter, 2 unions raster tiles, 1 adds tiles separately (may require user input) 
  }
+ # remove any NULL parameters
+ uri_config = {key:val for key, val in uri_config.items() if val != NULL}
  # get the metadata for the raster provider and configure the URI
  md = QgsProviderRegistry.instance().providerMetadata('postgresraster')
  uri = QgsDataSourceUri(md.encodeUri(uri_config))

--- a/docs/pyqgis_developer_cookbook/loadlayer.rst
+++ b/docs/pyqgis_developer_cookbook/loadlayer.rst
@@ -304,42 +304,43 @@ in the layer list) in one step.
 
 To load a PostGIS raster:
 
-PostGIS rasters, similar to PostGIS vectors, can be added to a project using a URI string. It is efficient to create a dictionary of strings of the database connection parameters and load them into an empty URI, before adding the raster. Note that None should be used when it is desired to leave the parameter blank: 
+PostGIS rasters, similar to PostGIS vectors, can be added to a project using a URI string. It is efficient to create a dictionary of strings for the database connection parameters. The dictionary is then loaded into an empty URI, before adding the raster. Note that None should be used when it is desired to leave the parameter blank: 
 
 .. code-block:: python
 
  uri = QgsDataSourceUri()
  uri_config = {'dbname':'gis_db', # The PostgreSQL database to connect to.
-'host':'localhost',    # The host IP address or localhost.
-'port':'5432',         # The port to connect on.
-'user':None,           # The PostgreSQL user name, also accepts the new WFS provider naming.
-'password':None,       # The PostgreSQL password for the user.
-'service':None,        # The PostgreSQL service to be used for connection to the database.
-'authcfg':'QconfigId', # The QGIS athentication database ID holding connection details.
-'schema':'public',     # The database schema that the table is located in.
-'table':'my_rasters',  # The database table to be loaded.
-'sql':None,            # An SQL WHERE clause. It should be placed at the end of the string.
-'key':None,            # A key column from the table.
-'srid':None,           # A string designating the SRID of the coordinate reference system.
-'estimatedmetadata':'false', # A boolean value telling if the metadata is estimated.
-'type':None,           # A WKT string designating the WKB Type.
-'selectatid':None,     # Set to True to disable selection by feature ID.
-'connect_timeout':None, # The connection timeout time.
-'options':None,        # PostgreSQL connection options.
-'sslmode':None,        # disable, prefer, require, verify-ca, verify-full
-'hostaddr':None,
-'driver':None,
-'tty':None,
-'requiressl':None,
-'krbsrvname':None,
-'gsslib':None
-}
+ 'host':'localhost',    # The host IP address or localhost.
+ 'port':'5432',         # The port to connect on.
+ 'user':None,           # The PostgreSQL user name, also accepts the new WFS provider naming.
+ 'password':None,       # The PostgreSQL password for the user.
+ 'service':None,        # The PostgreSQL service to be used for connection to the database.
+ 'authcfg':'QconfigId', # The QGIS athentication database ID holding connection details.
+ 'schema':'public',     # The database schema that the table is located in.
+ 'table':'my_rasters',  # The database table to be loaded.
+ 'sql':None,            # An SQL WHERE clause. It should be placed at the end of the string.
+ 'key':None,            # A key column from the table.
+ 'srid':None,           # A string designating the SRID of the coordinate reference system.
+ 'estimatedmetadata':'false', # A boolean value telling if the metadata is estimated.
+ 'type':None,           # A WKT string designating the WKB Type.
+ 'selectatid':None,     # Set to True to disable selection by feature ID.
+ 'connect_timeout':None, # The connection timeout time.
+ 'options':None,        # PostgreSQL connection options.
+ 'sslmode':None,        # disable, prefer, require, verify-ca, verify-full
+ 'hostaddr':None,
+ 'driver':None,
+ 'tty':None,
+ 'requiressl':None,
+ 'krbsrvname':None,
+ 'gsslib':None
+ }
  for param in uri_config:
      if (uri_config[param] != None):
          uri.setParam(param, uri_config[param])
  
- # the raster can then be loaded
- rlayer = iface.addRasterLayer(uri.uri(False), "raster layer name", "postgresraster") 
+ # the raster can then be loaded into the project
+ rlayer = iface.addRasterLayer(uri.uri(False), "raster layer name", "postgresraster")
+ 
 
 
 Raster layers can also be created from a WCS service:

--- a/docs/pyqgis_developer_cookbook/loadlayer.rst
+++ b/docs/pyqgis_developer_cookbook/loadlayer.rst
@@ -320,7 +320,7 @@ After that the raster can be added to the project.
      'sslmode':QgsDataSourceUri.SslDisable, # SslAllow, SslPrefer, SslRequire, SslVerifyCa, SslVerifyFull
      # user and password are not needed if stored in the authcfg or service
      'authcfg':'QconfigId',  # The QGIS athentication database ID holding connection details.
-     'service':NULL,         # The PostgreSQL service to be used for connection to the database.
+     'service': None,         # The PostgreSQL service to be used for connection to the database.
      'username':NULL,        # The PostgreSQL user name.
      'password':NULL,        # The PostgreSQL password for the user.
      # table and raster column details

--- a/docs/pyqgis_developer_cookbook/loadlayer.rst
+++ b/docs/pyqgis_developer_cookbook/loadlayer.rst
@@ -306,8 +306,9 @@ To load a PostGIS raster:
 
 PostGIS rasters, similar to PostGIS vectors, can be added to a project using a URI string.
 It is efficient to keep a reusable dictionary of strings for the database connection parameters. 
-Editing those strings for the applicable connection.
-The dictionary is then loaded into an empty URI, before adding the raster.
+This makes it easy to edit the dictionary for the applicable connection.
+The dictionary is then encoded into a URI using the 'postgresraster' provider metadata object.
+After that the raster can be added to the project.
 
 .. testcode:: loadlayer
 

--- a/docs/pyqgis_developer_cookbook/loadlayer.rst
+++ b/docs/pyqgis_developer_cookbook/loadlayer.rst
@@ -13,6 +13,7 @@
         QgsApplication,
         QgsDataSourceUri,
         QgsLayerTreeLayer,
+        QgsProviderRegistry
     )
 
     iface = start_qgis()

--- a/docs/pyqgis_developer_cookbook/loadlayer.rst
+++ b/docs/pyqgis_developer_cookbook/loadlayer.rst
@@ -316,6 +316,9 @@ Note that None should be used when it is desired to leave the parameter blank:
  'dbname':'gis_db', # The PostgreSQL database to connect to.
  'host':'localhost',     # The host IP address or localhost.
  'port':'5432',          # The port to connect on.
+ # SSL/TLS mode, comment/uncomment for your pyQgis version
+ 'sslmode':QgsDataSourceUri.SslDisable, # pyQgis 3.13+ SslAllow, SslDisable, SslPrefer, SslRequire, SslVerifyCa, SslVerifyFull
+ #'sslmode':'disable',    # pyQgis 3.12 allow, disable, prefer, require, verify-ca, verify-full
  # user and password are not needed if stored in the authcfg or service
  'user':None,            # pyQgis 3.12 The PostgreSQL user name, also accepts the new WFS provider naming.
  'username':None,        # pyQgis 3.13+ user name
@@ -327,6 +330,7 @@ Note that None should be used when it is desired to leave the parameter blank:
  'table':'my_rasters',   # The database table to be loaded.
  'geometrycolumn':'rast',# pyQgis 3.13+ raster column in PostGIS table
  'column':'rast',        # pyQgis 3.12  raster column in PostGIS table
+ 'mode':'2',             # GDAL 'mode' parameter, 2 unions raster tiles, 1 adds tiles separately (may require user input)
  'sql':None,             # An SQL WHERE clause. It should be placed at the end of the string.
  'key':None,             # A key column from the table.
  'srid':None,            # A string designating the SRID of the coordinate reference system.
@@ -334,9 +338,6 @@ Note that None should be used when it is desired to leave the parameter blank:
  'type':None,            # A WKT string designating the WKB Type.
  'selectatid':None,      # Set to True to disable selection by feature ID.
  'options':None,         # other PostgreSQL connection options not in this list.
- # SSL/TLS mode, comment/uncomment for your pyQgis version
- 'sslmode':QgsDataSourceUri.SslDisable, # pyQgis 3.13+ SslAllow, SslDisable, SslPrefer, SslRequire, SslVerifyCa, SslVerifyFull
- #'sslmode':'disable',    # pyQgis 3.12 allow, disable, prefer, require, verify-ca, verify-full
  # pyQgis 3.12 parameters
  #   These must must be manually added in 3.13: uri.setParam(key, value)
  'connect_timeout':None, # The connection timeout time.

--- a/docs/pyqgis_developer_cookbook/loadlayer.rst
+++ b/docs/pyqgis_developer_cookbook/loadlayer.rst
@@ -327,7 +327,7 @@ After that the raster can be added to the project.
      'schema':'public',      # The database schema that the table is located in.
      'table':'my_rasters',   # The database table to be loaded.
      'geometrycolumn':'rast',# raster column in PostGIS table
-     'where':'rid > 5',      # An SQL WHERE clause. It should be placed at the end of the string.
+     'sql':NULL,      # An SQL WHERE clause. It should be placed at the end of the string.
      'key':NULL,             # A key column from the table.
      'srid':NULL,            # A string designating the SRID of the coordinate reference system.
      'estimatedmetadata':'False', # A boolean value telling if the metadata is estimated.

--- a/docs/pyqgis_developer_cookbook/loadlayer.rst
+++ b/docs/pyqgis_developer_cookbook/loadlayer.rst
@@ -327,7 +327,7 @@ After that the raster can be added to the project.
      'schema':'public',      # The database schema that the table is located in.
      'table':'my_rasters',   # The database table to be loaded.
      'geometrycolumn':'rast',# raster column in PostGIS table
-     'sql':NULL,      # An SQL WHERE clause. It should be placed at the end of the string.
+     'sql':NULL,             # An SQL WHERE clause. It should be placed at the end of the string.
      'key':NULL,             # A key column from the table.
      'srid':NULL,            # A string designating the SRID of the coordinate reference system.
      'estimatedmetadata':'False', # A boolean value telling if the metadata is estimated.

--- a/docs/pyqgis_developer_cookbook/loadlayer.rst
+++ b/docs/pyqgis_developer_cookbook/loadlayer.rst
@@ -321,22 +321,22 @@ After that the raster can be added to the project.
      # user and password are not needed if stored in the authcfg or service
      'authcfg':'QconfigId',  # The QGIS athentication database ID holding connection details.
      'service': None,         # The PostgreSQL service to be used for connection to the database.
-     'username':NULL,        # The PostgreSQL user name.
-     'password':NULL,        # The PostgreSQL password for the user.
+     'username':None,        # The PostgreSQL user name.
+     'password':None,        # The PostgreSQL password for the user.
      # table and raster column details
      'schema':'public',      # The database schema that the table is located in.
      'table':'my_rasters',   # The database table to be loaded.
      'geometrycolumn':'rast',# raster column in PostGIS table
-     'sql':NULL,             # An SQL WHERE clause. It should be placed at the end of the string.
-     'key':NULL,             # A key column from the table.
-     'srid':NULL,            # A string designating the SRID of the coordinate reference system.
+     'sql':None,             # An SQL WHERE clause. It should be placed at the end of the string.
+     'key':None,             # A key column from the table.
+     'srid':None,            # A string designating the SRID of the coordinate reference system.
      'estimatedmetadata':'False', # A boolean value telling if the metadata is estimated.
-     'type':NULL,            # A WKT string designating the WKB Type.
-     'selectatid':NULL,      # Set to True to disable selection by feature ID.
-     'options':NULL,         # other PostgreSQL connection options not in this list.
-     'enableTime': NULL,
-     'temporalDefaultTime': NULL,
-     'temporalFieldIndex': NULL,     
+     'type':None,            # A WKT string designating the WKB Type.
+     'selectatid':None,      # Set to True to disable selection by feature ID.
+     'options':None,         # other PostgreSQL connection options not in this list.
+     'enableTime': None,
+     'temporalDefaultTime': None,
+     'temporalFieldIndex': None,     
      'mode':'2',             # GDAL 'mode' parameter, 2 unions raster tiles, 1 adds tiles separately (may require user input) 
  }
  # remove any NULL parameters

--- a/docs/pyqgis_developer_cookbook/loadlayer.rst
+++ b/docs/pyqgis_developer_cookbook/loadlayer.rst
@@ -301,6 +301,40 @@ function of the :class:`QgisInterface <qgis.gui.QgisInterface>` object:
 This creates a new layer and adds it to the current project (making it appear
 in the layer list) in one step.
 
+
+To load a PostGIS raster:
+
+PostGIS rasters, similar to PostGIS vectors, can be loaded using a URI string. The string should be constructed manually. Options include:
+
+* **dbname** : The PostgreSQL database to connect to.
+* **host** : The host IP address or localhost.
+* **port** : The port to connect on.
+* **user** : The PostgreSQL user name, also accepts the new WFS provider naming.
+* **password** : The PostgreSQL password for the user.
+
+* **service** : The PostgreSQL service to be used for connection to the database.
+* **authcfg** : The QGIS athentication database ID holding connection details.
+
+* **schema** : The database schema that the table is located in.
+* **table** : The database table to be loaded.
+* **sql** : An SQL WHERE clause. It should be placed at the end of the string.
+* **key** : A key column from the table.
+* **srid** : A string designating the SRID of the coordinate reference system.
+* **estimatedmetadata** : A boolean value telling if the metadata is estimated.
+* **type** : A WKT string designating the WKB Type.
+* **selectatid** : Set to True to disable selection by feature ID.
+
+* **connect_timeout** : The connection timeout time.
+* **options** : PostgreSQL connection options.
+* **sslmode** : disable, prefer, require, verifyca, verifyfull
+* **hostaddr**, **driver**, **tty**, **requiressl**, **krbsrvname**, **gsslib**
+
+.. code-block:: python
+
+ uri = QgsDataSourceUri("PG:  dbname='database_name' host=host.address port=5432 sslmode=disable authcfg=idnumber mode=2 schema='schema_name' column='rast' table='raster_table_name'")
+ rlayer = iface.addRasterLayer(uri.uri(False), "raster layer name", "postgresraster") 
+
+
 Raster layers can also be created from a WCS service:
 
 .. code-block:: python

--- a/docs/pyqgis_developer_cookbook/loadlayer.rst
+++ b/docs/pyqgis_developer_cookbook/loadlayer.rst
@@ -304,7 +304,10 @@ in the layer list) in one step.
 
 To load a PostGIS raster:
 
-PostGIS rasters, similar to PostGIS vectors, can be added to a project using a URI string. It is efficient to create a dictionary of strings for the database connection parameters. The dictionary is then loaded into an empty URI, before adding the raster. Note that None should be used when it is desired to leave the parameter blank: 
+PostGIS rasters, similar to PostGIS vectors, can be added to a project using a URI string.
+It is efficient to create a dictionary of strings for the database connection parameters.
+The dictionary is then loaded into an empty URI, before adding the raster.
+Note that None should be used when it is desired to leave the parameter blank: 
 
 .. code-block:: python
 

--- a/docs/pyqgis_developer_cookbook/loadlayer.rst
+++ b/docs/pyqgis_developer_cookbook/loadlayer.rst
@@ -340,7 +340,7 @@ After that the raster can be added to the project.
      'mode':'2',             # GDAL 'mode' parameter, 2 unions raster tiles, 1 adds tiles separately (may require user input) 
  }
  # remove any NULL parameters
- uri_config = {key:val for key, val in uri_config.items() if val != NULL}
+ uri_config = {key:val for key, val in uri_config.items() if val is not None}
  # get the metadata for the raster provider and configure the URI
  md = QgsProviderRegistry.instance().providerMetadata('postgresraster')
  uri = QgsDataSourceUri(md.encodeUri(uri_config))

--- a/docs/pyqgis_developer_cookbook/loadlayer.rst
+++ b/docs/pyqgis_developer_cookbook/loadlayer.rst
@@ -311,35 +311,55 @@ Note that None should be used when it is desired to leave the parameter blank:
 
 .. code-block:: python
 
- uri = QgsDataSourceUri()
- uri_config = {'dbname':'gis_db', # The PostgreSQL database to connect to.
- 'host':'localhost',    # The host IP address or localhost.
- 'port':'5432',         # The port to connect on.
- 'user':None,           # The PostgreSQL user name, also accepts the new WFS provider naming.
- 'password':None,       # The PostgreSQL password for the user.
- 'service':None,        # The PostgreSQL service to be used for connection to the database.
- 'authcfg':'QconfigId', # The QGIS athentication database ID holding connection details.
- 'schema':'public',     # The database schema that the table is located in.
- 'table':'my_rasters',  # The database table to be loaded.
- 'sql':None,            # An SQL WHERE clause. It should be placed at the end of the string.
- 'key':None,            # A key column from the table.
- 'srid':None,           # A string designating the SRID of the coordinate reference system.
- 'estimatedmetadata':'false', # A boolean value telling if the metadata is estimated.
- 'type':None,           # A WKT string designating the WKB Type.
- 'selectatid':None,     # Set to True to disable selection by feature ID.
+ uri_config = {#
+ # database parameters
+ 'dbname':'gis_db', # The PostgreSQL database to connect to.
+ 'host':'localhost',     # The host IP address or localhost.
+ 'port':'5432',          # The port to connect on.
+ # user and password are not needed if stored in the authcfg or service
+ 'user':None,            # pyQgis 3.12 The PostgreSQL user name, also accepts the new WFS provider naming.
+ 'username':None,        # pyQgis 3.13+ user name
+ 'password':None,        # The PostgreSQL password for the user.
+ 'service':None,         # The PostgreSQL service to be used for connection to the database.
+ 'authcfg':'QconfigId',  # The QGIS athentication database ID holding connection details.
+ # table and raster column details
+ 'schema':'public',      # The database schema that the table is located in.
+ 'table':'my_rasters',   # The database table to be loaded.
+ 'geometrycolumn':'rast',# pyQgis 3.13+ raster column in PostGIS table
+ 'column':'rast',        # pyQgis 3.12  raster column in PostGIS table
+ 'sql':None,             # An SQL WHERE clause. It should be placed at the end of the string.
+ 'key':None,             # A key column from the table.
+ 'srid':None,            # A string designating the SRID of the coordinate reference system.
+ 'estimatedmetadata':'False', # A boolean value telling if the metadata is estimated.
+ 'type':None,            # A WKT string designating the WKB Type.
+ 'selectatid':None,      # Set to True to disable selection by feature ID.
+ 'options':None,         # other PostgreSQL connection options not in this list.
+ # SSL/TLS mode, comment/uncomment for your pyQgis version
+ 'sslmode':QgsDataSourceUri.SslDisable, # pyQgis 3.13+ SslAllow, SslDisable, SslPrefer, SslRequire, SslVerifyCa, SslVerifyFull
+ #'sslmode':'disable',    # pyQgis 3.12 allow, disable, prefer, require, verify-ca, verify-full
+ # pyQgis 3.12 parameters
+ #   These must must be manually added in 3.13: uri.setParam(key, value)
  'connect_timeout':None, # The connection timeout time.
- 'options':None,        # PostgreSQL connection options.
- 'sslmode':None,        # disable, prefer, require, verify-ca, verify-full
  'hostaddr':None,
  'driver':None,
  'tty':None,
  'requiressl':None,
  'krbsrvname':None,
- 'gsslib':None
+ 'gsslib':None,
+ # Added in pyQgis 3.13+
+ 'enableTime': None,
+ 'temporalDefaultTime': None,
+ 'temporalFieldIndex': None,
  }
+ ### For pyQgis 3.13+ use this syntax:
+ md = QgsProviderRegistry.instance().providerMetadata('postgresraster')
+ uri = QgsDataSourceUri(md.encodeUri(uri_config))
+ 
+ ### For pyQgis 3.12 use this syntax: 
+ uri = QgsDataSourceUri()
  for param in uri_config:
      if (uri_config[param] != None):
-         uri.setParam(param, uri_config[param])
+         uri.setParam(param, uri_config[param]) # this command can be used to manually add parameters to the URI
  
  # the raster can then be loaded into the project
  rlayer = iface.addRasterLayer(uri.uri(False), "raster layer name", "postgresraster")

--- a/docs/pyqgis_developer_cookbook/loadlayer.rst
+++ b/docs/pyqgis_developer_cookbook/loadlayer.rst
@@ -304,34 +304,41 @@ in the layer list) in one step.
 
 To load a PostGIS raster:
 
-PostGIS rasters, similar to PostGIS vectors, can be loaded using a URI string. The string should be constructed manually. Options include:
-
-* **dbname** : The PostgreSQL database to connect to.
-* **host** : The host IP address or localhost.
-* **port** : The port to connect on.
-* **user** : The PostgreSQL user name, also accepts the new WFS provider naming.
-* **password** : The PostgreSQL password for the user.
-
-* **service** : The PostgreSQL service to be used for connection to the database.
-* **authcfg** : The QGIS athentication database ID holding connection details.
-
-* **schema** : The database schema that the table is located in.
-* **table** : The database table to be loaded.
-* **sql** : An SQL WHERE clause. It should be placed at the end of the string.
-* **key** : A key column from the table.
-* **srid** : A string designating the SRID of the coordinate reference system.
-* **estimatedmetadata** : A boolean value telling if the metadata is estimated.
-* **type** : A WKT string designating the WKB Type.
-* **selectatid** : Set to True to disable selection by feature ID.
-
-* **connect_timeout** : The connection timeout time.
-* **options** : PostgreSQL connection options.
-* **sslmode** : disable, prefer, require, verifyca, verifyfull
-* **hostaddr**, **driver**, **tty**, **requiressl**, **krbsrvname**, **gsslib**
+PostGIS rasters, similar to PostGIS vectors, can be added to a project using a URI string. It is efficient to create a dictionary of strings of the database connection parameters and load them into an empty URI, before adding the raster. Note that None should be used when it is desired to leave the parameter blank: 
 
 .. code-block:: python
 
- uri = QgsDataSourceUri("PG:  dbname='database_name' host=host.address port=5432 sslmode=disable authcfg=idnumber mode=2 schema='schema_name' column='rast' table='raster_table_name'")
+ uri = QgsDataSourceUri()
+ uri_config = {'dbname':'gis_db', # The PostgreSQL database to connect to.
+'host':'localhost',    # The host IP address or localhost.
+'port':'5432',         # The port to connect on.
+'user':None,           # The PostgreSQL user name, also accepts the new WFS provider naming.
+'password':None,       # The PostgreSQL password for the user.
+'service':None,        # The PostgreSQL service to be used for connection to the database.
+'authcfg':'QconfigId', # The QGIS athentication database ID holding connection details.
+'schema':'public',     # The database schema that the table is located in.
+'table':'my_rasters',  # The database table to be loaded.
+'sql':None,            # An SQL WHERE clause. It should be placed at the end of the string.
+'key':None,            # A key column from the table.
+'srid':None,           # A string designating the SRID of the coordinate reference system.
+'estimatedmetadata':'false', # A boolean value telling if the metadata is estimated.
+'type':None,           # A WKT string designating the WKB Type.
+'selectatid':None,     # Set to True to disable selection by feature ID.
+'connect_timeout':None, # The connection timeout time.
+'options':None,        # PostgreSQL connection options.
+'sslmode':None,        # disable, prefer, require, verify-ca, verify-full
+'hostaddr':None,
+'driver':None,
+'tty':None,
+'requiressl':None,
+'krbsrvname':None,
+'gsslib':None
+}
+ for param in uri_config:
+     if (uri_config[param] != None):
+         uri.setParam(param, uri_config[param])
+ 
+ # the raster can then be loaded
  rlayer = iface.addRasterLayer(uri.uri(False), "raster layer name", "postgresraster") 
 
 


### PR DESCRIPTION
Manual URI has to be used b/c set methods are written for geometry and not for raster. Therefore a description of the parameters is given.

<!---
Include a few sentences describing the overall goals for this Pull Request.
 
A list of issues is at https://github.com/qgis/QGIS-Documentation/issues.
Add "fix #issuenumber" for each issue the PR fixes. The ticket(s) will be closed automatically.
If your PR doesn't fix entirely the ticket, only add the ticket(s) reference preceded by # character.
-->
Goal:

Ticket(s): #
<!---
Indicate whether the fix should be backported to previous release.
Replace the space between square brackets by a `x` to make it checked.
-->
- [ ] Backport to LTR documentation is required

<!---
Reviewing is a process done by community members, mostly on a volunteer basis.
We try to keep the overhead as small as possible and appreciate if you help us.
Please read carefully and ensure you comply with our writing guidelines at
https://docs.qgis.org/testing/en/docs/documentation_guidelines/index.html.
Feel free to ask in a comment or the (qgis-community-team mailing list)
[https://lists.osgeo.org/mailman/listinfo/qgis-community-team] if you have troubles with any item.
--->
