### PR TITLE
Allow doc build preview for pull requests also

### DIFF
--- a/.github/workflows/html.yml
+++ b/.github/workflows/html.yml
@@ -1,6 +1,6 @@
 name: HTML build
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   build:


### PR DESCRIPTION
Could help reviewers and contributors to preview the docs before merge, and exempt them from building locally.
Refs https://github.com/qgis/QGIS-Documentation/pull/5383#issuecomment-622982192