### PR TITLE
Reinstate the version 3.4 project file

### DIFF
--- a/qgis-projects/user_manual/working_with_vector_02.qgs
+++ b/qgis-projects/user_manual/working_with_vector_02.qgs
@@ -1,5 +1,5 @@
 <!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
-<qgis projectname="Alaska" version="3.10.2-A Coruña">
+<qgis version="3.9.0-Master" projectname="Alaska">
   <homePath path=""/>
   <title>Alaska</title>
   <autotransaction active="0"/>
@@ -7,7 +7,6 @@
   <trust active="0"/>
   <projectCrs>
     <spatialrefsys>
-      <wkt>PROJCS["NAD27 / Alaska Albers",GEOGCS["NAD27",DATUM["North_American_Datum_1927",SPHEROID["Clarke 1866",6378206.4,294.9786982138982,AUTHORITY["EPSG","7008"]],AUTHORITY["EPSG","6267"]],PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9122"]],AUTHORITY["EPSG","4267"]],PROJECTION["Albers_Conic_Equal_Area"],PARAMETER["standard_parallel_1",55],PARAMETER["standard_parallel_2",65],PARAMETER["latitude_of_center",50],PARAMETER["longitude_of_center",-154],PARAMETER["false_easting",0],PARAMETER["false_northing",0],UNIT["US survey foot",0.3048006096012192,AUTHORITY["EPSG","9003"]],AXIS["X",EAST],AXIS["Y",NORTH],AUTHORITY["EPSG","2964"]]</wkt>
       <proj4>+proj=aea +lat_1=55 +lat_2=65 +lat_0=50 +lon_0=-154 +x_0=0 +y_0=0 +datum=NAD27 +units=us-ft +no_defs</proj4>
       <srsid>932</srsid>
       <srid>2964</srid>
@@ -20,74 +19,74 @@
   </projectCrs>
   <layer-tree-group>
     <customproperties/>
-    <layer-tree-group checked="Qt::Checked" name="Boundaries Group" expanded="1">
+    <layer-tree-group name="Boundaries Group" checked="Qt::Checked" expanded="1">
       <customproperties/>
-      <layer-tree-layer providerKey="ogr" checked="Qt::Checked" name="regions" expanded="0" source="../../../qgis_sample_data/shapefiles/regions.shp" id="regions20130517221648766">
+      <layer-tree-layer name="regions" checked="Qt::Checked" expanded="0" providerKey="ogr" id="regions20130517221648766" source="../../../qgis_sample_data/shapefiles/regions.shp">
         <customproperties/>
       </layer-tree-layer>
-      <layer-tree-layer providerKey="ogr" checked="Qt::Checked" name="alaska" expanded="1" source="../../../qgis_sample_data/shapefiles/alaska.shp" id="alaska20130517221648216">
+      <layer-tree-layer name="alaska" checked="Qt::Checked" expanded="1" providerKey="ogr" id="alaska20130517221648216" source="../../../qgis_sample_data/shapefiles/alaska.shp">
         <customproperties/>
       </layer-tree-layer>
     </layer-tree-group>
-    <layer-tree-group checked="Qt::Checked" name="Water Group" expanded="1">
+    <layer-tree-group name="Water Group" checked="Qt::Checked" expanded="1">
       <customproperties/>
-      <layer-tree-layer providerKey="ogr" checked="Qt::Unchecked" name="rivers" expanded="0" source="../../../qgis_sample_data/shapefiles/rivers.shp" id="rivers20130517221648798">
+      <layer-tree-layer name="rivers" checked="Qt::Unchecked" expanded="0" providerKey="ogr" id="rivers20130517221648798" source="../../../qgis_sample_data/shapefiles/rivers.shp">
         <customproperties/>
       </layer-tree-layer>
-      <layer-tree-layer providerKey="ogr" checked="Qt::Checked" name="majrivers" expanded="1" source="../../../qgis_sample_data/shapefiles/majrivers.shp" id="majrivers_copy20141004123744134">
+      <layer-tree-layer name="majrivers" checked="Qt::Checked" expanded="1" providerKey="ogr" id="majrivers_copy20141004123744134" source="../../../qgis_sample_data/shapefiles/majrivers.shp">
         <customproperties/>
       </layer-tree-layer>
-      <layer-tree-layer providerKey="ogr" checked="Qt::Checked" name="lakes" expanded="1" source="../../../qgis_sample_data/shapefiles/lakes.shp" id="lakes20130517221648410">
+      <layer-tree-layer name="lakes" checked="Qt::Checked" expanded="1" providerKey="ogr" id="lakes20130517221648410" source="../../../qgis_sample_data/shapefiles/lakes.shp">
         <customproperties/>
       </layer-tree-layer>
-      <layer-tree-layer providerKey="ogr" checked="Qt::Unchecked" name="swamp" expanded="0" source="../../../qgis_sample_data/shapefiles/swamp.shp" id="swamp20130517232331437">
+      <layer-tree-layer name="swamp" checked="Qt::Unchecked" expanded="0" providerKey="ogr" id="swamp20130517232331437" source="../../../qgis_sample_data/shapefiles/swamp.shp">
         <customproperties/>
       </layer-tree-layer>
     </layer-tree-group>
-    <layer-tree-group checked="Qt::Checked" name="group1" expanded="1">
+    <layer-tree-group name="group1" checked="Qt::Checked" expanded="1">
       <customproperties/>
-      <layer-tree-layer providerKey="ogr" checked="Qt::Unchecked" name="popp" expanded="1" source="../../../qgis_sample_data/shapefiles/popp.shp" id="popp20130517221648651">
+      <layer-tree-layer name="popp" checked="Qt::Unchecked" expanded="1" providerKey="ogr" id="popp20130517221648651" source="../../../qgis_sample_data/shapefiles/popp.shp">
         <customproperties/>
       </layer-tree-layer>
-      <layer-tree-layer providerKey="ogr" checked="Qt::Unchecked" name="airports" expanded="1" source="../../../qgis_sample_data/shapefiles/airports.shp" id="airports20130517221648088">
+      <layer-tree-layer name="airports" checked="Qt::Unchecked" expanded="1" providerKey="ogr" id="airports20130517221648088" source="../../../qgis_sample_data/shapefiles/airports.shp">
         <customproperties/>
       </layer-tree-layer>
-      <layer-tree-layer providerKey="ogr" checked="Qt::Unchecked" name="storagep" expanded="1" source="../../../qgis_sample_data/shapefiles/storagep.shp" id="storagep20130517221648873">
+      <layer-tree-layer name="storagep" checked="Qt::Unchecked" expanded="1" providerKey="ogr" id="storagep20130517221648873" source="../../../qgis_sample_data/shapefiles/storagep.shp">
         <customproperties/>
       </layer-tree-layer>
     </layer-tree-group>
-    <layer-tree-group checked="Qt::Checked" name="Style_menu_properties_Scr" expanded="1">
+    <layer-tree-group name="Style_menu_properties_Scr" checked="Qt::Checked" expanded="1">
       <customproperties/>
-      <layer-tree-layer providerKey="ogr" checked="Qt::Unchecked" name="regions mask" expanded="1" source="../../../qgis_sample_data/shapefiles/regions.shp|layerid=0|subset=&quot;NAME_2&quot; = 'Wade Hampton'" id="regions_copy20141115000434943">
+      <layer-tree-layer name="regions mask" checked="Qt::Unchecked" expanded="1" providerKey="ogr" id="regions_copy20141115000434943" source="../../../qgis_sample_data/shapefiles/regions.shp|layerid=0|subset=&quot;NAME_2&quot; = 'Wade Hampton'">
         <customproperties/>
       </layer-tree-layer>
-      <layer-tree-layer providerKey="ogr" checked="Qt::Unchecked" name="rivers" expanded="1" source="../../../qgis_sample_data/shapefiles/rivers.shp" id="rivers_copy20141003182252298">
+      <layer-tree-layer name="rivers" checked="Qt::Unchecked" expanded="1" providerKey="ogr" id="rivers_copy20141003182252298" source="../../../qgis_sample_data/shapefiles/rivers.shp">
         <customproperties/>
       </layer-tree-layer>
-      <layer-tree-layer providerKey="ogr" checked="Qt::Unchecked" name="majrivers" expanded="1" source="../../../qgis_sample_data/shapefiles/majrivers.shp" id="majrivers20130517221648531">
+      <layer-tree-layer name="majrivers" checked="Qt::Unchecked" expanded="0" providerKey="ogr" id="majrivers20130517221648531" source="../../../qgis_sample_data/shapefiles/majrivers.shp">
         <customproperties/>
       </layer-tree-layer>
-      <layer-tree-layer providerKey="ogr" checked="Qt::Unchecked" name="majrivers" expanded="0" source="../../../qgis_sample_data/shapefiles/majrivers.shp" id="majrivers_copy20140330174217828">
+      <layer-tree-layer name="majrivers" checked="Qt::Unchecked" expanded="0" providerKey="ogr" id="majrivers_copy20140330174217828" source="../../../qgis_sample_data/shapefiles/majrivers.shp">
         <customproperties>
-          <property value="{e2c9f3ce-edfe-4d1d-a1b9-6a3e41897539}" key="expandedLegendNodes"/>
+          <property key="expandedLegendNodes" value="{e2c9f3ce-edfe-4d1d-a1b9-6a3e41897539}"/>
         </customproperties>
       </layer-tree-layer>
-      <layer-tree-layer providerKey="ogr" checked="Qt::Unchecked" name="rivers" expanded="1" source="../../../qgis_sample_data/shapefiles/rivers.shp" id="rivers_copy20141003190204569">
+      <layer-tree-layer name="rivers" checked="Qt::Unchecked" expanded="0" providerKey="ogr" id="rivers_copy20141003190204569" source="../../../qgis_sample_data/shapefiles/rivers.shp">
         <customproperties/>
       </layer-tree-layer>
-      <layer-tree-layer providerKey="ogr" checked="Qt::Unchecked" name="popp copy" expanded="1" source="../../../qgis_sample_data/shapefiles/popp.shp" id="popp_copy20160311145147574">
+      <layer-tree-layer name="popp copy" checked="Qt::Unchecked" expanded="1" providerKey="ogr" id="popp_copy20160311145147574" source="../../../qgis_sample_data/shapefiles/popp.shp">
         <customproperties/>
       </layer-tree-layer>
-      <layer-tree-layer providerKey="ogr" checked="Qt::Unchecked" name="airports copy" expanded="1" source="../../../qgis_sample_data/shapefiles/airports.shp" id="airports_copy20160212095908158">
+      <layer-tree-layer name="airports copy" checked="Qt::Unchecked" expanded="1" providerKey="ogr" id="airports_copy20160212095908158" source="../../../qgis_sample_data/shapefiles/airports.shp">
         <customproperties/>
       </layer-tree-layer>
     </layer-tree-group>
-    <layer-tree-group checked="Qt::Checked" name="Labels" expanded="1">
+    <layer-tree-group name="Labels" checked="Qt::Checked" expanded="1">
       <customproperties/>
-      <layer-tree-layer providerKey="ogr" checked="Qt::Checked" name="airports" expanded="1" source="../../../qgis_sample_data/shapefiles/airports.shp" id="airports_copy20140330175838921">
+      <layer-tree-layer name="airports" checked="Qt::Checked" expanded="1" providerKey="ogr" id="airports_copy20140330175838921" source="../../../qgis_sample_data/shapefiles/airports.shp">
         <customproperties/>
       </layer-tree-layer>
-      <layer-tree-layer providerKey="ogr" checked="Qt::Unchecked" name="regions copy" expanded="1" source="../../../qgis_sample_data/shapefiles/regions.shp" id="regions_copy20170517143021967">
+      <layer-tree-layer name="regions copy" checked="Qt::Unchecked" expanded="1" providerKey="ogr" id="regions_copy20170517143021967" source="../../../qgis_sample_data/shapefiles/regions.shp">
         <customproperties/>
       </layer-tree-layer>
     </layer-tree-group>
@@ -112,41 +111,40 @@
       <item>regions_copy20170517143021967</item>
     </custom-order>
   </layer-tree-group>
-  <snapping-settings enabled="0" unit="2" mode="1" tolerance="0" type="1" intersection-snapping="1">
+  <snapping-settings type="1" enabled="0" tolerance="0" intersection-snapping="1" mode="1" unit="2">
     <individual-layer-settings>
-      <layer-setting enabled="1" tolerance="5" type="2" units="1" id="regions20130517221648766"/>
-      <layer-setting enabled="0" tolerance="0" type="2" units="2" id="airports_copy20160212095908158"/>
-      <layer-setting enabled="0" tolerance="0" type="2" units="0" id="storagep20130517221648873"/>
-      <layer-setting enabled="0" tolerance="0" type="2" units="0" id="rivers_copy20141003182252298"/>
-      <layer-setting enabled="0" tolerance="0" type="2" units="0" id="regions_copy20141115000434943"/>
-      <layer-setting enabled="0" tolerance="0" type="2" units="0" id="airports_copy20140330175838921"/>
-      <layer-setting enabled="0" tolerance="0" type="2" units="0" id="rivers_copy20141003190204569"/>
-      <layer-setting enabled="0" tolerance="0" type="2" units="0" id="alaska20130517221648216"/>
-      <layer-setting enabled="0" tolerance="0" type="2" units="0" id="majrivers20130517221648531"/>
-      <layer-setting enabled="0" tolerance="0" type="2" units="0" id="popp20130517221648651"/>
-      <layer-setting enabled="0" tolerance="0" type="2" units="2" id="regions_copy20170517143021967"/>
-      <layer-setting enabled="0" tolerance="0" type="2" units="2" id="popp_copy20160311145147574"/>
-      <layer-setting enabled="0" tolerance="0" type="2" units="0" id="rivers20130517221648798"/>
-      <layer-setting enabled="0" tolerance="0" type="2" units="0" id="majrivers_copy20141004123744134"/>
-      <layer-setting enabled="0" tolerance="0" type="2" units="0" id="airports20130517221648088"/>
-      <layer-setting enabled="0" tolerance="0" type="2" units="0" id="majrivers_copy20140330174217828"/>
-      <layer-setting enabled="0" tolerance="0" type="2" units="0" id="lakes20130517221648410"/>
-      <layer-setting enabled="1" tolerance="0" type="2" units="0" id="swamp20130517232331437"/>
+      <layer-setting units="0" type="2" enabled="0" tolerance="0" id="alaska20130517221648216"/>
+      <layer-setting units="2" type="2" enabled="0" tolerance="0" id="popp_copy20160311145147574"/>
+      <layer-setting units="2" type="2" enabled="0" tolerance="0" id="airports_copy20160212095908158"/>
+      <layer-setting units="0" type="2" enabled="0" tolerance="0" id="majrivers20130517221648531"/>
+      <layer-setting units="0" type="2" enabled="0" tolerance="0" id="rivers_copy20141003182252298"/>
+      <layer-setting units="1" type="2" enabled="1" tolerance="5" id="regions20130517221648766"/>
+      <layer-setting units="0" type="2" enabled="0" tolerance="0" id="majrivers_copy20140330174217828"/>
+      <layer-setting units="0" type="2" enabled="0" tolerance="0" id="rivers_copy20141003190204569"/>
+      <layer-setting units="0" type="2" enabled="1" tolerance="0" id="swamp20130517232331437"/>
+      <layer-setting units="0" type="2" enabled="0" tolerance="0" id="majrivers_copy20141004123744134"/>
+      <layer-setting units="0" type="2" enabled="0" tolerance="0" id="popp20130517221648651"/>
+      <layer-setting units="0" type="2" enabled="0" tolerance="0" id="storagep20130517221648873"/>
+      <layer-setting units="0" type="2" enabled="0" tolerance="0" id="airports_copy20140330175838921"/>
+      <layer-setting units="0" type="2" enabled="0" tolerance="0" id="airports20130517221648088"/>
+      <layer-setting units="0" type="2" enabled="0" tolerance="0" id="rivers20130517221648798"/>
+      <layer-setting units="2" type="2" enabled="0" tolerance="0" id="regions_copy20170517143021967"/>
+      <layer-setting units="0" type="2" enabled="0" tolerance="0" id="regions_copy20141115000434943"/>
+      <layer-setting units="0" type="2" enabled="0" tolerance="0" id="lakes20130517221648410"/>
     </individual-layer-settings>
   </snapping-settings>
   <relations/>
   <mapcanvas name="theMapCanvas" annotationsVisible="1">
     <units>feet</units>
     <extent>
-      <xmin>-972707.22809038055129349</xmin>
-      <ymin>3086259.37957362737506628</ymin>
-      <xmax>90660.82746517495252192</xmax>
-      <ymax>3617116.52705937251448631</ymax>
+      <xmin>-1147760.66054891282692552</xmin>
+      <ymin>2712101.9657943993806839</ymin>
+      <xmax>978975.4505621986463666</xmax>
+      <ymax>3773816.26076588965952396</ymax>
     </extent>
     <rotation>0</rotation>
     <destinationsrs>
       <spatialrefsys>
-        <wkt>PROJCS["NAD27 / Alaska Albers",GEOGCS["NAD27",DATUM["North_American_Datum_1927",SPHEROID["Clarke 1866",6378206.4,294.9786982138982,AUTHORITY["EPSG","7008"]],AUTHORITY["EPSG","6267"]],PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9122"]],AUTHORITY["EPSG","4267"]],PROJECTION["Albers_Conic_Equal_Area"],PARAMETER["standard_parallel_1",55],PARAMETER["standard_parallel_2",65],PARAMETER["latitude_of_center",50],PARAMETER["longitude_of_center",-154],PARAMETER["false_easting",0],PARAMETER["false_northing",0],UNIT["US survey foot",0.3048006096012192,AUTHORITY["EPSG","9003"]],AXIS["X",EAST],AXIS["Y",NORTH],AUTHORITY["EPSG","2964"]]</wkt>
         <proj4>+proj=aea +lat_1=55 +lat_2=65 +lat_0=50 +lon_0=-154 +x_0=0 +y_0=0 +datum=NAD27 +units=us-ft +no_defs</proj4>
         <srsid>932</srsid>
         <srid>2964</srid>
@@ -160,185 +158,105 @@
     <rendermaptile>0</rendermaptile>
     <expressionContextScope/>
   </mapcanvas>
-  <DataPlotly>
-    <Option type="Map">
-      <Option name="dynamic_properties" type="Map">
-        <Option value="" name="name" type="QString"/>
-        <Option name="properties"/>
-        <Option value="collection" name="type" type="QString"/>
-      </Option>
-      <Option name="plot_layout" type="Map">
-        <Option value="" name="additional_info_expression" type="QString"/>
-        <Option value="group" name="bar_mode" type="QString"/>
-        <Option value="0" name="bargaps" type="double"/>
-        <Option value="false" name="bins_check" type="bool"/>
-        <Option value="true" name="legend" type="bool"/>
-        <Option value="v" name="legend_orientation" type="QString"/>
-        <Option name="legend_title" type="invalid"/>
-        <Option name="polar" type="Map">
-          <Option name="angularaxis" type="Map">
-            <Option value="clockwise" name="direction" type="QString"/>
-          </Option>
-        </Option>
-        <Option name="range_slider" type="Map">
-          <Option value="1" name="borderwidth" type="int"/>
-          <Option value="false" name="visible" type="bool"/>
-        </Option>
-        <Option value="" name="title" type="QString"/>
-        <Option name="x_inv" type="invalid"/>
-        <Option value="" name="x_title" type="QString"/>
-        <Option value="linear" name="x_type" type="QString"/>
-        <Option name="xaxis" type="invalid"/>
-        <Option name="y_inv" type="invalid"/>
-        <Option value="" name="y_title" type="QString"/>
-        <Option value="linear" name="y_type" type="QString"/>
-        <Option value="" name="z_title" type="QString"/>
-      </Option>
-      <Option name="plot_properties" type="Map">
-        <Option name="additional_hover_text" type="invalid"/>
-        <Option value="10" name="bins" type="int"/>
-        <Option value="v" name="box_orientation" type="QString"/>
-        <Option value="false" name="box_outliers" type="bool"/>
-        <Option value="false" name="box_stat" type="bool"/>
-        <Option name="color_scale" type="invalid"/>
-        <Option value="false" name="color_scale_data_defined_in_check" type="bool"/>
-        <Option value="false" name="color_scale_data_defined_in_invert_check" type="bool"/>
-        <Option value="fill" name="cont_type" type="QString"/>
-        <Option value="Fill" name="contour_type_combo" type="QString"/>
-        <Option value="false" name="cumulative" type="bool"/>
-        <Option name="custom" type="List">
-          <Option value="" type="QString"/>
-        </Option>
-        <Option value="all" name="hover_text" type="QString"/>
-        <Option value="#8ebad9" name="in_color" type="QString"/>
-        <Option value="false" name="invert_color_scale" type="bool"/>
-        <Option value="increasing" name="invert_hist" type="QString"/>
-        <Option value="Solid Line" name="line_combo" type="QString"/>
-        <Option value="solid" name="line_dash" type="QString"/>
-        <Option value="markers" name="marker" type="QString"/>
-        <Option value="10" name="marker_size" type="double"/>
-        <Option value="0" name="marker_symbol" type="int"/>
-        <Option value="Points" name="marker_type_combo" type="QString"/>
-        <Option value="1" name="marker_width" type="double"/>
-        <Option value="" name="name" type="QString"/>
-        <Option value="" name="normalization" type="QString"/>
-        <Option value="1" name="opacity" type="double"/>
-        <Option value="#1f77b4" name="out_color" type="QString"/>
-        <Option value="" name="point_combo" type="QString"/>
-        <Option value="false" name="selected_features_only" type="bool"/>
-        <Option value="false" name="show_colorscale_legend" type="bool"/>
-        <Option value="true" name="show_lines" type="bool"/>
-        <Option value="true" name="show_lines_check" type="bool"/>
-        <Option value="true" name="show_mean_line" type="bool"/>
-        <Option value="both" name="violin_side" type="QString"/>
-        <Option value="false" name="visible_features_only" type="bool"/>
-        <Option value="" name="x_name" type="QString"/>
-        <Option value="" name="y_name" type="QString"/>
-        <Option value="" name="z_name" type="QString"/>
-      </Option>
-      <Option value="scatter" name="plot_type" type="QString"/>
-      <Option value="airports20130517221648088" name="source_layer_id" type="QString"/>
-    </Option>
-  </DataPlotly>
   <projectModels/>
   <legend updateDrawingOrder="false">
-    <legendgroup checked="Qt::Checked" name="Boundaries Group" open="true">
-      <legendlayer checked="Qt::Checked" name="regions" showFeatureCount="0" drawingOrder="8" open="false">
+    <legendgroup name="Boundaries Group" checked="Qt::Checked" open="true">
+      <legendlayer showFeatureCount="0" checked="Qt::Checked" name="regions" drawingOrder="8" open="false">
         <filegroup hidden="false" open="false">
-          <legendlayerfile layerid="regions20130517221648766" isInOverview="0" visible="1"/>
+          <legendlayerfile visible="1" isInOverview="0" layerid="regions20130517221648766"/>
         </filegroup>
       </legendlayer>
-      <legendlayer checked="Qt::Checked" name="alaska" showFeatureCount="0" drawingOrder="11" open="true">
+      <legendlayer showFeatureCount="0" checked="Qt::Checked" name="alaska" drawingOrder="11" open="true">
         <filegroup hidden="false" open="true">
-          <legendlayerfile layerid="alaska20130517221648216" isInOverview="0" visible="1"/>
+          <legendlayerfile visible="1" isInOverview="0" layerid="alaska20130517221648216"/>
         </filegroup>
       </legendlayer>
     </legendgroup>
-    <legendgroup checked="Qt::Checked" name="Water Group" open="true">
-      <legendlayer checked="Qt::Unchecked" name="rivers" showFeatureCount="0" drawingOrder="7" open="false">
+    <legendgroup name="Water Group" checked="Qt::Checked" open="true">
+      <legendlayer showFeatureCount="0" checked="Qt::Unchecked" name="rivers" drawingOrder="7" open="false">
         <filegroup hidden="false" open="false">
-          <legendlayerfile layerid="rivers20130517221648798" isInOverview="0" visible="0"/>
+          <legendlayerfile visible="0" isInOverview="0" layerid="rivers20130517221648798"/>
         </filegroup>
       </legendlayer>
-      <legendlayer checked="Qt::Checked" name="majrivers" showFeatureCount="0" drawingOrder="14" open="true">
+      <legendlayer showFeatureCount="0" checked="Qt::Checked" name="majrivers" drawingOrder="14" open="true">
         <filegroup hidden="false" open="true">
-          <legendlayerfile layerid="majrivers_copy20141004123744134" isInOverview="0" visible="1"/>
+          <legendlayerfile visible="1" isInOverview="0" layerid="majrivers_copy20141004123744134"/>
         </filegroup>
       </legendlayer>
-      <legendlayer checked="Qt::Checked" name="lakes" showFeatureCount="0" drawingOrder="9" open="true">
+      <legendlayer showFeatureCount="0" checked="Qt::Checked" name="lakes" drawingOrder="9" open="true">
         <filegroup hidden="false" open="true">
-          <legendlayerfile layerid="lakes20130517221648410" isInOverview="0" visible="1"/>
+          <legendlayerfile visible="1" isInOverview="0" layerid="lakes20130517221648410"/>
         </filegroup>
       </legendlayer>
-      <legendlayer checked="Qt::Unchecked" name="swamp" showFeatureCount="0" drawingOrder="10" open="false">
+      <legendlayer showFeatureCount="0" checked="Qt::Unchecked" name="swamp" drawingOrder="10" open="false">
         <filegroup hidden="false" open="false">
-          <legendlayerfile layerid="swamp20130517232331437" isInOverview="0" visible="0"/>
+          <legendlayerfile visible="0" isInOverview="0" layerid="swamp20130517232331437"/>
         </filegroup>
       </legendlayer>
     </legendgroup>
-    <legendgroup checked="Qt::Checked" name="group1" open="true">
-      <legendlayer checked="Qt::Unchecked" name="popp" showFeatureCount="0" drawingOrder="5" open="true">
+    <legendgroup name="group1" checked="Qt::Checked" open="true">
+      <legendlayer showFeatureCount="0" checked="Qt::Unchecked" name="popp" drawingOrder="5" open="true">
         <filegroup hidden="false" open="true">
-          <legendlayerfile layerid="popp20130517221648651" isInOverview="0" visible="0"/>
+          <legendlayerfile visible="0" isInOverview="0" layerid="popp20130517221648651"/>
         </filegroup>
       </legendlayer>
-      <legendlayer checked="Qt::Unchecked" name="airports" showFeatureCount="0" drawingOrder="4" open="true">
+      <legendlayer showFeatureCount="0" checked="Qt::Unchecked" name="airports" drawingOrder="4" open="true">
         <filegroup hidden="false" open="true">
-          <legendlayerfile layerid="airports20130517221648088" isInOverview="0" visible="0"/>
+          <legendlayerfile visible="0" isInOverview="0" layerid="airports20130517221648088"/>
         </filegroup>
       </legendlayer>
-      <legendlayer checked="Qt::Unchecked" name="storagep" showFeatureCount="0" drawingOrder="6" open="true">
+      <legendlayer showFeatureCount="0" checked="Qt::Unchecked" name="storagep" drawingOrder="6" open="true">
         <filegroup hidden="false" open="true">
-          <legendlayerfile layerid="storagep20130517221648873" isInOverview="0" visible="0"/>
+          <legendlayerfile visible="0" isInOverview="0" layerid="storagep20130517221648873"/>
         </filegroup>
       </legendlayer>
     </legendgroup>
-    <legendgroup checked="Qt::Checked" name="Style_menu_properties_Scr" open="true">
-      <legendlayer checked="Qt::Unchecked" name="regions mask" showFeatureCount="0" drawingOrder="0" open="true">
+    <legendgroup name="Style_menu_properties_Scr" checked="Qt::Checked" open="true">
+      <legendlayer showFeatureCount="0" checked="Qt::Unchecked" name="regions mask" drawingOrder="0" open="true">
         <filegroup hidden="false" open="true">
-          <legendlayerfile layerid="regions_copy20141115000434943" isInOverview="0" visible="0"/>
+          <legendlayerfile visible="0" isInOverview="0" layerid="regions_copy20141115000434943"/>
         </filegroup>
       </legendlayer>
-      <legendlayer checked="Qt::Unchecked" name="rivers" showFeatureCount="0" drawingOrder="12" open="true">
+      <legendlayer showFeatureCount="0" checked="Qt::Unchecked" name="rivers" drawingOrder="12" open="true">
         <filegroup hidden="false" open="true">
-          <legendlayerfile layerid="rivers_copy20141003182252298" isInOverview="0" visible="0"/>
+          <legendlayerfile visible="0" isInOverview="0" layerid="rivers_copy20141003182252298"/>
         </filegroup>
       </legendlayer>
-      <legendlayer checked="Qt::Unchecked" name="majrivers" showFeatureCount="0" drawingOrder="1" open="true">
-        <filegroup hidden="false" open="true">
-          <legendlayerfile layerid="majrivers20130517221648531" isInOverview="0" visible="0"/>
-        </filegroup>
-      </legendlayer>
-      <legendlayer checked="Qt::Unchecked" name="majrivers" showFeatureCount="0" drawingOrder="2" open="false">
+      <legendlayer showFeatureCount="0" checked="Qt::Unchecked" name="majrivers" drawingOrder="1" open="false">
         <filegroup hidden="false" open="false">
-          <legendlayerfile layerid="majrivers_copy20140330174217828" isInOverview="0" visible="0"/>
+          <legendlayerfile visible="0" isInOverview="0" layerid="majrivers20130517221648531"/>
         </filegroup>
       </legendlayer>
-      <legendlayer checked="Qt::Unchecked" name="rivers" showFeatureCount="0" drawingOrder="13" open="true">
-        <filegroup hidden="false" open="true">
-          <legendlayerfile layerid="rivers_copy20141003190204569" isInOverview="0" visible="0"/>
+      <legendlayer showFeatureCount="0" checked="Qt::Unchecked" name="majrivers" drawingOrder="2" open="false">
+        <filegroup hidden="false" open="false">
+          <legendlayerfile visible="0" isInOverview="0" layerid="majrivers_copy20140330174217828"/>
         </filegroup>
       </legendlayer>
-      <legendlayer checked="Qt::Unchecked" name="popp copy" showFeatureCount="0" drawingOrder="16" open="true">
-        <filegroup hidden="false" open="true">
-          <legendlayerfile layerid="popp_copy20160311145147574" isInOverview="0" visible="0"/>
+      <legendlayer showFeatureCount="0" checked="Qt::Unchecked" name="rivers" drawingOrder="13" open="false">
+        <filegroup hidden="false" open="false">
+          <legendlayerfile visible="0" isInOverview="0" layerid="rivers_copy20141003190204569"/>
         </filegroup>
       </legendlayer>
-      <legendlayer checked="Qt::Unchecked" name="airports copy" showFeatureCount="0" drawingOrder="15" open="true">
+      <legendlayer showFeatureCount="0" checked="Qt::Unchecked" name="popp copy" drawingOrder="16" open="true">
         <filegroup hidden="false" open="true">
-          <legendlayerfile layerid="airports_copy20160212095908158" isInOverview="0" visible="0"/>
+          <legendlayerfile visible="0" isInOverview="0" layerid="popp_copy20160311145147574"/>
+        </filegroup>
+      </legendlayer>
+      <legendlayer showFeatureCount="0" checked="Qt::Unchecked" name="airports copy" drawingOrder="15" open="true">
+        <filegroup hidden="false" open="true">
+          <legendlayerfile visible="0" isInOverview="0" layerid="airports_copy20160212095908158"/>
         </filegroup>
       </legendlayer>
     </legendgroup>
-    <legendgroup checked="Qt::Checked" name="Labels" open="true">
-      <legendlayer checked="Qt::Checked" name="airports" showFeatureCount="0" drawingOrder="3" open="true">
+    <legendgroup name="Labels" checked="Qt::Checked" open="true">
+      <legendlayer showFeatureCount="0" checked="Qt::Checked" name="airports" drawingOrder="3" open="true">
         <filegroup hidden="false" open="true">
-          <legendlayerfile layerid="airports_copy20140330175838921" isInOverview="0" visible="1"/>
+          <legendlayerfile visible="1" isInOverview="0" layerid="airports_copy20140330175838921"/>
         </filegroup>
       </legendlayer>
-      <legendlayer checked="Qt::Unchecked" name="regions copy" showFeatureCount="0" drawingOrder="17" open="true">
+      <legendlayer showFeatureCount="0" checked="Qt::Unchecked" name="regions copy" drawingOrder="17" open="true">
         <filegroup hidden="false" open="true">
-          <legendlayerfile layerid="regions_copy20170517143021967" isInOverview="0" visible="0"/>
+          <legendlayerfile visible="0" isInOverview="0" layerid="regions_copy20170517143021967"/>
         </filegroup>
       </legendlayer>
     </legendgroup>
@@ -346,7 +264,7 @@
   <mapViewDocks/>
   <mapViewDocks3D/>
   <projectlayers>
-    <maplayer simplifyDrawingHints="0" simplifyAlgorithm="0" labelsEnabled="1" refreshOnNotifyMessage="" wkbType="Point" minScale="1e+8" readOnly="0" refreshOnNotifyEnabled="0" type="vector" maxScale="0" simplifyLocal="1" autoRefreshTime="0" hasScaleBasedVisibilityFlag="0" geometry="Point" styleCategories="AllStyleCategories" autoRefreshEnabled="0" simplifyDrawingTol="1" simplifyMaxScale="1">
+    <maplayer refreshOnNotifyEnabled="0" refreshOnNotifyMessage="" styleCategories="AllStyleCategories" maxScale="0" hasScaleBasedVisibilityFlag="0" simplifyAlgorithm="0" type="vector" labelsEnabled="1" minScale="1e+8" simplifyLocal="1" simplifyDrawingHints="0" autoRefreshTime="0" readOnly="0" geometry="Point" simplifyDrawingTol="1" autoRefreshEnabled="0" simplifyMaxScale="1" wkbType="Point">
       <extent>
         <xmin>-4480198.52221446391195059</xmin>
         <ymin>1433525.79887208016589284</ymin>
@@ -361,7 +279,6 @@
       <layername>airports</layername>
       <srs>
         <spatialrefsys>
-          <wkt>PROJCS["NAD27 / Alaska Albers",GEOGCS["NAD27",DATUM["North_American_Datum_1927",SPHEROID["Clarke 1866",6378206.4,294.9786982138982,AUTHORITY["EPSG","7008"]],AUTHORITY["EPSG","6267"]],PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9122"]],AUTHORITY["EPSG","4267"]],PROJECTION["Albers_Conic_Equal_Area"],PARAMETER["standard_parallel_1",55],PARAMETER["standard_parallel_2",65],PARAMETER["latitude_of_center",50],PARAMETER["longitude_of_center",-154],PARAMETER["false_easting",0],PARAMETER["false_northing",0],UNIT["US survey foot",0.3048006096012192,AUTHORITY["EPSG","9003"]],AXIS["X",EAST],AXIS["Y",NORTH],AUTHORITY["EPSG","2964"]]</wkt>
           <proj4>+proj=aea +lat_1=55 +lat_2=65 +lat_0=50 +lon_0=-154 +x_0=0 +y_0=0 +datum=NAD27 +units=us-ft +no_defs</proj4>
           <srsid>932</srsid>
           <srid>2964</srid>
@@ -384,7 +301,6 @@
         <encoding></encoding>
         <crs>
           <spatialrefsys>
-            <wkt></wkt>
             <proj4></proj4>
             <srsid>0</srsid>
             <srid>0</srid>
@@ -392,7 +308,7 @@
             <description></description>
             <projectionacronym></projectionacronym>
             <ellipsoidacronym></ellipsoidacronym>
-            <geographicflag>false</geographicflag>
+            <geographicflag>true</geographicflag>
           </spatialrefsys>
         </crs>
         <extent/>
@@ -405,27 +321,27 @@
       <expressionfields/>
       <map-layer-style-manager current="moved_label">
         <map-layer-style name="default">
-          <qgis simplifyDrawingHints="0" maximumScale="1e+08" scaleBasedLabelVisibilityFlag="0" simplifyLocal="1" hasScaleBasedVisibilityFlag="0" minLabelScale="0" readOnly="0" simplifyAlgorithm="0" simplifyMaxScale="1" maxLabelScale="1e+08" version="2.18.7" minimumScale="0" simplifyDrawingTol="1">
+          <qgis simplifyDrawingHints="0" simplifyLocal="1" version="2.18.7" minLabelScale="0" simplifyMaxScale="1" readOnly="0" maxLabelScale="1e+08" maximumScale="1e+08" minimumScale="0" hasScaleBasedVisibilityFlag="0" simplifyDrawingTol="1" simplifyAlgorithm="0" scaleBasedLabelVisibilityFlag="0">
             <edittypes>
-              <edittype name="ID" widgetv2type="TextEdit">
-                <widgetv2config constraint="" IsMultiline="0" constraintDescription="" notNull="0" UseHtml="0" labelOnTop="0" fieldEditable="1"/>
+              <edittype widgetv2type="TextEdit" name="ID">
+                <widgetv2config constraint="" notNull="0" IsMultiline="0" UseHtml="0" constraintDescription="" fieldEditable="1" labelOnTop="0"/>
               </edittype>
-              <edittype name="fk_region" widgetv2type="TextEdit">
-                <widgetv2config constraint="" IsMultiline="0" constraintDescription="" notNull="0" UseHtml="0" labelOnTop="0" fieldEditable="1"/>
+              <edittype widgetv2type="TextEdit" name="fk_region">
+                <widgetv2config constraint="" notNull="0" IsMultiline="0" UseHtml="0" constraintDescription="" fieldEditable="1" labelOnTop="0"/>
               </edittype>
-              <edittype name="ELEV" widgetv2type="TextEdit">
-                <widgetv2config constraint="" IsMultiline="0" constraintDescription="" notNull="0" UseHtml="0" labelOnTop="0" fieldEditable="1"/>
+              <edittype widgetv2type="TextEdit" name="ELEV">
+                <widgetv2config constraint="" notNull="0" IsMultiline="0" UseHtml="0" constraintDescription="" fieldEditable="1" labelOnTop="0"/>
               </edittype>
-              <edittype name="NAME" widgetv2type="TextEdit">
-                <widgetv2config constraint="" IsMultiline="0" constraintDescription="" notNull="0" UseHtml="0" labelOnTop="0" fieldEditable="1"/>
+              <edittype widgetv2type="TextEdit" name="NAME">
+                <widgetv2config constraint="" notNull="0" IsMultiline="0" UseHtml="0" constraintDescription="" fieldEditable="1" labelOnTop="0"/>
               </edittype>
-              <edittype name="USE" widgetv2type="TextEdit">
-                <widgetv2config constraint="" IsMultiline="0" constraintDescription="" notNull="0" UseHtml="0" labelOnTop="0" fieldEditable="1"/>
+              <edittype widgetv2type="TextEdit" name="USE">
+                <widgetv2config constraint="" notNull="0" IsMultiline="0" UseHtml="0" constraintDescription="" fieldEditable="1" labelOnTop="0"/>
               </edittype>
             </edittypes>
-            <renderer-v2 symbollevels="0" type="singleSymbol" forceraster="0" enableorderby="0">
+            <renderer-v2 type="singleSymbol" symbollevels="0" forceraster="0" enableorderby="0">
               <symbols>
-                <symbol name="0" clip_to_extent="1" alpha="1" type="marker">
+                <symbol clip_to_extent="1" type="marker" name="0" alpha="1">
                   <layer pass="0" class="FontMarker" locked="0">
                     <prop k="angle" v="0"/>
                     <prop k="chr" v="l"/>
@@ -630,30 +546,30 @@
             <label>0</label>
             <labelattributes>
               <label text="Label" fieldname=""/>
-              <family name="Ubuntu" fieldname=""/>
+              <family fieldname="" name="Ubuntu"/>
               <size value="12" units="pt" fieldname=""/>
-              <bold on="0" fieldname=""/>
-              <italic on="0" fieldname=""/>
-              <underline on="0" fieldname=""/>
-              <strikeout on="0" fieldname=""/>
-              <color green="0" blue="0" red="0" fieldname=""/>
+              <bold fieldname="" on="0"/>
+              <italic fieldname="" on="0"/>
+              <underline fieldname="" on="0"/>
+              <strikeout fieldname="" on="0"/>
+              <color fieldname="" green="0" blue="0" red="0"/>
               <x fieldname=""/>
               <y fieldname=""/>
-              <offset y="0" xfieldname="" x="0" units="pt" yfieldname=""/>
+              <offset units="pt" xfieldname="" yfieldname="" x="0" y="0"/>
               <angle value="0" auto="0" fieldname=""/>
               <alignment value="center" fieldname=""/>
-              <buffercolor green="255" blue="255" red="255" fieldname=""/>
+              <buffercolor fieldname="" green="255" blue="255" red="255"/>
               <buffersize value="1" units="pt" fieldname=""/>
-              <bufferenabled on="" fieldname=""/>
-              <multilineenabled on="" fieldname=""/>
+              <bufferenabled fieldname="" on=""/>
+              <multilineenabled fieldname="" on=""/>
               <selectedonly on=""/>
             </labelattributes>
-            <SingleCategoryDiagramRenderer diagramType="Pie" sizeLegend="0" attributeLegend="1">
-              <DiagramCategory backgroundAlpha="255" sizeScale="0,0,0,0,0,0" scaleBasedVisibility="0" transparency="0" width="15" backgroundColor="#ffffff" minScaleDenominator="0" minimumSize="0" penAlpha="255" scaleDependency="Area" lineSizeScale="0,0,0,0,0,0" penWidth="0" barWidth="5" height="15" angleOffset="1440" labelPlacementMethod="XHeight" lineSizeType="MM" diagramOrientation="Up" sizeType="MM" enabled="0" penColor="#000000" maxScaleDenominator="1e+08">
+            <SingleCategoryDiagramRenderer sizeLegend="0" attributeLegend="1" diagramType="Pie">
+              <DiagramCategory minScaleDenominator="0" diagramOrientation="Up" backgroundColor="#ffffff" penWidth="0" barWidth="5" penColor="#000000" angleOffset="1440" maxScaleDenominator="1e+08" scaleBasedVisibility="0" penAlpha="255" scaleDependency="Area" labelPlacementMethod="XHeight" enabled="0" width="15" sizeType="MM" lineSizeScale="0,0,0,0,0,0" height="15" backgroundAlpha="255" lineSizeType="MM" minimumSize="0" sizeScale="0,0,0,0,0,0" transparency="0">
                 <fontProperties description="Ubuntu,11,-1,5,50,0,0,0,0,0" style=""/>
-                <attribute label="" field="" color="#000000"/>
+                <attribute label="" color="#000000" field=""/>
               </DiagramCategory>
-              <symbol name="sizeSymbol" clip_to_extent="1" alpha="1" type="marker">
+              <symbol clip_to_extent="1" type="marker" name="sizeSymbol" alpha="1">
                 <layer pass="0" class="SimpleMarker" locked="0">
                   <prop k="angle" v="0"/>
                   <prop k="color" v="255,0,0,255"/>
@@ -676,14 +592,14 @@
                 </layer>
               </symbol>
             </SingleCategoryDiagramRenderer>
-            <DiagramLayerSettings priority="0" xPosColumn="-1" obstacle="0" yPosColumn="-1" zIndex="0" showAll="1" showColumn="0" placement="0" dist="0" linePlacementFlags="10"/>
+            <DiagramLayerSettings showAll="1" priority="0" showColumn="0" yPosColumn="-1" placement="0" linePlacementFlags="10" zIndex="0" dist="0" xPosColumn="-1" obstacle="0"/>
             <annotationform>../../Layouts_Alex</annotationform>
             <aliases>
-              <alias name="" index="0" field="ID"/>
-              <alias name="" index="1" field="fk_region"/>
-              <alias name="" index="2" field="ELEV"/>
-              <alias name="" index="3" field="NAME"/>
-              <alias name="" index="4" field="USE"/>
+              <alias name="" field="ID" index="0"/>
+              <alias name="" field="fk_region" index="1"/>
+              <alias name="" field="ELEV" index="2"/>
+              <alias name="" field="NAME" index="3"/>
+              <alias name="" field="USE" index="4"/>
             </aliases>
             <excludeAttributesWMS/>
             <excludeAttributesWFS/>
@@ -738,9 +654,9 @@ def my_form_open(dialog, layer, feature):
         <Removable>1</Removable>
         <Searchable>1</Searchable>
       </flags>
-      <renderer-v2 symbollevels="0" type="singleSymbol" forceraster="0" enableorderby="0">
+      <renderer-v2 type="singleSymbol" symbollevels="0" forceraster="0" enableorderby="0">
         <symbols>
-          <symbol force_rhr="0" name="0" clip_to_extent="1" alpha="1" type="marker">
+          <symbol clip_to_extent="1" force_rhr="0" type="marker" name="0" alpha="1">
             <layer enabled="1" pass="0" class="FontMarker" locked="0">
               <prop k="angle" v="0"/>
               <prop k="chr" v="l"/>
@@ -761,9 +677,9 @@ def my_form_open(dialog, layer, feature):
               <prop k="vertical_anchor_point" v="1"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
@@ -787,9 +703,9 @@ def my_form_open(dialog, layer, feature):
               <prop k="vertical_anchor_point" v="1"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
@@ -798,12 +714,12 @@ def my_form_open(dialog, layer, feature):
               <prop k="geometryModifier" v="$geometry"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
-              <symbol force_rhr="0" name="@0@2" clip_to_extent="1" alpha="1" type="line">
+              <symbol clip_to_extent="1" force_rhr="0" type="line" name="@0@2" alpha="1">
                 <layer enabled="1" pass="0" class="SimpleLine" locked="0">
                   <prop k="capstyle" v="square"/>
                   <prop k="customdash" v="5;2"/>
@@ -823,9 +739,9 @@ def my_form_open(dialog, layer, feature):
                   <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
                   <data_defined_properties>
                     <Option type="Map">
-                      <Option value="" name="name" type="QString"/>
+                      <Option value="" type="QString" name="name"/>
                       <Option name="properties"/>
-                      <Option value="collection" name="type" type="QString"/>
+                      <Option value="collection" type="QString" name="type"/>
                     </Option>
                   </data_defined_properties>
                 </layer>
@@ -837,83 +753,54 @@ def my_form_open(dialog, layer, feature):
         <sizescale/>
       </renderer-v2>
       <labeling type="simple">
-        <settings calloutType="simple">
-          <text-style fontSize="11" textOpacity="1" fontFamily="Ubuntu" fontItalic="1" fontCapitals="2" textOrientation="horizontal" fontStrikeout="0" blendMode="0" fieldName="NAME" previewBkgrdColor="255,255,255,255" fontUnderline="0" fontWordSpacing="0" fontSizeUnit="Point" namedStyle="Bold Italic" fontKerning="1" isExpression="0" useSubstitutions="0" textColor="0,0,0,255" fontSizeMapUnitScale="3x:0,0,0,0,0,0" multilineHeight="1" fontLetterSpacing="0" fontWeight="75">
-            <text-buffer bufferSizeUnits="MM" bufferDraw="1" bufferNoFill="0" bufferColor="255,255,255,255" bufferOpacity="0.6" bufferBlendMode="1" bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferJoinStyle="64" bufferSize="1.5"/>
-            <background shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeOpacity="1" shapeSizeX="0" shapeRadiiX="0" shapeSVGFile="" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeOffsetX="0" shapeType="0" shapeBlendMode="0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeJoinStyle="64" shapeDraw="0" shapeSizeUnit="MM" shapeSizeType="0" shapeRotationType="0" shapeRotation="0" shapeOffsetUnit="MM" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeBorderWidthUnit="MM" shapeSizeY="0" shapeBorderWidth="0" shapeRadiiY="0" shapeOffsetY="0" shapeBorderColor="128,128,128,255" shapeRadiiUnit="MM" shapeFillColor="255,255,255,255"/>
-            <shadow shadowDraw="0" shadowOffsetUnit="MM" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowRadiusUnit="MM" shadowScale="100" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowRadiusAlphaOnly="0" shadowBlendMode="6" shadowOffsetAngle="135" shadowOffsetDist="1" shadowOffsetGlobal="1" shadowUnder="0" shadowRadius="1.5" shadowColor="0,0,0,255" shadowOpacity="0.7"/>
-            <dd_properties>
-              <Option type="Map">
-                <Option value="" name="name" type="QString"/>
-                <Option name="properties"/>
-                <Option value="collection" name="type" type="QString"/>
-              </Option>
-            </dd_properties>
+        <settings>
+          <text-style namedStyle="Bold Italic" fieldName="NAME" fontWeight="75" fontWordSpacing="0" fontSizeUnit="Point" fontItalic="1" fontSizeMapUnitScale="3x:0,0,0,0,0,0" fontCapitals="2" fontFamily="Ubuntu" textColor="0,0,0,255" fontSize="11" fontLetterSpacing="0" previewBkgrdColor="255,255,255,255" fontStrikeout="0" multilineHeight="1" useSubstitutions="0" textOpacity="1" isExpression="0" blendMode="0" fontUnderline="0">
+            <text-buffer bufferDraw="1" bufferNoFill="0" bufferBlendMode="1" bufferSize="1.5" bufferSizeUnits="MM" bufferColor="255,255,255,255" bufferJoinStyle="64" bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferOpacity="0.6"/>
+            <background shapeRadiiX="0" shapeSizeUnit="MM" shapeOffsetY="0" shapeRadiiUnit="MM" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeBlendMode="0" shapeRotation="0" shapeSizeX="0" shapeSizeY="0" shapeDraw="0" shapeRadiiY="0" shapeOffsetX="0" shapeRotationType="0" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeOffsetUnit="MM" shapeBorderWidth="0" shapeBorderWidthUnit="MM" shapeJoinStyle="64" shapeBorderColor="128,128,128,255" shapeFillColor="255,255,255,255" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeType="0" shapeSVGFile="" shapeSizeType="0" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeOpacity="1"/>
+            <shadow shadowDraw="0" shadowOffsetGlobal="1" shadowOffsetAngle="135" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowColor="0,0,0,255" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowOpacity="0.7" shadowRadiusUnit="MM" shadowUnder="0" shadowOffsetUnit="MM" shadowScale="100" shadowBlendMode="6" shadowRadiusAlphaOnly="0" shadowOffsetDist="1" shadowRadius="1.5"/>
             <substitutions/>
           </text-style>
-          <text-format addDirectionSymbol="0" rightDirectionSymbol=">" plussign="0" reverseDirectionSymbol="0" placeDirectionSymbol="0" multilineAlign="0" leftDirectionSymbol="&lt;" formatNumbers="0" wrapChar="" autoWrapLength="0" useMaxLineLengthForAutoWrap="1" decimals="0"/>
-          <placement geometryGeneratorEnabled="0" fitInPolygonOnly="0" maxCurvedCharAngleOut="-20" rotationAngle="0" priority="5" geometryGeneratorType="PointGeometry" predefinedPositionOrder="TR,TL,BR,BL,R,L,TSR,BSR" distUnits="MM" repeatDistance="0" xOffset="0" centroidWhole="0" preserveRotation="1" offsetUnits="MapUnit" overrunDistance="0" repeatDistanceMapUnitScale="3x:0,0,0,0,0,0" placement="0" repeatDistanceUnits="MM" labelOffsetMapUnitScale="3x:0,0,0,0,0,0" layerType="UnknownGeometry" distMapUnitScale="3x:0,0,0,0,0,0" yOffset="0" offsetType="0" quadOffset="4" dist="2" overrunDistanceMapUnitScale="3x:0,0,0,0,0,0" placementFlags="0" maxCurvedCharAngleIn="20" overrunDistanceUnit="MM" geometryGenerator="" centroidInside="0"/>
-          <rendering obstacle="1" drawLabels="1" fontMaxPixelSize="10000" maxNumLabels="2000" minFeatureSize="0" scaleVisibility="0" mergeLines="0" scaleMin="1" zIndex="0" fontMinPixelSize="3" upsidedownLabels="0" obstacleType="0" obstacleFactor="1" limitNumLabels="0" labelPerPart="0" scaleMax="10000000" displayAll="0" fontLimitPixelSize="0"/>
+          <text-format formatNumbers="0" useMaxLineLengthForAutoWrap="1" rightDirectionSymbol=">" leftDirectionSymbol="&lt;" wrapChar="" autoWrapLength="0" addDirectionSymbol="0" decimals="0" plussign="0" reverseDirectionSymbol="0" multilineAlign="0" placeDirectionSymbol="0"/>
+          <placement fitInPolygonOnly="0" geometryGenerator="" geometryGeneratorEnabled="0" geometryGeneratorType="PointGeometry" priority="5" repeatDistanceUnits="MM" placementFlags="0" dist="2" maxCurvedCharAngleOut="-20" distUnits="MM" predefinedPositionOrder="TR,TL,BR,BL,R,L,TSR,BSR" repeatDistanceMapUnitScale="3x:0,0,0,0,0,0" labelOffsetMapUnitScale="3x:0,0,0,0,0,0" centroidWhole="0" centroidInside="0" rotationAngle="0" preserveRotation="1" offsetUnits="MapUnit" xOffset="0" quadOffset="4" distMapUnitScale="3x:0,0,0,0,0,0" repeatDistance="0" yOffset="0" placement="0" maxCurvedCharAngleIn="20" layerType="UnknownGeometry" offsetType="0"/>
+          <rendering obstacle="1" minFeatureSize="0" labelPerPart="0" maxNumLabels="2000" upsidedownLabels="0" drawLabels="1" fontMaxPixelSize="10000" fontMinPixelSize="3" scaleMax="10000000" zIndex="0" scaleVisibility="0" fontLimitPixelSize="0" obstacleFactor="1" limitNumLabels="0" mergeLines="0" scaleMin="1" obstacleType="0" displayAll="0"/>
           <dd_properties>
             <Option type="Map">
-              <Option value="" name="name" type="QString"/>
+              <Option value="" type="QString" name="name"/>
               <Option name="properties"/>
-              <Option value="collection" name="type" type="QString"/>
+              <Option value="collection" type="QString" name="type"/>
             </Option>
           </dd_properties>
-          <callout type="simple">
-            <Option type="Map">
-              <Option value="pole_of_inaccessibility" name="anchorPoint" type="QString"/>
-              <Option name="ddProperties" type="Map">
-                <Option value="" name="name" type="QString"/>
-                <Option name="properties"/>
-                <Option value="collection" name="type" type="QString"/>
-              </Option>
-              <Option value="false" name="drawToAllParts" type="bool"/>
-              <Option value="0" name="enabled" type="QString"/>
-              <Option value="&lt;symbol force_rhr=&quot;0&quot; name=&quot;symbol&quot; clip_to_extent=&quot;1&quot; alpha=&quot;1&quot; type=&quot;line&quot;>&lt;layer enabled=&quot;1&quot; pass=&quot;0&quot; class=&quot;SimpleLine&quot; locked=&quot;0&quot;>&lt;prop k=&quot;capstyle&quot; v=&quot;square&quot;/>&lt;prop k=&quot;customdash&quot; v=&quot;5;2&quot;/>&lt;prop k=&quot;customdash_map_unit_scale&quot; v=&quot;3x:0,0,0,0,0,0&quot;/>&lt;prop k=&quot;customdash_unit&quot; v=&quot;MM&quot;/>&lt;prop k=&quot;draw_inside_polygon&quot; v=&quot;0&quot;/>&lt;prop k=&quot;joinstyle&quot; v=&quot;bevel&quot;/>&lt;prop k=&quot;line_color&quot; v=&quot;60,60,60,255&quot;/>&lt;prop k=&quot;line_style&quot; v=&quot;solid&quot;/>&lt;prop k=&quot;line_width&quot; v=&quot;0.3&quot;/>&lt;prop k=&quot;line_width_unit&quot; v=&quot;MM&quot;/>&lt;prop k=&quot;offset&quot; v=&quot;0&quot;/>&lt;prop k=&quot;offset_map_unit_scale&quot; v=&quot;3x:0,0,0,0,0,0&quot;/>&lt;prop k=&quot;offset_unit&quot; v=&quot;MM&quot;/>&lt;prop k=&quot;ring_filter&quot; v=&quot;0&quot;/>&lt;prop k=&quot;use_custom_dash&quot; v=&quot;0&quot;/>&lt;prop k=&quot;width_map_unit_scale&quot; v=&quot;3x:0,0,0,0,0,0&quot;/>&lt;data_defined_properties>&lt;Option type=&quot;Map&quot;>&lt;Option value=&quot;&quot; name=&quot;name&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;properties&quot;/>&lt;Option value=&quot;collection&quot; name=&quot;type&quot; type=&quot;QString&quot;/>&lt;/Option>&lt;/data_defined_properties>&lt;/layer>&lt;/symbol>" name="lineSymbol" type="QString"/>
-              <Option value="0" name="minLength" type="double"/>
-              <Option value="3x:0,0,0,0,0,0" name="minLengthMapUnitScale" type="QString"/>
-              <Option value="MM" name="minLengthUnit" type="QString"/>
-              <Option value="0" name="offsetFromAnchor" type="double"/>
-              <Option value="3x:0,0,0,0,0,0" name="offsetFromAnchorMapUnitScale" type="QString"/>
-              <Option value="MM" name="offsetFromAnchorUnit" type="QString"/>
-              <Option value="0" name="offsetFromLabel" type="double"/>
-              <Option value="3x:0,0,0,0,0,0" name="offsetFromLabelMapUnitScale" type="QString"/>
-              <Option value="MM" name="offsetFromLabelUnit" type="QString"/>
-            </Option>
-          </callout>
         </settings>
       </labeling>
       <customproperties>
-        <property value="_fields_" key="variableNames"/>
-        <property value="" key="variableValues"/>
+        <property key="variableNames" value="_fields_"/>
+        <property key="variableValues" value=""/>
       </customproperties>
       <blendMode>0</blendMode>
       <featureBlendMode>0</featureBlendMode>
       <layerOpacity>1</layerOpacity>
-      <SingleCategoryDiagramRenderer diagramType="Pie" attributeLegend="1">
-        <DiagramCategory backgroundAlpha="255" sizeScale="3x:0,0,0,0,0,0" opacity="1" scaleBasedVisibility="0" width="15" backgroundColor="#ffffff" minScaleDenominator="0" rotationOffset="270" minimumSize="0" penAlpha="255" lineSizeScale="3x:0,0,0,0,0,0" scaleDependency="Area" penWidth="0" barWidth="5" height="15" labelPlacementMethod="XHeight" lineSizeType="MM" diagramOrientation="Up" enabled="0" sizeType="MM" penColor="#000000" maxScaleDenominator="1e+8">
+      <SingleCategoryDiagramRenderer attributeLegend="1" diagramType="Pie">
+        <DiagramCategory minScaleDenominator="0" diagramOrientation="Up" backgroundColor="#ffffff" penWidth="0" barWidth="5" penColor="#000000" opacity="1" maxScaleDenominator="1e+8" rotationOffset="270" scaleBasedVisibility="0" penAlpha="255" scaleDependency="Area" labelPlacementMethod="XHeight" enabled="0" width="15" sizeType="MM" lineSizeScale="3x:0,0,0,0,0,0" height="15" lineSizeType="MM" backgroundAlpha="255" sizeScale="3x:0,0,0,0,0,0" minimumSize="0">
           <fontProperties description="Ubuntu,11,-1,5,50,0,0,0,0,0" style=""/>
-          <attribute field="" label="" color="#000000"/>
+          <attribute label="" color="#000000" field=""/>
         </DiagramCategory>
       </SingleCategoryDiagramRenderer>
-      <DiagramLayerSettings priority="0" obstacle="0" zIndex="0" showAll="1" placement="0" dist="0" linePlacementFlags="10">
+      <DiagramLayerSettings showAll="1" priority="0" placement="0" linePlacementFlags="10" zIndex="0" dist="0" obstacle="0">
         <properties>
           <Option type="Map">
-            <Option value="" name="name" type="QString"/>
-            <Option name="properties" type="Map">
-              <Option name="show" type="Map">
-                <Option value="true" name="active" type="bool"/>
-                <Option value="ID" name="field" type="QString"/>
-                <Option value="2" name="type" type="int"/>
+            <Option value="" type="QString" name="name"/>
+            <Option type="Map" name="properties">
+              <Option type="Map" name="show">
+                <Option value="true" type="bool" name="active"/>
+                <Option value="ID" type="QString" name="field"/>
+                <Option value="2" type="int" name="type"/>
               </Option>
             </Option>
-            <Option value="collection" name="type" type="QString"/>
+            <Option value="collection" type="QString" name="type"/>
           </Option>
         </properties>
       </DiagramLayerSettings>
-      <geometryOptions removeDuplicateNodes="0" geometryPrecision="0">
+      <geometryOptions geometryPrecision="0" removeDuplicateNodes="0">
         <activeChecks/>
         <checkConfiguration/>
       </geometryOptions>
@@ -922,8 +809,8 @@ def my_form_open(dialog, layer, feature):
           <editWidget type="TextEdit">
             <config>
               <Option type="Map">
-                <Option value="0" name="IsMultiline" type="QString"/>
-                <Option value="0" name="UseHtml" type="QString"/>
+                <Option value="0" type="QString" name="IsMultiline"/>
+                <Option value="0" type="QString" name="UseHtml"/>
               </Option>
             </config>
           </editWidget>
@@ -932,8 +819,8 @@ def my_form_open(dialog, layer, feature):
           <editWidget type="TextEdit">
             <config>
               <Option type="Map">
-                <Option value="0" name="IsMultiline" type="QString"/>
-                <Option value="0" name="UseHtml" type="QString"/>
+                <Option value="0" type="QString" name="IsMultiline"/>
+                <Option value="0" type="QString" name="UseHtml"/>
               </Option>
             </config>
           </editWidget>
@@ -942,8 +829,8 @@ def my_form_open(dialog, layer, feature):
           <editWidget type="TextEdit">
             <config>
               <Option type="Map">
-                <Option value="0" name="IsMultiline" type="QString"/>
-                <Option value="0" name="UseHtml" type="QString"/>
+                <Option value="0" type="QString" name="IsMultiline"/>
+                <Option value="0" type="QString" name="UseHtml"/>
               </Option>
             </config>
           </editWidget>
@@ -952,8 +839,8 @@ def my_form_open(dialog, layer, feature):
           <editWidget type="TextEdit">
             <config>
               <Option type="Map">
-                <Option value="0" name="IsMultiline" type="QString"/>
-                <Option value="0" name="UseHtml" type="QString"/>
+                <Option value="0" type="QString" name="IsMultiline"/>
+                <Option value="0" type="QString" name="UseHtml"/>
               </Option>
             </config>
           </editWidget>
@@ -962,46 +849,46 @@ def my_form_open(dialog, layer, feature):
           <editWidget type="TextEdit">
             <config>
               <Option type="Map">
-                <Option value="0" name="IsMultiline" type="QString"/>
-                <Option value="0" name="UseHtml" type="QString"/>
+                <Option value="0" type="QString" name="IsMultiline"/>
+                <Option value="0" type="QString" name="UseHtml"/>
               </Option>
             </config>
           </editWidget>
         </field>
       </fieldConfiguration>
       <aliases>
-        <alias name="" index="0" field="ID"/>
-        <alias name="" index="1" field="fk_region"/>
-        <alias name="" index="2" field="ELEV"/>
-        <alias name="" index="3" field="NAME"/>
-        <alias name="" index="4" field="USE"/>
+        <alias name="" field="ID" index="0"/>
+        <alias name="" field="fk_region" index="1"/>
+        <alias name="" field="ELEV" index="2"/>
+        <alias name="" field="NAME" index="3"/>
+        <alias name="" field="USE" index="4"/>
       </aliases>
       <excludeAttributesWMS/>
       <excludeAttributesWFS/>
       <defaults>
-        <default field="ID" applyOnUpdate="0" expression=""/>
-        <default field="fk_region" applyOnUpdate="0" expression=""/>
-        <default field="ELEV" applyOnUpdate="0" expression=""/>
-        <default field="NAME" applyOnUpdate="0" expression=""/>
-        <default field="USE" applyOnUpdate="0" expression=""/>
+        <default field="ID" expression="" applyOnUpdate="0"/>
+        <default field="fk_region" expression="" applyOnUpdate="0"/>
+        <default field="ELEV" expression="" applyOnUpdate="0"/>
+        <default field="NAME" expression="" applyOnUpdate="0"/>
+        <default field="USE" expression="" applyOnUpdate="0"/>
       </defaults>
       <constraints>
-        <constraint field="ID" notnull_strength="0" constraints="0" unique_strength="0" exp_strength="0"/>
-        <constraint field="fk_region" notnull_strength="0" constraints="0" unique_strength="0" exp_strength="0"/>
-        <constraint field="ELEV" notnull_strength="0" constraints="0" unique_strength="0" exp_strength="0"/>
-        <constraint field="NAME" notnull_strength="0" constraints="0" unique_strength="0" exp_strength="0"/>
-        <constraint field="USE" notnull_strength="0" constraints="0" unique_strength="0" exp_strength="0"/>
+        <constraint notnull_strength="0" exp_strength="0" field="ID" unique_strength="0" constraints="0"/>
+        <constraint notnull_strength="0" exp_strength="0" field="fk_region" unique_strength="0" constraints="0"/>
+        <constraint notnull_strength="0" exp_strength="0" field="ELEV" unique_strength="0" constraints="0"/>
+        <constraint notnull_strength="0" exp_strength="0" field="NAME" unique_strength="0" constraints="0"/>
+        <constraint notnull_strength="0" exp_strength="0" field="USE" unique_strength="0" constraints="0"/>
       </constraints>
       <constraintExpressions>
-        <constraint field="ID" exp="" desc=""/>
-        <constraint field="fk_region" exp="" desc=""/>
-        <constraint field="ELEV" exp="" desc=""/>
-        <constraint field="NAME" exp="" desc=""/>
-        <constraint field="USE" exp="" desc=""/>
+        <constraint field="ID" desc="" exp=""/>
+        <constraint field="fk_region" desc="" exp=""/>
+        <constraint field="ELEV" desc="" exp=""/>
+        <constraint field="NAME" desc="" exp=""/>
+        <constraint field="USE" desc="" exp=""/>
       </constraintExpressions>
       <expressionfields/>
       <attributeactions>
-        <defaultAction value="{00000000-0000-0000-0000-000000000000}" key="Canvas"/>
+        <defaultAction key="Canvas" value="{00000000-0000-0000-0000-000000000000}"/>
       </attributeactions>
       <attributetableconfig sortExpression="" actionWidgetStyle="dropDown" sortOrder="0">
         <columns/>
@@ -1010,7 +897,6 @@ def my_form_open(dialog, layer, feature):
         <rowstyles/>
         <fieldstyles/>
       </conditionalstyles>
-      <storedexpressions/>
       <editform tolerant="1"></editform>
       <editforminit/>
       <editforminitcodesource>0</editforminitcodesource>
@@ -1040,7 +926,7 @@ def my_form_open(dialog, layer, feature):
       <previewExpression>cat</previewExpression>
       <mapTip>cat</mapTip>
     </maplayer>
-    <maplayer simplifyDrawingHints="0" simplifyAlgorithm="0" labelsEnabled="1" refreshOnNotifyMessage="" wkbType="Point" minScale="1e+8" readOnly="0" refreshOnNotifyEnabled="0" type="vector" maxScale="0" simplifyLocal="1" autoRefreshTime="0" hasScaleBasedVisibilityFlag="0" geometry="Point" styleCategories="AllStyleCategories" autoRefreshEnabled="0" simplifyDrawingTol="1" simplifyMaxScale="1">
+    <maplayer refreshOnNotifyEnabled="0" refreshOnNotifyMessage="" styleCategories="AllStyleCategories" maxScale="0" hasScaleBasedVisibilityFlag="0" simplifyAlgorithm="0" type="vector" labelsEnabled="1" minScale="1e+8" simplifyLocal="1" simplifyDrawingHints="0" autoRefreshTime="0" readOnly="0" geometry="Point" simplifyDrawingTol="1" autoRefreshEnabled="0" simplifyMaxScale="1" wkbType="Point">
       <extent>
         <xmin>-4480198.52221446391195059</xmin>
         <ymin>1433525.79887208016589284</ymin>
@@ -1055,7 +941,6 @@ def my_form_open(dialog, layer, feature):
       <layername>airports</layername>
       <srs>
         <spatialrefsys>
-          <wkt>PROJCS["NAD27 / Alaska Albers",GEOGCS["NAD27",DATUM["North_American_Datum_1927",SPHEROID["Clarke 1866",6378206.4,294.9786982138982,AUTHORITY["EPSG","7008"]],AUTHORITY["EPSG","6267"]],PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9122"]],AUTHORITY["EPSG","4267"]],PROJECTION["Albers_Conic_Equal_Area"],PARAMETER["standard_parallel_1",55],PARAMETER["standard_parallel_2",65],PARAMETER["latitude_of_center",50],PARAMETER["longitude_of_center",-154],PARAMETER["false_easting",0],PARAMETER["false_northing",0],UNIT["US survey foot",0.3048006096012192,AUTHORITY["EPSG","9003"]],AXIS["X",EAST],AXIS["Y",NORTH],AUTHORITY["EPSG","2964"]]</wkt>
           <proj4>+proj=aea +lat_1=55 +lat_2=65 +lat_0=50 +lon_0=-154 +x_0=0 +y_0=0 +datum=NAD27 +units=us-ft +no_defs</proj4>
           <srsid>932</srsid>
           <srid>2964</srid>
@@ -1078,7 +963,6 @@ def my_form_open(dialog, layer, feature):
         <encoding></encoding>
         <crs>
           <spatialrefsys>
-            <wkt></wkt>
             <proj4></proj4>
             <srsid>0</srsid>
             <srid>0</srid>
@@ -1086,7 +970,7 @@ def my_form_open(dialog, layer, feature):
             <description></description>
             <projectionacronym></projectionacronym>
             <ellipsoidacronym></ellipsoidacronym>
-            <geographicflag>false</geographicflag>
+            <geographicflag>true</geographicflag>
           </spatialrefsys>
         </crs>
         <extent/>
@@ -1106,9 +990,9 @@ def my_form_open(dialog, layer, feature):
         <Removable>1</Removable>
         <Searchable>1</Searchable>
       </flags>
-      <renderer-v2 symbollevels="0" type="singleSymbol" forceraster="0" enableorderby="0">
+      <renderer-v2 type="singleSymbol" symbollevels="0" forceraster="0" enableorderby="0">
         <symbols>
-          <symbol force_rhr="0" name="0" clip_to_extent="1" alpha="1" type="marker">
+          <symbol clip_to_extent="1" force_rhr="0" type="marker" name="0" alpha="1">
             <layer enabled="0" pass="0" class="FontMarker" locked="0">
               <prop k="angle" v="0"/>
               <prop k="chr" v="l"/>
@@ -1129,9 +1013,9 @@ def my_form_open(dialog, layer, feature):
               <prop k="vertical_anchor_point" v="1"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
@@ -1155,9 +1039,9 @@ def my_form_open(dialog, layer, feature):
               <prop k="vertical_anchor_point" v="1"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
@@ -1166,12 +1050,12 @@ def my_form_open(dialog, layer, feature):
               <prop k="geometryModifier" v="$geometry"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
-              <symbol force_rhr="0" name="@0@2" clip_to_extent="1" alpha="1" type="line">
+              <symbol clip_to_extent="1" force_rhr="0" type="line" name="@0@2" alpha="1">
                 <layer enabled="1" pass="0" class="SimpleLine" locked="0">
                   <prop k="capstyle" v="square"/>
                   <prop k="customdash" v="5;2"/>
@@ -1191,9 +1075,9 @@ def my_form_open(dialog, layer, feature):
                   <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
                   <data_defined_properties>
                     <Option type="Map">
-                      <Option value="" name="name" type="QString"/>
+                      <Option value="" type="QString" name="name"/>
                       <Option name="properties"/>
-                      <Option value="collection" name="type" type="QString"/>
+                      <Option value="collection" type="QString" name="type"/>
                     </Option>
                   </data_defined_properties>
                 </layer>
@@ -1205,115 +1089,70 @@ def my_form_open(dialog, layer, feature):
         <sizescale/>
       </renderer-v2>
       <labeling type="simple">
-        <settings calloutType="simple">
-          <text-style fontSize="11" textOpacity="1" fontFamily="Ubuntu" fontItalic="0" fontCapitals="0" textOrientation="horizontal" fontStrikeout="0" blendMode="0" fieldName="title(  lower( &quot;NAME&quot;) )" previewBkgrdColor="255,255,255,255" fontUnderline="0" fontWordSpacing="0" fontSizeUnit="Point" namedStyle="Normal" fontKerning="1" isExpression="1" useSubstitutions="0" textColor="0,0,0,255" fontSizeMapUnitScale="3x:0,0,0,0,0,0" multilineHeight="1" fontLetterSpacing="0" fontWeight="50">
-            <text-buffer bufferSizeUnits="MM" bufferDraw="1" bufferNoFill="0" bufferColor="255,255,255,255" bufferOpacity="0.6" bufferBlendMode="1" bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferJoinStyle="64" bufferSize="1.5"/>
-            <background shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeOpacity="1" shapeSizeX="0" shapeRadiiX="0" shapeSVGFile="" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeOffsetX="0" shapeType="0" shapeBlendMode="0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeJoinStyle="64" shapeDraw="0" shapeSizeUnit="MM" shapeSizeType="0" shapeRotationType="0" shapeRotation="0" shapeOffsetUnit="MM" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeBorderWidthUnit="MM" shapeSizeY="0" shapeBorderWidth="0" shapeRadiiY="0" shapeOffsetY="0" shapeBorderColor="128,128,128,255" shapeRadiiUnit="MM" shapeFillColor="255,255,255,255"/>
-            <shadow shadowDraw="0" shadowOffsetUnit="MM" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowRadiusUnit="MM" shadowScale="100" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowRadiusAlphaOnly="0" shadowBlendMode="6" shadowOffsetAngle="135" shadowOffsetDist="1" shadowOffsetGlobal="1" shadowUnder="0" shadowRadius="1.5" shadowColor="0,0,0,255" shadowOpacity="0.7"/>
-            <dd_properties>
-              <Option type="Map">
-                <Option value="" name="name" type="QString"/>
-                <Option name="properties" type="Map">
-                  <Option name="Color" type="Map">
-                    <Option value="true" name="active" type="bool"/>
-                    <Option value="CASE&#xd;&#xa;    WHEN &quot;USE&quot; like '%Military%' THEN '150, 150, 150'&#xd;&#xa;    ELSE '0, 0, 255'&#xd;&#xa;END" name="expression" type="QString"/>
-                    <Option value="3" name="type" type="int"/>
-                  </Option>
-                  <Option name="FontCase" type="Map">
-                    <Option value="false" name="active" type="bool"/>
-                    <Option value="title(  lower( &quot;NAME&quot;) )" name="expression" type="QString"/>
-                    <Option value="3" name="type" type="int"/>
-                  </Option>
-                  <Option name="Size" type="Map">
-                    <Option value="true" name="active" type="bool"/>
-                    <Option value="CASE&#xd;&#xa;    WHEN &quot;USE&quot; like '%Military%' THEN 8 -- because compatible values are 'Military'&#xd;&#xa;                                        --- and 'Joint Military/Civilian'&#xd;&#xa;    ELSE 10&#xd;&#xa;END" name="expression" type="QString"/>
-                    <Option value="3" name="type" type="int"/>
-                  </Option>
-                </Option>
-                <Option value="collection" name="type" type="QString"/>
-              </Option>
-            </dd_properties>
+        <settings>
+          <text-style namedStyle="Normal" fieldName="title(  lower( &quot;NAME&quot;) )" fontWeight="50" fontWordSpacing="0" fontSizeUnit="Point" fontItalic="0" fontSizeMapUnitScale="3x:0,0,0,0,0,0" fontCapitals="0" fontFamily="Ubuntu" textColor="0,0,0,255" fontSize="11" fontLetterSpacing="0" previewBkgrdColor="255,255,255,255" fontStrikeout="0" multilineHeight="1" useSubstitutions="0" textOpacity="1" isExpression="1" blendMode="0" fontUnderline="0">
+            <text-buffer bufferDraw="1" bufferNoFill="0" bufferBlendMode="1" bufferSize="1.5" bufferSizeUnits="MM" bufferColor="255,255,255,255" bufferJoinStyle="64" bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferOpacity="0.6"/>
+            <background shapeRadiiX="0" shapeSizeUnit="MM" shapeOffsetY="0" shapeRadiiUnit="MM" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeBlendMode="0" shapeRotation="0" shapeSizeX="0" shapeSizeY="0" shapeDraw="0" shapeRadiiY="0" shapeOffsetX="0" shapeRotationType="0" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeOffsetUnit="MM" shapeBorderWidth="0" shapeBorderWidthUnit="MM" shapeJoinStyle="64" shapeBorderColor="128,128,128,255" shapeFillColor="255,255,255,255" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeType="0" shapeSVGFile="" shapeSizeType="0" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeOpacity="1"/>
+            <shadow shadowDraw="0" shadowOffsetGlobal="1" shadowOffsetAngle="135" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowColor="0,0,0,255" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowOpacity="0.7" shadowRadiusUnit="MM" shadowUnder="0" shadowOffsetUnit="MM" shadowScale="100" shadowBlendMode="6" shadowRadiusAlphaOnly="0" shadowOffsetDist="1" shadowRadius="1.5"/>
             <substitutions/>
           </text-style>
-          <text-format addDirectionSymbol="0" rightDirectionSymbol=">" plussign="0" reverseDirectionSymbol="0" placeDirectionSymbol="0" multilineAlign="0" leftDirectionSymbol="&lt;" formatNumbers="0" wrapChar="" autoWrapLength="0" useMaxLineLengthForAutoWrap="1" decimals="0"/>
-          <placement geometryGeneratorEnabled="0" fitInPolygonOnly="0" maxCurvedCharAngleOut="-20" rotationAngle="0" priority="5" geometryGeneratorType="PointGeometry" predefinedPositionOrder="TR,TL,BR,BL,R,L,TSR,BSR" distUnits="MM" repeatDistance="0" xOffset="0" centroidWhole="0" preserveRotation="1" offsetUnits="MapUnit" overrunDistance="0" repeatDistanceMapUnitScale="3x:0,0,0,0,0,0" placement="0" repeatDistanceUnits="MM" labelOffsetMapUnitScale="3x:0,0,0,0,0,0" layerType="UnknownGeometry" distMapUnitScale="3x:0,0,0,0,0,0" yOffset="0" offsetType="0" quadOffset="4" dist="2" overrunDistanceMapUnitScale="3x:0,0,0,0,0,0" placementFlags="0" maxCurvedCharAngleIn="20" overrunDistanceUnit="MM" geometryGenerator="" centroidInside="0"/>
-          <rendering obstacle="1" drawLabels="1" fontMaxPixelSize="10000" maxNumLabels="2000" minFeatureSize="0" scaleVisibility="0" mergeLines="0" scaleMin="1" zIndex="0" fontMinPixelSize="3" upsidedownLabels="0" obstacleType="0" obstacleFactor="1" limitNumLabels="0" labelPerPart="0" scaleMax="10000000" displayAll="0" fontLimitPixelSize="0"/>
+          <text-format formatNumbers="0" useMaxLineLengthForAutoWrap="1" rightDirectionSymbol=">" leftDirectionSymbol="&lt;" wrapChar="" autoWrapLength="0" addDirectionSymbol="0" decimals="0" plussign="0" reverseDirectionSymbol="0" multilineAlign="0" placeDirectionSymbol="0"/>
+          <placement fitInPolygonOnly="0" geometryGenerator="" geometryGeneratorEnabled="0" geometryGeneratorType="PointGeometry" priority="5" repeatDistanceUnits="MM" placementFlags="0" dist="2" maxCurvedCharAngleOut="-20" distUnits="MM" predefinedPositionOrder="TR,TL,BR,BL,R,L,TSR,BSR" repeatDistanceMapUnitScale="3x:0,0,0,0,0,0" labelOffsetMapUnitScale="3x:0,0,0,0,0,0" centroidWhole="0" centroidInside="0" rotationAngle="0" preserveRotation="1" offsetUnits="MapUnit" xOffset="0" quadOffset="4" distMapUnitScale="3x:0,0,0,0,0,0" repeatDistance="0" yOffset="0" placement="0" maxCurvedCharAngleIn="20" layerType="UnknownGeometry" offsetType="0"/>
+          <rendering obstacle="1" minFeatureSize="0" labelPerPart="0" maxNumLabels="2000" upsidedownLabels="0" drawLabels="1" fontMaxPixelSize="10000" fontMinPixelSize="3" scaleMax="10000000" zIndex="0" scaleVisibility="0" fontLimitPixelSize="0" obstacleFactor="1" limitNumLabels="0" mergeLines="0" scaleMin="1" obstacleType="0" displayAll="0"/>
           <dd_properties>
             <Option type="Map">
-              <Option value="" name="name" type="QString"/>
-              <Option name="properties" type="Map">
-                <Option name="Color" type="Map">
-                  <Option value="true" name="active" type="bool"/>
-                  <Option value="CASE&#xd;&#xa;    WHEN &quot;USE&quot; like '%Military%' THEN '150, 150, 150'&#xd;&#xa;    ELSE '0, 0, 255'&#xd;&#xa;END" name="expression" type="QString"/>
-                  <Option value="3" name="type" type="int"/>
+              <Option value="" type="QString" name="name"/>
+              <Option type="Map" name="properties">
+                <Option type="Map" name="Color">
+                  <Option value="true" type="bool" name="active"/>
+                  <Option value="CASE&#xd;&#xa;    WHEN &quot;USE&quot; like '%Military%' THEN '150, 150, 150'&#xd;&#xa;    ELSE '0, 0, 255'&#xd;&#xa;END" type="QString" name="expression"/>
+                  <Option value="3" type="int" name="type"/>
                 </Option>
-                <Option name="FontCase" type="Map">
-                  <Option value="false" name="active" type="bool"/>
-                  <Option value="title(  lower( &quot;NAME&quot;) )" name="expression" type="QString"/>
-                  <Option value="3" name="type" type="int"/>
+                <Option type="Map" name="FontCase">
+                  <Option value="false" type="bool" name="active"/>
+                  <Option value="title(  lower( &quot;NAME&quot;) )" type="QString" name="expression"/>
+                  <Option value="3" type="int" name="type"/>
                 </Option>
-                <Option name="Size" type="Map">
-                  <Option value="true" name="active" type="bool"/>
-                  <Option value="CASE&#xd;&#xa;    WHEN &quot;USE&quot; like '%Military%' THEN 8 -- because compatible values are 'Military'&#xd;&#xa;                                        --- and 'Joint Military/Civilian'&#xd;&#xa;    ELSE 10&#xd;&#xa;END" name="expression" type="QString"/>
-                  <Option value="3" name="type" type="int"/>
+                <Option type="Map" name="Size">
+                  <Option value="true" type="bool" name="active"/>
+                  <Option value="CASE&#xd;&#xa;    WHEN &quot;USE&quot; like '%Military%' THEN 8 -- because compatible values are 'Military'&#xd;&#xa;                                        --- and 'Joint Military/Civilian'&#xd;&#xa;    ELSE 10&#xd;&#xa;END" type="QString" name="expression"/>
+                  <Option value="3" type="int" name="type"/>
                 </Option>
               </Option>
-              <Option value="collection" name="type" type="QString"/>
+              <Option value="collection" type="QString" name="type"/>
             </Option>
           </dd_properties>
-          <callout type="simple">
-            <Option type="Map">
-              <Option value="pole_of_inaccessibility" name="anchorPoint" type="QString"/>
-              <Option name="ddProperties" type="Map">
-                <Option value="" name="name" type="QString"/>
-                <Option name="properties"/>
-                <Option value="collection" name="type" type="QString"/>
-              </Option>
-              <Option value="false" name="drawToAllParts" type="bool"/>
-              <Option value="0" name="enabled" type="QString"/>
-              <Option value="&lt;symbol force_rhr=&quot;0&quot; name=&quot;symbol&quot; clip_to_extent=&quot;1&quot; alpha=&quot;1&quot; type=&quot;line&quot;>&lt;layer enabled=&quot;1&quot; pass=&quot;0&quot; class=&quot;SimpleLine&quot; locked=&quot;0&quot;>&lt;prop k=&quot;capstyle&quot; v=&quot;square&quot;/>&lt;prop k=&quot;customdash&quot; v=&quot;5;2&quot;/>&lt;prop k=&quot;customdash_map_unit_scale&quot; v=&quot;3x:0,0,0,0,0,0&quot;/>&lt;prop k=&quot;customdash_unit&quot; v=&quot;MM&quot;/>&lt;prop k=&quot;draw_inside_polygon&quot; v=&quot;0&quot;/>&lt;prop k=&quot;joinstyle&quot; v=&quot;bevel&quot;/>&lt;prop k=&quot;line_color&quot; v=&quot;60,60,60,255&quot;/>&lt;prop k=&quot;line_style&quot; v=&quot;solid&quot;/>&lt;prop k=&quot;line_width&quot; v=&quot;0.3&quot;/>&lt;prop k=&quot;line_width_unit&quot; v=&quot;MM&quot;/>&lt;prop k=&quot;offset&quot; v=&quot;0&quot;/>&lt;prop k=&quot;offset_map_unit_scale&quot; v=&quot;3x:0,0,0,0,0,0&quot;/>&lt;prop k=&quot;offset_unit&quot; v=&quot;MM&quot;/>&lt;prop k=&quot;ring_filter&quot; v=&quot;0&quot;/>&lt;prop k=&quot;use_custom_dash&quot; v=&quot;0&quot;/>&lt;prop k=&quot;width_map_unit_scale&quot; v=&quot;3x:0,0,0,0,0,0&quot;/>&lt;data_defined_properties>&lt;Option type=&quot;Map&quot;>&lt;Option value=&quot;&quot; name=&quot;name&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;properties&quot;/>&lt;Option value=&quot;collection&quot; name=&quot;type&quot; type=&quot;QString&quot;/>&lt;/Option>&lt;/data_defined_properties>&lt;/layer>&lt;/symbol>" name="lineSymbol" type="QString"/>
-              <Option value="0" name="minLength" type="double"/>
-              <Option value="3x:0,0,0,0,0,0" name="minLengthMapUnitScale" type="QString"/>
-              <Option value="MM" name="minLengthUnit" type="QString"/>
-              <Option value="0" name="offsetFromAnchor" type="double"/>
-              <Option value="3x:0,0,0,0,0,0" name="offsetFromAnchorMapUnitScale" type="QString"/>
-              <Option value="MM" name="offsetFromAnchorUnit" type="QString"/>
-              <Option value="0" name="offsetFromLabel" type="double"/>
-              <Option value="3x:0,0,0,0,0,0" name="offsetFromLabelMapUnitScale" type="QString"/>
-              <Option value="MM" name="offsetFromLabelUnit" type="QString"/>
-            </Option>
-          </callout>
         </settings>
       </labeling>
       <customproperties>
-        <property value="_fields_" key="variableNames"/>
-        <property value="" key="variableValues"/>
+        <property key="variableNames" value="_fields_"/>
+        <property key="variableValues" value=""/>
       </customproperties>
       <blendMode>0</blendMode>
       <featureBlendMode>0</featureBlendMode>
       <layerOpacity>1</layerOpacity>
-      <SingleCategoryDiagramRenderer diagramType="Pie" attributeLegend="1">
-        <DiagramCategory backgroundAlpha="255" sizeScale="3x:0,0,0,0,0,0" opacity="1" scaleBasedVisibility="0" width="15" backgroundColor="#ffffff" minScaleDenominator="0" rotationOffset="270" minimumSize="0" penAlpha="255" lineSizeScale="3x:0,0,0,0,0,0" scaleDependency="Area" penWidth="0" barWidth="5" height="15" labelPlacementMethod="XHeight" lineSizeType="MM" diagramOrientation="Up" enabled="0" sizeType="MM" penColor="#000000" maxScaleDenominator="1e+8">
+      <SingleCategoryDiagramRenderer attributeLegend="1" diagramType="Pie">
+        <DiagramCategory minScaleDenominator="0" diagramOrientation="Up" backgroundColor="#ffffff" penWidth="0" barWidth="5" penColor="#000000" opacity="1" maxScaleDenominator="1e+8" rotationOffset="270" scaleBasedVisibility="0" penAlpha="255" scaleDependency="Area" labelPlacementMethod="XHeight" enabled="0" width="15" sizeType="MM" lineSizeScale="3x:0,0,0,0,0,0" height="15" lineSizeType="MM" backgroundAlpha="255" sizeScale="3x:0,0,0,0,0,0" minimumSize="0">
           <fontProperties description="Ubuntu,11,-1,5,50,0,0,0,0,0" style=""/>
-          <attribute field="" label="" color="#000000"/>
+          <attribute label="" color="#000000" field=""/>
         </DiagramCategory>
       </SingleCategoryDiagramRenderer>
-      <DiagramLayerSettings priority="0" obstacle="0" zIndex="0" showAll="1" placement="0" dist="0" linePlacementFlags="10">
+      <DiagramLayerSettings showAll="1" priority="0" placement="0" linePlacementFlags="10" zIndex="0" dist="0" obstacle="0">
         <properties>
           <Option type="Map">
-            <Option value="" name="name" type="QString"/>
-            <Option name="properties" type="Map">
-              <Option name="show" type="Map">
-                <Option value="true" name="active" type="bool"/>
-                <Option value="ID" name="field" type="QString"/>
-                <Option value="2" name="type" type="int"/>
+            <Option value="" type="QString" name="name"/>
+            <Option type="Map" name="properties">
+              <Option type="Map" name="show">
+                <Option value="true" type="bool" name="active"/>
+                <Option value="ID" type="QString" name="field"/>
+                <Option value="2" type="int" name="type"/>
               </Option>
             </Option>
-            <Option value="collection" name="type" type="QString"/>
+            <Option value="collection" type="QString" name="type"/>
           </Option>
         </properties>
       </DiagramLayerSettings>
-      <geometryOptions removeDuplicateNodes="0" geometryPrecision="0">
+      <geometryOptions geometryPrecision="0" removeDuplicateNodes="0">
         <activeChecks/>
         <checkConfiguration/>
       </geometryOptions>
@@ -1322,8 +1161,8 @@ def my_form_open(dialog, layer, feature):
           <editWidget type="TextEdit">
             <config>
               <Option type="Map">
-                <Option value="0" name="IsMultiline" type="QString"/>
-                <Option value="0" name="UseHtml" type="QString"/>
+                <Option value="0" type="QString" name="IsMultiline"/>
+                <Option value="0" type="QString" name="UseHtml"/>
               </Option>
             </config>
           </editWidget>
@@ -1332,8 +1171,8 @@ def my_form_open(dialog, layer, feature):
           <editWidget type="TextEdit">
             <config>
               <Option type="Map">
-                <Option value="0" name="IsMultiline" type="QString"/>
-                <Option value="0" name="UseHtml" type="QString"/>
+                <Option value="0" type="QString" name="IsMultiline"/>
+                <Option value="0" type="QString" name="UseHtml"/>
               </Option>
             </config>
           </editWidget>
@@ -1342,8 +1181,8 @@ def my_form_open(dialog, layer, feature):
           <editWidget type="TextEdit">
             <config>
               <Option type="Map">
-                <Option value="0" name="IsMultiline" type="QString"/>
-                <Option value="0" name="UseHtml" type="QString"/>
+                <Option value="0" type="QString" name="IsMultiline"/>
+                <Option value="0" type="QString" name="UseHtml"/>
               </Option>
             </config>
           </editWidget>
@@ -1352,8 +1191,8 @@ def my_form_open(dialog, layer, feature):
           <editWidget type="TextEdit">
             <config>
               <Option type="Map">
-                <Option value="0" name="IsMultiline" type="QString"/>
-                <Option value="0" name="UseHtml" type="QString"/>
+                <Option value="0" type="QString" name="IsMultiline"/>
+                <Option value="0" type="QString" name="UseHtml"/>
               </Option>
             </config>
           </editWidget>
@@ -1362,46 +1201,46 @@ def my_form_open(dialog, layer, feature):
           <editWidget type="TextEdit">
             <config>
               <Option type="Map">
-                <Option value="0" name="IsMultiline" type="QString"/>
-                <Option value="0" name="UseHtml" type="QString"/>
+                <Option value="0" type="QString" name="IsMultiline"/>
+                <Option value="0" type="QString" name="UseHtml"/>
               </Option>
             </config>
           </editWidget>
         </field>
       </fieldConfiguration>
       <aliases>
-        <alias name="" index="0" field="ID"/>
-        <alias name="" index="1" field="fk_region"/>
-        <alias name="" index="2" field="ELEV"/>
-        <alias name="" index="3" field="NAME"/>
-        <alias name="" index="4" field="USE"/>
+        <alias name="" field="ID" index="0"/>
+        <alias name="" field="fk_region" index="1"/>
+        <alias name="" field="ELEV" index="2"/>
+        <alias name="" field="NAME" index="3"/>
+        <alias name="" field="USE" index="4"/>
       </aliases>
       <excludeAttributesWMS/>
       <excludeAttributesWFS/>
       <defaults>
-        <default field="ID" applyOnUpdate="0" expression=""/>
-        <default field="fk_region" applyOnUpdate="0" expression=""/>
-        <default field="ELEV" applyOnUpdate="0" expression=""/>
-        <default field="NAME" applyOnUpdate="0" expression=""/>
-        <default field="USE" applyOnUpdate="0" expression=""/>
+        <default field="ID" expression="" applyOnUpdate="0"/>
+        <default field="fk_region" expression="" applyOnUpdate="0"/>
+        <default field="ELEV" expression="" applyOnUpdate="0"/>
+        <default field="NAME" expression="" applyOnUpdate="0"/>
+        <default field="USE" expression="" applyOnUpdate="0"/>
       </defaults>
       <constraints>
-        <constraint field="ID" notnull_strength="0" constraints="0" unique_strength="0" exp_strength="0"/>
-        <constraint field="fk_region" notnull_strength="0" constraints="0" unique_strength="0" exp_strength="0"/>
-        <constraint field="ELEV" notnull_strength="0" constraints="0" unique_strength="0" exp_strength="0"/>
-        <constraint field="NAME" notnull_strength="0" constraints="0" unique_strength="0" exp_strength="0"/>
-        <constraint field="USE" notnull_strength="0" constraints="0" unique_strength="0" exp_strength="0"/>
+        <constraint notnull_strength="0" exp_strength="0" field="ID" unique_strength="0" constraints="0"/>
+        <constraint notnull_strength="0" exp_strength="0" field="fk_region" unique_strength="0" constraints="0"/>
+        <constraint notnull_strength="0" exp_strength="0" field="ELEV" unique_strength="0" constraints="0"/>
+        <constraint notnull_strength="0" exp_strength="0" field="NAME" unique_strength="0" constraints="0"/>
+        <constraint notnull_strength="0" exp_strength="0" field="USE" unique_strength="0" constraints="0"/>
       </constraints>
       <constraintExpressions>
-        <constraint field="ID" exp="" desc=""/>
-        <constraint field="fk_region" exp="" desc=""/>
-        <constraint field="ELEV" exp="" desc=""/>
-        <constraint field="NAME" exp="" desc=""/>
-        <constraint field="USE" exp="" desc=""/>
+        <constraint field="ID" desc="" exp=""/>
+        <constraint field="fk_region" desc="" exp=""/>
+        <constraint field="ELEV" desc="" exp=""/>
+        <constraint field="NAME" desc="" exp=""/>
+        <constraint field="USE" desc="" exp=""/>
       </constraintExpressions>
       <expressionfields/>
       <attributeactions>
-        <defaultAction value="{00000000-0000-0000-0000-000000000000}" key="Canvas"/>
+        <defaultAction key="Canvas" value="{00000000-0000-0000-0000-000000000000}"/>
       </attributeactions>
       <attributetableconfig sortExpression="" actionWidgetStyle="dropDown" sortOrder="0">
         <columns/>
@@ -1410,7 +1249,6 @@ def my_form_open(dialog, layer, feature):
         <rowstyles/>
         <fieldstyles/>
       </conditionalstyles>
-      <storedexpressions/>
       <editform tolerant="1"></editform>
       <editforminit/>
       <editforminitcodesource>0</editforminitcodesource>
@@ -1440,7 +1278,7 @@ def my_form_open(dialog, layer, feature):
       <previewExpression>cat</previewExpression>
       <mapTip>cat</mapTip>
     </maplayer>
-    <maplayer simplifyDrawingHints="0" simplifyAlgorithm="0" labelsEnabled="1" refreshOnNotifyMessage="" wkbType="Point" minScale="1e+8" readOnly="0" refreshOnNotifyEnabled="0" type="vector" maxScale="0" simplifyLocal="1" autoRefreshTime="0" hasScaleBasedVisibilityFlag="0" geometry="Point" styleCategories="AllStyleCategories" autoRefreshEnabled="0" simplifyDrawingTol="1" simplifyMaxScale="1">
+    <maplayer refreshOnNotifyEnabled="0" refreshOnNotifyMessage="" styleCategories="AllStyleCategories" maxScale="0" hasScaleBasedVisibilityFlag="0" simplifyAlgorithm="0" type="vector" labelsEnabled="1" minScale="1e+8" simplifyLocal="1" simplifyDrawingHints="0" autoRefreshTime="0" readOnly="0" geometry="Point" simplifyDrawingTol="1" autoRefreshEnabled="0" simplifyMaxScale="1" wkbType="Point">
       <extent>
         <xmin>-4480198.52221446391195059</xmin>
         <ymin>1433525.79887208016589284</ymin>
@@ -1456,7 +1294,6 @@ def my_form_open(dialog, layer, feature):
       <layername>airports copy</layername>
       <srs>
         <spatialrefsys>
-          <wkt>PROJCS["NAD27 / Alaska Albers",GEOGCS["NAD27",DATUM["North_American_Datum_1927",SPHEROID["Clarke 1866",6378206.4,294.9786982138982,AUTHORITY["EPSG","7008"]],AUTHORITY["EPSG","6267"]],PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9122"]],AUTHORITY["EPSG","4267"]],PROJECTION["Albers_Conic_Equal_Area"],PARAMETER["standard_parallel_1",55],PARAMETER["standard_parallel_2",65],PARAMETER["latitude_of_center",50],PARAMETER["longitude_of_center",-154],PARAMETER["false_easting",0],PARAMETER["false_northing",0],UNIT["US survey foot",0.3048006096012192,AUTHORITY["EPSG","9003"]],AXIS["X",EAST],AXIS["Y",NORTH],AUTHORITY["EPSG","2964"]]</wkt>
           <proj4>+proj=aea +lat_1=55 +lat_2=65 +lat_0=50 +lon_0=-154 +x_0=0 +y_0=0 +datum=NAD27 +units=us-ft +no_defs</proj4>
           <srsid>932</srsid>
           <srid>2964</srid>
@@ -1479,7 +1316,6 @@ def my_form_open(dialog, layer, feature):
         <encoding></encoding>
         <crs>
           <spatialrefsys>
-            <wkt></wkt>
             <proj4></proj4>
             <srsid>0</srsid>
             <srid>0</srid>
@@ -1487,7 +1323,7 @@ def my_form_open(dialog, layer, feature):
             <description></description>
             <projectionacronym></projectionacronym>
             <ellipsoidacronym></ellipsoidacronym>
-            <geographicflag>false</geographicflag>
+            <geographicflag>true</geographicflag>
           </spatialrefsys>
         </crs>
         <extent/>
@@ -1507,11 +1343,11 @@ def my_form_open(dialog, layer, feature):
         <Removable>1</Removable>
         <Searchable>1</Searchable>
       </flags>
-      <renderer-v2 tolerance="100000" circleWidth="0.4" labelDistanceFactor="0.5" circleColor="125,125,125,255" toleranceUnit="MapUnit" maxLabelScaleDenominator="-1" toleranceUnitScale="3x:0,0,0,0,0,0" type="pointDisplacement" labelAttributeName="IKO" forceraster="0" placement="0" labelColor="0,0,0,255" enableorderby="0" circleRadiusAddition="0.5">
+      <renderer-v2 labelDistanceFactor="0.5" maxLabelScaleDenominator="-1" toleranceUnit="MapUnit" circleColor="125,125,125,255" type="pointDisplacement" circleWidth="0.4" toleranceUnitScale="3x:0,0,0,0,0,0" placement="0" tolerance="100000" forceraster="0" labelAttributeName="IKO" labelColor="0,0,0,255" circleRadiusAddition="0.5" enableorderby="0">
         <labelFontProperties description="Ubuntu,11,-1,5,50,0,0,0,0,0" style=""/>
-        <renderer-v2 symbollevels="0" type="singleSymbol" forceraster="0" enableorderby="0">
+        <renderer-v2 type="singleSymbol" symbollevels="0" forceraster="0" enableorderby="0">
           <symbols>
-            <symbol force_rhr="0" name="0" clip_to_extent="1" alpha="1" type="marker">
+            <symbol clip_to_extent="1" force_rhr="0" type="marker" name="0" alpha="1">
               <layer enabled="1" pass="0" class="SimpleMarker" locked="0">
                 <prop k="angle" v="0"/>
                 <prop k="color" v="119,120,171,255"/>
@@ -1533,9 +1369,9 @@ def my_form_open(dialog, layer, feature):
                 <prop k="vertical_anchor_point" v="1"/>
                 <data_defined_properties>
                   <Option type="Map">
-                    <Option value="" name="name" type="QString"/>
+                    <Option value="" type="QString" name="name"/>
                     <Option name="properties"/>
-                    <Option value="collection" name="type" type="QString"/>
+                    <Option value="collection" type="QString" name="type"/>
                   </Option>
                 </data_defined_properties>
               </layer>
@@ -1544,7 +1380,7 @@ def my_form_open(dialog, layer, feature):
           <rotation/>
           <sizescale/>
         </renderer-v2>
-        <symbol force_rhr="0" name="centerSymbol" clip_to_extent="1" alpha="1" type="marker">
+        <symbol clip_to_extent="1" force_rhr="0" type="marker" name="centerSymbol" alpha="1">
           <layer enabled="1" pass="0" class="SimpleMarker" locked="0">
             <prop k="angle" v="0"/>
             <prop k="color" v="125,125,125,255"/>
@@ -1566,9 +1402,9 @@ def my_form_open(dialog, layer, feature):
             <prop k="vertical_anchor_point" v="1"/>
             <data_defined_properties>
               <Option type="Map">
-                <Option value="" name="name" type="QString"/>
+                <Option value="" type="QString" name="name"/>
                 <Option name="properties"/>
-                <Option value="collection" name="type" type="QString"/>
+                <Option value="collection" type="QString" name="type"/>
               </Option>
             </data_defined_properties>
           </layer>
@@ -1578,7 +1414,7 @@ def my_form_open(dialog, layer, feature):
       <blendMode>0</blendMode>
       <featureBlendMode>0</featureBlendMode>
       <layerOpacity>1</layerOpacity>
-      <geometryOptions removeDuplicateNodes="0" geometryPrecision="0">
+      <geometryOptions geometryPrecision="0" removeDuplicateNodes="0">
         <activeChecks/>
         <checkConfiguration/>
       </geometryOptions>
@@ -1587,8 +1423,8 @@ def my_form_open(dialog, layer, feature):
           <editWidget type="TextEdit">
             <config>
               <Option type="Map">
-                <Option value="0" name="IsMultiline" type="QString"/>
-                <Option value="0" name="UseHtml" type="QString"/>
+                <Option value="0" type="QString" name="IsMultiline"/>
+                <Option value="0" type="QString" name="UseHtml"/>
               </Option>
             </config>
           </editWidget>
@@ -1597,8 +1433,8 @@ def my_form_open(dialog, layer, feature):
           <editWidget type="TextEdit">
             <config>
               <Option type="Map">
-                <Option value="0" name="IsMultiline" type="QString"/>
-                <Option value="0" name="UseHtml" type="QString"/>
+                <Option value="0" type="QString" name="IsMultiline"/>
+                <Option value="0" type="QString" name="UseHtml"/>
               </Option>
             </config>
           </editWidget>
@@ -1607,8 +1443,8 @@ def my_form_open(dialog, layer, feature):
           <editWidget type="TextEdit">
             <config>
               <Option type="Map">
-                <Option value="0" name="IsMultiline" type="QString"/>
-                <Option value="0" name="UseHtml" type="QString"/>
+                <Option value="0" type="QString" name="IsMultiline"/>
+                <Option value="0" type="QString" name="UseHtml"/>
               </Option>
             </config>
           </editWidget>
@@ -1617,8 +1453,8 @@ def my_form_open(dialog, layer, feature):
           <editWidget type="TextEdit">
             <config>
               <Option type="Map">
-                <Option value="0" name="IsMultiline" type="QString"/>
-                <Option value="0" name="UseHtml" type="QString"/>
+                <Option value="0" type="QString" name="IsMultiline"/>
+                <Option value="0" type="QString" name="UseHtml"/>
               </Option>
             </config>
           </editWidget>
@@ -1627,46 +1463,46 @@ def my_form_open(dialog, layer, feature):
           <editWidget type="TextEdit">
             <config>
               <Option type="Map">
-                <Option value="0" name="IsMultiline" type="QString"/>
-                <Option value="0" name="UseHtml" type="QString"/>
+                <Option value="0" type="QString" name="IsMultiline"/>
+                <Option value="0" type="QString" name="UseHtml"/>
               </Option>
             </config>
           </editWidget>
         </field>
       </fieldConfiguration>
       <aliases>
-        <alias name="" index="0" field="ID"/>
-        <alias name="" index="1" field="fk_region"/>
-        <alias name="" index="2" field="ELEV"/>
-        <alias name="" index="3" field="NAME"/>
-        <alias name="" index="4" field="USE"/>
+        <alias name="" field="ID" index="0"/>
+        <alias name="" field="fk_region" index="1"/>
+        <alias name="" field="ELEV" index="2"/>
+        <alias name="" field="NAME" index="3"/>
+        <alias name="" field="USE" index="4"/>
       </aliases>
       <excludeAttributesWMS/>
       <excludeAttributesWFS/>
       <defaults>
-        <default field="ID" applyOnUpdate="0" expression=""/>
-        <default field="fk_region" applyOnUpdate="0" expression=""/>
-        <default field="ELEV" applyOnUpdate="0" expression=""/>
-        <default field="NAME" applyOnUpdate="0" expression=""/>
-        <default field="USE" applyOnUpdate="0" expression=""/>
+        <default field="ID" expression="" applyOnUpdate="0"/>
+        <default field="fk_region" expression="" applyOnUpdate="0"/>
+        <default field="ELEV" expression="" applyOnUpdate="0"/>
+        <default field="NAME" expression="" applyOnUpdate="0"/>
+        <default field="USE" expression="" applyOnUpdate="0"/>
       </defaults>
       <constraints>
-        <constraint field="ID" notnull_strength="0" constraints="0" unique_strength="0" exp_strength="0"/>
-        <constraint field="fk_region" notnull_strength="0" constraints="0" unique_strength="0" exp_strength="0"/>
-        <constraint field="ELEV" notnull_strength="0" constraints="0" unique_strength="0" exp_strength="0"/>
-        <constraint field="NAME" notnull_strength="0" constraints="0" unique_strength="0" exp_strength="0"/>
-        <constraint field="USE" notnull_strength="0" constraints="0" unique_strength="0" exp_strength="0"/>
+        <constraint notnull_strength="0" exp_strength="0" field="ID" unique_strength="0" constraints="0"/>
+        <constraint notnull_strength="0" exp_strength="0" field="fk_region" unique_strength="0" constraints="0"/>
+        <constraint notnull_strength="0" exp_strength="0" field="ELEV" unique_strength="0" constraints="0"/>
+        <constraint notnull_strength="0" exp_strength="0" field="NAME" unique_strength="0" constraints="0"/>
+        <constraint notnull_strength="0" exp_strength="0" field="USE" unique_strength="0" constraints="0"/>
       </constraints>
       <constraintExpressions>
-        <constraint field="ID" exp="" desc=""/>
-        <constraint field="fk_region" exp="" desc=""/>
-        <constraint field="ELEV" exp="" desc=""/>
-        <constraint field="NAME" exp="" desc=""/>
-        <constraint field="USE" exp="" desc=""/>
+        <constraint field="ID" desc="" exp=""/>
+        <constraint field="fk_region" desc="" exp=""/>
+        <constraint field="ELEV" desc="" exp=""/>
+        <constraint field="NAME" desc="" exp=""/>
+        <constraint field="USE" desc="" exp=""/>
       </constraintExpressions>
       <expressionfields/>
       <attributeactions>
-        <defaultAction value="{00000000-0000-0000-0000-000000000000}" key="Canvas"/>
+        <defaultAction key="Canvas" value="{00000000-0000-0000-0000-000000000000}"/>
       </attributeactions>
       <attributetableconfig sortExpression="" actionWidgetStyle="dropDown" sortOrder="0">
         <columns/>
@@ -1675,7 +1511,6 @@ def my_form_open(dialog, layer, feature):
         <rowstyles/>
         <fieldstyles/>
       </conditionalstyles>
-      <storedexpressions/>
       <editform tolerant="1"></editform>
       <editforminit/>
       <editforminitcodesource>0</editforminitcodesource>
@@ -1689,7 +1524,7 @@ def my_form_open(dialog, layer, feature):
       <previewExpression></previewExpression>
       <mapTip>cat</mapTip>
     </maplayer>
-    <maplayer simplifyDrawingHints="1" simplifyAlgorithm="0" labelsEnabled="1" refreshOnNotifyMessage="" wkbType="MultiPolygon" minScale="1e+8" readOnly="0" refreshOnNotifyEnabled="0" type="vector" maxScale="-4.65661e-10" simplifyLocal="1" autoRefreshTime="0" hasScaleBasedVisibilityFlag="0" geometry="Polygon" styleCategories="AllStyleCategories" autoRefreshEnabled="0" simplifyDrawingTol="1" simplifyMaxScale="1">
+    <maplayer refreshOnNotifyEnabled="0" refreshOnNotifyMessage="" styleCategories="AllStyleCategories" maxScale="-4.65661e-10" hasScaleBasedVisibilityFlag="0" simplifyAlgorithm="0" type="vector" labelsEnabled="1" minScale="1e+8" simplifyLocal="1" simplifyDrawingHints="1" autoRefreshTime="0" readOnly="0" geometry="Polygon" simplifyDrawingTol="1" autoRefreshEnabled="0" simplifyMaxScale="1" wkbType="MultiPolygon">
       <extent>
         <xmin>-7115212.9837922714650631</xmin>
         <ymin>1368239.60631786310113966</ymin>
@@ -1704,7 +1539,6 @@ def my_form_open(dialog, layer, feature):
       <layername>alaska</layername>
       <srs>
         <spatialrefsys>
-          <wkt>PROJCS["NAD27 / Alaska Albers",GEOGCS["NAD27",DATUM["North_American_Datum_1927",SPHEROID["Clarke 1866",6378206.4,294.9786982138982,AUTHORITY["EPSG","7008"]],AUTHORITY["EPSG","6267"]],PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9122"]],AUTHORITY["EPSG","4267"]],PROJECTION["Albers_Conic_Equal_Area"],PARAMETER["standard_parallel_1",55],PARAMETER["standard_parallel_2",65],PARAMETER["latitude_of_center",50],PARAMETER["longitude_of_center",-154],PARAMETER["false_easting",0],PARAMETER["false_northing",0],UNIT["US survey foot",0.3048006096012192,AUTHORITY["EPSG","9003"]],AXIS["X",EAST],AXIS["Y",NORTH],AUTHORITY["EPSG","2964"]]</wkt>
           <proj4>+proj=aea +lat_1=55 +lat_2=65 +lat_0=50 +lon_0=-154 +x_0=0 +y_0=0 +datum=NAD27 +units=us-ft +no_defs</proj4>
           <srsid>932</srsid>
           <srid>2964</srid>
@@ -1727,7 +1561,6 @@ def my_form_open(dialog, layer, feature):
         <encoding></encoding>
         <crs>
           <spatialrefsys>
-            <wkt></wkt>
             <proj4></proj4>
             <srsid>0</srsid>
             <srid>0</srid>
@@ -1735,14 +1568,14 @@ def my_form_open(dialog, layer, feature):
             <description></description>
             <projectionacronym></projectionacronym>
             <ellipsoidacronym></ellipsoidacronym>
-            <geographicflag>false</geographicflag>
+            <geographicflag>true</geographicflag>
           </spatialrefsys>
         </crs>
         <extent/>
       </resourceMetadata>
       <provider encoding="UTF-8">ogr</provider>
       <vectorjoins>
-        <join targetFieldName="NAME" memoryCache="1" joinLayerId="regions20130517221648766" dynamicForm="0" joinFieldName="NAME_1" editable="0" upsertOnEdit="0" cascadedDelete="0"/>
+        <join dynamicForm="0" targetFieldName="NAME" cascadedDelete="0" joinLayerId="regions20130517221648766" upsertOnEdit="0" editable="0" joinFieldName="NAME_1" memoryCache="1"/>
       </vectorjoins>
       <layerDependencies/>
       <dataDependencies/>
@@ -1757,9 +1590,9 @@ def my_form_open(dialog, layer, feature):
         <Removable>1</Removable>
         <Searchable>1</Searchable>
       </flags>
-      <renderer-v2 symbollevels="0" type="singleSymbol" forceraster="0" enableorderby="0">
+      <renderer-v2 type="singleSymbol" symbollevels="0" forceraster="0" enableorderby="0">
         <symbols>
-          <symbol force_rhr="0" name="0" clip_to_extent="1" alpha="1" type="fill">
+          <symbol clip_to_extent="1" force_rhr="0" type="fill" name="0" alpha="1">
             <layer enabled="1" pass="0" class="SimpleFill" locked="0">
               <prop k="border_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <prop k="color" v="253,242,186,255"/>
@@ -1774,9 +1607,9 @@ def my_form_open(dialog, layer, feature):
               <prop k="style" v="solid"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
@@ -1789,7 +1622,7 @@ def my_form_open(dialog, layer, feature):
       <blendMode>0</blendMode>
       <featureBlendMode>0</featureBlendMode>
       <layerOpacity>1</layerOpacity>
-      <geometryOptions removeDuplicateNodes="0" geometryPrecision="0">
+      <geometryOptions geometryPrecision="0" removeDuplicateNodes="0">
         <activeChecks/>
         <checkConfiguration/>
       </geometryOptions>
@@ -1798,8 +1631,8 @@ def my_form_open(dialog, layer, feature):
           <editWidget type="TextEdit">
             <config>
               <Option type="Map">
-                <Option value="0" name="IsMultiline" type="QString"/>
-                <Option value="0" name="UseHtml" type="QString"/>
+                <Option value="0" type="QString" name="IsMultiline"/>
+                <Option value="0" type="QString" name="UseHtml"/>
               </Option>
             </config>
           </editWidget>
@@ -1808,8 +1641,8 @@ def my_form_open(dialog, layer, feature):
           <editWidget type="TextEdit">
             <config>
               <Option type="Map">
-                <Option value="0" name="IsMultiline" type="QString"/>
-                <Option value="0" name="UseHtml" type="QString"/>
+                <Option value="0" type="QString" name="IsMultiline"/>
+                <Option value="0" type="QString" name="UseHtml"/>
               </Option>
             </config>
           </editWidget>
@@ -1818,8 +1651,8 @@ def my_form_open(dialog, layer, feature):
           <editWidget type="TextEdit">
             <config>
               <Option type="Map">
-                <Option value="0" name="IsMultiline" type="QString"/>
-                <Option value="0" name="UseHtml" type="QString"/>
+                <Option value="0" type="QString" name="IsMultiline"/>
+                <Option value="0" type="QString" name="UseHtml"/>
               </Option>
             </config>
           </editWidget>
@@ -1828,8 +1661,8 @@ def my_form_open(dialog, layer, feature):
           <editWidget type="TextEdit">
             <config>
               <Option type="Map">
-                <Option value="0" name="IsMultiline" type="QString"/>
-                <Option value="0" name="UseHtml" type="QString"/>
+                <Option value="0" type="QString" name="IsMultiline"/>
+                <Option value="0" type="QString" name="UseHtml"/>
               </Option>
             </config>
           </editWidget>
@@ -1838,8 +1671,8 @@ def my_form_open(dialog, layer, feature):
           <editWidget type="TextEdit">
             <config>
               <Option type="Map">
-                <Option value="0" name="IsMultiline" type="QString"/>
-                <Option value="0" name="UseHtml" type="QString"/>
+                <Option value="0" type="QString" name="IsMultiline"/>
+                <Option value="0" type="QString" name="UseHtml"/>
               </Option>
             </config>
           </editWidget>
@@ -1848,46 +1681,46 @@ def my_form_open(dialog, layer, feature):
           <editWidget type="TextEdit">
             <config>
               <Option type="Map">
-                <Option value="0" name="IsMultiline" type="QString"/>
-                <Option value="0" name="UseHtml" type="QString"/>
+                <Option value="0" type="QString" name="IsMultiline"/>
+                <Option value="0" type="QString" name="UseHtml"/>
               </Option>
             </config>
           </editWidget>
         </field>
       </fieldConfiguration>
       <aliases>
-        <alias name="" index="0" field="cat"/>
-        <alias name="" index="1" field="NAME"/>
-        <alias name="" index="2" field="AREA_MI"/>
-        <alias name="" index="3" field="regions_ID"/>
-        <alias name="" index="4" field="regions_NAME_2"/>
-        <alias name="" index="5" field="regions_TYPE_2"/>
+        <alias name="" field="cat" index="0"/>
+        <alias name="" field="NAME" index="1"/>
+        <alias name="" field="AREA_MI" index="2"/>
+        <alias name="" field="regions_ID" index="3"/>
+        <alias name="" field="regions_NAME_2" index="4"/>
+        <alias name="" field="regions_TYPE_2" index="5"/>
       </aliases>
       <excludeAttributesWMS/>
       <excludeAttributesWFS/>
       <defaults>
-        <default field="cat" applyOnUpdate="0" expression=""/>
-        <default field="NAME" applyOnUpdate="0" expression=""/>
-        <default field="AREA_MI" applyOnUpdate="0" expression=""/>
-        <default field="regions_ID" applyOnUpdate="0" expression=""/>
-        <default field="regions_NAME_2" applyOnUpdate="0" expression=""/>
-        <default field="regions_TYPE_2" applyOnUpdate="0" expression=""/>
+        <default field="cat" expression="" applyOnUpdate="0"/>
+        <default field="NAME" expression="" applyOnUpdate="0"/>
+        <default field="AREA_MI" expression="" applyOnUpdate="0"/>
+        <default field="regions_ID" expression="" applyOnUpdate="0"/>
+        <default field="regions_NAME_2" expression="" applyOnUpdate="0"/>
+        <default field="regions_TYPE_2" expression="" applyOnUpdate="0"/>
       </defaults>
       <constraints>
-        <constraint field="cat" notnull_strength="0" constraints="0" unique_strength="0" exp_strength="0"/>
-        <constraint field="NAME" notnull_strength="0" constraints="0" unique_strength="0" exp_strength="0"/>
-        <constraint field="AREA_MI" notnull_strength="0" constraints="0" unique_strength="0" exp_strength="0"/>
-        <constraint field="regions_ID" notnull_strength="0" constraints="0" unique_strength="0" exp_strength="0"/>
-        <constraint field="regions_NAME_2" notnull_strength="0" constraints="0" unique_strength="0" exp_strength="0"/>
-        <constraint field="regions_TYPE_2" notnull_strength="0" constraints="0" unique_strength="0" exp_strength="0"/>
+        <constraint notnull_strength="0" exp_strength="0" field="cat" unique_strength="0" constraints="0"/>
+        <constraint notnull_strength="0" exp_strength="0" field="NAME" unique_strength="0" constraints="0"/>
+        <constraint notnull_strength="0" exp_strength="0" field="AREA_MI" unique_strength="0" constraints="0"/>
+        <constraint notnull_strength="0" exp_strength="0" field="regions_ID" unique_strength="0" constraints="0"/>
+        <constraint notnull_strength="0" exp_strength="0" field="regions_NAME_2" unique_strength="0" constraints="0"/>
+        <constraint notnull_strength="0" exp_strength="0" field="regions_TYPE_2" unique_strength="0" constraints="0"/>
       </constraints>
       <constraintExpressions>
-        <constraint field="cat" exp="" desc=""/>
-        <constraint field="NAME" exp="" desc=""/>
-        <constraint field="AREA_MI" exp="" desc=""/>
-        <constraint field="regions_ID" exp="" desc=""/>
-        <constraint field="regions_NAME_2" exp="" desc=""/>
-        <constraint field="regions_TYPE_2" exp="" desc=""/>
+        <constraint field="cat" desc="" exp=""/>
+        <constraint field="NAME" desc="" exp=""/>
+        <constraint field="AREA_MI" desc="" exp=""/>
+        <constraint field="regions_ID" desc="" exp=""/>
+        <constraint field="regions_NAME_2" desc="" exp=""/>
+        <constraint field="regions_TYPE_2" desc="" exp=""/>
       </constraintExpressions>
       <expressionfields/>
       <attributeactions/>
@@ -1898,7 +1731,6 @@ def my_form_open(dialog, layer, feature):
         <rowstyles/>
         <fieldstyles/>
       </conditionalstyles>
-      <storedexpressions/>
       <editform tolerant="1"></editform>
       <editforminit/>
       <editforminitcodesource>0</editforminitcodesource>
@@ -1912,7 +1744,7 @@ def my_form_open(dialog, layer, feature):
       <previewExpression>cat</previewExpression>
       <mapTip></mapTip>
     </maplayer>
-    <maplayer simplifyDrawingHints="1" simplifyAlgorithm="0" labelsEnabled="0" refreshOnNotifyMessage="" wkbType="PolygonZ" minScale="1e+8" readOnly="0" refreshOnNotifyEnabled="0" type="vector" maxScale="0" simplifyLocal="1" autoRefreshTime="0" hasScaleBasedVisibilityFlag="0" geometry="Polygon" styleCategories="AllStyleCategories" autoRefreshEnabled="0" simplifyDrawingTol="1" simplifyMaxScale="1">
+    <maplayer refreshOnNotifyEnabled="0" refreshOnNotifyMessage="" styleCategories="AllStyleCategories" maxScale="0" hasScaleBasedVisibilityFlag="0" simplifyAlgorithm="0" type="vector" labelsEnabled="0" minScale="1e+8" simplifyLocal="1" simplifyDrawingHints="1" autoRefreshTime="0" readOnly="0" geometry="Polygon" simplifyDrawingTol="1" autoRefreshEnabled="0" simplifyMaxScale="1" wkbType="PolygonZ">
       <extent>
         <xmin>-1829520.49845402874052525</xmin>
         <ymin>2714990.22347463946789503</ymin>
@@ -1925,11 +1757,10 @@ def my_form_open(dialog, layer, feature):
         <value></value>
       </keywordList>
       <dataUrl format="text/html">http://geobretagne.fr/geonetwork/srv/fr/metadata.show?uuid=abe1149d-5a8d-4dbf-9140-97294b22bd4f</dataUrl>
-      <metadataUrl format="text/xml" type="TC211">http://geobretagne.fr/geonetwork/srv/fr/iso19139.xml?id=2791</metadataUrl>
+      <metadataUrl type="TC211" format="text/xml">http://geobretagne.fr/geonetwork/srv/fr/iso19139.xml?id=2791</metadataUrl>
       <layername>lakes</layername>
       <srs>
         <spatialrefsys>
-          <wkt>PROJCS["NAD27 / Alaska Albers",GEOGCS["NAD27",DATUM["North_American_Datum_1927",SPHEROID["Clarke 1866",6378206.4,294.9786982138982,AUTHORITY["EPSG","7008"]],AUTHORITY["EPSG","6267"]],PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9122"]],AUTHORITY["EPSG","4267"]],PROJECTION["Albers_Conic_Equal_Area"],PARAMETER["standard_parallel_1",55],PARAMETER["standard_parallel_2",65],PARAMETER["latitude_of_center",50],PARAMETER["longitude_of_center",-154],PARAMETER["false_easting",0],PARAMETER["false_northing",0],UNIT["US survey foot",0.3048006096012192,AUTHORITY["EPSG","9003"]],AXIS["X",EAST],AXIS["Y",NORTH],AUTHORITY["EPSG","2964"]]</wkt>
           <proj4>+proj=aea +lat_1=55 +lat_2=65 +lat_0=50 +lon_0=-154 +x_0=0 +y_0=0 +datum=NAD27 +units=us-ft +no_defs</proj4>
           <srsid>932</srsid>
           <srid>2964</srid>
@@ -1952,7 +1783,6 @@ def my_form_open(dialog, layer, feature):
         <encoding></encoding>
         <crs>
           <spatialrefsys>
-            <wkt></wkt>
             <proj4></proj4>
             <srsid>0</srsid>
             <srid>0</srid>
@@ -1960,7 +1790,7 @@ def my_form_open(dialog, layer, feature):
             <description></description>
             <projectionacronym></projectionacronym>
             <ellipsoidacronym></ellipsoidacronym>
-            <geographicflag>false</geographicflag>
+            <geographicflag>true</geographicflag>
           </spatialrefsys>
         </crs>
         <extent/>
@@ -1980,9 +1810,9 @@ def my_form_open(dialog, layer, feature):
         <Removable>1</Removable>
         <Searchable>1</Searchable>
       </flags>
-      <renderer-v2 symbollevels="0" type="singleSymbol" forceraster="0" enableorderby="0">
+      <renderer-v2 type="singleSymbol" symbollevels="0" forceraster="0" enableorderby="0">
         <symbols>
-          <symbol force_rhr="0" name="0" clip_to_extent="1" alpha="1" type="fill">
+          <symbol clip_to_extent="1" force_rhr="0" type="fill" name="0" alpha="1">
             <layer enabled="1" pass="0" class="SimpleFill" locked="0">
               <prop k="border_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <prop k="color" v="165,191,221,255"/>
@@ -1997,9 +1827,9 @@ def my_form_open(dialog, layer, feature):
               <prop k="style" v="solid"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
@@ -2009,110 +1839,65 @@ def my_form_open(dialog, layer, feature):
         <sizescale/>
       </renderer-v2>
       <labeling type="simple">
-        <settings calloutType="simple">
-          <text-style fontSize="11" textOpacity="1" fontFamily="Ubuntu" fontItalic="0" fontCapitals="0" textOrientation="horizontal" fontStrikeout="0" blendMode="0" fieldName="NAMES" previewBkgrdColor="255,255,255,255" fontUnderline="0" fontWordSpacing="0" fontSizeUnit="Point" namedStyle="Normal" fontKerning="1" isExpression="0" useSubstitutions="0" textColor="2,80,175,255" fontSizeMapUnitScale="3x:0,0,0,0,0,0" multilineHeight="1" fontLetterSpacing="0" fontWeight="50">
-            <text-buffer bufferSizeUnits="MM" bufferDraw="1" bufferNoFill="0" bufferColor="255,255,255,255" bufferOpacity="1" bufferBlendMode="0" bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferJoinStyle="64" bufferSize="1"/>
-            <background shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeOpacity="1" shapeSizeX="0" shapeRadiiX="0" shapeSVGFile="" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeOffsetX="0" shapeType="0" shapeBlendMode="0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeJoinStyle="64" shapeDraw="0" shapeSizeUnit="MM" shapeSizeType="0" shapeRotationType="0" shapeRotation="0" shapeOffsetUnit="MM" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeBorderWidthUnit="MM" shapeSizeY="0" shapeBorderWidth="0" shapeRadiiY="0" shapeOffsetY="0" shapeBorderColor="128,128,128,255" shapeRadiiUnit="MM" shapeFillColor="255,255,255,255"/>
-            <shadow shadowDraw="0" shadowOffsetUnit="MM" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowRadiusUnit="MM" shadowScale="100" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowRadiusAlphaOnly="0" shadowBlendMode="6" shadowOffsetAngle="135" shadowOffsetDist="1" shadowOffsetGlobal="1" shadowUnder="0" shadowRadius="1.5" shadowColor="0,0,0,255" shadowOpacity="0.7"/>
-            <dd_properties>
-              <Option type="Map">
-                <Option value="" name="name" type="QString"/>
-                <Option name="properties" type="Map">
-                  <Option name="LabelRotation" type="Map">
-                    <Option value="true" name="active" type="bool"/>
-                    <Option value="360 - (&quot;rotation&quot;)" name="expression" type="QString"/>
-                    <Option value="3" name="type" type="int"/>
-                  </Option>
-                  <Option name="PositionX" type="Map">
-                    <Option value="true" name="active" type="bool"/>
-                    <Option value="xlabel" name="field" type="QString"/>
-                    <Option value="2" name="type" type="int"/>
-                  </Option>
-                  <Option name="PositionY" type="Map">
-                    <Option value="true" name="active" type="bool"/>
-                    <Option value="ylabel" name="field" type="QString"/>
-                    <Option value="2" name="type" type="int"/>
-                  </Option>
-                </Option>
-                <Option value="collection" name="type" type="QString"/>
-              </Option>
-            </dd_properties>
+        <settings>
+          <text-style namedStyle="Normal" fieldName="NAMES" fontWeight="50" fontWordSpacing="0" fontSizeUnit="Point" fontItalic="0" fontSizeMapUnitScale="3x:0,0,0,0,0,0" fontCapitals="0" fontFamily="Ubuntu" textColor="2,80,175,255" fontSize="11" fontLetterSpacing="0" previewBkgrdColor="255,255,255,255" fontStrikeout="0" multilineHeight="1" useSubstitutions="0" textOpacity="1" isExpression="0" blendMode="0" fontUnderline="0">
+            <text-buffer bufferDraw="1" bufferNoFill="0" bufferBlendMode="0" bufferSize="1" bufferSizeUnits="MM" bufferColor="255,255,255,255" bufferJoinStyle="64" bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferOpacity="1"/>
+            <background shapeRadiiX="0" shapeSizeUnit="MM" shapeOffsetY="0" shapeRadiiUnit="MM" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeBlendMode="0" shapeRotation="0" shapeSizeX="0" shapeSizeY="0" shapeDraw="0" shapeRadiiY="0" shapeOffsetX="0" shapeRotationType="0" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeOffsetUnit="MM" shapeBorderWidth="0" shapeBorderWidthUnit="MM" shapeJoinStyle="64" shapeBorderColor="128,128,128,255" shapeFillColor="255,255,255,255" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeType="0" shapeSVGFile="" shapeSizeType="0" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeOpacity="1"/>
+            <shadow shadowDraw="0" shadowOffsetGlobal="1" shadowOffsetAngle="135" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowColor="0,0,0,255" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowOpacity="0.7" shadowRadiusUnit="MM" shadowUnder="0" shadowOffsetUnit="MM" shadowScale="100" shadowBlendMode="6" shadowRadiusAlphaOnly="0" shadowOffsetDist="1" shadowRadius="1.5"/>
             <substitutions/>
           </text-style>
-          <text-format addDirectionSymbol="0" rightDirectionSymbol=">" plussign="0" reverseDirectionSymbol="0" placeDirectionSymbol="0" multilineAlign="0" leftDirectionSymbol="&lt;" formatNumbers="0" wrapChar="" autoWrapLength="0" useMaxLineLengthForAutoWrap="1" decimals="0"/>
-          <placement geometryGeneratorEnabled="0" fitInPolygonOnly="0" maxCurvedCharAngleOut="-20" rotationAngle="0" priority="5" geometryGeneratorType="PointGeometry" predefinedPositionOrder="TR,TL,BR,BL,R,L,TSR,BSR" distUnits="MM" repeatDistance="0" xOffset="0" centroidWhole="0" preserveRotation="1" offsetUnits="MapUnit" overrunDistance="0" repeatDistanceMapUnitScale="3x:0,0,0,0,0,0" placement="0" repeatDistanceUnits="MM" labelOffsetMapUnitScale="3x:0,0,0,0,0,0" layerType="UnknownGeometry" distMapUnitScale="3x:0,0,0,0,0,0" yOffset="0" offsetType="0" quadOffset="4" dist="0" overrunDistanceMapUnitScale="3x:0,0,0,0,0,0" placementFlags="0" maxCurvedCharAngleIn="20" overrunDistanceUnit="MM" geometryGenerator="" centroidInside="0"/>
-          <rendering obstacle="1" drawLabels="1" fontMaxPixelSize="10000" maxNumLabels="2000" minFeatureSize="0" scaleVisibility="0" mergeLines="0" scaleMin="1" zIndex="0" fontMinPixelSize="3" upsidedownLabels="0" obstacleType="0" obstacleFactor="1" limitNumLabels="0" labelPerPart="0" scaleMax="10000000" displayAll="0" fontLimitPixelSize="0"/>
+          <text-format formatNumbers="0" useMaxLineLengthForAutoWrap="1" rightDirectionSymbol=">" leftDirectionSymbol="&lt;" wrapChar="" autoWrapLength="0" addDirectionSymbol="0" decimals="0" plussign="0" reverseDirectionSymbol="0" multilineAlign="0" placeDirectionSymbol="0"/>
+          <placement fitInPolygonOnly="0" geometryGenerator="" geometryGeneratorEnabled="0" geometryGeneratorType="PointGeometry" priority="5" repeatDistanceUnits="MM" placementFlags="0" dist="0" maxCurvedCharAngleOut="-20" distUnits="MM" predefinedPositionOrder="TR,TL,BR,BL,R,L,TSR,BSR" repeatDistanceMapUnitScale="3x:0,0,0,0,0,0" labelOffsetMapUnitScale="3x:0,0,0,0,0,0" centroidWhole="0" centroidInside="0" rotationAngle="0" preserveRotation="1" offsetUnits="MapUnit" xOffset="0" quadOffset="4" distMapUnitScale="3x:0,0,0,0,0,0" repeatDistance="0" yOffset="0" placement="0" maxCurvedCharAngleIn="20" layerType="UnknownGeometry" offsetType="0"/>
+          <rendering obstacle="1" minFeatureSize="0" labelPerPart="0" maxNumLabels="2000" upsidedownLabels="0" drawLabels="1" fontMaxPixelSize="10000" fontMinPixelSize="3" scaleMax="10000000" zIndex="0" scaleVisibility="0" fontLimitPixelSize="0" obstacleFactor="1" limitNumLabels="0" mergeLines="0" scaleMin="1" obstacleType="0" displayAll="0"/>
           <dd_properties>
             <Option type="Map">
-              <Option value="" name="name" type="QString"/>
-              <Option name="properties" type="Map">
-                <Option name="LabelRotation" type="Map">
-                  <Option value="true" name="active" type="bool"/>
-                  <Option value="360 - (&quot;rotation&quot;)" name="expression" type="QString"/>
-                  <Option value="3" name="type" type="int"/>
+              <Option value="" type="QString" name="name"/>
+              <Option type="Map" name="properties">
+                <Option type="Map" name="LabelRotation">
+                  <Option value="true" type="bool" name="active"/>
+                  <Option value="360 - (&quot;rotation&quot;)" type="QString" name="expression"/>
+                  <Option value="3" type="int" name="type"/>
                 </Option>
-                <Option name="PositionX" type="Map">
-                  <Option value="true" name="active" type="bool"/>
-                  <Option value="xlabel" name="field" type="QString"/>
-                  <Option value="2" name="type" type="int"/>
+                <Option type="Map" name="PositionX">
+                  <Option value="true" type="bool" name="active"/>
+                  <Option value="xlabel" type="QString" name="field"/>
+                  <Option value="2" type="int" name="type"/>
                 </Option>
-                <Option name="PositionY" type="Map">
-                  <Option value="true" name="active" type="bool"/>
-                  <Option value="ylabel" name="field" type="QString"/>
-                  <Option value="2" name="type" type="int"/>
+                <Option type="Map" name="PositionY">
+                  <Option value="true" type="bool" name="active"/>
+                  <Option value="ylabel" type="QString" name="field"/>
+                  <Option value="2" type="int" name="type"/>
                 </Option>
               </Option>
-              <Option value="collection" name="type" type="QString"/>
+              <Option value="collection" type="QString" name="type"/>
             </Option>
           </dd_properties>
-          <callout type="simple">
-            <Option type="Map">
-              <Option value="pole_of_inaccessibility" name="anchorPoint" type="QString"/>
-              <Option name="ddProperties" type="Map">
-                <Option value="" name="name" type="QString"/>
-                <Option name="properties"/>
-                <Option value="collection" name="type" type="QString"/>
-              </Option>
-              <Option value="false" name="drawToAllParts" type="bool"/>
-              <Option value="0" name="enabled" type="QString"/>
-              <Option value="&lt;symbol force_rhr=&quot;0&quot; name=&quot;symbol&quot; clip_to_extent=&quot;1&quot; alpha=&quot;1&quot; type=&quot;line&quot;>&lt;layer enabled=&quot;1&quot; pass=&quot;0&quot; class=&quot;SimpleLine&quot; locked=&quot;0&quot;>&lt;prop k=&quot;capstyle&quot; v=&quot;square&quot;/>&lt;prop k=&quot;customdash&quot; v=&quot;5;2&quot;/>&lt;prop k=&quot;customdash_map_unit_scale&quot; v=&quot;3x:0,0,0,0,0,0&quot;/>&lt;prop k=&quot;customdash_unit&quot; v=&quot;MM&quot;/>&lt;prop k=&quot;draw_inside_polygon&quot; v=&quot;0&quot;/>&lt;prop k=&quot;joinstyle&quot; v=&quot;bevel&quot;/>&lt;prop k=&quot;line_color&quot; v=&quot;60,60,60,255&quot;/>&lt;prop k=&quot;line_style&quot; v=&quot;solid&quot;/>&lt;prop k=&quot;line_width&quot; v=&quot;0.3&quot;/>&lt;prop k=&quot;line_width_unit&quot; v=&quot;MM&quot;/>&lt;prop k=&quot;offset&quot; v=&quot;0&quot;/>&lt;prop k=&quot;offset_map_unit_scale&quot; v=&quot;3x:0,0,0,0,0,0&quot;/>&lt;prop k=&quot;offset_unit&quot; v=&quot;MM&quot;/>&lt;prop k=&quot;ring_filter&quot; v=&quot;0&quot;/>&lt;prop k=&quot;use_custom_dash&quot; v=&quot;0&quot;/>&lt;prop k=&quot;width_map_unit_scale&quot; v=&quot;3x:0,0,0,0,0,0&quot;/>&lt;data_defined_properties>&lt;Option type=&quot;Map&quot;>&lt;Option value=&quot;&quot; name=&quot;name&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;properties&quot;/>&lt;Option value=&quot;collection&quot; name=&quot;type&quot; type=&quot;QString&quot;/>&lt;/Option>&lt;/data_defined_properties>&lt;/layer>&lt;/symbol>" name="lineSymbol" type="QString"/>
-              <Option value="0" name="minLength" type="double"/>
-              <Option value="3x:0,0,0,0,0,0" name="minLengthMapUnitScale" type="QString"/>
-              <Option value="MM" name="minLengthUnit" type="QString"/>
-              <Option value="0" name="offsetFromAnchor" type="double"/>
-              <Option value="3x:0,0,0,0,0,0" name="offsetFromAnchorMapUnitScale" type="QString"/>
-              <Option value="MM" name="offsetFromAnchorUnit" type="QString"/>
-              <Option value="0" name="offsetFromLabel" type="double"/>
-              <Option value="3x:0,0,0,0,0,0" name="offsetFromLabelMapUnitScale" type="QString"/>
-              <Option value="MM" name="offsetFromLabelUnit" type="QString"/>
-            </Option>
-          </callout>
         </settings>
       </labeling>
       <customproperties>
-        <property value="0" key="embeddedWidgets/count"/>
+        <property key="embeddedWidgets/count" value="0"/>
         <property key="variableNames"/>
         <property key="variableValues"/>
       </customproperties>
       <blendMode>0</blendMode>
       <featureBlendMode>0</featureBlendMode>
       <layerOpacity>1</layerOpacity>
-      <SingleCategoryDiagramRenderer diagramType="Histogram" attributeLegend="1">
-        <DiagramCategory backgroundAlpha="255" sizeScale="3x:0,0,0,0,0,0" opacity="1" scaleBasedVisibility="0" width="15" backgroundColor="#ffffff" minScaleDenominator="inf" rotationOffset="270" minimumSize="0" penAlpha="255" lineSizeScale="3x:0,0,0,0,0,0" scaleDependency="Area" penWidth="0" barWidth="5" height="15" labelPlacementMethod="XHeight" lineSizeType="MM" diagramOrientation="Up" enabled="0" sizeType="MM" penColor="#000000" maxScaleDenominator="1e+8">
+      <SingleCategoryDiagramRenderer attributeLegend="1" diagramType="Histogram">
+        <DiagramCategory minScaleDenominator="inf" diagramOrientation="Up" backgroundColor="#ffffff" penWidth="0" barWidth="5" penColor="#000000" opacity="1" maxScaleDenominator="1e+8" rotationOffset="270" scaleBasedVisibility="0" penAlpha="255" scaleDependency="Area" labelPlacementMethod="XHeight" enabled="0" width="15" sizeType="MM" lineSizeScale="3x:0,0,0,0,0,0" height="15" lineSizeType="MM" backgroundAlpha="255" sizeScale="3x:0,0,0,0,0,0" minimumSize="0">
           <fontProperties description="Ubuntu,11,-1,5,50,0,0,0,0,0" style=""/>
-          <attribute field="" label="" color="#000000"/>
+          <attribute label="" color="#000000" field=""/>
         </DiagramCategory>
       </SingleCategoryDiagramRenderer>
-      <DiagramLayerSettings priority="0" obstacle="0" zIndex="0" showAll="1" placement="0" dist="0" linePlacementFlags="10">
+      <DiagramLayerSettings showAll="1" priority="0" placement="0" linePlacementFlags="10" zIndex="0" dist="0" obstacle="0">
         <properties>
           <Option type="Map">
-            <Option value="" name="name" type="QString"/>
+            <Option value="" type="QString" name="name"/>
             <Option name="properties"/>
-            <Option value="collection" name="type" type="QString"/>
+            <Option value="collection" type="QString" name="type"/>
           </Option>
         </properties>
       </DiagramLayerSettings>
-      <geometryOptions removeDuplicateNodes="0" geometryPrecision="0">
+      <geometryOptions geometryPrecision="0" removeDuplicateNodes="0">
         <activeChecks/>
         <checkConfiguration/>
       </geometryOptions>
@@ -2121,11 +1906,11 @@ def my_form_open(dialog, layer, feature):
           <editWidget type="Range">
             <config>
               <Option type="Map">
-                <Option value="0" name="AllowNull" type="QString"/>
-                <Option value="30" name="Max" type="QString"/>
-                <Option value="1" name="Min" type="QString"/>
-                <Option value="1" name="Step" type="QString"/>
-                <Option value="Edit" name="Style" type="QString"/>
+                <Option value="0" type="QString" name="AllowNull"/>
+                <Option value="30" type="QString" name="Max"/>
+                <Option value="1" type="QString" name="Min"/>
+                <Option value="1" type="QString" name="Step"/>
+                <Option value="Edit" type="QString" name="Style"/>
               </Option>
             </config>
           </editWidget>
@@ -2134,8 +1919,8 @@ def my_form_open(dialog, layer, feature):
           <editWidget type="TextEdit">
             <config>
               <Option type="Map">
-                <Option value="0" name="IsMultiline" type="QString"/>
-                <Option value="0" name="UseHtml" type="QString"/>
+                <Option value="0" type="QString" name="IsMultiline"/>
+                <Option value="0" type="QString" name="UseHtml"/>
               </Option>
             </config>
           </editWidget>
@@ -2144,8 +1929,8 @@ def my_form_open(dialog, layer, feature):
           <editWidget type="TextEdit">
             <config>
               <Option type="Map">
-                <Option value="0" name="IsMultiline" type="QString"/>
-                <Option value="0" name="UseHtml" type="QString"/>
+                <Option value="0" type="QString" name="IsMultiline"/>
+                <Option value="0" type="QString" name="UseHtml"/>
               </Option>
             </config>
           </editWidget>
@@ -2154,8 +1939,8 @@ def my_form_open(dialog, layer, feature):
           <editWidget type="TextEdit">
             <config>
               <Option type="Map">
-                <Option value="0" name="IsMultiline" type="QString"/>
-                <Option value="0" name="UseHtml" type="QString"/>
+                <Option value="0" type="QString" name="IsMultiline"/>
+                <Option value="0" type="QString" name="UseHtml"/>
               </Option>
             </config>
           </editWidget>
@@ -2164,8 +1949,8 @@ def my_form_open(dialog, layer, feature):
           <editWidget type="TextEdit">
             <config>
               <Option type="Map">
-                <Option value="0" name="IsMultiline" type="QString"/>
-                <Option value="0" name="UseHtml" type="QString"/>
+                <Option value="0" type="QString" name="IsMultiline"/>
+                <Option value="0" type="QString" name="UseHtml"/>
               </Option>
             </config>
           </editWidget>
@@ -2174,75 +1959,74 @@ def my_form_open(dialog, layer, feature):
           <editWidget type="Range">
             <config>
               <Option type="Map">
-                <Option value="1" name="AllowNull" type="QString"/>
-                <Option value="360" name="Max" type="QString"/>
-                <Option value="0" name="Min" type="QString"/>
-                <Option value="1" name="Step" type="QString"/>
-                <Option value="SpinBox" name="Style" type="QString"/>
+                <Option value="1" type="QString" name="AllowNull"/>
+                <Option value="360" type="QString" name="Max"/>
+                <Option value="0" type="QString" name="Min"/>
+                <Option value="1" type="QString" name="Step"/>
+                <Option value="SpinBox" type="QString" name="Style"/>
               </Option>
             </config>
           </editWidget>
         </field>
       </fieldConfiguration>
       <aliases>
-        <alias name="" index="0" field="cat"/>
-        <alias name="" index="1" field="NAMES"/>
-        <alias name="" index="2" field="AREA_MI"/>
-        <alias name="" index="3" field="xlabel"/>
-        <alias name="" index="4" field="ylabel"/>
-        <alias name="" index="5" field="rotation"/>
+        <alias name="" field="cat" index="0"/>
+        <alias name="" field="NAMES" index="1"/>
+        <alias name="" field="AREA_MI" index="2"/>
+        <alias name="" field="xlabel" index="3"/>
+        <alias name="" field="ylabel" index="4"/>
+        <alias name="" field="rotation" index="5"/>
       </aliases>
       <excludeAttributesWMS/>
       <excludeAttributesWFS/>
       <defaults>
-        <default field="cat" applyOnUpdate="0" expression=""/>
-        <default field="NAMES" applyOnUpdate="0" expression=""/>
-        <default field="AREA_MI" applyOnUpdate="0" expression=""/>
-        <default field="xlabel" applyOnUpdate="0" expression=""/>
-        <default field="ylabel" applyOnUpdate="0" expression=""/>
-        <default field="rotation" applyOnUpdate="0" expression="0"/>
+        <default field="cat" expression="" applyOnUpdate="0"/>
+        <default field="NAMES" expression="" applyOnUpdate="0"/>
+        <default field="AREA_MI" expression="" applyOnUpdate="0"/>
+        <default field="xlabel" expression="" applyOnUpdate="0"/>
+        <default field="ylabel" expression="" applyOnUpdate="0"/>
+        <default field="rotation" expression="0" applyOnUpdate="0"/>
       </defaults>
       <constraints>
-        <constraint field="cat" notnull_strength="0" constraints="0" unique_strength="0" exp_strength="0"/>
-        <constraint field="NAMES" notnull_strength="0" constraints="0" unique_strength="0" exp_strength="0"/>
-        <constraint field="AREA_MI" notnull_strength="0" constraints="0" unique_strength="0" exp_strength="0"/>
-        <constraint field="xlabel" notnull_strength="0" constraints="0" unique_strength="0" exp_strength="0"/>
-        <constraint field="ylabel" notnull_strength="0" constraints="0" unique_strength="0" exp_strength="0"/>
-        <constraint field="rotation" notnull_strength="0" constraints="0" unique_strength="0" exp_strength="0"/>
+        <constraint notnull_strength="0" exp_strength="0" field="cat" unique_strength="0" constraints="0"/>
+        <constraint notnull_strength="0" exp_strength="0" field="NAMES" unique_strength="0" constraints="0"/>
+        <constraint notnull_strength="0" exp_strength="0" field="AREA_MI" unique_strength="0" constraints="0"/>
+        <constraint notnull_strength="0" exp_strength="0" field="xlabel" unique_strength="0" constraints="0"/>
+        <constraint notnull_strength="0" exp_strength="0" field="ylabel" unique_strength="0" constraints="0"/>
+        <constraint notnull_strength="0" exp_strength="0" field="rotation" unique_strength="0" constraints="0"/>
       </constraints>
       <constraintExpressions>
-        <constraint field="cat" exp="" desc=""/>
-        <constraint field="NAMES" exp="" desc=""/>
-        <constraint field="AREA_MI" exp="" desc=""/>
-        <constraint field="xlabel" exp="" desc=""/>
-        <constraint field="ylabel" exp="" desc=""/>
-        <constraint field="rotation" exp="" desc=""/>
+        <constraint field="cat" desc="" exp=""/>
+        <constraint field="NAMES" desc="" exp=""/>
+        <constraint field="AREA_MI" desc="" exp=""/>
+        <constraint field="xlabel" desc="" exp=""/>
+        <constraint field="ylabel" desc="" exp=""/>
+        <constraint field="rotation" desc="" exp=""/>
       </constraintExpressions>
       <expressionfields/>
       <attributeactions>
-        <defaultAction value="{00000000-0000-0000-0000-000000000000}" key="Canvas"/>
-        <actionsetting icon="" notificationMessage="" name="Google search" type="5" capture="0" shortTitle="" id="{fc632414-a838-4dce-bb24-b27524be6d1b}" action="firefox http://www.google.com/search?q=[% &quot;NAMES&quot; %]" isEnabledOnlyWhenEditable="0">
+        <defaultAction key="Canvas" value="{00000000-0000-0000-0000-000000000000}"/>
+        <actionsetting isEnabledOnlyWhenEditable="0" notificationMessage="" icon="" action="firefox http://www.google.com/search?q=[% &quot;NAMES&quot; %]" type="5" shortTitle="" name="Google search" capture="0" id="{fc632414-a838-4dce-bb24-b27524be6d1b}">
           <actionScope id="Canvas"/>
-          <actionScope id="Field"/>
           <actionScope id="Feature"/>
+          <actionScope id="Field"/>
         </actionsetting>
       </attributeactions>
       <attributetableconfig sortExpression="&quot;NAMES&quot;" actionWidgetStyle="dropDown" sortOrder="0">
         <columns>
-          <column hidden="0" name="cat" type="field" width="-1"/>
-          <column hidden="0" name="NAMES" type="field" width="-1"/>
-          <column hidden="0" name="AREA_MI" type="field" width="-1"/>
-          <column hidden="0" name="xlabel" type="field" width="-1"/>
-          <column hidden="0" name="ylabel" type="field" width="-1"/>
-          <column hidden="0" name="rotation" type="field" width="-1"/>
-          <column hidden="1" type="actions" width="-1"/>
+          <column type="field" name="cat" hidden="0" width="-1"/>
+          <column type="field" name="NAMES" hidden="0" width="-1"/>
+          <column type="field" name="AREA_MI" hidden="0" width="-1"/>
+          <column type="field" name="xlabel" hidden="0" width="-1"/>
+          <column type="field" name="ylabel" hidden="0" width="-1"/>
+          <column type="field" name="rotation" hidden="0" width="-1"/>
+          <column type="actions" hidden="1" width="-1"/>
         </columns>
       </attributetableconfig>
       <conditionalstyles>
         <rowstyles/>
         <fieldstyles/>
       </conditionalstyles>
-      <storedexpressions/>
       <editform tolerant="1"></editform>
       <editforminit/>
       <editforminitcodesource>0</editforminitcodesource>
@@ -2267,24 +2051,24 @@ def my_form_open(dialog, layer, feature):
       <featformsuppress>0</featformsuppress>
       <editorlayout>generatedlayout</editorlayout>
       <attributeEditorForm>
-        <attributeEditorContainer columnCount="0" groupBox="0" visibilityExpressionEnabled="0" name="main" visibilityExpression="" showLabel="1">
-          <attributeEditorContainer columnCount="0" groupBox="1" visibilityExpressionEnabled="0" name="Fields" visibilityExpression="" showLabel="1">
-            <attributeEditorField name="cat" index="0" showLabel="1"/>
-            <attributeEditorField name="NAMES" index="1" showLabel="1"/>
-            <attributeEditorField name="AREA_MI" index="2" showLabel="1"/>
-            <attributeEditorContainer columnCount="0" groupBox="1" visibilityExpressionEnabled="0" name="more" visibilityExpression="" showLabel="1">
-              <attributeEditorField name="rotation" index="5" showLabel="1"/>
+        <attributeEditorContainer columnCount="0" name="main" groupBox="0" visibilityExpressionEnabled="0" visibilityExpression="" showLabel="1">
+          <attributeEditorContainer columnCount="0" name="Fields" groupBox="1" visibilityExpressionEnabled="0" visibilityExpression="" showLabel="1">
+            <attributeEditorField name="cat" showLabel="1" index="0"/>
+            <attributeEditorField name="NAMES" showLabel="1" index="1"/>
+            <attributeEditorField name="AREA_MI" showLabel="1" index="2"/>
+            <attributeEditorContainer columnCount="0" name="more" groupBox="1" visibilityExpressionEnabled="0" visibilityExpression="" showLabel="1">
+              <attributeEditorField name="rotation" showLabel="1" index="5"/>
             </attributeEditorContainer>
           </attributeEditorContainer>
-          <attributeEditorContainer columnCount="0" groupBox="1" visibilityExpressionEnabled="0" name="Label control" visibilityExpression="" showLabel="1">
-            <attributeEditorField name="xlabel" index="3" showLabel="1"/>
-            <attributeEditorField name="ylabel" index="4" showLabel="1"/>
+          <attributeEditorContainer columnCount="0" name="Label control" groupBox="1" visibilityExpressionEnabled="0" visibilityExpression="" showLabel="1">
+            <attributeEditorField name="xlabel" showLabel="1" index="3"/>
+            <attributeEditorField name="ylabel" showLabel="1" index="4"/>
           </attributeEditorContainer>
         </attributeEditorContainer>
-        <attributeEditorContainer columnCount="0" groupBox="0" visibilityExpressionEnabled="0" name="new" visibilityExpression="" showLabel="1">
-          <attributeEditorField name="xlabel" index="3" showLabel="1"/>
-          <attributeEditorField name="ylabel" index="4" showLabel="1"/>
-          <attributeEditorField name="rotation" index="5" showLabel="1"/>
+        <attributeEditorContainer columnCount="0" name="new" groupBox="0" visibilityExpressionEnabled="0" visibilityExpression="" showLabel="1">
+          <attributeEditorField name="xlabel" showLabel="1" index="3"/>
+          <attributeEditorField name="ylabel" showLabel="1" index="4"/>
+          <attributeEditorField name="rotation" showLabel="1" index="5"/>
         </attributeEditorContainer>
       </attributeEditorForm>
       <editable/>
@@ -2293,7 +2077,7 @@ def my_form_open(dialog, layer, feature):
       <previewExpression>cat</previewExpression>
       <mapTip></mapTip>
     </maplayer>
-    <maplayer simplifyDrawingHints="1" simplifyAlgorithm="0" labelsEnabled="1" refreshOnNotifyMessage="" wkbType="MultiLineString" minScale="1e+8" readOnly="0" refreshOnNotifyEnabled="0" type="vector" maxScale="-4.65661e-10" simplifyLocal="1" autoRefreshTime="0" hasScaleBasedVisibilityFlag="0" geometry="Line" styleCategories="AllStyleCategories" autoRefreshEnabled="0" simplifyDrawingTol="1" simplifyMaxScale="1">
+    <maplayer refreshOnNotifyEnabled="0" refreshOnNotifyMessage="" styleCategories="AllStyleCategories" maxScale="-4.65661e-10" hasScaleBasedVisibilityFlag="0" simplifyAlgorithm="0" type="vector" labelsEnabled="1" minScale="1e+8" simplifyLocal="1" simplifyDrawingHints="1" autoRefreshTime="0" readOnly="0" geometry="Line" simplifyDrawingTol="1" autoRefreshEnabled="0" simplifyMaxScale="1" wkbType="MultiLineString">
       <extent>
         <xmin>-2038395.83981025964021683</xmin>
         <ymin>3963487.82406435115262866</ymin>
@@ -2308,7 +2092,6 @@ def my_form_open(dialog, layer, feature):
       <layername>majrivers</layername>
       <srs>
         <spatialrefsys>
-          <wkt>PROJCS["NAD27 / Alaska Albers",GEOGCS["NAD27",DATUM["North_American_Datum_1927",SPHEROID["Clarke 1866",6378206.4,294.9786982138982,AUTHORITY["EPSG","7008"]],AUTHORITY["EPSG","6267"]],PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9122"]],AUTHORITY["EPSG","4267"]],PROJECTION["Albers_Conic_Equal_Area"],PARAMETER["standard_parallel_1",55],PARAMETER["standard_parallel_2",65],PARAMETER["latitude_of_center",50],PARAMETER["longitude_of_center",-154],PARAMETER["false_easting",0],PARAMETER["false_northing",0],UNIT["US survey foot",0.3048006096012192,AUTHORITY["EPSG","9003"]],AXIS["X",EAST],AXIS["Y",NORTH],AUTHORITY["EPSG","2964"]]</wkt>
           <proj4>+proj=aea +lat_1=55 +lat_2=65 +lat_0=50 +lon_0=-154 +x_0=0 +y_0=0 +datum=NAD27 +units=us-ft +no_defs</proj4>
           <srsid>932</srsid>
           <srid>2964</srid>
@@ -2331,7 +2114,6 @@ def my_form_open(dialog, layer, feature):
         <encoding></encoding>
         <crs>
           <spatialrefsys>
-            <wkt></wkt>
             <proj4></proj4>
             <srsid>0</srsid>
             <srid>0</srid>
@@ -2339,7 +2121,7 @@ def my_form_open(dialog, layer, feature):
             <description></description>
             <projectionacronym></projectionacronym>
             <ellipsoidacronym></ellipsoidacronym>
-            <geographicflag>false</geographicflag>
+            <geographicflag>true</geographicflag>
           </spatialrefsys>
         </crs>
         <extent/>
@@ -2359,16 +2141,16 @@ def my_form_open(dialog, layer, feature):
         <Removable>1</Removable>
         <Searchable>1</Searchable>
       </flags>
-      <renderer-v2 attr="LENGTH" symbollevels="0" type="graduatedSymbol" forceraster="0" graduatedMethod="GraduatedColor" enableorderby="0">
+      <renderer-v2 type="graduatedSymbol" symbollevels="0" graduatedMethod="GraduatedColor" forceraster="0" attr="LENGTH" enableorderby="0">
         <ranges>
-          <range label=" 0.00 - 0.02 m" render="true" symbol="0" upper="0.015200000000000" lower="0.000000000000000"/>
-          <range label=" 0.02 - 0.03 m" render="true" symbol="1" upper="0.030400000000000" lower="0.015200000000000"/>
-          <range label=" 0.03 - 0.05 m" render="true" symbol="2" upper="0.045600000000000" lower="0.030400000000000"/>
-          <range label=" 0.05 - 0.06 m" render="true" symbol="3" upper="0.060800000000000" lower="0.045600000000000"/>
-          <range label=" 0.06 - 0.08 m" render="true" symbol="4" upper="0.076000000000000" lower="0.060800000000000"/>
+          <range label=" 0.00 - 0.02 m" symbol="0" upper="0.015200000000000" lower="0.000000000000000" render="true"/>
+          <range label=" 0.02 - 0.03 m" symbol="1" upper="0.030400000000000" lower="0.015200000000000" render="true"/>
+          <range label=" 0.03 - 0.05 m" symbol="2" upper="0.045600000000000" lower="0.030400000000000" render="true"/>
+          <range label=" 0.05 - 0.06 m" symbol="3" upper="0.060800000000000" lower="0.045600000000000" render="true"/>
+          <range label=" 0.06 - 0.08 m" symbol="4" upper="0.076000000000000" lower="0.060800000000000" render="true"/>
         </ranges>
         <symbols>
-          <symbol force_rhr="0" name="0" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="0" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -2388,14 +2170,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="1" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="1" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -2415,14 +2197,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="2" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="2" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -2442,14 +2224,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="3" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="3" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -2469,14 +2251,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="4" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="4" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -2496,16 +2278,16 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
         </symbols>
         <source-symbol>
-          <symbol force_rhr="0" name="0" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="0" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -2525,107 +2307,76 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
         </source-symbol>
-        <colorramp name="[source]" type="gradient">
+        <colorramp type="gradient" name="[source]">
           <prop k="color1" v="254,240,217,255"/>
           <prop k="color2" v="179,0,0,255"/>
           <prop k="discrete" v="0"/>
           <prop k="rampType" v="gradient"/>
           <prop k="stops" v="0.25;253,204,138,255:0.5;252,141,89,255:0.75;227,74,51,255"/>
         </colorramp>
-        <classificationMethod id="EqualInterval">
-          <symmetricMode enabled="0" astride="0" symmetrypoint="0"/>
-          <labelFormat format="%1 - %2 " labelprecision="4" trimtrailingzeroes="1"/>
-          <extraInformation/>
-        </classificationMethod>
+        <mode name="equal"/>
+        <symmetricMode enabled="false" symmetryPoint="0" astride="false"/>
         <rotation/>
         <sizescale/>
+        <labelformat trimtrailingzeroes="false" format=" %1 - %2 m" decimalplaces="2"/>
       </renderer-v2>
       <labeling type="simple">
-        <settings calloutType="simple">
-          <text-style fontSize="11" textOpacity="1" fontFamily="Ubuntu" fontItalic="1" fontCapitals="0" textOrientation="horizontal" fontStrikeout="0" blendMode="0" fieldName="DECRIPTION" previewBkgrdColor="255,255,255,255" fontUnderline="0" fontWordSpacing="0" fontSizeUnit="Point" namedStyle="Bold Italic" fontKerning="1" isExpression="0" useSubstitutions="0" textColor="24,96,185,255" fontSizeMapUnitScale="3x:0,0,0,0,0,0" multilineHeight="1" fontLetterSpacing="0" fontWeight="75">
-            <text-buffer bufferSizeUnits="MM" bufferDraw="0" bufferNoFill="0" bufferColor="255,255,255,255" bufferOpacity="1" bufferBlendMode="0" bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferJoinStyle="64" bufferSize="1"/>
-            <background shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeOpacity="1" shapeSizeX="0" shapeRadiiX="0" shapeSVGFile="" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeOffsetX="0" shapeType="0" shapeBlendMode="0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeJoinStyle="64" shapeDraw="0" shapeSizeUnit="MM" shapeSizeType="0" shapeRotationType="0" shapeRotation="0" shapeOffsetUnit="MM" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeBorderWidthUnit="MM" shapeSizeY="0" shapeBorderWidth="0" shapeRadiiY="0" shapeOffsetY="0" shapeBorderColor="128,128,128,255" shapeRadiiUnit="MM" shapeFillColor="255,255,255,255"/>
-            <shadow shadowDraw="0" shadowOffsetUnit="MM" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowRadiusUnit="MM" shadowScale="100" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowRadiusAlphaOnly="0" shadowBlendMode="6" shadowOffsetAngle="135" shadowOffsetDist="1" shadowOffsetGlobal="1" shadowUnder="0" shadowRadius="1.5" shadowColor="0,0,0,255" shadowOpacity="0.7"/>
-            <dd_properties>
-              <Option type="Map">
-                <Option value="" name="name" type="QString"/>
-                <Option name="properties"/>
-                <Option value="collection" name="type" type="QString"/>
-              </Option>
-            </dd_properties>
+        <settings>
+          <text-style namedStyle="Bold Italic" fieldName="DECRIPTION" fontWeight="75" fontWordSpacing="0" fontSizeUnit="Point" fontItalic="1" fontSizeMapUnitScale="3x:0,0,0,0,0,0" fontCapitals="0" fontFamily="Ubuntu" textColor="24,96,185,255" fontSize="11" fontLetterSpacing="0" previewBkgrdColor="255,255,255,255" fontStrikeout="0" multilineHeight="1" useSubstitutions="0" textOpacity="1" isExpression="0" blendMode="0" fontUnderline="0">
+            <text-buffer bufferDraw="0" bufferNoFill="0" bufferBlendMode="0" bufferSize="1" bufferSizeUnits="MM" bufferColor="255,255,255,255" bufferJoinStyle="64" bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferOpacity="1"/>
+            <background shapeRadiiX="0" shapeSizeUnit="MM" shapeOffsetY="0" shapeRadiiUnit="MM" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeBlendMode="0" shapeRotation="0" shapeSizeX="0" shapeSizeY="0" shapeDraw="0" shapeRadiiY="0" shapeOffsetX="0" shapeRotationType="0" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeOffsetUnit="MM" shapeBorderWidth="0" shapeBorderWidthUnit="MM" shapeJoinStyle="64" shapeBorderColor="128,128,128,255" shapeFillColor="255,255,255,255" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeType="0" shapeSVGFile="" shapeSizeType="0" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeOpacity="1"/>
+            <shadow shadowDraw="0" shadowOffsetGlobal="1" shadowOffsetAngle="135" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowColor="0,0,0,255" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowOpacity="0.7" shadowRadiusUnit="MM" shadowUnder="0" shadowOffsetUnit="MM" shadowScale="100" shadowBlendMode="6" shadowRadiusAlphaOnly="0" shadowOffsetDist="1" shadowRadius="1.5"/>
             <substitutions/>
           </text-style>
-          <text-format addDirectionSymbol="0" rightDirectionSymbol=">" plussign="0" reverseDirectionSymbol="0" placeDirectionSymbol="0" multilineAlign="0" leftDirectionSymbol="&lt;" formatNumbers="0" wrapChar="" autoWrapLength="0" useMaxLineLengthForAutoWrap="1" decimals="0"/>
-          <placement geometryGeneratorEnabled="0" fitInPolygonOnly="0" maxCurvedCharAngleOut="-20" rotationAngle="0" priority="5" geometryGeneratorType="PointGeometry" predefinedPositionOrder="TR,TL,BR,BL,R,L,TSR,BSR" distUnits="MM" repeatDistance="0" xOffset="0" centroidWhole="0" preserveRotation="1" offsetUnits="MapUnit" overrunDistance="0" repeatDistanceMapUnitScale="3x:0,0,0,0,0,0" placement="3" repeatDistanceUnits="MM" labelOffsetMapUnitScale="3x:0,0,0,0,0,0" layerType="UnknownGeometry" distMapUnitScale="3x:0,0,0,0,0,0" yOffset="0" offsetType="0" quadOffset="4" dist="0" overrunDistanceMapUnitScale="3x:0,0,0,0,0,0" placementFlags="10" maxCurvedCharAngleIn="20" overrunDistanceUnit="MM" geometryGenerator="" centroidInside="0"/>
-          <rendering obstacle="1" drawLabels="1" fontMaxPixelSize="10000" maxNumLabels="2000" minFeatureSize="0" scaleVisibility="0" mergeLines="1" scaleMin="1" zIndex="0" fontMinPixelSize="3" upsidedownLabels="0" obstacleType="0" obstacleFactor="1" limitNumLabels="0" labelPerPart="0" scaleMax="10000000" displayAll="1" fontLimitPixelSize="0"/>
+          <text-format formatNumbers="0" useMaxLineLengthForAutoWrap="1" rightDirectionSymbol=">" leftDirectionSymbol="&lt;" wrapChar="" autoWrapLength="0" addDirectionSymbol="0" decimals="0" plussign="0" reverseDirectionSymbol="0" multilineAlign="0" placeDirectionSymbol="0"/>
+          <placement fitInPolygonOnly="0" geometryGenerator="" geometryGeneratorEnabled="0" geometryGeneratorType="PointGeometry" priority="5" repeatDistanceUnits="MM" placementFlags="10" dist="0" maxCurvedCharAngleOut="-20" distUnits="MM" predefinedPositionOrder="TR,TL,BR,BL,R,L,TSR,BSR" repeatDistanceMapUnitScale="3x:0,0,0,0,0,0" labelOffsetMapUnitScale="3x:0,0,0,0,0,0" centroidWhole="0" centroidInside="0" rotationAngle="0" preserveRotation="1" offsetUnits="MapUnit" xOffset="0" quadOffset="4" distMapUnitScale="3x:0,0,0,0,0,0" repeatDistance="0" yOffset="0" placement="3" maxCurvedCharAngleIn="20" layerType="UnknownGeometry" offsetType="0"/>
+          <rendering obstacle="1" minFeatureSize="0" labelPerPart="0" maxNumLabels="2000" upsidedownLabels="0" drawLabels="1" fontMaxPixelSize="10000" fontMinPixelSize="3" scaleMax="10000000" zIndex="0" scaleVisibility="0" fontLimitPixelSize="0" obstacleFactor="1" limitNumLabels="0" mergeLines="1" scaleMin="1" obstacleType="0" displayAll="1"/>
           <dd_properties>
             <Option type="Map">
-              <Option value="" name="name" type="QString"/>
+              <Option value="" type="QString" name="name"/>
               <Option name="properties"/>
-              <Option value="collection" name="type" type="QString"/>
+              <Option value="collection" type="QString" name="type"/>
             </Option>
           </dd_properties>
-          <callout type="simple">
-            <Option type="Map">
-              <Option value="pole_of_inaccessibility" name="anchorPoint" type="QString"/>
-              <Option name="ddProperties" type="Map">
-                <Option value="" name="name" type="QString"/>
-                <Option name="properties"/>
-                <Option value="collection" name="type" type="QString"/>
-              </Option>
-              <Option value="false" name="drawToAllParts" type="bool"/>
-              <Option value="0" name="enabled" type="QString"/>
-              <Option value="&lt;symbol force_rhr=&quot;0&quot; name=&quot;symbol&quot; clip_to_extent=&quot;1&quot; alpha=&quot;1&quot; type=&quot;line&quot;>&lt;layer enabled=&quot;1&quot; pass=&quot;0&quot; class=&quot;SimpleLine&quot; locked=&quot;0&quot;>&lt;prop k=&quot;capstyle&quot; v=&quot;square&quot;/>&lt;prop k=&quot;customdash&quot; v=&quot;5;2&quot;/>&lt;prop k=&quot;customdash_map_unit_scale&quot; v=&quot;3x:0,0,0,0,0,0&quot;/>&lt;prop k=&quot;customdash_unit&quot; v=&quot;MM&quot;/>&lt;prop k=&quot;draw_inside_polygon&quot; v=&quot;0&quot;/>&lt;prop k=&quot;joinstyle&quot; v=&quot;bevel&quot;/>&lt;prop k=&quot;line_color&quot; v=&quot;60,60,60,255&quot;/>&lt;prop k=&quot;line_style&quot; v=&quot;solid&quot;/>&lt;prop k=&quot;line_width&quot; v=&quot;0.3&quot;/>&lt;prop k=&quot;line_width_unit&quot; v=&quot;MM&quot;/>&lt;prop k=&quot;offset&quot; v=&quot;0&quot;/>&lt;prop k=&quot;offset_map_unit_scale&quot; v=&quot;3x:0,0,0,0,0,0&quot;/>&lt;prop k=&quot;offset_unit&quot; v=&quot;MM&quot;/>&lt;prop k=&quot;ring_filter&quot; v=&quot;0&quot;/>&lt;prop k=&quot;use_custom_dash&quot; v=&quot;0&quot;/>&lt;prop k=&quot;width_map_unit_scale&quot; v=&quot;3x:0,0,0,0,0,0&quot;/>&lt;data_defined_properties>&lt;Option type=&quot;Map&quot;>&lt;Option value=&quot;&quot; name=&quot;name&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;properties&quot;/>&lt;Option value=&quot;collection&quot; name=&quot;type&quot; type=&quot;QString&quot;/>&lt;/Option>&lt;/data_defined_properties>&lt;/layer>&lt;/symbol>" name="lineSymbol" type="QString"/>
-              <Option value="0" name="minLength" type="double"/>
-              <Option value="3x:0,0,0,0,0,0" name="minLengthMapUnitScale" type="QString"/>
-              <Option value="MM" name="minLengthUnit" type="QString"/>
-              <Option value="0" name="offsetFromAnchor" type="double"/>
-              <Option value="3x:0,0,0,0,0,0" name="offsetFromAnchorMapUnitScale" type="QString"/>
-              <Option value="MM" name="offsetFromAnchorUnit" type="QString"/>
-              <Option value="0" name="offsetFromLabel" type="double"/>
-              <Option value="3x:0,0,0,0,0,0" name="offsetFromLabelMapUnitScale" type="QString"/>
-              <Option value="MM" name="offsetFromLabelUnit" type="QString"/>
-            </Option>
-          </callout>
         </settings>
       </labeling>
       <customproperties>
-        <property value="_fields_" key="variableNames"/>
-        <property value="" key="variableValues"/>
+        <property key="variableNames" value="_fields_"/>
+        <property key="variableValues" value=""/>
       </customproperties>
       <blendMode>0</blendMode>
       <featureBlendMode>0</featureBlendMode>
       <layerOpacity>1</layerOpacity>
-      <SingleCategoryDiagramRenderer diagramType="Pie" attributeLegend="1">
-        <DiagramCategory backgroundAlpha="255" sizeScale="3x:0,0,0,0,0,0" opacity="1" scaleBasedVisibility="0" width="15" backgroundColor="#ffffff" minScaleDenominator="-4.65661e-10" rotationOffset="270" minimumSize="0" penAlpha="255" lineSizeScale="3x:0,0,0,0,0,0" scaleDependency="Area" penWidth="0" barWidth="5" height="15" labelPlacementMethod="XHeight" lineSizeType="MM" diagramOrientation="Up" enabled="0" sizeType="MM" penColor="#000000" maxScaleDenominator="1e+8">
+      <SingleCategoryDiagramRenderer attributeLegend="1" diagramType="Pie">
+        <DiagramCategory minScaleDenominator="-4.65661e-10" diagramOrientation="Up" backgroundColor="#ffffff" penWidth="0" barWidth="5" penColor="#000000" opacity="1" maxScaleDenominator="1e+8" rotationOffset="270" scaleBasedVisibility="0" penAlpha="255" scaleDependency="Area" labelPlacementMethod="XHeight" enabled="0" width="15" sizeType="MM" lineSizeScale="3x:0,0,0,0,0,0" height="15" lineSizeType="MM" backgroundAlpha="255" sizeScale="3x:0,0,0,0,0,0" minimumSize="0">
           <fontProperties description="Ubuntu,11,-1,5,50,0,0,0,0,0" style=""/>
-          <attribute field="" label="" color="#000000"/>
+          <attribute label="" color="#000000" field=""/>
         </DiagramCategory>
       </SingleCategoryDiagramRenderer>
-      <DiagramLayerSettings priority="0" obstacle="0" zIndex="0" showAll="1" placement="2" dist="0" linePlacementFlags="10">
+      <DiagramLayerSettings showAll="1" priority="0" placement="2" linePlacementFlags="10" zIndex="0" dist="0" obstacle="0">
         <properties>
           <Option type="Map">
-            <Option value="" name="name" type="QString"/>
-            <Option name="properties" type="Map">
-              <Option name="show" type="Map">
-                <Option value="true" name="active" type="bool"/>
-                <Option value="cat" name="field" type="QString"/>
-                <Option value="2" name="type" type="int"/>
+            <Option value="" type="QString" name="name"/>
+            <Option type="Map" name="properties">
+              <Option type="Map" name="show">
+                <Option value="true" type="bool" name="active"/>
+                <Option value="cat" type="QString" name="field"/>
+                <Option value="2" type="int" name="type"/>
               </Option>
             </Option>
-            <Option value="collection" name="type" type="QString"/>
+            <Option value="collection" type="QString" name="type"/>
           </Option>
         </properties>
       </DiagramLayerSettings>
-      <geometryOptions removeDuplicateNodes="0" geometryPrecision="0">
+      <geometryOptions geometryPrecision="0" removeDuplicateNodes="0">
         <activeChecks/>
         <checkConfiguration/>
       </geometryOptions>
@@ -2634,8 +2385,8 @@ def my_form_open(dialog, layer, feature):
           <editWidget type="TextEdit">
             <config>
               <Option type="Map">
-                <Option value="0" name="IsMultiline" type="QString"/>
-                <Option value="0" name="UseHtml" type="QString"/>
+                <Option value="0" type="QString" name="IsMultiline"/>
+                <Option value="0" type="QString" name="UseHtml"/>
               </Option>
             </config>
           </editWidget>
@@ -2644,8 +2395,8 @@ def my_form_open(dialog, layer, feature):
           <editWidget type="TextEdit">
             <config>
               <Option type="Map">
-                <Option value="0" name="IsMultiline" type="QString"/>
-                <Option value="0" name="UseHtml" type="QString"/>
+                <Option value="0" type="QString" name="IsMultiline"/>
+                <Option value="0" type="QString" name="UseHtml"/>
               </Option>
             </config>
           </editWidget>
@@ -2654,39 +2405,37 @@ def my_form_open(dialog, layer, feature):
           <editWidget type="TextEdit">
             <config>
               <Option type="Map">
-                <Option value="0" name="IsMultiline" type="QString"/>
-                <Option value="0" name="UseHtml" type="QString"/>
+                <Option value="0" type="QString" name="IsMultiline"/>
+                <Option value="0" type="QString" name="UseHtml"/>
               </Option>
             </config>
           </editWidget>
         </field>
       </fieldConfiguration>
       <aliases>
-        <alias name="" index="0" field="cat"/>
-        <alias name="" index="1" field="LENGTH"/>
-        <alias name="" index="2" field="DECRIPTION"/>
+        <alias name="" field="cat" index="0"/>
+        <alias name="" field="LENGTH" index="1"/>
+        <alias name="" field="DECRIPTION" index="2"/>
       </aliases>
       <excludeAttributesWMS/>
       <excludeAttributesWFS/>
       <defaults>
-        <default field="cat" applyOnUpdate="0" expression=""/>
-        <default field="LENGTH" applyOnUpdate="0" expression=""/>
-        <default field="DECRIPTION" applyOnUpdate="0" expression=""/>
+        <default field="cat" expression="" applyOnUpdate="0"/>
+        <default field="LENGTH" expression="" applyOnUpdate="0"/>
+        <default field="DECRIPTION" expression="" applyOnUpdate="0"/>
       </defaults>
       <constraints>
-        <constraint field="cat" notnull_strength="0" constraints="0" unique_strength="0" exp_strength="0"/>
-        <constraint field="LENGTH" notnull_strength="0" constraints="0" unique_strength="0" exp_strength="0"/>
-        <constraint field="DECRIPTION" notnull_strength="0" constraints="0" unique_strength="0" exp_strength="0"/>
+        <constraint notnull_strength="0" exp_strength="0" field="cat" unique_strength="0" constraints="0"/>
+        <constraint notnull_strength="0" exp_strength="0" field="LENGTH" unique_strength="0" constraints="0"/>
+        <constraint notnull_strength="0" exp_strength="0" field="DECRIPTION" unique_strength="0" constraints="0"/>
       </constraints>
       <constraintExpressions>
-        <constraint field="cat" exp="" desc=""/>
-        <constraint field="LENGTH" exp="" desc=""/>
-        <constraint field="DECRIPTION" exp="" desc=""/>
+        <constraint field="cat" desc="" exp=""/>
+        <constraint field="LENGTH" desc="" exp=""/>
+        <constraint field="DECRIPTION" desc="" exp=""/>
       </constraintExpressions>
       <expressionfields/>
-      <attributeactions>
-        <defaultAction value="{00000000-0000-0000-0000-000000000000}" key="Canvas"/>
-      </attributeactions>
+      <attributeactions/>
       <attributetableconfig sortExpression="" actionWidgetStyle="dropDown" sortOrder="0">
         <columns/>
       </attributetableconfig>
@@ -2694,7 +2443,6 @@ def my_form_open(dialog, layer, feature):
         <rowstyles/>
         <fieldstyles/>
       </conditionalstyles>
-      <storedexpressions/>
       <editform tolerant="1"></editform>
       <editforminit/>
       <editforminitcodesource>0</editforminitcodesource>
@@ -2724,7 +2472,7 @@ def my_form_open(dialog, layer, feature):
       <previewExpression>"cat"||', '||"LENGTH"||', '||"DECRIPTION"</previewExpression>
       <mapTip></mapTip>
     </maplayer>
-    <maplayer simplifyDrawingHints="1" simplifyAlgorithm="0" labelsEnabled="1" refreshOnNotifyMessage="" wkbType="MultiLineString" minScale="1e+8" readOnly="0" refreshOnNotifyEnabled="0" type="vector" maxScale="-4.65661e-10" simplifyLocal="1" autoRefreshTime="0" hasScaleBasedVisibilityFlag="0" geometry="Line" styleCategories="AllStyleCategories" autoRefreshEnabled="0" simplifyDrawingTol="1" simplifyMaxScale="1">
+    <maplayer refreshOnNotifyEnabled="0" refreshOnNotifyMessage="" styleCategories="AllStyleCategories" maxScale="-4.65661e-10" hasScaleBasedVisibilityFlag="0" simplifyAlgorithm="0" type="vector" labelsEnabled="1" minScale="1e+8" simplifyLocal="1" simplifyDrawingHints="1" autoRefreshTime="0" readOnly="0" geometry="Line" simplifyDrawingTol="1" autoRefreshEnabled="0" simplifyMaxScale="1" wkbType="MultiLineString">
       <extent>
         <xmin>-2038395.83981025964021683</xmin>
         <ymin>3963487.82406435115262866</ymin>
@@ -2739,7 +2487,6 @@ def my_form_open(dialog, layer, feature):
       <layername>majrivers</layername>
       <srs>
         <spatialrefsys>
-          <wkt>PROJCS["NAD27 / Alaska Albers",GEOGCS["NAD27",DATUM["North_American_Datum_1927",SPHEROID["Clarke 1866",6378206.4,294.9786982138982,AUTHORITY["EPSG","7008"]],AUTHORITY["EPSG","6267"]],PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9122"]],AUTHORITY["EPSG","4267"]],PROJECTION["Albers_Conic_Equal_Area"],PARAMETER["standard_parallel_1",55],PARAMETER["standard_parallel_2",65],PARAMETER["latitude_of_center",50],PARAMETER["longitude_of_center",-154],PARAMETER["false_easting",0],PARAMETER["false_northing",0],UNIT["US survey foot",0.3048006096012192,AUTHORITY["EPSG","9003"]],AXIS["X",EAST],AXIS["Y",NORTH],AUTHORITY["EPSG","2964"]]</wkt>
           <proj4>+proj=aea +lat_1=55 +lat_2=65 +lat_0=50 +lon_0=-154 +x_0=0 +y_0=0 +datum=NAD27 +units=us-ft +no_defs</proj4>
           <srsid>932</srsid>
           <srid>2964</srid>
@@ -2762,7 +2509,6 @@ def my_form_open(dialog, layer, feature):
         <encoding></encoding>
         <crs>
           <spatialrefsys>
-            <wkt></wkt>
             <proj4></proj4>
             <srsid>0</srsid>
             <srid>0</srid>
@@ -2770,7 +2516,7 @@ def my_form_open(dialog, layer, feature):
             <description></description>
             <projectionacronym></projectionacronym>
             <ellipsoidacronym></ellipsoidacronym>
-            <geographicflag>false</geographicflag>
+            <geographicflag>true</geographicflag>
           </spatialrefsys>
         </crs>
         <extent/>
@@ -2790,16 +2536,16 @@ def my_form_open(dialog, layer, feature):
         <Removable>1</Removable>
         <Searchable>1</Searchable>
       </flags>
-      <renderer-v2 symbollevels="0" type="RuleRenderer" forceraster="0" enableorderby="0">
+      <renderer-v2 type="RuleRenderer" symbollevels="0" forceraster="0" enableorderby="0">
         <rules key="{66457aa0-324f-4ef6-ac0b-c9562e6cc780}">
           <rule key="{e2c9f3ce-edfe-4d1d-a1b9-6a3e41897539}" label="&quot;DECRIPTION&quot;  = 'Aniak River' " filter=" &quot;DECRIPTION&quot;  = 'Aniak River' ">
-            <rule key="{f4a04681-2a45-488b-aca1-c1bc5ec48fe5}" label=" &quot;LENGTH&quot;  &lt; 2000" symbol="0" filter=" &quot;LENGTH&quot;  &lt; 2000"/>
-            <rule key="{4e0e5dd4-6ddd-4045-b85e-51e6c1927f3f}" label=" &quot;LENGTH&quot; >= 2000" symbol="1" filter=" &quot;LENGTH&quot; >= 2000"/>
+            <rule key="{f4a04681-2a45-488b-aca1-c1bc5ec48fe5}" label=" &quot;LENGTH&quot;  &lt; 2000" filter=" &quot;LENGTH&quot;  &lt; 2000" symbol="0"/>
+            <rule key="{4e0e5dd4-6ddd-4045-b85e-51e6c1927f3f}" label=" &quot;LENGTH&quot; >= 2000" filter=" &quot;LENGTH&quot; >= 2000" symbol="1"/>
           </rule>
-          <rule key="{fafc7e06-31b1-4e36-ba7a-535ca0d7794a}" label="ELSE" symbol="2" filter="ELSE"/>
+          <rule key="{fafc7e06-31b1-4e36-ba7a-535ca0d7794a}" label="ELSE" filter="ELSE" symbol="2"/>
         </rules>
         <symbols>
-          <symbol force_rhr="0" name="0" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="0" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="round"/>
               <prop k="customdash" v="5;2"/>
@@ -2819,14 +2565,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="1" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="1" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="round"/>
               <prop k="customdash" v="5;2"/>
@@ -2846,14 +2592,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="2" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="2" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="round"/>
               <prop k="customdash" v="5;2"/>
@@ -2873,9 +2619,9 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
@@ -2883,83 +2629,54 @@ def my_form_open(dialog, layer, feature):
         </symbols>
       </renderer-v2>
       <labeling type="simple">
-        <settings calloutType="simple">
-          <text-style fontSize="11" textOpacity="1" fontFamily="Ubuntu" fontItalic="1" fontCapitals="0" textOrientation="horizontal" fontStrikeout="0" blendMode="0" fieldName="DECRIPTION" previewBkgrdColor="255,255,255,255" fontUnderline="0" fontWordSpacing="0" fontSizeUnit="Point" namedStyle="Bold Italic" fontKerning="1" isExpression="0" useSubstitutions="0" textColor="24,96,185,255" fontSizeMapUnitScale="3x:0,0,0,0,0,0" multilineHeight="1" fontLetterSpacing="0" fontWeight="75">
-            <text-buffer bufferSizeUnits="MM" bufferDraw="0" bufferNoFill="0" bufferColor="255,255,255,255" bufferOpacity="1" bufferBlendMode="0" bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferJoinStyle="64" bufferSize="1"/>
-            <background shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeOpacity="1" shapeSizeX="0" shapeRadiiX="0" shapeSVGFile="" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeOffsetX="0" shapeType="0" shapeBlendMode="0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeJoinStyle="64" shapeDraw="0" shapeSizeUnit="MM" shapeSizeType="0" shapeRotationType="0" shapeRotation="0" shapeOffsetUnit="MM" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeBorderWidthUnit="MM" shapeSizeY="0" shapeBorderWidth="0" shapeRadiiY="0" shapeOffsetY="0" shapeBorderColor="128,128,128,255" shapeRadiiUnit="MM" shapeFillColor="255,255,255,255"/>
-            <shadow shadowDraw="0" shadowOffsetUnit="MM" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowRadiusUnit="MM" shadowScale="100" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowRadiusAlphaOnly="0" shadowBlendMode="6" shadowOffsetAngle="135" shadowOffsetDist="1" shadowOffsetGlobal="1" shadowUnder="0" shadowRadius="1.5" shadowColor="0,0,0,255" shadowOpacity="0.7"/>
-            <dd_properties>
-              <Option type="Map">
-                <Option value="" name="name" type="QString"/>
-                <Option name="properties"/>
-                <Option value="collection" name="type" type="QString"/>
-              </Option>
-            </dd_properties>
+        <settings>
+          <text-style namedStyle="Bold Italic" fieldName="DECRIPTION" fontWeight="75" fontWordSpacing="0" fontSizeUnit="Point" fontItalic="1" fontSizeMapUnitScale="3x:0,0,0,0,0,0" fontCapitals="0" fontFamily="Ubuntu" textColor="24,96,185,255" fontSize="11" fontLetterSpacing="0" previewBkgrdColor="255,255,255,255" fontStrikeout="0" multilineHeight="1" useSubstitutions="0" textOpacity="1" isExpression="0" blendMode="0" fontUnderline="0">
+            <text-buffer bufferDraw="0" bufferNoFill="0" bufferBlendMode="0" bufferSize="1" bufferSizeUnits="MM" bufferColor="255,255,255,255" bufferJoinStyle="64" bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferOpacity="1"/>
+            <background shapeRadiiX="0" shapeSizeUnit="MM" shapeOffsetY="0" shapeRadiiUnit="MM" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeBlendMode="0" shapeRotation="0" shapeSizeX="0" shapeSizeY="0" shapeDraw="0" shapeRadiiY="0" shapeOffsetX="0" shapeRotationType="0" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeOffsetUnit="MM" shapeBorderWidth="0" shapeBorderWidthUnit="MM" shapeJoinStyle="64" shapeBorderColor="128,128,128,255" shapeFillColor="255,255,255,255" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeType="0" shapeSVGFile="" shapeSizeType="0" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeOpacity="1"/>
+            <shadow shadowDraw="0" shadowOffsetGlobal="1" shadowOffsetAngle="135" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowColor="0,0,0,255" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowOpacity="0.7" shadowRadiusUnit="MM" shadowUnder="0" shadowOffsetUnit="MM" shadowScale="100" shadowBlendMode="6" shadowRadiusAlphaOnly="0" shadowOffsetDist="1" shadowRadius="1.5"/>
             <substitutions/>
           </text-style>
-          <text-format addDirectionSymbol="0" rightDirectionSymbol=">" plussign="0" reverseDirectionSymbol="0" placeDirectionSymbol="0" multilineAlign="0" leftDirectionSymbol="&lt;" formatNumbers="0" wrapChar="" autoWrapLength="0" useMaxLineLengthForAutoWrap="1" decimals="0"/>
-          <placement geometryGeneratorEnabled="0" fitInPolygonOnly="0" maxCurvedCharAngleOut="-20" rotationAngle="0" priority="5" geometryGeneratorType="PointGeometry" predefinedPositionOrder="TR,TL,BR,BL,R,L,TSR,BSR" distUnits="MM" repeatDistance="0" xOffset="0" centroidWhole="0" preserveRotation="1" offsetUnits="MapUnit" overrunDistance="0" repeatDistanceMapUnitScale="3x:0,0,0,0,0,0" placement="3" repeatDistanceUnits="MM" labelOffsetMapUnitScale="3x:0,0,0,0,0,0" layerType="UnknownGeometry" distMapUnitScale="3x:0,0,0,0,0,0" yOffset="0" offsetType="0" quadOffset="4" dist="0" overrunDistanceMapUnitScale="3x:0,0,0,0,0,0" placementFlags="10" maxCurvedCharAngleIn="20" overrunDistanceUnit="MM" geometryGenerator="" centroidInside="0"/>
-          <rendering obstacle="1" drawLabels="1" fontMaxPixelSize="10000" maxNumLabels="2000" minFeatureSize="0" scaleVisibility="0" mergeLines="1" scaleMin="1" zIndex="0" fontMinPixelSize="3" upsidedownLabels="0" obstacleType="0" obstacleFactor="1" limitNumLabels="0" labelPerPart="0" scaleMax="10000000" displayAll="1" fontLimitPixelSize="0"/>
+          <text-format formatNumbers="0" useMaxLineLengthForAutoWrap="1" rightDirectionSymbol=">" leftDirectionSymbol="&lt;" wrapChar="" autoWrapLength="0" addDirectionSymbol="0" decimals="0" plussign="0" reverseDirectionSymbol="0" multilineAlign="0" placeDirectionSymbol="0"/>
+          <placement fitInPolygonOnly="0" geometryGenerator="" geometryGeneratorEnabled="0" geometryGeneratorType="PointGeometry" priority="5" repeatDistanceUnits="MM" placementFlags="10" dist="0" maxCurvedCharAngleOut="-20" distUnits="MM" predefinedPositionOrder="TR,TL,BR,BL,R,L,TSR,BSR" repeatDistanceMapUnitScale="3x:0,0,0,0,0,0" labelOffsetMapUnitScale="3x:0,0,0,0,0,0" centroidWhole="0" centroidInside="0" rotationAngle="0" preserveRotation="1" offsetUnits="MapUnit" xOffset="0" quadOffset="4" distMapUnitScale="3x:0,0,0,0,0,0" repeatDistance="0" yOffset="0" placement="3" maxCurvedCharAngleIn="20" layerType="UnknownGeometry" offsetType="0"/>
+          <rendering obstacle="1" minFeatureSize="0" labelPerPart="0" maxNumLabels="2000" upsidedownLabels="0" drawLabels="1" fontMaxPixelSize="10000" fontMinPixelSize="3" scaleMax="10000000" zIndex="0" scaleVisibility="0" fontLimitPixelSize="0" obstacleFactor="1" limitNumLabels="0" mergeLines="1" scaleMin="1" obstacleType="0" displayAll="1"/>
           <dd_properties>
             <Option type="Map">
-              <Option value="" name="name" type="QString"/>
+              <Option value="" type="QString" name="name"/>
               <Option name="properties"/>
-              <Option value="collection" name="type" type="QString"/>
+              <Option value="collection" type="QString" name="type"/>
             </Option>
           </dd_properties>
-          <callout type="simple">
-            <Option type="Map">
-              <Option value="pole_of_inaccessibility" name="anchorPoint" type="QString"/>
-              <Option name="ddProperties" type="Map">
-                <Option value="" name="name" type="QString"/>
-                <Option name="properties"/>
-                <Option value="collection" name="type" type="QString"/>
-              </Option>
-              <Option value="false" name="drawToAllParts" type="bool"/>
-              <Option value="0" name="enabled" type="QString"/>
-              <Option value="&lt;symbol force_rhr=&quot;0&quot; name=&quot;symbol&quot; clip_to_extent=&quot;1&quot; alpha=&quot;1&quot; type=&quot;line&quot;>&lt;layer enabled=&quot;1&quot; pass=&quot;0&quot; class=&quot;SimpleLine&quot; locked=&quot;0&quot;>&lt;prop k=&quot;capstyle&quot; v=&quot;square&quot;/>&lt;prop k=&quot;customdash&quot; v=&quot;5;2&quot;/>&lt;prop k=&quot;customdash_map_unit_scale&quot; v=&quot;3x:0,0,0,0,0,0&quot;/>&lt;prop k=&quot;customdash_unit&quot; v=&quot;MM&quot;/>&lt;prop k=&quot;draw_inside_polygon&quot; v=&quot;0&quot;/>&lt;prop k=&quot;joinstyle&quot; v=&quot;bevel&quot;/>&lt;prop k=&quot;line_color&quot; v=&quot;60,60,60,255&quot;/>&lt;prop k=&quot;line_style&quot; v=&quot;solid&quot;/>&lt;prop k=&quot;line_width&quot; v=&quot;0.3&quot;/>&lt;prop k=&quot;line_width_unit&quot; v=&quot;MM&quot;/>&lt;prop k=&quot;offset&quot; v=&quot;0&quot;/>&lt;prop k=&quot;offset_map_unit_scale&quot; v=&quot;3x:0,0,0,0,0,0&quot;/>&lt;prop k=&quot;offset_unit&quot; v=&quot;MM&quot;/>&lt;prop k=&quot;ring_filter&quot; v=&quot;0&quot;/>&lt;prop k=&quot;use_custom_dash&quot; v=&quot;0&quot;/>&lt;prop k=&quot;width_map_unit_scale&quot; v=&quot;3x:0,0,0,0,0,0&quot;/>&lt;data_defined_properties>&lt;Option type=&quot;Map&quot;>&lt;Option value=&quot;&quot; name=&quot;name&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;properties&quot;/>&lt;Option value=&quot;collection&quot; name=&quot;type&quot; type=&quot;QString&quot;/>&lt;/Option>&lt;/data_defined_properties>&lt;/layer>&lt;/symbol>" name="lineSymbol" type="QString"/>
-              <Option value="0" name="minLength" type="double"/>
-              <Option value="3x:0,0,0,0,0,0" name="minLengthMapUnitScale" type="QString"/>
-              <Option value="MM" name="minLengthUnit" type="QString"/>
-              <Option value="0" name="offsetFromAnchor" type="double"/>
-              <Option value="3x:0,0,0,0,0,0" name="offsetFromAnchorMapUnitScale" type="QString"/>
-              <Option value="MM" name="offsetFromAnchorUnit" type="QString"/>
-              <Option value="0" name="offsetFromLabel" type="double"/>
-              <Option value="3x:0,0,0,0,0,0" name="offsetFromLabelMapUnitScale" type="QString"/>
-              <Option value="MM" name="offsetFromLabelUnit" type="QString"/>
-            </Option>
-          </callout>
         </settings>
       </labeling>
       <customproperties>
-        <property value="_fields_" key="variableNames"/>
-        <property value="" key="variableValues"/>
+        <property key="variableNames" value="_fields_"/>
+        <property key="variableValues" value=""/>
       </customproperties>
       <blendMode>0</blendMode>
       <featureBlendMode>0</featureBlendMode>
       <layerOpacity>1</layerOpacity>
-      <SingleCategoryDiagramRenderer diagramType="Pie" attributeLegend="1">
-        <DiagramCategory backgroundAlpha="255" sizeScale="3x:0,0,0,0,0,0" opacity="1" scaleBasedVisibility="0" width="15" backgroundColor="#ffffff" minScaleDenominator="-4.65661e-10" rotationOffset="270" minimumSize="0" penAlpha="255" lineSizeScale="3x:0,0,0,0,0,0" scaleDependency="Area" penWidth="0" barWidth="5" height="15" labelPlacementMethod="XHeight" lineSizeType="MM" diagramOrientation="Up" enabled="0" sizeType="MM" penColor="#000000" maxScaleDenominator="1e+8">
+      <SingleCategoryDiagramRenderer attributeLegend="1" diagramType="Pie">
+        <DiagramCategory minScaleDenominator="-4.65661e-10" diagramOrientation="Up" backgroundColor="#ffffff" penWidth="0" barWidth="5" penColor="#000000" opacity="1" maxScaleDenominator="1e+8" rotationOffset="270" scaleBasedVisibility="0" penAlpha="255" scaleDependency="Area" labelPlacementMethod="XHeight" enabled="0" width="15" sizeType="MM" lineSizeScale="3x:0,0,0,0,0,0" height="15" lineSizeType="MM" backgroundAlpha="255" sizeScale="3x:0,0,0,0,0,0" minimumSize="0">
           <fontProperties description="Ubuntu,11,-1,5,50,0,0,0,0,0" style=""/>
-          <attribute field="" label="" color="#000000"/>
+          <attribute label="" color="#000000" field=""/>
         </DiagramCategory>
       </SingleCategoryDiagramRenderer>
-      <DiagramLayerSettings priority="0" obstacle="0" zIndex="0" showAll="1" placement="2" dist="0" linePlacementFlags="10">
+      <DiagramLayerSettings showAll="1" priority="0" placement="2" linePlacementFlags="10" zIndex="0" dist="0" obstacle="0">
         <properties>
           <Option type="Map">
-            <Option value="" name="name" type="QString"/>
-            <Option name="properties" type="Map">
-              <Option name="show" type="Map">
-                <Option value="true" name="active" type="bool"/>
-                <Option value="cat" name="field" type="QString"/>
-                <Option value="2" name="type" type="int"/>
+            <Option value="" type="QString" name="name"/>
+            <Option type="Map" name="properties">
+              <Option type="Map" name="show">
+                <Option value="true" type="bool" name="active"/>
+                <Option value="cat" type="QString" name="field"/>
+                <Option value="2" type="int" name="type"/>
               </Option>
             </Option>
-            <Option value="collection" name="type" type="QString"/>
+            <Option value="collection" type="QString" name="type"/>
           </Option>
         </properties>
       </DiagramLayerSettings>
-      <geometryOptions removeDuplicateNodes="0" geometryPrecision="0">
+      <geometryOptions geometryPrecision="0" removeDuplicateNodes="0">
         <activeChecks/>
         <checkConfiguration/>
       </geometryOptions>
@@ -2968,8 +2685,8 @@ def my_form_open(dialog, layer, feature):
           <editWidget type="TextEdit">
             <config>
               <Option type="Map">
-                <Option value="0" name="IsMultiline" type="QString"/>
-                <Option value="0" name="UseHtml" type="QString"/>
+                <Option value="0" type="QString" name="IsMultiline"/>
+                <Option value="0" type="QString" name="UseHtml"/>
               </Option>
             </config>
           </editWidget>
@@ -2978,8 +2695,8 @@ def my_form_open(dialog, layer, feature):
           <editWidget type="TextEdit">
             <config>
               <Option type="Map">
-                <Option value="0" name="IsMultiline" type="QString"/>
-                <Option value="0" name="UseHtml" type="QString"/>
+                <Option value="0" type="QString" name="IsMultiline"/>
+                <Option value="0" type="QString" name="UseHtml"/>
               </Option>
             </config>
           </editWidget>
@@ -2988,34 +2705,34 @@ def my_form_open(dialog, layer, feature):
           <editWidget type="TextEdit">
             <config>
               <Option type="Map">
-                <Option value="0" name="IsMultiline" type="QString"/>
-                <Option value="0" name="UseHtml" type="QString"/>
+                <Option value="0" type="QString" name="IsMultiline"/>
+                <Option value="0" type="QString" name="UseHtml"/>
               </Option>
             </config>
           </editWidget>
         </field>
       </fieldConfiguration>
       <aliases>
-        <alias name="" index="0" field="cat"/>
-        <alias name="" index="1" field="LENGTH"/>
-        <alias name="" index="2" field="DECRIPTION"/>
+        <alias name="" field="cat" index="0"/>
+        <alias name="" field="LENGTH" index="1"/>
+        <alias name="" field="DECRIPTION" index="2"/>
       </aliases>
       <excludeAttributesWMS/>
       <excludeAttributesWFS/>
       <defaults>
-        <default field="cat" applyOnUpdate="0" expression=""/>
-        <default field="LENGTH" applyOnUpdate="0" expression=""/>
-        <default field="DECRIPTION" applyOnUpdate="0" expression=""/>
+        <default field="cat" expression="" applyOnUpdate="0"/>
+        <default field="LENGTH" expression="" applyOnUpdate="0"/>
+        <default field="DECRIPTION" expression="" applyOnUpdate="0"/>
       </defaults>
       <constraints>
-        <constraint field="cat" notnull_strength="0" constraints="0" unique_strength="0" exp_strength="0"/>
-        <constraint field="LENGTH" notnull_strength="0" constraints="0" unique_strength="0" exp_strength="0"/>
-        <constraint field="DECRIPTION" notnull_strength="0" constraints="0" unique_strength="0" exp_strength="0"/>
+        <constraint notnull_strength="0" exp_strength="0" field="cat" unique_strength="0" constraints="0"/>
+        <constraint notnull_strength="0" exp_strength="0" field="LENGTH" unique_strength="0" constraints="0"/>
+        <constraint notnull_strength="0" exp_strength="0" field="DECRIPTION" unique_strength="0" constraints="0"/>
       </constraints>
       <constraintExpressions>
-        <constraint field="cat" exp="" desc=""/>
-        <constraint field="LENGTH" exp="" desc=""/>
-        <constraint field="DECRIPTION" exp="" desc=""/>
+        <constraint field="cat" desc="" exp=""/>
+        <constraint field="LENGTH" desc="" exp=""/>
+        <constraint field="DECRIPTION" desc="" exp=""/>
       </constraintExpressions>
       <expressionfields/>
       <attributeactions/>
@@ -3026,7 +2743,6 @@ def my_form_open(dialog, layer, feature):
         <rowstyles/>
         <fieldstyles/>
       </conditionalstyles>
-      <storedexpressions/>
       <editform tolerant="1"></editform>
       <editforminit/>
       <editforminitcodesource>0</editforminitcodesource>
@@ -3056,7 +2772,7 @@ def my_form_open(dialog, layer, feature):
       <previewExpression>COALESCE( "cat", '&lt;NULL>' )</previewExpression>
       <mapTip></mapTip>
     </maplayer>
-    <maplayer simplifyDrawingHints="1" simplifyAlgorithm="0" labelsEnabled="1" refreshOnNotifyMessage="" wkbType="MultiLineString" minScale="1e+8" readOnly="0" refreshOnNotifyEnabled="0" type="vector" maxScale="-4.65661e-10" simplifyLocal="1" autoRefreshTime="0" hasScaleBasedVisibilityFlag="0" geometry="Line" styleCategories="AllStyleCategories" autoRefreshEnabled="0" simplifyDrawingTol="1" simplifyMaxScale="1">
+    <maplayer refreshOnNotifyEnabled="0" refreshOnNotifyMessage="" styleCategories="AllStyleCategories" maxScale="-4.65661e-10" hasScaleBasedVisibilityFlag="0" simplifyAlgorithm="0" type="vector" labelsEnabled="1" minScale="1e+8" simplifyLocal="1" simplifyDrawingHints="1" autoRefreshTime="0" readOnly="0" geometry="Line" simplifyDrawingTol="1" autoRefreshEnabled="0" simplifyMaxScale="1" wkbType="MultiLineString">
       <extent>
         <xmin>-2038395.83981025964021683</xmin>
         <ymin>3963487.82406435115262866</ymin>
@@ -3071,7 +2787,6 @@ def my_form_open(dialog, layer, feature):
       <layername>majrivers</layername>
       <srs>
         <spatialrefsys>
-          <wkt>PROJCS["NAD27 / Alaska Albers",GEOGCS["NAD27",DATUM["North_American_Datum_1927",SPHEROID["Clarke 1866",6378206.4,294.9786982138982,AUTHORITY["EPSG","7008"]],AUTHORITY["EPSG","6267"]],PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9122"]],AUTHORITY["EPSG","4267"]],PROJECTION["Albers_Conic_Equal_Area"],PARAMETER["standard_parallel_1",55],PARAMETER["standard_parallel_2",65],PARAMETER["latitude_of_center",50],PARAMETER["longitude_of_center",-154],PARAMETER["false_easting",0],PARAMETER["false_northing",0],UNIT["US survey foot",0.3048006096012192,AUTHORITY["EPSG","9003"]],AXIS["X",EAST],AXIS["Y",NORTH],AUTHORITY["EPSG","2964"]]</wkt>
           <proj4>+proj=aea +lat_1=55 +lat_2=65 +lat_0=50 +lon_0=-154 +x_0=0 +y_0=0 +datum=NAD27 +units=us-ft +no_defs</proj4>
           <srsid>932</srsid>
           <srid>2964</srid>
@@ -3094,7 +2809,6 @@ def my_form_open(dialog, layer, feature):
         <encoding></encoding>
         <crs>
           <spatialrefsys>
-            <wkt></wkt>
             <proj4></proj4>
             <srsid>0</srsid>
             <srid>0</srid>
@@ -3102,7 +2816,7 @@ def my_form_open(dialog, layer, feature):
             <description></description>
             <projectionacronym></projectionacronym>
             <ellipsoidacronym></ellipsoidacronym>
-            <geographicflag>false</geographicflag>
+            <geographicflag>true</geographicflag>
           </spatialrefsys>
         </crs>
         <extent/>
@@ -3122,9 +2836,9 @@ def my_form_open(dialog, layer, feature):
         <Removable>1</Removable>
         <Searchable>1</Searchable>
       </flags>
-      <renderer-v2 symbollevels="0" type="singleSymbol" forceraster="0" enableorderby="0">
+      <renderer-v2 type="singleSymbol" symbollevels="0" forceraster="0" enableorderby="0">
         <symbols>
-          <symbol force_rhr="0" name="0" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="0" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -3144,9 +2858,9 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
@@ -3156,59 +2870,30 @@ def my_form_open(dialog, layer, feature):
         <sizescale/>
       </renderer-v2>
       <labeling type="simple">
-        <settings calloutType="simple">
-          <text-style fontSize="11" textOpacity="1" fontFamily="Ubuntu" fontItalic="1" fontCapitals="0" textOrientation="horizontal" fontStrikeout="0" blendMode="0" fieldName="DECRIPTION" previewBkgrdColor="255,255,255,255" fontUnderline="0" fontWordSpacing="0" fontSizeUnit="Point" namedStyle="Bold Italic" fontKerning="1" isExpression="0" useSubstitutions="0" textColor="24,96,185,255" fontSizeMapUnitScale="3x:0,0,0,0,0,0" multilineHeight="1" fontLetterSpacing="0" fontWeight="75">
-            <text-buffer bufferSizeUnits="MM" bufferDraw="0" bufferNoFill="0" bufferColor="255,255,255,255" bufferOpacity="1" bufferBlendMode="0" bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferJoinStyle="64" bufferSize="1"/>
-            <background shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeOpacity="1" shapeSizeX="0" shapeRadiiX="0" shapeSVGFile="" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeOffsetX="0" shapeType="0" shapeBlendMode="0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeJoinStyle="64" shapeDraw="0" shapeSizeUnit="MM" shapeSizeType="0" shapeRotationType="0" shapeRotation="0" shapeOffsetUnit="MM" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeBorderWidthUnit="MM" shapeSizeY="0" shapeBorderWidth="0" shapeRadiiY="0" shapeOffsetY="0" shapeBorderColor="128,128,128,255" shapeRadiiUnit="MM" shapeFillColor="255,255,255,255"/>
-            <shadow shadowDraw="0" shadowOffsetUnit="MM" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowRadiusUnit="MM" shadowScale="100" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowRadiusAlphaOnly="0" shadowBlendMode="6" shadowOffsetAngle="135" shadowOffsetDist="1" shadowOffsetGlobal="1" shadowUnder="0" shadowRadius="1.5" shadowColor="0,0,0,255" shadowOpacity="0.7"/>
-            <dd_properties>
-              <Option type="Map">
-                <Option value="" name="name" type="QString"/>
-                <Option name="properties"/>
-                <Option value="collection" name="type" type="QString"/>
-              </Option>
-            </dd_properties>
+        <settings>
+          <text-style namedStyle="Bold Italic" fieldName="DECRIPTION" fontWeight="75" fontWordSpacing="0" fontSizeUnit="Point" fontItalic="1" fontSizeMapUnitScale="3x:0,0,0,0,0,0" fontCapitals="0" fontFamily="Ubuntu" textColor="24,96,185,255" fontSize="11" fontLetterSpacing="0" previewBkgrdColor="255,255,255,255" fontStrikeout="0" multilineHeight="1" useSubstitutions="0" textOpacity="1" isExpression="0" blendMode="0" fontUnderline="0">
+            <text-buffer bufferDraw="0" bufferNoFill="0" bufferBlendMode="0" bufferSize="1" bufferSizeUnits="MM" bufferColor="255,255,255,255" bufferJoinStyle="64" bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferOpacity="1"/>
+            <background shapeRadiiX="0" shapeSizeUnit="MM" shapeOffsetY="0" shapeRadiiUnit="MM" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeBlendMode="0" shapeRotation="0" shapeSizeX="0" shapeSizeY="0" shapeDraw="0" shapeRadiiY="0" shapeOffsetX="0" shapeRotationType="0" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeOffsetUnit="MM" shapeBorderWidth="0" shapeBorderWidthUnit="MM" shapeJoinStyle="64" shapeBorderColor="128,128,128,255" shapeFillColor="255,255,255,255" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeType="0" shapeSVGFile="" shapeSizeType="0" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeOpacity="1"/>
+            <shadow shadowDraw="0" shadowOffsetGlobal="1" shadowOffsetAngle="135" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowColor="0,0,0,255" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowOpacity="0.7" shadowRadiusUnit="MM" shadowUnder="0" shadowOffsetUnit="MM" shadowScale="100" shadowBlendMode="6" shadowRadiusAlphaOnly="0" shadowOffsetDist="1" shadowRadius="1.5"/>
             <substitutions/>
           </text-style>
-          <text-format addDirectionSymbol="0" rightDirectionSymbol=">" plussign="0" reverseDirectionSymbol="0" placeDirectionSymbol="0" multilineAlign="0" leftDirectionSymbol="&lt;" formatNumbers="0" wrapChar="" autoWrapLength="0" useMaxLineLengthForAutoWrap="1" decimals="0"/>
-          <placement geometryGeneratorEnabled="0" fitInPolygonOnly="0" maxCurvedCharAngleOut="-20" rotationAngle="0" priority="5" geometryGeneratorType="PointGeometry" predefinedPositionOrder="TR,TL,BR,BL,R,L,TSR,BSR" distUnits="MM" repeatDistance="0" xOffset="0" centroidWhole="0" preserveRotation="1" offsetUnits="MapUnit" overrunDistance="0" repeatDistanceMapUnitScale="3x:0,0,0,0,0,0" placement="3" repeatDistanceUnits="MM" labelOffsetMapUnitScale="3x:0,0,0,0,0,0" layerType="UnknownGeometry" distMapUnitScale="3x:0,0,0,0,0,0" yOffset="0" offsetType="0" quadOffset="4" dist="0" overrunDistanceMapUnitScale="3x:0,0,0,0,0,0" placementFlags="10" maxCurvedCharAngleIn="20" overrunDistanceUnit="MM" geometryGenerator="" centroidInside="0"/>
-          <rendering obstacle="1" drawLabels="1" fontMaxPixelSize="10000" maxNumLabels="2000" minFeatureSize="0" scaleVisibility="0" mergeLines="1" scaleMin="1" zIndex="0" fontMinPixelSize="3" upsidedownLabels="0" obstacleType="0" obstacleFactor="1" limitNumLabels="0" labelPerPart="0" scaleMax="10000000" displayAll="1" fontLimitPixelSize="0"/>
+          <text-format formatNumbers="0" useMaxLineLengthForAutoWrap="1" rightDirectionSymbol=">" leftDirectionSymbol="&lt;" wrapChar="" autoWrapLength="0" addDirectionSymbol="0" decimals="0" plussign="0" reverseDirectionSymbol="0" multilineAlign="0" placeDirectionSymbol="0"/>
+          <placement fitInPolygonOnly="0" geometryGenerator="" geometryGeneratorEnabled="0" geometryGeneratorType="PointGeometry" priority="5" repeatDistanceUnits="MM" placementFlags="10" dist="0" maxCurvedCharAngleOut="-20" distUnits="MM" predefinedPositionOrder="TR,TL,BR,BL,R,L,TSR,BSR" repeatDistanceMapUnitScale="3x:0,0,0,0,0,0" labelOffsetMapUnitScale="3x:0,0,0,0,0,0" centroidWhole="0" centroidInside="0" rotationAngle="0" preserveRotation="1" offsetUnits="MapUnit" xOffset="0" quadOffset="4" distMapUnitScale="3x:0,0,0,0,0,0" repeatDistance="0" yOffset="0" placement="3" maxCurvedCharAngleIn="20" layerType="UnknownGeometry" offsetType="0"/>
+          <rendering obstacle="1" minFeatureSize="0" labelPerPart="0" maxNumLabels="2000" upsidedownLabels="0" drawLabels="1" fontMaxPixelSize="10000" fontMinPixelSize="3" scaleMax="10000000" zIndex="0" scaleVisibility="0" fontLimitPixelSize="0" obstacleFactor="1" limitNumLabels="0" mergeLines="1" scaleMin="1" obstacleType="0" displayAll="1"/>
           <dd_properties>
             <Option type="Map">
-              <Option value="" name="name" type="QString"/>
+              <Option value="" type="QString" name="name"/>
               <Option name="properties"/>
-              <Option value="collection" name="type" type="QString"/>
+              <Option value="collection" type="QString" name="type"/>
             </Option>
           </dd_properties>
-          <callout type="simple">
-            <Option type="Map">
-              <Option value="pole_of_inaccessibility" name="anchorPoint" type="QString"/>
-              <Option name="ddProperties" type="Map">
-                <Option value="" name="name" type="QString"/>
-                <Option name="properties"/>
-                <Option value="collection" name="type" type="QString"/>
-              </Option>
-              <Option value="false" name="drawToAllParts" type="bool"/>
-              <Option value="0" name="enabled" type="QString"/>
-              <Option value="&lt;symbol force_rhr=&quot;0&quot; name=&quot;symbol&quot; clip_to_extent=&quot;1&quot; alpha=&quot;1&quot; type=&quot;line&quot;>&lt;layer enabled=&quot;1&quot; pass=&quot;0&quot; class=&quot;SimpleLine&quot; locked=&quot;0&quot;>&lt;prop k=&quot;capstyle&quot; v=&quot;square&quot;/>&lt;prop k=&quot;customdash&quot; v=&quot;5;2&quot;/>&lt;prop k=&quot;customdash_map_unit_scale&quot; v=&quot;3x:0,0,0,0,0,0&quot;/>&lt;prop k=&quot;customdash_unit&quot; v=&quot;MM&quot;/>&lt;prop k=&quot;draw_inside_polygon&quot; v=&quot;0&quot;/>&lt;prop k=&quot;joinstyle&quot; v=&quot;bevel&quot;/>&lt;prop k=&quot;line_color&quot; v=&quot;60,60,60,255&quot;/>&lt;prop k=&quot;line_style&quot; v=&quot;solid&quot;/>&lt;prop k=&quot;line_width&quot; v=&quot;0.3&quot;/>&lt;prop k=&quot;line_width_unit&quot; v=&quot;MM&quot;/>&lt;prop k=&quot;offset&quot; v=&quot;0&quot;/>&lt;prop k=&quot;offset_map_unit_scale&quot; v=&quot;3x:0,0,0,0,0,0&quot;/>&lt;prop k=&quot;offset_unit&quot; v=&quot;MM&quot;/>&lt;prop k=&quot;ring_filter&quot; v=&quot;0&quot;/>&lt;prop k=&quot;use_custom_dash&quot; v=&quot;0&quot;/>&lt;prop k=&quot;width_map_unit_scale&quot; v=&quot;3x:0,0,0,0,0,0&quot;/>&lt;data_defined_properties>&lt;Option type=&quot;Map&quot;>&lt;Option value=&quot;&quot; name=&quot;name&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;properties&quot;/>&lt;Option value=&quot;collection&quot; name=&quot;type&quot; type=&quot;QString&quot;/>&lt;/Option>&lt;/data_defined_properties>&lt;/layer>&lt;/symbol>" name="lineSymbol" type="QString"/>
-              <Option value="0" name="minLength" type="double"/>
-              <Option value="3x:0,0,0,0,0,0" name="minLengthMapUnitScale" type="QString"/>
-              <Option value="MM" name="minLengthUnit" type="QString"/>
-              <Option value="0" name="offsetFromAnchor" type="double"/>
-              <Option value="3x:0,0,0,0,0,0" name="offsetFromAnchorMapUnitScale" type="QString"/>
-              <Option value="MM" name="offsetFromAnchorUnit" type="QString"/>
-              <Option value="0" name="offsetFromLabel" type="double"/>
-              <Option value="3x:0,0,0,0,0,0" name="offsetFromLabelMapUnitScale" type="QString"/>
-              <Option value="MM" name="offsetFromLabelUnit" type="QString"/>
-            </Option>
-          </callout>
         </settings>
       </labeling>
       <customproperties/>
       <blendMode>0</blendMode>
       <featureBlendMode>0</featureBlendMode>
       <layerOpacity>1</layerOpacity>
-      <geometryOptions removeDuplicateNodes="0" geometryPrecision="0">
+      <geometryOptions geometryPrecision="0" removeDuplicateNodes="0">
         <activeChecks/>
         <checkConfiguration/>
       </geometryOptions>
@@ -3217,8 +2902,8 @@ def my_form_open(dialog, layer, feature):
           <editWidget type="TextEdit">
             <config>
               <Option type="Map">
-                <Option value="0" name="IsMultiline" type="QString"/>
-                <Option value="0" name="UseHtml" type="QString"/>
+                <Option value="0" type="QString" name="IsMultiline"/>
+                <Option value="0" type="QString" name="UseHtml"/>
               </Option>
             </config>
           </editWidget>
@@ -3227,8 +2912,8 @@ def my_form_open(dialog, layer, feature):
           <editWidget type="TextEdit">
             <config>
               <Option type="Map">
-                <Option value="0" name="IsMultiline" type="QString"/>
-                <Option value="0" name="UseHtml" type="QString"/>
+                <Option value="0" type="QString" name="IsMultiline"/>
+                <Option value="0" type="QString" name="UseHtml"/>
               </Option>
             </config>
           </editWidget>
@@ -3237,34 +2922,34 @@ def my_form_open(dialog, layer, feature):
           <editWidget type="TextEdit">
             <config>
               <Option type="Map">
-                <Option value="0" name="IsMultiline" type="QString"/>
-                <Option value="0" name="UseHtml" type="QString"/>
+                <Option value="0" type="QString" name="IsMultiline"/>
+                <Option value="0" type="QString" name="UseHtml"/>
               </Option>
             </config>
           </editWidget>
         </field>
       </fieldConfiguration>
       <aliases>
-        <alias name="" index="0" field="cat"/>
-        <alias name="" index="1" field="LENGTH"/>
-        <alias name="" index="2" field="DECRIPTION"/>
+        <alias name="" field="cat" index="0"/>
+        <alias name="" field="LENGTH" index="1"/>
+        <alias name="" field="DECRIPTION" index="2"/>
       </aliases>
       <excludeAttributesWMS/>
       <excludeAttributesWFS/>
       <defaults>
-        <default field="cat" applyOnUpdate="0" expression=""/>
-        <default field="LENGTH" applyOnUpdate="0" expression=""/>
-        <default field="DECRIPTION" applyOnUpdate="0" expression=""/>
+        <default field="cat" expression="" applyOnUpdate="0"/>
+        <default field="LENGTH" expression="" applyOnUpdate="0"/>
+        <default field="DECRIPTION" expression="" applyOnUpdate="0"/>
       </defaults>
       <constraints>
-        <constraint field="cat" notnull_strength="0" constraints="0" unique_strength="0" exp_strength="0"/>
-        <constraint field="LENGTH" notnull_strength="0" constraints="0" unique_strength="0" exp_strength="0"/>
-        <constraint field="DECRIPTION" notnull_strength="0" constraints="0" unique_strength="0" exp_strength="0"/>
+        <constraint notnull_strength="0" exp_strength="0" field="cat" unique_strength="0" constraints="0"/>
+        <constraint notnull_strength="0" exp_strength="0" field="LENGTH" unique_strength="0" constraints="0"/>
+        <constraint notnull_strength="0" exp_strength="0" field="DECRIPTION" unique_strength="0" constraints="0"/>
       </constraints>
       <constraintExpressions>
-        <constraint field="cat" exp="" desc=""/>
-        <constraint field="LENGTH" exp="" desc=""/>
-        <constraint field="DECRIPTION" exp="" desc=""/>
+        <constraint field="cat" desc="" exp=""/>
+        <constraint field="LENGTH" desc="" exp=""/>
+        <constraint field="DECRIPTION" desc="" exp=""/>
       </constraintExpressions>
       <expressionfields/>
       <attributeactions/>
@@ -3275,7 +2960,6 @@ def my_form_open(dialog, layer, feature):
         <rowstyles/>
         <fieldstyles/>
       </conditionalstyles>
-      <storedexpressions/>
       <editform tolerant="1"></editform>
       <editforminit/>
       <editforminitcodesource>0</editforminitcodesource>
@@ -3289,7 +2973,7 @@ def my_form_open(dialog, layer, feature):
       <previewExpression>"cat"</previewExpression>
       <mapTip></mapTip>
     </maplayer>
-    <maplayer simplifyDrawingHints="1" simplifyAlgorithm="0" labelsEnabled="1" refreshOnNotifyMessage="" wkbType="Point" minScale="1e+8" readOnly="0" refreshOnNotifyEnabled="0" type="vector" maxScale="-4.65661e-10" simplifyLocal="1" autoRefreshTime="0" hasScaleBasedVisibilityFlag="0" geometry="Point" styleCategories="AllStyleCategories" autoRefreshEnabled="0" simplifyDrawingTol="1" simplifyMaxScale="1">
+    <maplayer refreshOnNotifyEnabled="0" refreshOnNotifyMessage="" styleCategories="AllStyleCategories" maxScale="-4.65661e-10" hasScaleBasedVisibilityFlag="0" simplifyAlgorithm="0" type="vector" labelsEnabled="1" minScale="1e+8" simplifyLocal="1" simplifyDrawingHints="1" autoRefreshTime="0" readOnly="0" geometry="Point" simplifyDrawingTol="1" autoRefreshEnabled="0" simplifyMaxScale="1" wkbType="Point">
       <extent>
         <xmin>-4483330.6510413708165288</xmin>
         <ymin>1404268.91167207201942801</ymin>
@@ -3304,7 +2988,6 @@ def my_form_open(dialog, layer, feature):
       <layername>popp</layername>
       <srs>
         <spatialrefsys>
-          <wkt>PROJCS["NAD27 / Alaska Albers",GEOGCS["NAD27",DATUM["North_American_Datum_1927",SPHEROID["Clarke 1866",6378206.4,294.9786982138982,AUTHORITY["EPSG","7008"]],AUTHORITY["EPSG","6267"]],PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9122"]],AUTHORITY["EPSG","4267"]],PROJECTION["Albers_Conic_Equal_Area"],PARAMETER["standard_parallel_1",55],PARAMETER["standard_parallel_2",65],PARAMETER["latitude_of_center",50],PARAMETER["longitude_of_center",-154],PARAMETER["false_easting",0],PARAMETER["false_northing",0],UNIT["US survey foot",0.3048006096012192,AUTHORITY["EPSG","9003"]],AXIS["X",EAST],AXIS["Y",NORTH],AUTHORITY["EPSG","2964"]]</wkt>
           <proj4>+proj=aea +lat_1=55 +lat_2=65 +lat_0=50 +lon_0=-154 +x_0=0 +y_0=0 +datum=NAD27 +units=us-ft +no_defs</proj4>
           <srsid>932</srsid>
           <srid>2964</srid>
@@ -3327,7 +3010,6 @@ def my_form_open(dialog, layer, feature):
         <encoding></encoding>
         <crs>
           <spatialrefsys>
-            <wkt></wkt>
             <proj4></proj4>
             <srsid>0</srsid>
             <srid>0</srid>
@@ -3335,7 +3017,7 @@ def my_form_open(dialog, layer, feature):
             <description></description>
             <projectionacronym></projectionacronym>
             <ellipsoidacronym></ellipsoidacronym>
-            <geographicflag>false</geographicflag>
+            <geographicflag>true</geographicflag>
           </spatialrefsys>
         </crs>
         <extent/>
@@ -3355,9 +3037,9 @@ def my_form_open(dialog, layer, feature):
         <Removable>1</Removable>
         <Searchable>1</Searchable>
       </flags>
-      <renderer-v2 symbollevels="0" type="singleSymbol" forceraster="0" enableorderby="0">
+      <renderer-v2 type="singleSymbol" symbollevels="0" forceraster="0" enableorderby="0">
         <symbols>
-          <symbol force_rhr="0" name="0" clip_to_extent="1" alpha="1" type="marker">
+          <symbol clip_to_extent="1" force_rhr="0" type="marker" name="0" alpha="1">
             <layer enabled="1" pass="0" class="FontMarker" locked="0">
               <prop k="angle" v="0"/>
               <prop k="chr" v="l"/>
@@ -3378,9 +3060,9 @@ def my_form_open(dialog, layer, feature):
               <prop k="vertical_anchor_point" v="1"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
@@ -3393,7 +3075,7 @@ def my_form_open(dialog, layer, feature):
       <blendMode>0</blendMode>
       <featureBlendMode>0</featureBlendMode>
       <layerOpacity>1</layerOpacity>
-      <geometryOptions removeDuplicateNodes="0" geometryPrecision="0">
+      <geometryOptions geometryPrecision="0" removeDuplicateNodes="0">
         <activeChecks/>
         <checkConfiguration/>
       </geometryOptions>
@@ -3402,8 +3084,8 @@ def my_form_open(dialog, layer, feature):
           <editWidget type="TextEdit">
             <config>
               <Option type="Map">
-                <Option value="0" name="IsMultiline" type="QString"/>
-                <Option value="0" name="UseHtml" type="QString"/>
+                <Option value="0" type="QString" name="IsMultiline"/>
+                <Option value="0" type="QString" name="UseHtml"/>
               </Option>
             </config>
           </editWidget>
@@ -3412,8 +3094,8 @@ def my_form_open(dialog, layer, feature):
           <editWidget type="TextEdit">
             <config>
               <Option type="Map">
-                <Option value="0" name="IsMultiline" type="QString"/>
-                <Option value="0" name="UseHtml" type="QString"/>
+                <Option value="0" type="QString" name="IsMultiline"/>
+                <Option value="0" type="QString" name="UseHtml"/>
               </Option>
             </config>
           </editWidget>
@@ -3422,8 +3104,8 @@ def my_form_open(dialog, layer, feature):
           <editWidget type="TextEdit">
             <config>
               <Option type="Map">
-                <Option value="0" name="IsMultiline" type="QString"/>
-                <Option value="0" name="UseHtml" type="QString"/>
+                <Option value="0" type="QString" name="IsMultiline"/>
+                <Option value="0" type="QString" name="UseHtml"/>
               </Option>
             </config>
           </editWidget>
@@ -3432,43 +3114,41 @@ def my_form_open(dialog, layer, feature):
           <editWidget type="TextEdit">
             <config>
               <Option type="Map">
-                <Option value="0" name="IsMultiline" type="QString"/>
-                <Option value="0" name="UseHtml" type="QString"/>
+                <Option value="0" type="QString" name="IsMultiline"/>
+                <Option value="0" type="QString" name="UseHtml"/>
               </Option>
             </config>
           </editWidget>
         </field>
       </fieldConfiguration>
       <aliases>
-        <alias name="" index="0" field="cat"/>
-        <alias name="" index="1" field="F_CODEDESC"/>
-        <alias name="" index="2" field="F_CODE"/>
-        <alias name="" index="3" field="TYPE"/>
+        <alias name="" field="cat" index="0"/>
+        <alias name="" field="F_CODEDESC" index="1"/>
+        <alias name="" field="F_CODE" index="2"/>
+        <alias name="" field="TYPE" index="3"/>
       </aliases>
       <excludeAttributesWMS/>
       <excludeAttributesWFS/>
       <defaults>
-        <default field="cat" applyOnUpdate="0" expression=""/>
-        <default field="F_CODEDESC" applyOnUpdate="0" expression=""/>
-        <default field="F_CODE" applyOnUpdate="0" expression=""/>
-        <default field="TYPE" applyOnUpdate="0" expression=""/>
+        <default field="cat" expression="" applyOnUpdate="0"/>
+        <default field="F_CODEDESC" expression="" applyOnUpdate="0"/>
+        <default field="F_CODE" expression="" applyOnUpdate="0"/>
+        <default field="TYPE" expression="" applyOnUpdate="0"/>
       </defaults>
       <constraints>
-        <constraint field="cat" notnull_strength="0" constraints="0" unique_strength="0" exp_strength="0"/>
-        <constraint field="F_CODEDESC" notnull_strength="0" constraints="0" unique_strength="0" exp_strength="0"/>
-        <constraint field="F_CODE" notnull_strength="0" constraints="0" unique_strength="0" exp_strength="0"/>
-        <constraint field="TYPE" notnull_strength="0" constraints="0" unique_strength="0" exp_strength="0"/>
+        <constraint notnull_strength="0" exp_strength="0" field="cat" unique_strength="0" constraints="0"/>
+        <constraint notnull_strength="0" exp_strength="0" field="F_CODEDESC" unique_strength="0" constraints="0"/>
+        <constraint notnull_strength="0" exp_strength="0" field="F_CODE" unique_strength="0" constraints="0"/>
+        <constraint notnull_strength="0" exp_strength="0" field="TYPE" unique_strength="0" constraints="0"/>
       </constraints>
       <constraintExpressions>
-        <constraint field="cat" exp="" desc=""/>
-        <constraint field="F_CODEDESC" exp="" desc=""/>
-        <constraint field="F_CODE" exp="" desc=""/>
-        <constraint field="TYPE" exp="" desc=""/>
+        <constraint field="cat" desc="" exp=""/>
+        <constraint field="F_CODEDESC" desc="" exp=""/>
+        <constraint field="F_CODE" desc="" exp=""/>
+        <constraint field="TYPE" desc="" exp=""/>
       </constraintExpressions>
       <expressionfields/>
-      <attributeactions>
-        <defaultAction value="{00000000-0000-0000-0000-000000000000}" key="Canvas"/>
-      </attributeactions>
+      <attributeactions/>
       <attributetableconfig sortExpression="" actionWidgetStyle="dropDown" sortOrder="0">
         <columns/>
       </attributetableconfig>
@@ -3476,7 +3156,6 @@ def my_form_open(dialog, layer, feature):
         <rowstyles/>
         <fieldstyles/>
       </conditionalstyles>
-      <storedexpressions/>
       <editform tolerant="1"></editform>
       <editforminit/>
       <editforminitcodesource>0</editforminitcodesource>
@@ -3490,7 +3169,7 @@ def my_form_open(dialog, layer, feature):
       <previewExpression>"cat"||', '||"F_CODEDESC"||', '||"F_CODE"||', '||"TYPE"</previewExpression>
       <mapTip></mapTip>
     </maplayer>
-    <maplayer simplifyDrawingHints="0" simplifyAlgorithm="0" labelsEnabled="1" refreshOnNotifyMessage="" wkbType="Point" minScale="1e+8" readOnly="0" refreshOnNotifyEnabled="0" type="vector" maxScale="-4.65661e-10" simplifyLocal="1" autoRefreshTime="0" hasScaleBasedVisibilityFlag="0" geometry="Point" styleCategories="AllStyleCategories" autoRefreshEnabled="0" simplifyDrawingTol="1" simplifyMaxScale="1">
+    <maplayer refreshOnNotifyEnabled="0" refreshOnNotifyMessage="" styleCategories="AllStyleCategories" maxScale="-4.65661e-10" hasScaleBasedVisibilityFlag="0" simplifyAlgorithm="0" type="vector" labelsEnabled="1" minScale="1e+8" simplifyLocal="1" simplifyDrawingHints="0" autoRefreshTime="0" readOnly="0" geometry="Point" simplifyDrawingTol="1" autoRefreshEnabled="0" simplifyMaxScale="1" wkbType="Point">
       <extent>
         <xmin>-4483330.6510413708165288</xmin>
         <ymin>1404268.91167207201942801</ymin>
@@ -3506,7 +3185,6 @@ def my_form_open(dialog, layer, feature):
       <layername>popp copy</layername>
       <srs>
         <spatialrefsys>
-          <wkt>PROJCS["NAD27 / Alaska Albers",GEOGCS["NAD27",DATUM["North_American_Datum_1927",SPHEROID["Clarke 1866",6378206.4,294.9786982138982,AUTHORITY["EPSG","7008"]],AUTHORITY["EPSG","6267"]],PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9122"]],AUTHORITY["EPSG","4267"]],PROJECTION["Albers_Conic_Equal_Area"],PARAMETER["standard_parallel_1",55],PARAMETER["standard_parallel_2",65],PARAMETER["latitude_of_center",50],PARAMETER["longitude_of_center",-154],PARAMETER["false_easting",0],PARAMETER["false_northing",0],UNIT["US survey foot",0.3048006096012192,AUTHORITY["EPSG","9003"]],AXIS["X",EAST],AXIS["Y",NORTH],AUTHORITY["EPSG","2964"]]</wkt>
           <proj4>+proj=aea +lat_1=55 +lat_2=65 +lat_0=50 +lon_0=-154 +x_0=0 +y_0=0 +datum=NAD27 +units=us-ft +no_defs</proj4>
           <srsid>932</srsid>
           <srid>2964</srid>
@@ -3529,7 +3207,6 @@ def my_form_open(dialog, layer, feature):
         <encoding></encoding>
         <crs>
           <spatialrefsys>
-            <wkt></wkt>
             <proj4></proj4>
             <srsid>0</srsid>
             <srid>0</srid>
@@ -3537,7 +3214,7 @@ def my_form_open(dialog, layer, feature):
             <description></description>
             <projectionacronym></projectionacronym>
             <ellipsoidacronym></ellipsoidacronym>
-            <geographicflag>false</geographicflag>
+            <geographicflag>true</geographicflag>
           </spatialrefsys>
         </crs>
         <extent/>
@@ -3557,8 +3234,8 @@ def my_form_open(dialog, layer, feature):
         <Removable>1</Removable>
         <Searchable>1</Searchable>
       </flags>
-      <renderer-v2 radius_map_unit_scale="3x:0,0,0,0,0,0" quality="3" max_value="0" type="heatmapRenderer" forceraster="0" radius_unit="0" weight_expression="" enableorderby="0" radius="10">
-        <colorramp name="[source]" type="gradient">
+      <renderer-v2 type="heatmapRenderer" quality="3" radius="10" forceraster="0" radius_map_unit_scale="3x:0,0,0,0,0,0" weight_expression="" max_value="0" radius_unit="0" enableorderby="0">
+        <colorramp type="gradient" name="[source]">
           <prop k="color1" v="252,251,253,255"/>
           <prop k="color2" v="63,0,125,255"/>
           <prop k="discrete" v="0"/>
@@ -3567,34 +3244,34 @@ def my_form_open(dialog, layer, feature):
         </colorramp>
       </renderer-v2>
       <customproperties>
-        <property value="_fields_" key="variableNames"/>
-        <property value="" key="variableValues"/>
+        <property key="variableNames" value="_fields_"/>
+        <property key="variableValues" value=""/>
       </customproperties>
       <blendMode>0</blendMode>
       <featureBlendMode>0</featureBlendMode>
       <layerOpacity>1</layerOpacity>
-      <SingleCategoryDiagramRenderer diagramType="Pie" attributeLegend="1">
-        <DiagramCategory backgroundAlpha="255" sizeScale="3x:0,0,0,0,0,0" opacity="1" scaleBasedVisibility="0" width="15" backgroundColor="#ffffff" minScaleDenominator="-4.65661e-10" rotationOffset="270" minimumSize="0" penAlpha="255" lineSizeScale="3x:0,0,0,0,0,0" scaleDependency="Area" penWidth="0" barWidth="5" height="15" labelPlacementMethod="XHeight" lineSizeType="MM" diagramOrientation="Up" enabled="0" sizeType="MM" penColor="#000000" maxScaleDenominator="1e+8">
+      <SingleCategoryDiagramRenderer attributeLegend="1" diagramType="Pie">
+        <DiagramCategory minScaleDenominator="-4.65661e-10" diagramOrientation="Up" backgroundColor="#ffffff" penWidth="0" barWidth="5" penColor="#000000" opacity="1" maxScaleDenominator="1e+8" rotationOffset="270" scaleBasedVisibility="0" penAlpha="255" scaleDependency="Area" labelPlacementMethod="XHeight" enabled="0" width="15" sizeType="MM" lineSizeScale="3x:0,0,0,0,0,0" height="15" lineSizeType="MM" backgroundAlpha="255" sizeScale="3x:0,0,0,0,0,0" minimumSize="0">
           <fontProperties description="Ubuntu,11,-1,5,50,0,0,0,0,0" style=""/>
-          <attribute field="" label="" color="#000000"/>
+          <attribute label="" color="#000000" field=""/>
         </DiagramCategory>
       </SingleCategoryDiagramRenderer>
-      <DiagramLayerSettings priority="0" obstacle="0" zIndex="0" showAll="1" placement="0" dist="0" linePlacementFlags="10">
+      <DiagramLayerSettings showAll="1" priority="0" placement="0" linePlacementFlags="10" zIndex="0" dist="0" obstacle="0">
         <properties>
           <Option type="Map">
-            <Option value="" name="name" type="QString"/>
-            <Option name="properties" type="Map">
-              <Option name="show" type="Map">
-                <Option value="true" name="active" type="bool"/>
-                <Option value="cat" name="field" type="QString"/>
-                <Option value="2" name="type" type="int"/>
+            <Option value="" type="QString" name="name"/>
+            <Option type="Map" name="properties">
+              <Option type="Map" name="show">
+                <Option value="true" type="bool" name="active"/>
+                <Option value="cat" type="QString" name="field"/>
+                <Option value="2" type="int" name="type"/>
               </Option>
             </Option>
-            <Option value="collection" name="type" type="QString"/>
+            <Option value="collection" type="QString" name="type"/>
           </Option>
         </properties>
       </DiagramLayerSettings>
-      <geometryOptions removeDuplicateNodes="0" geometryPrecision="0">
+      <geometryOptions geometryPrecision="0" removeDuplicateNodes="0">
         <activeChecks/>
         <checkConfiguration/>
       </geometryOptions>
@@ -3603,8 +3280,8 @@ def my_form_open(dialog, layer, feature):
           <editWidget type="TextEdit">
             <config>
               <Option type="Map">
-                <Option value="0" name="IsMultiline" type="QString"/>
-                <Option value="0" name="UseHtml" type="QString"/>
+                <Option value="0" type="QString" name="IsMultiline"/>
+                <Option value="0" type="QString" name="UseHtml"/>
               </Option>
             </config>
           </editWidget>
@@ -3613,8 +3290,8 @@ def my_form_open(dialog, layer, feature):
           <editWidget type="TextEdit">
             <config>
               <Option type="Map">
-                <Option value="0" name="IsMultiline" type="QString"/>
-                <Option value="0" name="UseHtml" type="QString"/>
+                <Option value="0" type="QString" name="IsMultiline"/>
+                <Option value="0" type="QString" name="UseHtml"/>
               </Option>
             </config>
           </editWidget>
@@ -3623,8 +3300,8 @@ def my_form_open(dialog, layer, feature):
           <editWidget type="TextEdit">
             <config>
               <Option type="Map">
-                <Option value="0" name="IsMultiline" type="QString"/>
-                <Option value="0" name="UseHtml" type="QString"/>
+                <Option value="0" type="QString" name="IsMultiline"/>
+                <Option value="0" type="QString" name="UseHtml"/>
               </Option>
             </config>
           </editWidget>
@@ -3633,42 +3310,42 @@ def my_form_open(dialog, layer, feature):
           <editWidget type="TextEdit">
             <config>
               <Option type="Map">
-                <Option value="0" name="IsMultiline" type="QString"/>
-                <Option value="0" name="UseHtml" type="QString"/>
+                <Option value="0" type="QString" name="IsMultiline"/>
+                <Option value="0" type="QString" name="UseHtml"/>
               </Option>
             </config>
           </editWidget>
         </field>
       </fieldConfiguration>
       <aliases>
-        <alias name="" index="0" field="cat"/>
-        <alias name="" index="1" field="F_CODEDESC"/>
-        <alias name="" index="2" field="F_CODE"/>
-        <alias name="" index="3" field="TYPE"/>
+        <alias name="" field="cat" index="0"/>
+        <alias name="" field="F_CODEDESC" index="1"/>
+        <alias name="" field="F_CODE" index="2"/>
+        <alias name="" field="TYPE" index="3"/>
       </aliases>
       <excludeAttributesWMS/>
       <excludeAttributesWFS/>
       <defaults>
-        <default field="cat" applyOnUpdate="0" expression=""/>
-        <default field="F_CODEDESC" applyOnUpdate="0" expression=""/>
-        <default field="F_CODE" applyOnUpdate="0" expression=""/>
-        <default field="TYPE" applyOnUpdate="0" expression=""/>
+        <default field="cat" expression="" applyOnUpdate="0"/>
+        <default field="F_CODEDESC" expression="" applyOnUpdate="0"/>
+        <default field="F_CODE" expression="" applyOnUpdate="0"/>
+        <default field="TYPE" expression="" applyOnUpdate="0"/>
       </defaults>
       <constraints>
-        <constraint field="cat" notnull_strength="0" constraints="0" unique_strength="0" exp_strength="0"/>
-        <constraint field="F_CODEDESC" notnull_strength="0" constraints="0" unique_strength="0" exp_strength="0"/>
-        <constraint field="F_CODE" notnull_strength="0" constraints="0" unique_strength="0" exp_strength="0"/>
-        <constraint field="TYPE" notnull_strength="0" constraints="0" unique_strength="0" exp_strength="0"/>
+        <constraint notnull_strength="0" exp_strength="0" field="cat" unique_strength="0" constraints="0"/>
+        <constraint notnull_strength="0" exp_strength="0" field="F_CODEDESC" unique_strength="0" constraints="0"/>
+        <constraint notnull_strength="0" exp_strength="0" field="F_CODE" unique_strength="0" constraints="0"/>
+        <constraint notnull_strength="0" exp_strength="0" field="TYPE" unique_strength="0" constraints="0"/>
       </constraints>
       <constraintExpressions>
-        <constraint field="cat" exp="" desc=""/>
-        <constraint field="F_CODEDESC" exp="" desc=""/>
-        <constraint field="F_CODE" exp="" desc=""/>
-        <constraint field="TYPE" exp="" desc=""/>
+        <constraint field="cat" desc="" exp=""/>
+        <constraint field="F_CODEDESC" desc="" exp=""/>
+        <constraint field="F_CODE" desc="" exp=""/>
+        <constraint field="TYPE" desc="" exp=""/>
       </constraintExpressions>
       <expressionfields/>
       <attributeactions>
-        <defaultAction value="{00000000-0000-0000-0000-000000000000}" key="Canvas"/>
+        <defaultAction key="Canvas" value="{00000000-0000-0000-0000-000000000000}"/>
       </attributeactions>
       <attributetableconfig sortExpression="" actionWidgetStyle="dropDown" sortOrder="0">
         <columns/>
@@ -3677,7 +3354,6 @@ def my_form_open(dialog, layer, feature):
         <rowstyles/>
         <fieldstyles/>
       </conditionalstyles>
-      <storedexpressions/>
       <editform tolerant="1"></editform>
       <editforminit/>
       <editforminitcodesource>0</editforminitcodesource>
@@ -3707,7 +3383,7 @@ def my_form_open(dialog, layer, feature):
       <previewExpression>"cat"</previewExpression>
       <mapTip></mapTip>
     </maplayer>
-    <maplayer simplifyDrawingHints="1" simplifyAlgorithm="0" labelsEnabled="1" refreshOnNotifyMessage="" wkbType="MultiPolygon" minScale="1e+8" readOnly="0" refreshOnNotifyEnabled="0" type="vector" maxScale="-4.65661e-10" simplifyLocal="1" autoRefreshTime="0" hasScaleBasedVisibilityFlag="0" geometry="Polygon" styleCategories="AllStyleCategories" autoRefreshEnabled="0" simplifyDrawingTol="1" simplifyMaxScale="1">
+    <maplayer refreshOnNotifyEnabled="0" refreshOnNotifyMessage="" styleCategories="AllStyleCategories" maxScale="-4.65661e-10" hasScaleBasedVisibilityFlag="0" simplifyAlgorithm="0" type="vector" labelsEnabled="1" minScale="1e+8" simplifyLocal="1" simplifyDrawingHints="1" autoRefreshTime="0" readOnly="0" geometry="Polygon" simplifyDrawingTol="1" autoRefreshEnabled="0" simplifyMaxScale="1" wkbType="MultiPolygon">
       <extent>
         <xmin>-7117451.88276480510830879</xmin>
         <ymin>1357479.18457806529477239</ymin>
@@ -3722,7 +3398,6 @@ def my_form_open(dialog, layer, feature):
       <layername>regions</layername>
       <srs>
         <spatialrefsys>
-          <wkt>PROJCS["NAD27 / Alaska Albers",GEOGCS["NAD27",DATUM["North_American_Datum_1927",SPHEROID["Clarke 1866",6378206.4,294.9786982138982,AUTHORITY["EPSG","7008"]],AUTHORITY["EPSG","6267"]],PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9122"]],AUTHORITY["EPSG","4267"]],PROJECTION["Albers_Conic_Equal_Area"],PARAMETER["standard_parallel_1",55],PARAMETER["standard_parallel_2",65],PARAMETER["latitude_of_center",50],PARAMETER["longitude_of_center",-154],PARAMETER["false_easting",0],PARAMETER["false_northing",0],UNIT["US survey foot",0.3048006096012192,AUTHORITY["EPSG","9003"]],AXIS["X",EAST],AXIS["Y",NORTH],AUTHORITY["EPSG","2964"]]</wkt>
           <proj4>+proj=aea +lat_1=55 +lat_2=65 +lat_0=50 +lon_0=-154 +x_0=0 +y_0=0 +datum=NAD27 +units=us-ft +no_defs</proj4>
           <srsid>932</srsid>
           <srid>2964</srid>
@@ -3745,7 +3420,6 @@ def my_form_open(dialog, layer, feature):
         <encoding></encoding>
         <crs>
           <spatialrefsys>
-            <wkt></wkt>
             <proj4></proj4>
             <srsid>0</srsid>
             <srid>0</srid>
@@ -3753,7 +3427,7 @@ def my_form_open(dialog, layer, feature):
             <description></description>
             <projectionacronym></projectionacronym>
             <ellipsoidacronym></ellipsoidacronym>
-            <geographicflag>false</geographicflag>
+            <geographicflag>true</geographicflag>
           </spatialrefsys>
         </crs>
         <extent/>
@@ -3773,9 +3447,9 @@ def my_form_open(dialog, layer, feature):
         <Removable>1</Removable>
         <Searchable>1</Searchable>
       </flags>
-      <renderer-v2 symbollevels="0" type="singleSymbol" forceraster="0" enableorderby="0">
+      <renderer-v2 type="singleSymbol" symbollevels="0" forceraster="0" enableorderby="0">
         <symbols>
-          <symbol force_rhr="0" name="0" clip_to_extent="1" alpha="0.32549" type="fill">
+          <symbol clip_to_extent="1" force_rhr="0" type="fill" name="0" alpha="0.32549">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="round"/>
               <prop k="customdash" v="5;2"/>
@@ -3795,9 +3469,9 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
@@ -3807,89 +3481,30 @@ def my_form_open(dialog, layer, feature):
         <sizescale/>
       </renderer-v2>
       <labeling type="simple">
-        <settings calloutType="simple">
-          <text-style fontSize="11" textOpacity="1" fontFamily="Ubuntu" fontItalic="1" fontCapitals="0" textOrientation="horizontal" fontStrikeout="0" blendMode="0" fieldName=" upper(NAME_2)" previewBkgrdColor="255,255,255,255" fontUnderline="0" fontWordSpacing="0" fontSizeUnit="Point" namedStyle="Bold Italic" fontKerning="1" isExpression="1" useSubstitutions="0" textColor="144,144,144,255" fontSizeMapUnitScale="3x:0,0,0,0,0,0" multilineHeight="1" fontLetterSpacing="0" fontWeight="75">
-            <text-buffer bufferSizeUnits="MM" bufferDraw="1" bufferNoFill="0" bufferColor="255,255,255,255" bufferOpacity="0.55" bufferBlendMode="0" bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferJoinStyle="64" bufferSize="1"/>
-            <background shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeOpacity="1" shapeSizeX="0" shapeRadiiX="0" shapeSVGFile="" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeOffsetX="0" shapeType="0" shapeBlendMode="0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeJoinStyle="64" shapeDraw="0" shapeSizeUnit="MM" shapeSizeType="0" shapeRotationType="0" shapeRotation="0" shapeOffsetUnit="MM" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeBorderWidthUnit="MM" shapeSizeY="0" shapeBorderWidth="0" shapeRadiiY="0" shapeOffsetY="0" shapeBorderColor="128,128,128,255" shapeRadiiUnit="MM" shapeFillColor="255,255,255,255">
-              <symbol force_rhr="0" name="markerSymbol" clip_to_extent="1" alpha="1" type="marker">
-                <layer enabled="1" pass="0" class="SimpleMarker" locked="0">
-                  <prop k="angle" v="0"/>
-                  <prop k="color" v="141,90,153,255"/>
-                  <prop k="horizontal_anchor_point" v="1"/>
-                  <prop k="joinstyle" v="bevel"/>
-                  <prop k="name" v="circle"/>
-                  <prop k="offset" v="0,0"/>
-                  <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-                  <prop k="offset_unit" v="MM"/>
-                  <prop k="outline_color" v="35,35,35,255"/>
-                  <prop k="outline_style" v="solid"/>
-                  <prop k="outline_width" v="0"/>
-                  <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-                  <prop k="outline_width_unit" v="MM"/>
-                  <prop k="scale_method" v="diameter"/>
-                  <prop k="size" v="2"/>
-                  <prop k="size_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-                  <prop k="size_unit" v="MM"/>
-                  <prop k="vertical_anchor_point" v="1"/>
-                  <data_defined_properties>
-                    <Option type="Map">
-                      <Option value="" name="name" type="QString"/>
-                      <Option name="properties"/>
-                      <Option value="collection" name="type" type="QString"/>
-                    </Option>
-                  </data_defined_properties>
-                </layer>
-              </symbol>
-            </background>
-            <shadow shadowDraw="0" shadowOffsetUnit="MM" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowRadiusUnit="MM" shadowScale="100" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowRadiusAlphaOnly="0" shadowBlendMode="6" shadowOffsetAngle="135" shadowOffsetDist="1" shadowOffsetGlobal="1" shadowUnder="0" shadowRadius="1.5" shadowColor="0,0,0,255" shadowOpacity="0.7"/>
-            <dd_properties>
-              <Option type="Map">
-                <Option value="" name="name" type="QString"/>
-                <Option name="properties"/>
-                <Option value="collection" name="type" type="QString"/>
-              </Option>
-            </dd_properties>
+        <settings>
+          <text-style namedStyle="Bold Italic" fieldName=" upper(NAME_2)" fontWeight="75" fontWordSpacing="0" fontSizeUnit="Point" fontItalic="1" fontSizeMapUnitScale="3x:0,0,0,0,0,0" fontCapitals="0" fontFamily="Ubuntu" textColor="144,144,144,255" fontSize="11" fontLetterSpacing="0" previewBkgrdColor="255,255,255,255" fontStrikeout="0" multilineHeight="1" useSubstitutions="0" textOpacity="1" isExpression="1" blendMode="0" fontUnderline="0">
+            <text-buffer bufferDraw="1" bufferNoFill="0" bufferBlendMode="0" bufferSize="1" bufferSizeUnits="MM" bufferColor="255,255,255,255" bufferJoinStyle="64" bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferOpacity="0.55"/>
+            <background shapeRadiiX="0" shapeSizeUnit="MM" shapeOffsetY="0" shapeRadiiUnit="MM" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeBlendMode="0" shapeRotation="0" shapeSizeX="0" shapeSizeY="0" shapeDraw="0" shapeRadiiY="0" shapeOffsetX="0" shapeRotationType="0" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeOffsetUnit="MM" shapeBorderWidth="0" shapeBorderWidthUnit="MM" shapeJoinStyle="64" shapeBorderColor="128,128,128,255" shapeFillColor="255,255,255,255" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeType="0" shapeSVGFile="" shapeSizeType="0" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeOpacity="1"/>
+            <shadow shadowDraw="0" shadowOffsetGlobal="1" shadowOffsetAngle="135" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowColor="0,0,0,255" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowOpacity="0.7" shadowRadiusUnit="MM" shadowUnder="0" shadowOffsetUnit="MM" shadowScale="100" shadowBlendMode="6" shadowRadiusAlphaOnly="0" shadowOffsetDist="1" shadowRadius="1.5"/>
             <substitutions/>
           </text-style>
-          <text-format addDirectionSymbol="0" rightDirectionSymbol=">" plussign="0" reverseDirectionSymbol="0" placeDirectionSymbol="0" multilineAlign="0" leftDirectionSymbol="&lt;" formatNumbers="0" wrapChar="" autoWrapLength="0" useMaxLineLengthForAutoWrap="1" decimals="0"/>
-          <placement geometryGeneratorEnabled="0" fitInPolygonOnly="0" maxCurvedCharAngleOut="-20" rotationAngle="0" priority="5" geometryGeneratorType="PointGeometry" predefinedPositionOrder="TR,TL,BR,BL,R,L,TSR,BSR" distUnits="MM" repeatDistance="0" xOffset="0" centroidWhole="0" preserveRotation="1" offsetUnits="MapUnit" overrunDistance="0" repeatDistanceMapUnitScale="3x:0,0,0,0,0,0" placement="0" repeatDistanceUnits="MM" labelOffsetMapUnitScale="3x:0,0,0,0,0,0" layerType="PolygonGeometry" distMapUnitScale="3x:0,0,0,0,0,0" yOffset="0" offsetType="0" quadOffset="4" dist="0" overrunDistanceMapUnitScale="3x:0,0,0,0,0,0" placementFlags="0" maxCurvedCharAngleIn="20" overrunDistanceUnit="MM" geometryGenerator="" centroidInside="0"/>
-          <rendering obstacle="1" drawLabels="1" fontMaxPixelSize="10000" maxNumLabels="2000" minFeatureSize="0" scaleVisibility="0" mergeLines="0" scaleMin="1" zIndex="0" fontMinPixelSize="3" upsidedownLabels="0" obstacleType="0" obstacleFactor="1" limitNumLabels="0" labelPerPart="0" scaleMax="10000000" displayAll="0" fontLimitPixelSize="0"/>
+          <text-format formatNumbers="0" useMaxLineLengthForAutoWrap="1" rightDirectionSymbol=">" leftDirectionSymbol="&lt;" wrapChar="" autoWrapLength="0" addDirectionSymbol="0" decimals="0" plussign="0" reverseDirectionSymbol="0" multilineAlign="0" placeDirectionSymbol="0"/>
+          <placement fitInPolygonOnly="0" geometryGenerator="" geometryGeneratorEnabled="0" geometryGeneratorType="PointGeometry" priority="5" repeatDistanceUnits="MM" placementFlags="0" dist="0" maxCurvedCharAngleOut="-20" distUnits="MM" predefinedPositionOrder="TR,TL,BR,BL,R,L,TSR,BSR" repeatDistanceMapUnitScale="3x:0,0,0,0,0,0" labelOffsetMapUnitScale="3x:0,0,0,0,0,0" centroidWhole="0" centroidInside="0" rotationAngle="0" preserveRotation="1" offsetUnits="MapUnit" xOffset="0" quadOffset="4" distMapUnitScale="3x:0,0,0,0,0,0" repeatDistance="0" yOffset="0" placement="0" maxCurvedCharAngleIn="20" layerType="UnknownGeometry" offsetType="0"/>
+          <rendering obstacle="1" minFeatureSize="0" labelPerPart="0" maxNumLabels="2000" upsidedownLabels="0" drawLabels="1" fontMaxPixelSize="10000" fontMinPixelSize="3" scaleMax="10000000" zIndex="0" scaleVisibility="0" fontLimitPixelSize="0" obstacleFactor="1" limitNumLabels="0" mergeLines="0" scaleMin="1" obstacleType="0" displayAll="0"/>
           <dd_properties>
             <Option type="Map">
-              <Option value="" name="name" type="QString"/>
+              <Option value="" type="QString" name="name"/>
               <Option name="properties"/>
-              <Option value="collection" name="type" type="QString"/>
+              <Option value="collection" type="QString" name="type"/>
             </Option>
           </dd_properties>
-          <callout type="simple">
-            <Option type="Map">
-              <Option value="pole_of_inaccessibility" name="anchorPoint" type="QString"/>
-              <Option name="ddProperties" type="Map">
-                <Option value="" name="name" type="QString"/>
-                <Option name="properties"/>
-                <Option value="collection" name="type" type="QString"/>
-              </Option>
-              <Option value="false" name="drawToAllParts" type="bool"/>
-              <Option value="0" name="enabled" type="QString"/>
-              <Option value="&lt;symbol force_rhr=&quot;0&quot; name=&quot;symbol&quot; clip_to_extent=&quot;1&quot; alpha=&quot;1&quot; type=&quot;line&quot;>&lt;layer enabled=&quot;1&quot; pass=&quot;0&quot; class=&quot;SimpleLine&quot; locked=&quot;0&quot;>&lt;prop k=&quot;capstyle&quot; v=&quot;square&quot;/>&lt;prop k=&quot;customdash&quot; v=&quot;5;2&quot;/>&lt;prop k=&quot;customdash_map_unit_scale&quot; v=&quot;3x:0,0,0,0,0,0&quot;/>&lt;prop k=&quot;customdash_unit&quot; v=&quot;MM&quot;/>&lt;prop k=&quot;draw_inside_polygon&quot; v=&quot;0&quot;/>&lt;prop k=&quot;joinstyle&quot; v=&quot;bevel&quot;/>&lt;prop k=&quot;line_color&quot; v=&quot;60,60,60,255&quot;/>&lt;prop k=&quot;line_style&quot; v=&quot;solid&quot;/>&lt;prop k=&quot;line_width&quot; v=&quot;0.3&quot;/>&lt;prop k=&quot;line_width_unit&quot; v=&quot;MM&quot;/>&lt;prop k=&quot;offset&quot; v=&quot;0&quot;/>&lt;prop k=&quot;offset_map_unit_scale&quot; v=&quot;3x:0,0,0,0,0,0&quot;/>&lt;prop k=&quot;offset_unit&quot; v=&quot;MM&quot;/>&lt;prop k=&quot;ring_filter&quot; v=&quot;0&quot;/>&lt;prop k=&quot;use_custom_dash&quot; v=&quot;0&quot;/>&lt;prop k=&quot;width_map_unit_scale&quot; v=&quot;3x:0,0,0,0,0,0&quot;/>&lt;data_defined_properties>&lt;Option type=&quot;Map&quot;>&lt;Option value=&quot;&quot; name=&quot;name&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;properties&quot;/>&lt;Option value=&quot;collection&quot; name=&quot;type&quot; type=&quot;QString&quot;/>&lt;/Option>&lt;/data_defined_properties>&lt;/layer>&lt;/symbol>" name="lineSymbol" type="QString"/>
-              <Option value="0" name="minLength" type="double"/>
-              <Option value="3x:0,0,0,0,0,0" name="minLengthMapUnitScale" type="QString"/>
-              <Option value="MM" name="minLengthUnit" type="QString"/>
-              <Option value="0" name="offsetFromAnchor" type="double"/>
-              <Option value="3x:0,0,0,0,0,0" name="offsetFromAnchorMapUnitScale" type="QString"/>
-              <Option value="MM" name="offsetFromAnchorUnit" type="QString"/>
-              <Option value="0" name="offsetFromLabel" type="double"/>
-              <Option value="3x:0,0,0,0,0,0" name="offsetFromLabelMapUnitScale" type="QString"/>
-              <Option value="MM" name="offsetFromLabelUnit" type="QString"/>
-            </Option>
-          </callout>
         </settings>
       </labeling>
       <customproperties/>
       <blendMode>0</blendMode>
       <featureBlendMode>0</featureBlendMode>
       <layerOpacity>1</layerOpacity>
-      <geometryOptions removeDuplicateNodes="0" geometryPrecision="0">
+      <geometryOptions geometryPrecision="0" removeDuplicateNodes="0">
         <activeChecks/>
         <checkConfiguration/>
       </geometryOptions>
@@ -3898,8 +3513,8 @@ def my_form_open(dialog, layer, feature):
           <editWidget type="TextEdit">
             <config>
               <Option type="Map">
-                <Option value="0" name="IsMultiline" type="QString"/>
-                <Option value="0" name="UseHtml" type="QString"/>
+                <Option value="0" type="QString" name="IsMultiline"/>
+                <Option value="0" type="QString" name="UseHtml"/>
               </Option>
             </config>
           </editWidget>
@@ -3908,8 +3523,8 @@ def my_form_open(dialog, layer, feature):
           <editWidget type="TextEdit">
             <config>
               <Option type="Map">
-                <Option value="0" name="IsMultiline" type="QString"/>
-                <Option value="0" name="UseHtml" type="QString"/>
+                <Option value="0" type="QString" name="IsMultiline"/>
+                <Option value="0" type="QString" name="UseHtml"/>
               </Option>
             </config>
           </editWidget>
@@ -3918,38 +3533,38 @@ def my_form_open(dialog, layer, feature):
           <editWidget type="TextEdit">
             <config>
               <Option type="Map">
-                <Option value="0" name="IsMultiline" type="QString"/>
-                <Option value="0" name="UseHtml" type="QString"/>
+                <Option value="0" type="QString" name="IsMultiline"/>
+                <Option value="0" type="QString" name="UseHtml"/>
               </Option>
             </config>
           </editWidget>
         </field>
       </fieldConfiguration>
       <aliases>
-        <alias name="" index="0" field="ID"/>
-        <alias name="" index="1" field="NAME_2"/>
-        <alias name="" index="2" field="TYPE_2"/>
+        <alias name="" field="ID" index="0"/>
+        <alias name="" field="NAME_2" index="1"/>
+        <alias name="" field="TYPE_2" index="2"/>
       </aliases>
       <excludeAttributesWMS/>
       <excludeAttributesWFS/>
       <defaults>
-        <default field="ID" applyOnUpdate="0" expression=""/>
-        <default field="NAME_2" applyOnUpdate="0" expression=""/>
-        <default field="TYPE_2" applyOnUpdate="0" expression=""/>
+        <default field="ID" expression="" applyOnUpdate="0"/>
+        <default field="NAME_2" expression="" applyOnUpdate="0"/>
+        <default field="TYPE_2" expression="" applyOnUpdate="0"/>
       </defaults>
       <constraints>
-        <constraint field="ID" notnull_strength="0" constraints="0" unique_strength="0" exp_strength="0"/>
-        <constraint field="NAME_2" notnull_strength="0" constraints="0" unique_strength="0" exp_strength="0"/>
-        <constraint field="TYPE_2" notnull_strength="0" constraints="0" unique_strength="0" exp_strength="0"/>
+        <constraint notnull_strength="0" exp_strength="0" field="ID" unique_strength="0" constraints="0"/>
+        <constraint notnull_strength="0" exp_strength="0" field="NAME_2" unique_strength="0" constraints="0"/>
+        <constraint notnull_strength="0" exp_strength="0" field="TYPE_2" unique_strength="0" constraints="0"/>
       </constraints>
       <constraintExpressions>
-        <constraint field="ID" exp="" desc=""/>
-        <constraint field="NAME_2" exp="" desc=""/>
-        <constraint field="TYPE_2" exp="" desc=""/>
+        <constraint field="ID" desc="" exp=""/>
+        <constraint field="NAME_2" desc="" exp=""/>
+        <constraint field="TYPE_2" desc="" exp=""/>
       </constraintExpressions>
       <expressionfields/>
       <attributeactions>
-        <defaultAction value="{00000000-0000-0000-0000-000000000000}" key="Canvas"/>
+        <defaultAction key="Canvas" value="{00000000-0000-0000-0000-000000000000}"/>
       </attributeactions>
       <attributetableconfig sortExpression="" actionWidgetStyle="dropDown" sortOrder="0">
         <columns/>
@@ -3958,7 +3573,6 @@ def my_form_open(dialog, layer, feature):
         <rowstyles/>
         <fieldstyles/>
       </conditionalstyles>
-      <storedexpressions/>
       <editform tolerant="1"></editform>
       <editforminit/>
       <editforminitcodesource>0</editforminitcodesource>
@@ -3974,12 +3588,12 @@ def my_form_open(dialog, layer, feature):
 &lt;b> Is this place a Borough? &lt;/b> &lt;br> &#xd;
 [% CASE WHEN "TYPE_2"='Borough'THEN'Yes'ELSE'No. It is a '|| "TYPE_2"END%]</mapTip>
     </maplayer>
-    <maplayer simplifyDrawingHints="1" simplifyAlgorithm="0" labelsEnabled="1" refreshOnNotifyMessage="" wkbType="MultiPolygon" minScale="1e+8" readOnly="0" refreshOnNotifyEnabled="0" type="vector" maxScale="-4.65661e-10" simplifyLocal="1" autoRefreshTime="0" hasScaleBasedVisibilityFlag="0" geometry="Polygon" styleCategories="AllStyleCategories" autoRefreshEnabled="0" simplifyDrawingTol="1" simplifyMaxScale="1">
+    <maplayer refreshOnNotifyEnabled="0" refreshOnNotifyMessage="" styleCategories="AllStyleCategories" maxScale="-4.65661e-10" hasScaleBasedVisibilityFlag="0" simplifyAlgorithm="0" type="vector" labelsEnabled="1" minScale="1e+8" simplifyLocal="1" simplifyDrawingHints="1" autoRefreshTime="0" readOnly="0" geometry="Polygon" simplifyDrawingTol="1" autoRefreshEnabled="0" simplifyMaxScale="1" wkbType="MultiPolygon">
       <extent>
-        <xmin>-2104998.76567160896956921</xmin>
-        <ymin>4142198.89317932957783341</ymin>
-        <xmax>-1063678.40792613150551915</xmax>
-        <ymax>4972344.63515423890203238</ymax>
+        <xmin>-7117451.88276480510830879</xmin>
+        <ymin>1357479.18457806529477239</ymin>
+        <xmax>18764433.08787660673260689</xmax>
+        <ymax>9961531.59820250608026981</ymax>
       </extent>
       <id>regions_copy20141115000434943</id>
       <datasource>../../../qgis_sample_data/shapefiles/regions.shp|layerid=0|subset="NAME_2" = 'Wade Hampton'</datasource>
@@ -3989,11 +3603,10 @@ def my_form_open(dialog, layer, feature):
       <layername>regions mask</layername>
       <srs>
         <spatialrefsys>
-          <wkt>PROJCS["unnamed",GEOGCS["Clarke 1866",DATUM["unknown",SPHEROID["clrk66",6378206.4,294.9786982138982],TOWGS84[-10,158,187,0,0,0,0]],PRIMEM["Greenwich",0],UNIT["degree",0.0174532925199433]],PROJECTION["Albers_Conic_Equal_Area"],PARAMETER["standard_parallel_1",55],PARAMETER["standard_parallel_2",65],PARAMETER["latitude_of_center",50],PARAMETER["longitude_of_center",-154],PARAMETER["false_easting",0],PARAMETER["false_northing",0],UNIT["Foot_US",0.3048006096012192]]</wkt>
           <proj4>+proj=aea +lat_1=55 +lat_2=65 +lat_0=50 +lon_0=-154 +x_0=0 +y_0=0 +ellps=clrk66 +towgs84=-10,158,187,0,0,0,0 +units=us-ft +no_defs</proj4>
           <srsid>100025</srsid>
           <srid>0</srid>
-          <authid>:</authid>
+          <authid>USER:100025</authid>
           <description> * Generated CRS (+proj=aea +lat_1=55 +lat_2=65 +lat_0=50 +lon_0=-154 +x_0=0 +y_0=0 +ellps=clrk66 +towgs84=-10,158,187,0,0,0,0 +units=us-ft +no_defs)</description>
           <projectionacronym>aea</projectionacronym>
           <ellipsoidacronym>clrk66</ellipsoidacronym>
@@ -4012,7 +3625,6 @@ def my_form_open(dialog, layer, feature):
         <encoding></encoding>
         <crs>
           <spatialrefsys>
-            <wkt></wkt>
             <proj4></proj4>
             <srsid>0</srsid>
             <srid>0</srid>
@@ -4020,7 +3632,7 @@ def my_form_open(dialog, layer, feature):
             <description></description>
             <projectionacronym></projectionacronym>
             <ellipsoidacronym></ellipsoidacronym>
-            <geographicflag>false</geographicflag>
+            <geographicflag>true</geographicflag>
           </spatialrefsys>
         </crs>
         <extent/>
@@ -4040,10 +3652,10 @@ def my_form_open(dialog, layer, feature):
         <Removable>1</Removable>
         <Searchable>1</Searchable>
       </flags>
-      <renderer-v2 preprocessing="0" type="invertedPolygonRenderer" forceraster="0" enableorderby="0">
-        <renderer-v2 symbollevels="0" type="singleSymbol" forceraster="0" enableorderby="0">
+      <renderer-v2 type="invertedPolygonRenderer" forceraster="0" preprocessing="0" enableorderby="0">
+        <renderer-v2 type="singleSymbol" symbollevels="0" forceraster="0" enableorderby="0">
           <symbols>
-            <symbol force_rhr="0" name="0" clip_to_extent="1" alpha="0.686275" type="fill">
+            <symbol clip_to_extent="1" force_rhr="0" type="fill" name="0" alpha="0.686275">
               <layer enabled="1" pass="0" class="SimpleFill" locked="0">
                 <prop k="border_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
                 <prop k="color" v="255,255,255,255"/>
@@ -4058,9 +3670,9 @@ def my_form_open(dialog, layer, feature):
                 <prop k="style" v="solid"/>
                 <data_defined_properties>
                   <Option type="Map">
-                    <Option value="" name="name" type="QString"/>
+                    <Option value="" type="QString" name="name"/>
                     <Option name="properties"/>
-                    <Option value="collection" name="type" type="QString"/>
+                    <Option value="collection" type="QString" name="type"/>
                   </Option>
                 </data_defined_properties>
               </layer>
@@ -4074,7 +3686,7 @@ def my_form_open(dialog, layer, feature):
       <blendMode>0</blendMode>
       <featureBlendMode>0</featureBlendMode>
       <layerOpacity>1</layerOpacity>
-      <geometryOptions removeDuplicateNodes="0" geometryPrecision="0">
+      <geometryOptions geometryPrecision="0" removeDuplicateNodes="0">
         <activeChecks/>
         <checkConfiguration/>
       </geometryOptions>
@@ -4083,8 +3695,8 @@ def my_form_open(dialog, layer, feature):
           <editWidget type="TextEdit">
             <config>
               <Option type="Map">
-                <Option value="0" name="IsMultiline" type="QString"/>
-                <Option value="0" name="UseHtml" type="QString"/>
+                <Option value="0" type="QString" name="IsMultiline"/>
+                <Option value="0" type="QString" name="UseHtml"/>
               </Option>
             </config>
           </editWidget>
@@ -4093,8 +3705,8 @@ def my_form_open(dialog, layer, feature):
           <editWidget type="TextEdit">
             <config>
               <Option type="Map">
-                <Option value="0" name="IsMultiline" type="QString"/>
-                <Option value="0" name="UseHtml" type="QString"/>
+                <Option value="0" type="QString" name="IsMultiline"/>
+                <Option value="0" type="QString" name="UseHtml"/>
               </Option>
             </config>
           </editWidget>
@@ -4103,34 +3715,34 @@ def my_form_open(dialog, layer, feature):
           <editWidget type="TextEdit">
             <config>
               <Option type="Map">
-                <Option value="0" name="IsMultiline" type="QString"/>
-                <Option value="0" name="UseHtml" type="QString"/>
+                <Option value="0" type="QString" name="IsMultiline"/>
+                <Option value="0" type="QString" name="UseHtml"/>
               </Option>
             </config>
           </editWidget>
         </field>
       </fieldConfiguration>
       <aliases>
-        <alias name="" index="0" field="ID"/>
-        <alias name="" index="1" field="NAME_2"/>
-        <alias name="" index="2" field="TYPE_2"/>
+        <alias name="" field="ID" index="0"/>
+        <alias name="" field="NAME_2" index="1"/>
+        <alias name="" field="TYPE_2" index="2"/>
       </aliases>
       <excludeAttributesWMS/>
       <excludeAttributesWFS/>
       <defaults>
-        <default field="ID" applyOnUpdate="0" expression=""/>
-        <default field="NAME_2" applyOnUpdate="0" expression=""/>
-        <default field="TYPE_2" applyOnUpdate="0" expression=""/>
+        <default field="ID" expression="" applyOnUpdate="0"/>
+        <default field="NAME_2" expression="" applyOnUpdate="0"/>
+        <default field="TYPE_2" expression="" applyOnUpdate="0"/>
       </defaults>
       <constraints>
-        <constraint field="ID" notnull_strength="0" constraints="0" unique_strength="0" exp_strength="0"/>
-        <constraint field="NAME_2" notnull_strength="0" constraints="0" unique_strength="0" exp_strength="0"/>
-        <constraint field="TYPE_2" notnull_strength="0" constraints="0" unique_strength="0" exp_strength="0"/>
+        <constraint notnull_strength="0" exp_strength="0" field="ID" unique_strength="0" constraints="0"/>
+        <constraint notnull_strength="0" exp_strength="0" field="NAME_2" unique_strength="0" constraints="0"/>
+        <constraint notnull_strength="0" exp_strength="0" field="TYPE_2" unique_strength="0" constraints="0"/>
       </constraints>
       <constraintExpressions>
-        <constraint field="ID" exp="" desc=""/>
-        <constraint field="NAME_2" exp="" desc=""/>
-        <constraint field="TYPE_2" exp="" desc=""/>
+        <constraint field="ID" desc="" exp=""/>
+        <constraint field="NAME_2" desc="" exp=""/>
+        <constraint field="TYPE_2" desc="" exp=""/>
       </constraintExpressions>
       <expressionfields/>
       <attributeactions/>
@@ -4141,7 +3753,6 @@ def my_form_open(dialog, layer, feature):
         <rowstyles/>
         <fieldstyles/>
       </conditionalstyles>
-      <storedexpressions/>
       <editform tolerant="1"></editform>
       <editforminit/>
       <editforminitcodesource>0</editforminitcodesource>
@@ -4157,7 +3768,7 @@ def my_form_open(dialog, layer, feature):
 &lt;b> Is this place a Borough? &lt;/b> &lt;br> &#xd;
 [% CASE WHEN "TYPE_2"='Borough'THEN'Yes'ELSE'No. It is a '|| "TYPE_2"END%]</mapTip>
     </maplayer>
-    <maplayer simplifyDrawingHints="1" simplifyAlgorithm="0" labelsEnabled="1" refreshOnNotifyMessage="" wkbType="MultiPolygon" minScale="1e+8" readOnly="0" refreshOnNotifyEnabled="0" type="vector" maxScale="0" simplifyLocal="1" autoRefreshTime="0" hasScaleBasedVisibilityFlag="0" geometry="Polygon" styleCategories="AllStyleCategories" autoRefreshEnabled="0" simplifyDrawingTol="1" simplifyMaxScale="1">
+    <maplayer refreshOnNotifyEnabled="0" refreshOnNotifyMessage="" styleCategories="AllStyleCategories" maxScale="0" hasScaleBasedVisibilityFlag="0" simplifyAlgorithm="0" type="vector" labelsEnabled="1" minScale="1e+8" simplifyLocal="1" simplifyDrawingHints="1" autoRefreshTime="0" readOnly="0" geometry="Polygon" simplifyDrawingTol="1" autoRefreshEnabled="0" simplifyMaxScale="1" wkbType="MultiPolygon">
       <extent>
         <xmin>-7117451.88276480510830879</xmin>
         <ymin>1357479.18457806529477239</ymin>
@@ -4172,11 +3783,10 @@ def my_form_open(dialog, layer, feature):
       <layername>regions copy</layername>
       <srs>
         <spatialrefsys>
-          <wkt>PROJCS["unnamed",GEOGCS["Clarke 1866",DATUM["unknown",SPHEROID["clrk66",6378206.4,294.9786982138982],TOWGS84[-10,158,187,0,0,0,0]],PRIMEM["Greenwich",0],UNIT["degree",0.0174532925199433]],PROJECTION["Albers_Conic_Equal_Area"],PARAMETER["standard_parallel_1",55],PARAMETER["standard_parallel_2",65],PARAMETER["latitude_of_center",50],PARAMETER["longitude_of_center",-154],PARAMETER["false_easting",0],PARAMETER["false_northing",0],UNIT["Foot_US",0.3048006096012192]]</wkt>
           <proj4>+proj=aea +lat_1=55 +lat_2=65 +lat_0=50 +lon_0=-154 +x_0=0 +y_0=0 +ellps=clrk66 +towgs84=-10,158,187,0,0,0,0 +units=us-ft +no_defs</proj4>
           <srsid>100025</srsid>
           <srid>0</srid>
-          <authid>:</authid>
+          <authid>USER:100025</authid>
           <description> * Generated CRS (+proj=aea +lat_1=55 +lat_2=65 +lat_0=50 +lon_0=-154 +x_0=0 +y_0=0 +ellps=clrk66 +towgs84=-10,158,187,0,0,0,0 +units=us-ft +no_defs)</description>
           <projectionacronym>aea</projectionacronym>
           <ellipsoidacronym>clrk66</ellipsoidacronym>
@@ -4204,7 +3814,6 @@ def my_form_open(dialog, layer, feature):
         <encoding></encoding>
         <crs>
           <spatialrefsys>
-            <wkt></wkt>
             <proj4></proj4>
             <srsid>0</srsid>
             <srid>0</srid>
@@ -4212,11 +3821,11 @@ def my_form_open(dialog, layer, feature):
             <description></description>
             <projectionacronym></projectionacronym>
             <ellipsoidacronym></ellipsoidacronym>
-            <geographicflag>false</geographicflag>
+            <geographicflag>true</geographicflag>
           </spatialrefsys>
         </crs>
         <extent>
-          <spatial maxy="0" crs="" minz="0" minx="0" maxx="0" maxz="0" miny="0" dimensions="2"/>
+          <spatial maxx="0" crs="" dimensions="2" minz="0" maxy="0" minx="0" miny="0" maxz="0"/>
           <temporal>
             <period>
               <start></start>
@@ -4234,10 +3843,10 @@ def my_form_open(dialog, layer, feature):
       <map-layer-style-manager current="NoLabel">
         <map-layer-style name="NoLabel"/>
         <map-layer-style name="showAreaLabel">
-          <qgis simplifyDrawingHints="1" simplifyLocal="1" labelsEnabled="1" hasScaleBasedVisibilityFlag="0" maxScale="0" minScale="1e+8" readOnly="0" simplifyAlgorithm="0" simplifyMaxScale="1" version="3.3.0-Master" simplifyDrawingTol="1">
-            <renderer-v2 symbollevels="0" type="singleSymbol" forceraster="0" enableorderby="0">
+          <qgis simplifyDrawingHints="1" simplifyLocal="1" minScale="1e+8" maxScale="0" version="3.3.0-Master" simplifyMaxScale="1" readOnly="0" labelsEnabled="1" hasScaleBasedVisibilityFlag="0" simplifyDrawingTol="1" simplifyAlgorithm="0">
+            <renderer-v2 type="singleSymbol" symbollevels="0" forceraster="0" enableorderby="0">
               <symbols>
-                <symbol name="0" clip_to_extent="1" alpha="0.32549" type="fill">
+                <symbol clip_to_extent="1" type="fill" name="0" alpha="0.32549">
                   <layer enabled="1" pass="0" class="SimpleLine" locked="0">
                     <prop k="capstyle" v="round"/>
                     <prop k="customdash" v="5;2"/>
@@ -4256,9 +3865,9 @@ def my_form_open(dialog, layer, feature):
                     <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
                     <data_defined_properties>
                       <Option type="Map">
-                        <Option value="" name="name" type="QString"/>
+                        <Option value="" type="QString" name="name"/>
                         <Option name="properties"/>
-                        <Option value="collection" name="type" type="QString"/>
+                        <Option value="collection" type="QString" name="type"/>
                       </Option>
                     </data_defined_properties>
                   </layer>
@@ -4269,20 +3878,20 @@ def my_form_open(dialog, layer, feature):
             </renderer-v2>
             <labeling type="simple">
               <settings>
-                <text-style fontSize="11" textOpacity="1" fontFamily="MS Shell Dlg 2" fontCapitals="0" fontItalic="1" fontStrikeout="0" blendMode="0" fieldName="'Region: ' || &quot;NAME_2&quot; || '\nArea: ' ||&#xa;format_number($area/1000000,3) || ' km²'" previewBkgrdColor="#ffffff" fontUnderline="0" fontWordSpacing="0" fontSizeUnit="Point" namedStyle="Bold Italic" isExpression="1" useSubstitutions="0" textColor="144,144,144,255" fontSizeMapUnitScale="3x:0,0,0,0,0,0" multilineHeight="1" fontLetterSpacing="0" fontWeight="75">
-                  <text-buffer bufferSizeUnits="MM" bufferDraw="1" bufferNoFill="0" bufferColor="255,255,255,255" bufferOpacity="0.55" bufferBlendMode="0" bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferJoinStyle="64" bufferSize="1"/>
-                  <background shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeOpacity="1" shapeSizeX="0" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeRadiiX="0" shapeSVGFile="" shapeOffsetX="0" shapeType="0" shapeBlendMode="0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeJoinStyle="64" shapeDraw="0" shapeSizeUnit="MM" shapeSizeType="0" shapeRotationType="0" shapeRotation="0" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeOffsetUnit="MM" shapeBorderWidthUnit="MM" shapeSizeY="0" shapeBorderWidth="0" shapeRadiiY="0" shapeBorderColor="128,128,128,255" shapeOffsetY="0" shapeFillColor="255,255,255,255" shapeRadiiUnit="MM"/>
-                  <shadow shadowOffsetUnit="MM" shadowDraw="0" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowRadiusUnit="MM" shadowScale="100" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowRadiusAlphaOnly="0" shadowBlendMode="6" shadowOffsetAngle="135" shadowOffsetDist="1" shadowOffsetGlobal="1" shadowColor="0,0,0,255" shadowRadius="1.5" shadowUnder="0" shadowOpacity="0.7"/>
+                <text-style namedStyle="Bold Italic" fieldName="'Region: ' || &quot;NAME_2&quot; || '\nArea: ' ||&#xa;format_number($area/1000000,3) || ' km²'" fontWeight="75" fontWordSpacing="0" fontSizeUnit="Point" fontItalic="1" fontSizeMapUnitScale="3x:0,0,0,0,0,0" fontCapitals="0" fontFamily="MS Shell Dlg 2" textColor="144,144,144,255" fontSize="11" fontLetterSpacing="0" previewBkgrdColor="#ffffff" fontStrikeout="0" multilineHeight="1" useSubstitutions="0" textOpacity="1" isExpression="1" blendMode="0" fontUnderline="0">
+                  <text-buffer bufferDraw="1" bufferNoFill="0" bufferBlendMode="0" bufferSize="1" bufferSizeUnits="MM" bufferColor="255,255,255,255" bufferJoinStyle="64" bufferOpacity="0.55" bufferSizeMapUnitScale="3x:0,0,0,0,0,0"/>
+                  <background shapeRadiiX="0" shapeSizeUnit="MM" shapeOffsetY="0" shapeRadiiUnit="MM" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeBlendMode="0" shapeRotation="0" shapeSizeX="0" shapeSizeY="0" shapeDraw="0" shapeRadiiY="0" shapeOffsetX="0" shapeRotationType="0" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeOffsetUnit="MM" shapeBorderWidth="0" shapeJoinStyle="64" shapeBorderWidthUnit="MM" shapeBorderColor="128,128,128,255" shapeFillColor="255,255,255,255" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeType="0" shapeSVGFile="" shapeSizeType="0" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeOpacity="1"/>
+                  <shadow shadowDraw="0" shadowOffsetGlobal="1" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowColor="0,0,0,255" shadowOffsetAngle="135" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowOpacity="0.7" shadowRadiusUnit="MM" shadowUnder="0" shadowOffsetUnit="MM" shadowScale="100" shadowBlendMode="6" shadowRadiusAlphaOnly="0" shadowRadius="1.5" shadowOffsetDist="1"/>
                   <substitutions/>
                 </text-style>
-                <text-format addDirectionSymbol="0" rightDirectionSymbol=">" plussign="0" reverseDirectionSymbol="0" placeDirectionSymbol="0" multilineAlign="0" leftDirectionSymbol="&lt;" formatNumbers="0" wrapChar="" decimals="0"/>
-                <placement fitInPolygonOnly="0" maxCurvedCharAngleOut="-20" rotationAngle="0" priority="5" predefinedPositionOrder="TR,TL,BR,BL,R,L,TSR,BSR" distUnits="MM" repeatDistance="0" xOffset="0" centroidWhole="0" preserveRotation="1" offsetUnits="MapUnit" repeatDistanceMapUnitScale="3x:0,0,0,0,0,0" placement="0" repeatDistanceUnits="MM" labelOffsetMapUnitScale="3x:0,0,0,0,0,0" distMapUnitScale="3x:0,0,0,0,0,0" yOffset="0" offsetType="0" quadOffset="4" dist="0" maxCurvedCharAngleIn="20" placementFlags="0" centroidInside="0"/>
-                <rendering obstacle="1" drawLabels="1" fontMaxPixelSize="10000" maxNumLabels="2000" minFeatureSize="0" scaleVisibility="0" mergeLines="0" scaleMin="1" zIndex="0" fontMinPixelSize="3" upsidedownLabels="0" obstacleType="0" obstacleFactor="1" limitNumLabels="0" labelPerPart="0" scaleMax="10000000" displayAll="0" fontLimitPixelSize="0"/>
+                <text-format formatNumbers="0" rightDirectionSymbol=">" leftDirectionSymbol="&lt;" wrapChar="" addDirectionSymbol="0" decimals="0" plussign="0" reverseDirectionSymbol="0" multilineAlign="0" placeDirectionSymbol="0"/>
+                <placement fitInPolygonOnly="0" priority="5" repeatDistanceUnits="MM" placementFlags="0" maxCurvedCharAngleOut="-20" dist="0" distUnits="MM" predefinedPositionOrder="TR,TL,BR,BL,R,L,TSR,BSR" repeatDistanceMapUnitScale="3x:0,0,0,0,0,0" labelOffsetMapUnitScale="3x:0,0,0,0,0,0" centroidWhole="0" centroidInside="0" rotationAngle="0" preserveRotation="1" offsetUnits="MapUnit" xOffset="0" quadOffset="4" distMapUnitScale="3x:0,0,0,0,0,0" repeatDistance="0" yOffset="0" placement="0" maxCurvedCharAngleIn="20" offsetType="0"/>
+                <rendering obstacle="1" minFeatureSize="0" labelPerPart="0" maxNumLabels="2000" upsidedownLabels="0" drawLabels="1" fontMaxPixelSize="10000" fontMinPixelSize="3" scaleMax="10000000" zIndex="0" scaleVisibility="0" fontLimitPixelSize="0" obstacleFactor="1" limitNumLabels="0" mergeLines="0" scaleMin="1" obstacleType="0" displayAll="0"/>
                 <dd_properties>
                   <Option type="Map">
-                    <Option value="" name="name" type="QString"/>
+                    <Option value="" type="QString" name="name"/>
                     <Option name="properties"/>
-                    <Option value="collection" name="type" type="QString"/>
+                    <Option value="collection" type="QString" name="type"/>
                   </Option>
                 </dd_properties>
               </settings>
@@ -4295,18 +3904,18 @@ def my_form_open(dialog, layer, feature):
             <blendMode>0</blendMode>
             <featureBlendMode>0</featureBlendMode>
             <layerOpacity>1</layerOpacity>
-            <SingleCategoryDiagramRenderer diagramType="Histogram" attributeLegend="1">
-              <DiagramCategory backgroundAlpha="255" sizeScale="3x:0,0,0,0,0,0" opacity="1" scaleBasedVisibility="0" width="15" backgroundColor="#ffffff" minScaleDenominator="0" rotationOffset="270" minimumSize="0" penAlpha="255" scaleDependency="Area" lineSizeScale="3x:0,0,0,0,0,0" penWidth="0" barWidth="5" height="15" labelPlacementMethod="XHeight" lineSizeType="MM" diagramOrientation="Up" sizeType="MM" enabled="0" penColor="#000000" maxScaleDenominator="1e+8">
+            <SingleCategoryDiagramRenderer attributeLegend="1" diagramType="Histogram">
+              <DiagramCategory minScaleDenominator="0" diagramOrientation="Up" backgroundColor="#ffffff" penWidth="0" barWidth="5" penColor="#000000" opacity="1" maxScaleDenominator="1e+8" rotationOffset="270" scaleBasedVisibility="0" penAlpha="255" scaleDependency="Area" labelPlacementMethod="XHeight" enabled="0" width="15" sizeType="MM" lineSizeScale="3x:0,0,0,0,0,0" height="15" backgroundAlpha="255" lineSizeType="MM" minimumSize="0" sizeScale="3x:0,0,0,0,0,0">
                 <fontProperties description="Ubuntu,11,-1,5,50,0,0,0,0,0" style=""/>
-                <attribute label="" field="" color="#000000"/>
+                <attribute label="" color="#000000" field=""/>
               </DiagramCategory>
             </SingleCategoryDiagramRenderer>
-            <DiagramLayerSettings priority="0" obstacle="0" zIndex="0" showAll="1" placement="0" dist="0" linePlacementFlags="10">
+            <DiagramLayerSettings showAll="1" priority="0" placement="0" linePlacementFlags="10" zIndex="0" dist="0" obstacle="0">
               <properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </properties>
             </DiagramLayerSettings>
@@ -4315,8 +3924,8 @@ def my_form_open(dialog, layer, feature):
                 <editWidget type="TextEdit">
                   <config>
                     <Option type="Map">
-                      <Option value="0" name="IsMultiline" type="QString"/>
-                      <Option value="0" name="UseHtml" type="QString"/>
+                      <Option value="0" type="QString" name="IsMultiline"/>
+                      <Option value="0" type="QString" name="UseHtml"/>
                     </Option>
                   </config>
                 </editWidget>
@@ -4325,8 +3934,8 @@ def my_form_open(dialog, layer, feature):
                 <editWidget type="TextEdit">
                   <config>
                     <Option type="Map">
-                      <Option value="0" name="IsMultiline" type="QString"/>
-                      <Option value="0" name="UseHtml" type="QString"/>
+                      <Option value="0" type="QString" name="IsMultiline"/>
+                      <Option value="0" type="QString" name="UseHtml"/>
                     </Option>
                   </config>
                 </editWidget>
@@ -4335,8 +3944,8 @@ def my_form_open(dialog, layer, feature):
                 <editWidget type="TextEdit">
                   <config>
                     <Option type="Map">
-                      <Option value="0" name="IsMultiline" type="QString"/>
-                      <Option value="0" name="UseHtml" type="QString"/>
+                      <Option value="0" type="QString" name="IsMultiline"/>
+                      <Option value="0" type="QString" name="UseHtml"/>
                     </Option>
                   </config>
                 </editWidget>
@@ -4344,36 +3953,36 @@ def my_form_open(dialog, layer, feature):
             </fieldConfiguration>
             <geometryOptions geometryPrecision="0" removeDuplicateNodes="0"/>
             <aliases>
-              <alias name="" index="0" field="ID"/>
-              <alias name="" index="1" field="NAME_2"/>
-              <alias name="" index="2" field="TYPE_2"/>
+              <alias name="" field="ID" index="0"/>
+              <alias name="" field="NAME_2" index="1"/>
+              <alias name="" field="TYPE_2" index="2"/>
             </aliases>
             <excludeAttributesWMS/>
             <excludeAttributesWFS/>
             <defaults>
-              <default field="ID" applyOnUpdate="0" expression=""/>
-              <default field="NAME_2" applyOnUpdate="0" expression=""/>
-              <default field="TYPE_2" applyOnUpdate="0" expression=""/>
+              <default field="ID" expression="" applyOnUpdate="0"/>
+              <default field="NAME_2" expression="" applyOnUpdate="0"/>
+              <default field="TYPE_2" expression="" applyOnUpdate="0"/>
             </defaults>
             <constraints>
-              <constraint field="ID" notnull_strength="0" constraints="0" unique_strength="0" exp_strength="0"/>
-              <constraint field="NAME_2" notnull_strength="0" constraints="0" unique_strength="0" exp_strength="0"/>
-              <constraint field="TYPE_2" notnull_strength="0" constraints="0" unique_strength="0" exp_strength="0"/>
+              <constraint notnull_strength="0" exp_strength="0" field="ID" unique_strength="0" constraints="0"/>
+              <constraint notnull_strength="0" exp_strength="0" field="NAME_2" unique_strength="0" constraints="0"/>
+              <constraint notnull_strength="0" exp_strength="0" field="TYPE_2" unique_strength="0" constraints="0"/>
             </constraints>
             <constraintExpressions>
-              <constraint field="ID" exp="" desc=""/>
-              <constraint field="NAME_2" exp="" desc=""/>
-              <constraint field="TYPE_2" exp="" desc=""/>
+              <constraint field="ID" desc="" exp=""/>
+              <constraint field="NAME_2" desc="" exp=""/>
+              <constraint field="TYPE_2" desc="" exp=""/>
             </constraintExpressions>
             <attributeactions>
               <defaultAction value="{00000000-0000-0000-0000-000000000000}" key="Canvas"/>
             </attributeactions>
             <attributetableconfig sortExpression="" actionWidgetStyle="dropDown" sortOrder="0">
               <columns>
-                <column hidden="0" name="ID" type="field" width="-1"/>
-                <column hidden="0" name="NAME_2" type="field" width="-1"/>
-                <column hidden="0" name="TYPE_2" type="field" width="-1"/>
-                <column hidden="1" type="actions" width="-1"/>
+                <column type="field" hidden="0" name="ID" width="-1"/>
+                <column type="field" hidden="0" name="NAME_2" width="-1"/>
+                <column type="field" hidden="0" name="TYPE_2" width="-1"/>
+                <column type="actions" hidden="1" width="-1"/>
               </columns>
             </attributetableconfig>
             <editform tolerant="1"/>
@@ -4421,9 +4030,9 @@ def my_form_open(dialog, layer, feature):
         <Removable>1</Removable>
         <Searchable>1</Searchable>
       </flags>
-      <renderer-v2 symbollevels="0" type="singleSymbol" forceraster="0" enableorderby="0">
+      <renderer-v2 type="singleSymbol" symbollevels="0" forceraster="0" enableorderby="0">
         <symbols>
-          <symbol force_rhr="0" name="0" clip_to_extent="1" alpha="0.32549" type="fill">
+          <symbol clip_to_extent="1" force_rhr="0" type="fill" name="0" alpha="0.32549">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="round"/>
               <prop k="customdash" v="5;2"/>
@@ -4443,9 +4052,9 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
@@ -4455,78 +4064,49 @@ def my_form_open(dialog, layer, feature):
         <sizescale/>
       </renderer-v2>
       <labeling type="simple">
-        <settings calloutType="simple">
-          <text-style fontSize="11" textOpacity="1" fontFamily="Ubuntu" fontItalic="0" fontCapitals="0" textOrientation="horizontal" fontStrikeout="0" blendMode="0" fieldName="NAME_2" previewBkgrdColor="255,255,255,255" fontUnderline="0" fontWordSpacing="0" fontSizeUnit="Point" namedStyle="Normal" fontKerning="1" isExpression="0" useSubstitutions="0" textColor="144,144,144,255" fontSizeMapUnitScale="3x:0,0,0,0,0,0" multilineHeight="1" fontLetterSpacing="0" fontWeight="50">
-            <text-buffer bufferSizeUnits="MM" bufferDraw="1" bufferNoFill="0" bufferColor="255,255,255,255" bufferOpacity="0.55" bufferBlendMode="0" bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferJoinStyle="64" bufferSize="1"/>
-            <background shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeOpacity="1" shapeSizeX="0" shapeRadiiX="0" shapeSVGFile="" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeOffsetX="0" shapeType="0" shapeBlendMode="0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeJoinStyle="64" shapeDraw="0" shapeSizeUnit="MM" shapeSizeType="0" shapeRotationType="0" shapeRotation="0" shapeOffsetUnit="MM" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeBorderWidthUnit="MM" shapeSizeY="0" shapeBorderWidth="0" shapeRadiiY="0" shapeOffsetY="0" shapeBorderColor="128,128,128,255" shapeRadiiUnit="MM" shapeFillColor="255,255,255,255"/>
-            <shadow shadowDraw="0" shadowOffsetUnit="MM" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowRadiusUnit="MM" shadowScale="100" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowRadiusAlphaOnly="0" shadowBlendMode="6" shadowOffsetAngle="135" shadowOffsetDist="1" shadowOffsetGlobal="1" shadowUnder="0" shadowRadius="1.5" shadowColor="0,0,0,255" shadowOpacity="0.7"/>
-            <dd_properties>
-              <Option type="Map">
-                <Option value="" name="name" type="QString"/>
-                <Option name="properties"/>
-                <Option value="collection" name="type" type="QString"/>
-              </Option>
-            </dd_properties>
+        <settings>
+          <text-style namedStyle="Normal" fieldName="NAME_2" fontWeight="50" fontWordSpacing="0" fontSizeUnit="Point" fontItalic="0" fontSizeMapUnitScale="3x:0,0,0,0,0,0" fontCapitals="0" fontFamily="Ubuntu" textColor="144,144,144,255" fontSize="11" fontLetterSpacing="0" previewBkgrdColor="255,255,255,255" fontStrikeout="0" multilineHeight="1" useSubstitutions="0" textOpacity="1" isExpression="0" blendMode="0" fontUnderline="0">
+            <text-buffer bufferDraw="1" bufferNoFill="0" bufferBlendMode="0" bufferSize="1" bufferSizeUnits="MM" bufferColor="255,255,255,255" bufferJoinStyle="64" bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferOpacity="0.55"/>
+            <background shapeRadiiX="0" shapeSizeUnit="MM" shapeOffsetY="0" shapeRadiiUnit="MM" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeBlendMode="0" shapeRotation="0" shapeSizeX="0" shapeSizeY="0" shapeDraw="0" shapeRadiiY="0" shapeOffsetX="0" shapeRotationType="0" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeOffsetUnit="MM" shapeBorderWidth="0" shapeBorderWidthUnit="MM" shapeJoinStyle="64" shapeBorderColor="128,128,128,255" shapeFillColor="255,255,255,255" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeType="0" shapeSVGFile="" shapeSizeType="0" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeOpacity="1"/>
+            <shadow shadowDraw="0" shadowOffsetGlobal="1" shadowOffsetAngle="135" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowColor="0,0,0,255" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowOpacity="0.7" shadowRadiusUnit="MM" shadowUnder="0" shadowOffsetUnit="MM" shadowScale="100" shadowBlendMode="6" shadowRadiusAlphaOnly="0" shadowOffsetDist="1" shadowRadius="1.5"/>
             <substitutions/>
           </text-style>
-          <text-format addDirectionSymbol="0" rightDirectionSymbol=">" plussign="0" reverseDirectionSymbol="0" placeDirectionSymbol="0" multilineAlign="0" leftDirectionSymbol="&lt;" formatNumbers="0" wrapChar="" autoWrapLength="0" useMaxLineLengthForAutoWrap="1" decimals="0"/>
-          <placement geometryGeneratorEnabled="0" fitInPolygonOnly="0" maxCurvedCharAngleOut="-20" rotationAngle="0" priority="5" geometryGeneratorType="PointGeometry" predefinedPositionOrder="TR,TL,BR,BL,R,L,TSR,BSR" distUnits="MM" repeatDistance="0" xOffset="0" centroidWhole="0" preserveRotation="1" offsetUnits="MapUnit" overrunDistance="0" repeatDistanceMapUnitScale="3x:0,0,0,0,0,0" placement="0" repeatDistanceUnits="MM" labelOffsetMapUnitScale="3x:0,0,0,0,0,0" layerType="UnknownGeometry" distMapUnitScale="3x:0,0,0,0,0,0" yOffset="0" offsetType="0" quadOffset="4" dist="0" overrunDistanceMapUnitScale="3x:0,0,0,0,0,0" placementFlags="0" maxCurvedCharAngleIn="20" overrunDistanceUnit="MM" geometryGenerator="" centroidInside="0"/>
-          <rendering obstacle="1" drawLabels="1" fontMaxPixelSize="10000" maxNumLabels="2000" minFeatureSize="0" scaleVisibility="0" mergeLines="0" scaleMin="1" zIndex="0" fontMinPixelSize="3" upsidedownLabels="0" obstacleType="0" obstacleFactor="1" limitNumLabels="0" labelPerPart="0" scaleMax="10000000" displayAll="0" fontLimitPixelSize="0"/>
+          <text-format formatNumbers="0" useMaxLineLengthForAutoWrap="1" rightDirectionSymbol=">" leftDirectionSymbol="&lt;" wrapChar="" autoWrapLength="0" addDirectionSymbol="0" decimals="0" plussign="0" reverseDirectionSymbol="0" multilineAlign="0" placeDirectionSymbol="0"/>
+          <placement fitInPolygonOnly="0" geometryGenerator="" geometryGeneratorEnabled="0" geometryGeneratorType="PointGeometry" priority="5" repeatDistanceUnits="MM" placementFlags="0" dist="0" maxCurvedCharAngleOut="-20" distUnits="MM" predefinedPositionOrder="TR,TL,BR,BL,R,L,TSR,BSR" repeatDistanceMapUnitScale="3x:0,0,0,0,0,0" labelOffsetMapUnitScale="3x:0,0,0,0,0,0" centroidWhole="0" centroidInside="0" rotationAngle="0" preserveRotation="1" offsetUnits="MapUnit" xOffset="0" quadOffset="4" distMapUnitScale="3x:0,0,0,0,0,0" repeatDistance="0" yOffset="0" placement="0" maxCurvedCharAngleIn="20" layerType="UnknownGeometry" offsetType="0"/>
+          <rendering obstacle="1" minFeatureSize="0" labelPerPart="0" maxNumLabels="2000" upsidedownLabels="0" drawLabels="1" fontMaxPixelSize="10000" fontMinPixelSize="3" scaleMax="10000000" zIndex="0" scaleVisibility="0" fontLimitPixelSize="0" obstacleFactor="1" limitNumLabels="0" mergeLines="0" scaleMin="1" obstacleType="0" displayAll="0"/>
           <dd_properties>
             <Option type="Map">
-              <Option value="" name="name" type="QString"/>
+              <Option value="" type="QString" name="name"/>
               <Option name="properties"/>
-              <Option value="collection" name="type" type="QString"/>
+              <Option value="collection" type="QString" name="type"/>
             </Option>
           </dd_properties>
-          <callout type="simple">
-            <Option type="Map">
-              <Option value="pole_of_inaccessibility" name="anchorPoint" type="QString"/>
-              <Option name="ddProperties" type="Map">
-                <Option value="" name="name" type="QString"/>
-                <Option name="properties"/>
-                <Option value="collection" name="type" type="QString"/>
-              </Option>
-              <Option value="false" name="drawToAllParts" type="bool"/>
-              <Option value="0" name="enabled" type="QString"/>
-              <Option value="&lt;symbol force_rhr=&quot;0&quot; name=&quot;symbol&quot; clip_to_extent=&quot;1&quot; alpha=&quot;1&quot; type=&quot;line&quot;>&lt;layer enabled=&quot;1&quot; pass=&quot;0&quot; class=&quot;SimpleLine&quot; locked=&quot;0&quot;>&lt;prop k=&quot;capstyle&quot; v=&quot;square&quot;/>&lt;prop k=&quot;customdash&quot; v=&quot;5;2&quot;/>&lt;prop k=&quot;customdash_map_unit_scale&quot; v=&quot;3x:0,0,0,0,0,0&quot;/>&lt;prop k=&quot;customdash_unit&quot; v=&quot;MM&quot;/>&lt;prop k=&quot;draw_inside_polygon&quot; v=&quot;0&quot;/>&lt;prop k=&quot;joinstyle&quot; v=&quot;bevel&quot;/>&lt;prop k=&quot;line_color&quot; v=&quot;60,60,60,255&quot;/>&lt;prop k=&quot;line_style&quot; v=&quot;solid&quot;/>&lt;prop k=&quot;line_width&quot; v=&quot;0.3&quot;/>&lt;prop k=&quot;line_width_unit&quot; v=&quot;MM&quot;/>&lt;prop k=&quot;offset&quot; v=&quot;0&quot;/>&lt;prop k=&quot;offset_map_unit_scale&quot; v=&quot;3x:0,0,0,0,0,0&quot;/>&lt;prop k=&quot;offset_unit&quot; v=&quot;MM&quot;/>&lt;prop k=&quot;ring_filter&quot; v=&quot;0&quot;/>&lt;prop k=&quot;use_custom_dash&quot; v=&quot;0&quot;/>&lt;prop k=&quot;width_map_unit_scale&quot; v=&quot;3x:0,0,0,0,0,0&quot;/>&lt;data_defined_properties>&lt;Option type=&quot;Map&quot;>&lt;Option value=&quot;&quot; name=&quot;name&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;properties&quot;/>&lt;Option value=&quot;collection&quot; name=&quot;type&quot; type=&quot;QString&quot;/>&lt;/Option>&lt;/data_defined_properties>&lt;/layer>&lt;/symbol>" name="lineSymbol" type="QString"/>
-              <Option value="0" name="minLength" type="double"/>
-              <Option value="3x:0,0,0,0,0,0" name="minLengthMapUnitScale" type="QString"/>
-              <Option value="MM" name="minLengthUnit" type="QString"/>
-              <Option value="0" name="offsetFromAnchor" type="double"/>
-              <Option value="3x:0,0,0,0,0,0" name="offsetFromAnchorMapUnitScale" type="QString"/>
-              <Option value="MM" name="offsetFromAnchorUnit" type="QString"/>
-              <Option value="0" name="offsetFromLabel" type="double"/>
-              <Option value="3x:0,0,0,0,0,0" name="offsetFromLabelMapUnitScale" type="QString"/>
-              <Option value="MM" name="offsetFromLabelUnit" type="QString"/>
-            </Option>
-          </callout>
         </settings>
       </labeling>
       <customproperties>
-        <property value="0" key="embeddedWidgets/count"/>
+        <property key="embeddedWidgets/count" value="0"/>
         <property key="variableNames"/>
         <property key="variableValues"/>
       </customproperties>
       <blendMode>0</blendMode>
       <featureBlendMode>0</featureBlendMode>
       <layerOpacity>1</layerOpacity>
-      <SingleCategoryDiagramRenderer diagramType="Histogram" attributeLegend="1">
-        <DiagramCategory backgroundAlpha="255" sizeScale="3x:0,0,0,0,0,0" opacity="1" scaleBasedVisibility="0" width="15" backgroundColor="#ffffff" minScaleDenominator="0" rotationOffset="270" minimumSize="0" penAlpha="255" lineSizeScale="3x:0,0,0,0,0,0" scaleDependency="Area" penWidth="0" barWidth="5" height="15" labelPlacementMethod="XHeight" lineSizeType="MM" diagramOrientation="Up" enabled="0" sizeType="MM" penColor="#000000" maxScaleDenominator="1e+8">
+      <SingleCategoryDiagramRenderer attributeLegend="1" diagramType="Histogram">
+        <DiagramCategory minScaleDenominator="0" diagramOrientation="Up" backgroundColor="#ffffff" penWidth="0" barWidth="5" penColor="#000000" opacity="1" maxScaleDenominator="1e+8" rotationOffset="270" scaleBasedVisibility="0" penAlpha="255" scaleDependency="Area" labelPlacementMethod="XHeight" enabled="0" width="15" sizeType="MM" lineSizeScale="3x:0,0,0,0,0,0" height="15" lineSizeType="MM" backgroundAlpha="255" sizeScale="3x:0,0,0,0,0,0" minimumSize="0">
           <fontProperties description="Ubuntu,11,-1,5,50,0,0,0,0,0" style=""/>
-          <attribute field="" label="" color="#000000"/>
+          <attribute label="" color="#000000" field=""/>
         </DiagramCategory>
       </SingleCategoryDiagramRenderer>
-      <DiagramLayerSettings priority="0" obstacle="0" zIndex="0" showAll="1" placement="0" dist="0" linePlacementFlags="2">
+      <DiagramLayerSettings showAll="1" priority="0" placement="0" linePlacementFlags="2" zIndex="0" dist="0" obstacle="0">
         <properties>
           <Option type="Map">
-            <Option value="" name="name" type="QString"/>
+            <Option value="" type="QString" name="name"/>
             <Option name="properties"/>
-            <Option value="collection" name="type" type="QString"/>
+            <Option value="collection" type="QString" name="type"/>
           </Option>
         </properties>
       </DiagramLayerSettings>
-      <geometryOptions removeDuplicateNodes="0" geometryPrecision="0">
+      <geometryOptions geometryPrecision="0" removeDuplicateNodes="0">
         <activeChecks/>
         <checkConfiguration/>
       </geometryOptions>
@@ -4535,8 +4115,8 @@ def my_form_open(dialog, layer, feature):
           <editWidget type="TextEdit">
             <config>
               <Option type="Map">
-                <Option value="0" name="IsMultiline" type="QString"/>
-                <Option value="0" name="UseHtml" type="QString"/>
+                <Option value="0" type="QString" name="IsMultiline"/>
+                <Option value="0" type="QString" name="UseHtml"/>
               </Option>
             </config>
           </editWidget>
@@ -4545,8 +4125,8 @@ def my_form_open(dialog, layer, feature):
           <editWidget type="TextEdit">
             <config>
               <Option type="Map">
-                <Option value="0" name="IsMultiline" type="QString"/>
-                <Option value="0" name="UseHtml" type="QString"/>
+                <Option value="0" type="QString" name="IsMultiline"/>
+                <Option value="0" type="QString" name="UseHtml"/>
               </Option>
             </config>
           </editWidget>
@@ -4555,52 +4135,51 @@ def my_form_open(dialog, layer, feature):
           <editWidget type="TextEdit">
             <config>
               <Option type="Map">
-                <Option value="0" name="IsMultiline" type="QString"/>
-                <Option value="0" name="UseHtml" type="QString"/>
+                <Option value="0" type="QString" name="IsMultiline"/>
+                <Option value="0" type="QString" name="UseHtml"/>
               </Option>
             </config>
           </editWidget>
         </field>
       </fieldConfiguration>
       <aliases>
-        <alias name="" index="0" field="ID"/>
-        <alias name="" index="1" field="NAME_2"/>
-        <alias name="" index="2" field="TYPE_2"/>
+        <alias name="" field="ID" index="0"/>
+        <alias name="" field="NAME_2" index="1"/>
+        <alias name="" field="TYPE_2" index="2"/>
       </aliases>
       <excludeAttributesWMS/>
       <excludeAttributesWFS/>
       <defaults>
-        <default field="ID" applyOnUpdate="0" expression=""/>
-        <default field="NAME_2" applyOnUpdate="0" expression=""/>
-        <default field="TYPE_2" applyOnUpdate="0" expression=""/>
+        <default field="ID" expression="" applyOnUpdate="0"/>
+        <default field="NAME_2" expression="" applyOnUpdate="0"/>
+        <default field="TYPE_2" expression="" applyOnUpdate="0"/>
       </defaults>
       <constraints>
-        <constraint field="ID" notnull_strength="0" constraints="0" unique_strength="0" exp_strength="0"/>
-        <constraint field="NAME_2" notnull_strength="0" constraints="0" unique_strength="0" exp_strength="0"/>
-        <constraint field="TYPE_2" notnull_strength="0" constraints="0" unique_strength="0" exp_strength="0"/>
+        <constraint notnull_strength="0" exp_strength="0" field="ID" unique_strength="0" constraints="0"/>
+        <constraint notnull_strength="0" exp_strength="0" field="NAME_2" unique_strength="0" constraints="0"/>
+        <constraint notnull_strength="0" exp_strength="0" field="TYPE_2" unique_strength="0" constraints="0"/>
       </constraints>
       <constraintExpressions>
-        <constraint field="ID" exp="" desc=""/>
-        <constraint field="NAME_2" exp="" desc=""/>
-        <constraint field="TYPE_2" exp="" desc=""/>
+        <constraint field="ID" desc="" exp=""/>
+        <constraint field="NAME_2" desc="" exp=""/>
+        <constraint field="TYPE_2" desc="" exp=""/>
       </constraintExpressions>
       <expressionfields/>
       <attributeactions>
-        <defaultAction value="{00000000-0000-0000-0000-000000000000}" key="Canvas"/>
+        <defaultAction key="Canvas" value="{00000000-0000-0000-0000-000000000000}"/>
       </attributeactions>
       <attributetableconfig sortExpression="" actionWidgetStyle="dropDown" sortOrder="0">
         <columns>
-          <column hidden="0" name="ID" type="field" width="-1"/>
-          <column hidden="0" name="NAME_2" type="field" width="-1"/>
-          <column hidden="0" name="TYPE_2" type="field" width="-1"/>
-          <column hidden="1" type="actions" width="-1"/>
+          <column type="field" name="ID" hidden="0" width="-1"/>
+          <column type="field" name="NAME_2" hidden="0" width="-1"/>
+          <column type="field" name="TYPE_2" hidden="0" width="-1"/>
+          <column type="actions" hidden="1" width="-1"/>
         </columns>
       </attributetableconfig>
       <conditionalstyles>
         <rowstyles/>
         <fieldstyles/>
       </conditionalstyles>
-      <storedexpressions/>
       <editform tolerant="1"></editform>
       <editforminit/>
       <editforminitcodesource>0</editforminitcodesource>
@@ -4640,7 +4219,7 @@ def my_form_open(dialog, layer, feature):
 &lt;b> Is this place a Borough? &lt;/b> &lt;br> &#xd;
 [% CASE WHEN "TYPE_2"='Borough'THEN'Yes'ELSE'No. It is a '|| "TYPE_2"END%]</mapTip>
     </maplayer>
-    <maplayer simplifyDrawingHints="1" simplifyAlgorithm="0" labelsEnabled="1" refreshOnNotifyMessage="" wkbType="MultiLineString" minScale="1e+8" readOnly="0" refreshOnNotifyEnabled="0" type="vector" maxScale="0" simplifyLocal="1" autoRefreshTime="0" hasScaleBasedVisibilityFlag="0" geometry="Line" styleCategories="AllStyleCategories" autoRefreshEnabled="0" simplifyDrawingTol="1" simplifyMaxScale="1">
+    <maplayer refreshOnNotifyEnabled="0" refreshOnNotifyMessage="" styleCategories="AllStyleCategories" maxScale="0" hasScaleBasedVisibilityFlag="0" simplifyAlgorithm="0" type="vector" labelsEnabled="1" minScale="1e+8" simplifyLocal="1" simplifyDrawingHints="1" autoRefreshTime="0" readOnly="0" geometry="Line" simplifyDrawingTol="1" autoRefreshEnabled="0" simplifyMaxScale="1" wkbType="MultiLineString">
       <extent>
         <xmin>-2007180.32812365726567805</xmin>
         <ymin>2451582.79989858577027917</ymin>
@@ -4655,7 +4234,6 @@ def my_form_open(dialog, layer, feature):
       <layername>rivers</layername>
       <srs>
         <spatialrefsys>
-          <wkt>PROJCS["NAD27 / Alaska Albers",GEOGCS["NAD27",DATUM["North_American_Datum_1927",SPHEROID["Clarke 1866",6378206.4,294.9786982138982,AUTHORITY["EPSG","7008"]],AUTHORITY["EPSG","6267"]],PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9122"]],AUTHORITY["EPSG","4267"]],PROJECTION["Albers_Conic_Equal_Area"],PARAMETER["standard_parallel_1",55],PARAMETER["standard_parallel_2",65],PARAMETER["latitude_of_center",50],PARAMETER["longitude_of_center",-154],PARAMETER["false_easting",0],PARAMETER["false_northing",0],UNIT["US survey foot",0.3048006096012192,AUTHORITY["EPSG","9003"]],AXIS["X",EAST],AXIS["Y",NORTH],AUTHORITY["EPSG","2964"]]</wkt>
           <proj4>+proj=aea +lat_1=55 +lat_2=65 +lat_0=50 +lon_0=-154 +x_0=0 +y_0=0 +datum=NAD27 +units=us-ft +no_defs</proj4>
           <srsid>932</srsid>
           <srid>2964</srid>
@@ -4678,7 +4256,6 @@ def my_form_open(dialog, layer, feature):
         <encoding></encoding>
         <crs>
           <spatialrefsys>
-            <wkt></wkt>
             <proj4></proj4>
             <srsid>0</srsid>
             <srid>0</srid>
@@ -4686,7 +4263,7 @@ def my_form_open(dialog, layer, feature):
             <description></description>
             <projectionacronym></projectionacronym>
             <ellipsoidacronym></ellipsoidacronym>
-            <geographicflag>false</geographicflag>
+            <geographicflag>true</geographicflag>
           </spatialrefsys>
         </crs>
         <extent/>
@@ -4706,9 +4283,9 @@ def my_form_open(dialog, layer, feature):
         <Removable>1</Removable>
         <Searchable>1</Searchable>
       </flags>
-      <renderer-v2 symbollevels="0" type="singleSymbol" forceraster="0" enableorderby="0">
+      <renderer-v2 type="singleSymbol" symbollevels="0" forceraster="0" enableorderby="0">
         <symbols>
-          <symbol force_rhr="0" name="0" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="0" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -4728,9 +4305,9 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
@@ -4740,59 +4317,30 @@ def my_form_open(dialog, layer, feature):
         <sizescale/>
       </renderer-v2>
       <labeling type="simple">
-        <settings calloutType="simple">
-          <text-style fontSize="11" textOpacity="1" fontFamily="Ubuntu" fontItalic="1" fontCapitals="2" textOrientation="horizontal" fontStrikeout="0" blendMode="0" fieldName="NAM" previewBkgrdColor="255,255,255,255" fontUnderline="0" fontWordSpacing="5" fontSizeUnit="Point" namedStyle="Bold Italic" fontKerning="1" isExpression="0" useSubstitutions="0" textColor="165,191,221,255" fontSizeMapUnitScale="3x:0,0,0,0,0,0" multilineHeight="1" fontLetterSpacing="0" fontWeight="75">
-            <text-buffer bufferSizeUnits="MM" bufferDraw="0" bufferNoFill="0" bufferColor="255,255,255,255" bufferOpacity="1" bufferBlendMode="0" bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferJoinStyle="64" bufferSize="1"/>
-            <background shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeOpacity="1" shapeSizeX="0" shapeRadiiX="0" shapeSVGFile="" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeOffsetX="0" shapeType="0" shapeBlendMode="0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeJoinStyle="64" shapeDraw="0" shapeSizeUnit="MM" shapeSizeType="0" shapeRotationType="0" shapeRotation="0" shapeOffsetUnit="MM" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeBorderWidthUnit="MM" shapeSizeY="0" shapeBorderWidth="0" shapeRadiiY="0" shapeOffsetY="0" shapeBorderColor="128,128,128,255" shapeRadiiUnit="MM" shapeFillColor="255,255,255,255"/>
-            <shadow shadowDraw="0" shadowOffsetUnit="MM" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowRadiusUnit="MM" shadowScale="100" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowRadiusAlphaOnly="0" shadowBlendMode="6" shadowOffsetAngle="135" shadowOffsetDist="1" shadowOffsetGlobal="1" shadowUnder="0" shadowRadius="1.5" shadowColor="0,0,0,255" shadowOpacity="0.7"/>
-            <dd_properties>
-              <Option type="Map">
-                <Option value="" name="name" type="QString"/>
-                <Option name="properties"/>
-                <Option value="collection" name="type" type="QString"/>
-              </Option>
-            </dd_properties>
+        <settings>
+          <text-style namedStyle="Bold Italic" fieldName="NAM" fontWeight="75" fontWordSpacing="5" fontSizeUnit="Point" fontItalic="1" fontSizeMapUnitScale="3x:0,0,0,0,0,0" fontCapitals="2" fontFamily="Ubuntu" textColor="165,191,221,255" fontSize="11" fontLetterSpacing="0" previewBkgrdColor="255,255,255,255" fontStrikeout="0" multilineHeight="1" useSubstitutions="0" textOpacity="1" isExpression="0" blendMode="0" fontUnderline="0">
+            <text-buffer bufferDraw="0" bufferNoFill="0" bufferBlendMode="0" bufferSize="1" bufferSizeUnits="MM" bufferColor="255,255,255,255" bufferJoinStyle="64" bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferOpacity="1"/>
+            <background shapeRadiiX="0" shapeSizeUnit="MM" shapeOffsetY="0" shapeRadiiUnit="MM" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeBlendMode="0" shapeRotation="0" shapeSizeX="0" shapeSizeY="0" shapeDraw="0" shapeRadiiY="0" shapeOffsetX="0" shapeRotationType="0" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeOffsetUnit="MM" shapeBorderWidth="0" shapeBorderWidthUnit="MM" shapeJoinStyle="64" shapeBorderColor="128,128,128,255" shapeFillColor="255,255,255,255" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeType="0" shapeSVGFile="" shapeSizeType="0" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeOpacity="1"/>
+            <shadow shadowDraw="0" shadowOffsetGlobal="1" shadowOffsetAngle="135" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowColor="0,0,0,255" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowOpacity="0.7" shadowRadiusUnit="MM" shadowUnder="0" shadowOffsetUnit="MM" shadowScale="100" shadowBlendMode="6" shadowRadiusAlphaOnly="0" shadowOffsetDist="1" shadowRadius="1.5"/>
             <substitutions/>
           </text-style>
-          <text-format addDirectionSymbol="0" rightDirectionSymbol=">" plussign="0" reverseDirectionSymbol="0" placeDirectionSymbol="0" multilineAlign="0" leftDirectionSymbol="&lt;" formatNumbers="0" wrapChar="" autoWrapLength="0" useMaxLineLengthForAutoWrap="1" decimals="3"/>
-          <placement geometryGeneratorEnabled="0" fitInPolygonOnly="0" maxCurvedCharAngleOut="-20" rotationAngle="0" priority="5" geometryGeneratorType="PointGeometry" predefinedPositionOrder="TR,TL,BR,BL,R,L,TSR,BSR" distUnits="MM" repeatDistance="0" xOffset="0" centroidWhole="0" preserveRotation="1" offsetUnits="MapUnit" overrunDistance="0" repeatDistanceMapUnitScale="3x:0,0,0,0,0,0" placement="3" repeatDistanceUnits="MM" labelOffsetMapUnitScale="3x:0,0,0,0,0,0" layerType="UnknownGeometry" distMapUnitScale="3x:0,0,0,0,0,0" yOffset="0" offsetType="0" quadOffset="4" dist="1" overrunDistanceMapUnitScale="3x:0,0,0,0,0,0" placementFlags="2" maxCurvedCharAngleIn="20" overrunDistanceUnit="MM" geometryGenerator="" centroidInside="0"/>
-          <rendering obstacle="1" drawLabels="1" fontMaxPixelSize="10000" maxNumLabels="2000" minFeatureSize="0" scaleVisibility="0" mergeLines="1" scaleMin="1" zIndex="0" fontMinPixelSize="3" upsidedownLabels="0" obstacleType="0" obstacleFactor="1" limitNumLabels="0" labelPerPart="0" scaleMax="10000000" displayAll="0" fontLimitPixelSize="0"/>
+          <text-format formatNumbers="0" useMaxLineLengthForAutoWrap="1" rightDirectionSymbol=">" leftDirectionSymbol="&lt;" wrapChar="" autoWrapLength="0" addDirectionSymbol="0" decimals="3" plussign="0" reverseDirectionSymbol="0" multilineAlign="0" placeDirectionSymbol="0"/>
+          <placement fitInPolygonOnly="0" geometryGenerator="" geometryGeneratorEnabled="0" geometryGeneratorType="PointGeometry" priority="5" repeatDistanceUnits="MM" placementFlags="2" dist="1" maxCurvedCharAngleOut="-20" distUnits="MM" predefinedPositionOrder="TR,TL,BR,BL,R,L,TSR,BSR" repeatDistanceMapUnitScale="3x:0,0,0,0,0,0" labelOffsetMapUnitScale="3x:0,0,0,0,0,0" centroidWhole="0" centroidInside="0" rotationAngle="0" preserveRotation="1" offsetUnits="MapUnit" xOffset="0" quadOffset="4" distMapUnitScale="3x:0,0,0,0,0,0" repeatDistance="0" yOffset="0" placement="3" maxCurvedCharAngleIn="20" layerType="UnknownGeometry" offsetType="0"/>
+          <rendering obstacle="1" minFeatureSize="0" labelPerPart="0" maxNumLabels="2000" upsidedownLabels="0" drawLabels="1" fontMaxPixelSize="10000" fontMinPixelSize="3" scaleMax="10000000" zIndex="0" scaleVisibility="0" fontLimitPixelSize="0" obstacleFactor="1" limitNumLabels="0" mergeLines="1" scaleMin="1" obstacleType="0" displayAll="0"/>
           <dd_properties>
             <Option type="Map">
-              <Option value="" name="name" type="QString"/>
+              <Option value="" type="QString" name="name"/>
               <Option name="properties"/>
-              <Option value="collection" name="type" type="QString"/>
+              <Option value="collection" type="QString" name="type"/>
             </Option>
           </dd_properties>
-          <callout type="simple">
-            <Option type="Map">
-              <Option value="pole_of_inaccessibility" name="anchorPoint" type="QString"/>
-              <Option name="ddProperties" type="Map">
-                <Option value="" name="name" type="QString"/>
-                <Option name="properties"/>
-                <Option value="collection" name="type" type="QString"/>
-              </Option>
-              <Option value="false" name="drawToAllParts" type="bool"/>
-              <Option value="0" name="enabled" type="QString"/>
-              <Option value="&lt;symbol force_rhr=&quot;0&quot; name=&quot;symbol&quot; clip_to_extent=&quot;1&quot; alpha=&quot;1&quot; type=&quot;line&quot;>&lt;layer enabled=&quot;1&quot; pass=&quot;0&quot; class=&quot;SimpleLine&quot; locked=&quot;0&quot;>&lt;prop k=&quot;capstyle&quot; v=&quot;square&quot;/>&lt;prop k=&quot;customdash&quot; v=&quot;5;2&quot;/>&lt;prop k=&quot;customdash_map_unit_scale&quot; v=&quot;3x:0,0,0,0,0,0&quot;/>&lt;prop k=&quot;customdash_unit&quot; v=&quot;MM&quot;/>&lt;prop k=&quot;draw_inside_polygon&quot; v=&quot;0&quot;/>&lt;prop k=&quot;joinstyle&quot; v=&quot;bevel&quot;/>&lt;prop k=&quot;line_color&quot; v=&quot;60,60,60,255&quot;/>&lt;prop k=&quot;line_style&quot; v=&quot;solid&quot;/>&lt;prop k=&quot;line_width&quot; v=&quot;0.3&quot;/>&lt;prop k=&quot;line_width_unit&quot; v=&quot;MM&quot;/>&lt;prop k=&quot;offset&quot; v=&quot;0&quot;/>&lt;prop k=&quot;offset_map_unit_scale&quot; v=&quot;3x:0,0,0,0,0,0&quot;/>&lt;prop k=&quot;offset_unit&quot; v=&quot;MM&quot;/>&lt;prop k=&quot;ring_filter&quot; v=&quot;0&quot;/>&lt;prop k=&quot;use_custom_dash&quot; v=&quot;0&quot;/>&lt;prop k=&quot;width_map_unit_scale&quot; v=&quot;3x:0,0,0,0,0,0&quot;/>&lt;data_defined_properties>&lt;Option type=&quot;Map&quot;>&lt;Option value=&quot;&quot; name=&quot;name&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;properties&quot;/>&lt;Option value=&quot;collection&quot; name=&quot;type&quot; type=&quot;QString&quot;/>&lt;/Option>&lt;/data_defined_properties>&lt;/layer>&lt;/symbol>" name="lineSymbol" type="QString"/>
-              <Option value="0" name="minLength" type="double"/>
-              <Option value="3x:0,0,0,0,0,0" name="minLengthMapUnitScale" type="QString"/>
-              <Option value="MM" name="minLengthUnit" type="QString"/>
-              <Option value="0" name="offsetFromAnchor" type="double"/>
-              <Option value="3x:0,0,0,0,0,0" name="offsetFromAnchorMapUnitScale" type="QString"/>
-              <Option value="MM" name="offsetFromAnchorUnit" type="QString"/>
-              <Option value="0" name="offsetFromLabel" type="double"/>
-              <Option value="3x:0,0,0,0,0,0" name="offsetFromLabelMapUnitScale" type="QString"/>
-              <Option value="MM" name="offsetFromLabelUnit" type="QString"/>
-            </Option>
-          </callout>
         </settings>
       </labeling>
       <customproperties/>
       <blendMode>0</blendMode>
       <featureBlendMode>0</featureBlendMode>
       <layerOpacity>1</layerOpacity>
-      <geometryOptions removeDuplicateNodes="0" geometryPrecision="0">
+      <geometryOptions geometryPrecision="0" removeDuplicateNodes="0">
         <activeChecks/>
         <checkConfiguration/>
       </geometryOptions>
@@ -4801,8 +4349,8 @@ def my_form_open(dialog, layer, feature):
           <editWidget type="TextEdit">
             <config>
               <Option type="Map">
-                <Option value="0" name="IsMultiline" type="QString"/>
-                <Option value="0" name="UseHtml" type="QString"/>
+                <Option value="0" type="QString" name="IsMultiline"/>
+                <Option value="0" type="QString" name="UseHtml"/>
               </Option>
             </config>
           </editWidget>
@@ -4811,8 +4359,8 @@ def my_form_open(dialog, layer, feature):
           <editWidget type="TextEdit">
             <config>
               <Option type="Map">
-                <Option value="0" name="IsMultiline" type="QString"/>
-                <Option value="0" name="UseHtml" type="QString"/>
+                <Option value="0" type="QString" name="IsMultiline"/>
+                <Option value="0" type="QString" name="UseHtml"/>
               </Option>
             </config>
           </editWidget>
@@ -4821,8 +4369,8 @@ def my_form_open(dialog, layer, feature):
           <editWidget type="TextEdit">
             <config>
               <Option type="Map">
-                <Option value="0" name="IsMultiline" type="QString"/>
-                <Option value="0" name="UseHtml" type="QString"/>
+                <Option value="0" type="QString" name="IsMultiline"/>
+                <Option value="0" type="QString" name="UseHtml"/>
               </Option>
             </config>
           </editWidget>
@@ -4831,38 +4379,38 @@ def my_form_open(dialog, layer, feature):
           <editWidget type="TextEdit">
             <config>
               <Option type="Map">
-                <Option value="0" name="IsMultiline" type="QString"/>
-                <Option value="0" name="UseHtml" type="QString"/>
+                <Option value="0" type="QString" name="IsMultiline"/>
+                <Option value="0" type="QString" name="UseHtml"/>
               </Option>
             </config>
           </editWidget>
         </field>
       </fieldConfiguration>
       <aliases>
-        <alias name="" index="0" field="cat"/>
-        <alias name="" index="1" field="F_CODEDESC"/>
-        <alias name="" index="2" field="NAM"/>
-        <alias name="" index="3" field="F_CODE"/>
+        <alias name="" field="cat" index="0"/>
+        <alias name="" field="F_CODEDESC" index="1"/>
+        <alias name="" field="NAM" index="2"/>
+        <alias name="" field="F_CODE" index="3"/>
       </aliases>
       <excludeAttributesWMS/>
       <excludeAttributesWFS/>
       <defaults>
-        <default field="cat" applyOnUpdate="0" expression=""/>
-        <default field="F_CODEDESC" applyOnUpdate="0" expression=""/>
-        <default field="NAM" applyOnUpdate="0" expression=""/>
-        <default field="F_CODE" applyOnUpdate="0" expression=""/>
+        <default field="cat" expression="" applyOnUpdate="0"/>
+        <default field="F_CODEDESC" expression="" applyOnUpdate="0"/>
+        <default field="NAM" expression="" applyOnUpdate="0"/>
+        <default field="F_CODE" expression="" applyOnUpdate="0"/>
       </defaults>
       <constraints>
-        <constraint field="cat" notnull_strength="0" constraints="0" unique_strength="0" exp_strength="0"/>
-        <constraint field="F_CODEDESC" notnull_strength="0" constraints="0" unique_strength="0" exp_strength="0"/>
-        <constraint field="NAM" notnull_strength="0" constraints="0" unique_strength="0" exp_strength="0"/>
-        <constraint field="F_CODE" notnull_strength="0" constraints="0" unique_strength="0" exp_strength="0"/>
+        <constraint notnull_strength="0" exp_strength="0" field="cat" unique_strength="0" constraints="0"/>
+        <constraint notnull_strength="0" exp_strength="0" field="F_CODEDESC" unique_strength="0" constraints="0"/>
+        <constraint notnull_strength="0" exp_strength="0" field="NAM" unique_strength="0" constraints="0"/>
+        <constraint notnull_strength="0" exp_strength="0" field="F_CODE" unique_strength="0" constraints="0"/>
       </constraints>
       <constraintExpressions>
-        <constraint field="cat" exp="" desc=""/>
-        <constraint field="F_CODEDESC" exp="" desc=""/>
-        <constraint field="NAM" exp="" desc=""/>
-        <constraint field="F_CODE" exp="" desc=""/>
+        <constraint field="cat" desc="" exp=""/>
+        <constraint field="F_CODEDESC" desc="" exp=""/>
+        <constraint field="NAM" desc="" exp=""/>
+        <constraint field="F_CODE" desc="" exp=""/>
       </constraintExpressions>
       <expressionfields/>
       <attributeactions/>
@@ -4873,7 +4421,6 @@ def my_form_open(dialog, layer, feature):
         <rowstyles/>
         <fieldstyles/>
       </conditionalstyles>
-      <storedexpressions/>
       <editform tolerant="1"></editform>
       <editforminit/>
       <editforminitcodesource>0</editforminitcodesource>
@@ -4887,7 +4434,7 @@ def my_form_open(dialog, layer, feature):
       <previewExpression>cat</previewExpression>
       <mapTip></mapTip>
     </maplayer>
-    <maplayer simplifyDrawingHints="1" simplifyAlgorithm="0" labelsEnabled="1" refreshOnNotifyMessage="" wkbType="MultiLineString" minScale="1e+8" readOnly="0" refreshOnNotifyEnabled="0" type="vector" maxScale="-4.65661e-10" simplifyLocal="1" autoRefreshTime="0" hasScaleBasedVisibilityFlag="0" geometry="Line" styleCategories="AllStyleCategories" autoRefreshEnabled="0" simplifyDrawingTol="1" simplifyMaxScale="1">
+    <maplayer refreshOnNotifyEnabled="0" refreshOnNotifyMessage="" styleCategories="AllStyleCategories" maxScale="-4.65661e-10" hasScaleBasedVisibilityFlag="0" simplifyAlgorithm="0" type="vector" labelsEnabled="1" minScale="1e+8" simplifyLocal="1" simplifyDrawingHints="1" autoRefreshTime="0" readOnly="0" geometry="Line" simplifyDrawingTol="1" autoRefreshEnabled="0" simplifyMaxScale="1" wkbType="MultiLineString">
       <extent>
         <xmin>-2007180.32812365726567805</xmin>
         <ymin>2451582.79989858577027917</ymin>
@@ -4902,7 +4449,6 @@ def my_form_open(dialog, layer, feature):
       <layername>rivers</layername>
       <srs>
         <spatialrefsys>
-          <wkt>PROJCS["NAD27 / Alaska Albers",GEOGCS["NAD27",DATUM["North_American_Datum_1927",SPHEROID["Clarke 1866",6378206.4,294.9786982138982,AUTHORITY["EPSG","7008"]],AUTHORITY["EPSG","6267"]],PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9122"]],AUTHORITY["EPSG","4267"]],PROJECTION["Albers_Conic_Equal_Area"],PARAMETER["standard_parallel_1",55],PARAMETER["standard_parallel_2",65],PARAMETER["latitude_of_center",50],PARAMETER["longitude_of_center",-154],PARAMETER["false_easting",0],PARAMETER["false_northing",0],UNIT["US survey foot",0.3048006096012192,AUTHORITY["EPSG","9003"]],AXIS["X",EAST],AXIS["Y",NORTH],AUTHORITY["EPSG","2964"]]</wkt>
           <proj4>+proj=aea +lat_1=55 +lat_2=65 +lat_0=50 +lon_0=-154 +x_0=0 +y_0=0 +datum=NAD27 +units=us-ft +no_defs</proj4>
           <srsid>932</srsid>
           <srid>2964</srid>
@@ -4925,7 +4471,6 @@ def my_form_open(dialog, layer, feature):
         <encoding></encoding>
         <crs>
           <spatialrefsys>
-            <wkt></wkt>
             <proj4></proj4>
             <srsid>0</srsid>
             <srid>0</srid>
@@ -4933,7 +4478,7 @@ def my_form_open(dialog, layer, feature):
             <description></description>
             <projectionacronym></projectionacronym>
             <ellipsoidacronym></ellipsoidacronym>
-            <geographicflag>false</geographicflag>
+            <geographicflag>true</geographicflag>
           </spatialrefsys>
         </crs>
         <extent/>
@@ -4953,9 +4498,9 @@ def my_form_open(dialog, layer, feature):
         <Removable>1</Removable>
         <Searchable>1</Searchable>
       </flags>
-      <renderer-v2 symbollevels="0" type="singleSymbol" forceraster="0" enableorderby="0">
+      <renderer-v2 type="singleSymbol" symbollevels="0" forceraster="0" enableorderby="0">
         <symbols>
-          <symbol force_rhr="0" name="0" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="0" alpha="1">
             <layer enabled="1" pass="0" class="MarkerLine" locked="0">
               <prop k="average_angle_length" v="4"/>
               <prop k="average_angle_map_unit_scale" v="3x:0,0,0,0,0,0"/>
@@ -4974,12 +4519,12 @@ def my_form_open(dialog, layer, feature):
               <prop k="rotate" v="1"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
-              <symbol force_rhr="0" name="@0@0" clip_to_extent="1" alpha="1" type="marker">
+              <symbol clip_to_extent="1" force_rhr="0" type="marker" name="@0@0" alpha="1">
                 <layer enabled="1" pass="0" class="SimpleMarker" locked="0">
                   <prop k="angle" v="0"/>
                   <prop k="color" v="255,0,0,255"/>
@@ -5001,9 +4546,9 @@ def my_form_open(dialog, layer, feature):
                   <prop k="vertical_anchor_point" v="1"/>
                   <data_defined_properties>
                     <Option type="Map">
-                      <Option value="" name="name" type="QString"/>
+                      <Option value="" type="QString" name="name"/>
                       <Option name="properties"/>
-                      <Option value="collection" name="type" type="QString"/>
+                      <Option value="collection" type="QString" name="type"/>
                     </Option>
                   </data_defined_properties>
                 </layer>
@@ -5015,83 +4560,54 @@ def my_form_open(dialog, layer, feature):
         <sizescale/>
       </renderer-v2>
       <labeling type="simple">
-        <settings calloutType="simple">
-          <text-style fontSize="11" textOpacity="1" fontFamily="Ubuntu" fontItalic="1" fontCapitals="2" textOrientation="horizontal" fontStrikeout="0" blendMode="0" fieldName="NAM" previewBkgrdColor="255,255,255,255" fontUnderline="0" fontWordSpacing="5" fontSizeUnit="Point" namedStyle="Bold Italic" fontKerning="1" isExpression="0" useSubstitutions="0" textColor="0,87,168,255" fontSizeMapUnitScale="3x:0,0,0,0,0,0" multilineHeight="1" fontLetterSpacing="0" fontWeight="75">
-            <text-buffer bufferSizeUnits="MM" bufferDraw="0" bufferNoFill="0" bufferColor="255,255,255,255" bufferOpacity="1" bufferBlendMode="0" bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferJoinStyle="64" bufferSize="1"/>
-            <background shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeOpacity="1" shapeSizeX="0" shapeRadiiX="0" shapeSVGFile="" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeOffsetX="0" shapeType="0" shapeBlendMode="0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeJoinStyle="64" shapeDraw="0" shapeSizeUnit="MM" shapeSizeType="0" shapeRotationType="0" shapeRotation="0" shapeOffsetUnit="MM" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeBorderWidthUnit="MM" shapeSizeY="0" shapeBorderWidth="0" shapeRadiiY="0" shapeOffsetY="0" shapeBorderColor="128,128,128,255" shapeRadiiUnit="MM" shapeFillColor="255,255,255,255"/>
-            <shadow shadowDraw="0" shadowOffsetUnit="MM" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowRadiusUnit="MM" shadowScale="100" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowRadiusAlphaOnly="0" shadowBlendMode="6" shadowOffsetAngle="135" shadowOffsetDist="1" shadowOffsetGlobal="1" shadowUnder="0" shadowRadius="1.5" shadowColor="0,0,0,255" shadowOpacity="0.7"/>
-            <dd_properties>
-              <Option type="Map">
-                <Option value="" name="name" type="QString"/>
-                <Option name="properties"/>
-                <Option value="collection" name="type" type="QString"/>
-              </Option>
-            </dd_properties>
+        <settings>
+          <text-style namedStyle="Bold Italic" fieldName="NAM" fontWeight="75" fontWordSpacing="5" fontSizeUnit="Point" fontItalic="1" fontSizeMapUnitScale="3x:0,0,0,0,0,0" fontCapitals="2" fontFamily="Ubuntu" textColor="0,87,168,255" fontSize="11" fontLetterSpacing="0" previewBkgrdColor="255,255,255,255" fontStrikeout="0" multilineHeight="1" useSubstitutions="0" textOpacity="1" isExpression="0" blendMode="0" fontUnderline="0">
+            <text-buffer bufferDraw="0" bufferNoFill="0" bufferBlendMode="0" bufferSize="1" bufferSizeUnits="MM" bufferColor="255,255,255,255" bufferJoinStyle="64" bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferOpacity="1"/>
+            <background shapeRadiiX="0" shapeSizeUnit="MM" shapeOffsetY="0" shapeRadiiUnit="MM" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeBlendMode="0" shapeRotation="0" shapeSizeX="0" shapeSizeY="0" shapeDraw="0" shapeRadiiY="0" shapeOffsetX="0" shapeRotationType="0" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeOffsetUnit="MM" shapeBorderWidth="0" shapeBorderWidthUnit="MM" shapeJoinStyle="64" shapeBorderColor="128,128,128,255" shapeFillColor="255,255,255,255" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeType="0" shapeSVGFile="" shapeSizeType="0" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeOpacity="1"/>
+            <shadow shadowDraw="0" shadowOffsetGlobal="1" shadowOffsetAngle="135" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowColor="0,0,0,255" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowOpacity="0.7" shadowRadiusUnit="MM" shadowUnder="0" shadowOffsetUnit="MM" shadowScale="100" shadowBlendMode="6" shadowRadiusAlphaOnly="0" shadowOffsetDist="1" shadowRadius="1.5"/>
             <substitutions/>
           </text-style>
-          <text-format addDirectionSymbol="0" rightDirectionSymbol=">" plussign="0" reverseDirectionSymbol="0" placeDirectionSymbol="0" multilineAlign="0" leftDirectionSymbol="&lt;" formatNumbers="0" wrapChar="" autoWrapLength="0" useMaxLineLengthForAutoWrap="1" decimals="3"/>
-          <placement geometryGeneratorEnabled="0" fitInPolygonOnly="0" maxCurvedCharAngleOut="-20" rotationAngle="0" priority="5" geometryGeneratorType="PointGeometry" predefinedPositionOrder="TR,TL,BR,BL,R,L,TSR,BSR" distUnits="MM" repeatDistance="0" xOffset="0" centroidWhole="0" preserveRotation="1" offsetUnits="MapUnit" overrunDistance="0" repeatDistanceMapUnitScale="3x:0,0,0,0,0,0" placement="3" repeatDistanceUnits="MM" labelOffsetMapUnitScale="3x:0,0,0,0,0,0" layerType="UnknownGeometry" distMapUnitScale="3x:0,0,0,0,0,0" yOffset="0" offsetType="0" quadOffset="4" dist="1" overrunDistanceMapUnitScale="3x:0,0,0,0,0,0" placementFlags="2" maxCurvedCharAngleIn="20" overrunDistanceUnit="MM" geometryGenerator="" centroidInside="0"/>
-          <rendering obstacle="1" drawLabels="1" fontMaxPixelSize="10000" maxNumLabels="2000" minFeatureSize="0" scaleVisibility="0" mergeLines="1" scaleMin="1" zIndex="0" fontMinPixelSize="3" upsidedownLabels="0" obstacleType="0" obstacleFactor="1" limitNumLabels="0" labelPerPart="0" scaleMax="10000000" displayAll="0" fontLimitPixelSize="0"/>
+          <text-format formatNumbers="0" useMaxLineLengthForAutoWrap="1" rightDirectionSymbol=">" leftDirectionSymbol="&lt;" wrapChar="" autoWrapLength="0" addDirectionSymbol="0" decimals="3" plussign="0" reverseDirectionSymbol="0" multilineAlign="0" placeDirectionSymbol="0"/>
+          <placement fitInPolygonOnly="0" geometryGenerator="" geometryGeneratorEnabled="0" geometryGeneratorType="PointGeometry" priority="5" repeatDistanceUnits="MM" placementFlags="2" dist="1" maxCurvedCharAngleOut="-20" distUnits="MM" predefinedPositionOrder="TR,TL,BR,BL,R,L,TSR,BSR" repeatDistanceMapUnitScale="3x:0,0,0,0,0,0" labelOffsetMapUnitScale="3x:0,0,0,0,0,0" centroidWhole="0" centroidInside="0" rotationAngle="0" preserveRotation="1" offsetUnits="MapUnit" xOffset="0" quadOffset="4" distMapUnitScale="3x:0,0,0,0,0,0" repeatDistance="0" yOffset="0" placement="3" maxCurvedCharAngleIn="20" layerType="UnknownGeometry" offsetType="0"/>
+          <rendering obstacle="1" minFeatureSize="0" labelPerPart="0" maxNumLabels="2000" upsidedownLabels="0" drawLabels="1" fontMaxPixelSize="10000" fontMinPixelSize="3" scaleMax="10000000" zIndex="0" scaleVisibility="0" fontLimitPixelSize="0" obstacleFactor="1" limitNumLabels="0" mergeLines="1" scaleMin="1" obstacleType="0" displayAll="0"/>
           <dd_properties>
             <Option type="Map">
-              <Option value="" name="name" type="QString"/>
+              <Option value="" type="QString" name="name"/>
               <Option name="properties"/>
-              <Option value="collection" name="type" type="QString"/>
+              <Option value="collection" type="QString" name="type"/>
             </Option>
           </dd_properties>
-          <callout type="simple">
-            <Option type="Map">
-              <Option value="pole_of_inaccessibility" name="anchorPoint" type="QString"/>
-              <Option name="ddProperties" type="Map">
-                <Option value="" name="name" type="QString"/>
-                <Option name="properties"/>
-                <Option value="collection" name="type" type="QString"/>
-              </Option>
-              <Option value="false" name="drawToAllParts" type="bool"/>
-              <Option value="0" name="enabled" type="QString"/>
-              <Option value="&lt;symbol force_rhr=&quot;0&quot; name=&quot;symbol&quot; clip_to_extent=&quot;1&quot; alpha=&quot;1&quot; type=&quot;line&quot;>&lt;layer enabled=&quot;1&quot; pass=&quot;0&quot; class=&quot;SimpleLine&quot; locked=&quot;0&quot;>&lt;prop k=&quot;capstyle&quot; v=&quot;square&quot;/>&lt;prop k=&quot;customdash&quot; v=&quot;5;2&quot;/>&lt;prop k=&quot;customdash_map_unit_scale&quot; v=&quot;3x:0,0,0,0,0,0&quot;/>&lt;prop k=&quot;customdash_unit&quot; v=&quot;MM&quot;/>&lt;prop k=&quot;draw_inside_polygon&quot; v=&quot;0&quot;/>&lt;prop k=&quot;joinstyle&quot; v=&quot;bevel&quot;/>&lt;prop k=&quot;line_color&quot; v=&quot;60,60,60,255&quot;/>&lt;prop k=&quot;line_style&quot; v=&quot;solid&quot;/>&lt;prop k=&quot;line_width&quot; v=&quot;0.3&quot;/>&lt;prop k=&quot;line_width_unit&quot; v=&quot;MM&quot;/>&lt;prop k=&quot;offset&quot; v=&quot;0&quot;/>&lt;prop k=&quot;offset_map_unit_scale&quot; v=&quot;3x:0,0,0,0,0,0&quot;/>&lt;prop k=&quot;offset_unit&quot; v=&quot;MM&quot;/>&lt;prop k=&quot;ring_filter&quot; v=&quot;0&quot;/>&lt;prop k=&quot;use_custom_dash&quot; v=&quot;0&quot;/>&lt;prop k=&quot;width_map_unit_scale&quot; v=&quot;3x:0,0,0,0,0,0&quot;/>&lt;data_defined_properties>&lt;Option type=&quot;Map&quot;>&lt;Option value=&quot;&quot; name=&quot;name&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;properties&quot;/>&lt;Option value=&quot;collection&quot; name=&quot;type&quot; type=&quot;QString&quot;/>&lt;/Option>&lt;/data_defined_properties>&lt;/layer>&lt;/symbol>" name="lineSymbol" type="QString"/>
-              <Option value="0" name="minLength" type="double"/>
-              <Option value="3x:0,0,0,0,0,0" name="minLengthMapUnitScale" type="QString"/>
-              <Option value="MM" name="minLengthUnit" type="QString"/>
-              <Option value="0" name="offsetFromAnchor" type="double"/>
-              <Option value="3x:0,0,0,0,0,0" name="offsetFromAnchorMapUnitScale" type="QString"/>
-              <Option value="MM" name="offsetFromAnchorUnit" type="QString"/>
-              <Option value="0" name="offsetFromLabel" type="double"/>
-              <Option value="3x:0,0,0,0,0,0" name="offsetFromLabelMapUnitScale" type="QString"/>
-              <Option value="MM" name="offsetFromLabelUnit" type="QString"/>
-            </Option>
-          </callout>
         </settings>
       </labeling>
       <customproperties>
-        <property value="_fields_" key="variableNames"/>
-        <property value="" key="variableValues"/>
+        <property key="variableNames" value="_fields_"/>
+        <property key="variableValues" value=""/>
       </customproperties>
       <blendMode>0</blendMode>
       <featureBlendMode>0</featureBlendMode>
       <layerOpacity>1</layerOpacity>
-      <SingleCategoryDiagramRenderer diagramType="Pie" attributeLegend="1">
-        <DiagramCategory backgroundAlpha="255" sizeScale="3x:0,0,0,0,0,0" opacity="1" scaleBasedVisibility="0" width="15" backgroundColor="#ffffff" minScaleDenominator="-4.65661e-10" rotationOffset="270" minimumSize="0" penAlpha="255" lineSizeScale="3x:0,0,0,0,0,0" scaleDependency="Area" penWidth="0" barWidth="5" height="15" labelPlacementMethod="XHeight" lineSizeType="MM" diagramOrientation="Up" enabled="0" sizeType="MM" penColor="#000000" maxScaleDenominator="1e+8">
+      <SingleCategoryDiagramRenderer attributeLegend="1" diagramType="Pie">
+        <DiagramCategory minScaleDenominator="-4.65661e-10" diagramOrientation="Up" backgroundColor="#ffffff" penWidth="0" barWidth="5" penColor="#000000" opacity="1" maxScaleDenominator="1e+8" rotationOffset="270" scaleBasedVisibility="0" penAlpha="255" scaleDependency="Area" labelPlacementMethod="XHeight" enabled="0" width="15" sizeType="MM" lineSizeScale="3x:0,0,0,0,0,0" height="15" lineSizeType="MM" backgroundAlpha="255" sizeScale="3x:0,0,0,0,0,0" minimumSize="0">
           <fontProperties description="Ubuntu,11,-1,5,50,0,0,0,0,0" style=""/>
-          <attribute field="" label="" color="#000000"/>
+          <attribute label="" color="#000000" field=""/>
         </DiagramCategory>
       </SingleCategoryDiagramRenderer>
-      <DiagramLayerSettings priority="0" obstacle="0" zIndex="0" showAll="1" placement="2" dist="0" linePlacementFlags="10">
+      <DiagramLayerSettings showAll="1" priority="0" placement="2" linePlacementFlags="10" zIndex="0" dist="0" obstacle="0">
         <properties>
           <Option type="Map">
-            <Option value="" name="name" type="QString"/>
-            <Option name="properties" type="Map">
-              <Option name="show" type="Map">
-                <Option value="true" name="active" type="bool"/>
-                <Option value="cat" name="field" type="QString"/>
-                <Option value="2" name="type" type="int"/>
+            <Option value="" type="QString" name="name"/>
+            <Option type="Map" name="properties">
+              <Option type="Map" name="show">
+                <Option value="true" type="bool" name="active"/>
+                <Option value="cat" type="QString" name="field"/>
+                <Option value="2" type="int" name="type"/>
               </Option>
             </Option>
-            <Option value="collection" name="type" type="QString"/>
+            <Option value="collection" type="QString" name="type"/>
           </Option>
         </properties>
       </DiagramLayerSettings>
-      <geometryOptions removeDuplicateNodes="0" geometryPrecision="0">
+      <geometryOptions geometryPrecision="0" removeDuplicateNodes="0">
         <activeChecks/>
         <checkConfiguration/>
       </geometryOptions>
@@ -5100,8 +4616,8 @@ def my_form_open(dialog, layer, feature):
           <editWidget type="TextEdit">
             <config>
               <Option type="Map">
-                <Option value="0" name="IsMultiline" type="QString"/>
-                <Option value="0" name="UseHtml" type="QString"/>
+                <Option value="0" type="QString" name="IsMultiline"/>
+                <Option value="0" type="QString" name="UseHtml"/>
               </Option>
             </config>
           </editWidget>
@@ -5110,8 +4626,8 @@ def my_form_open(dialog, layer, feature):
           <editWidget type="TextEdit">
             <config>
               <Option type="Map">
-                <Option value="0" name="IsMultiline" type="QString"/>
-                <Option value="0" name="UseHtml" type="QString"/>
+                <Option value="0" type="QString" name="IsMultiline"/>
+                <Option value="0" type="QString" name="UseHtml"/>
               </Option>
             </config>
           </editWidget>
@@ -5120,8 +4636,8 @@ def my_form_open(dialog, layer, feature):
           <editWidget type="TextEdit">
             <config>
               <Option type="Map">
-                <Option value="0" name="IsMultiline" type="QString"/>
-                <Option value="0" name="UseHtml" type="QString"/>
+                <Option value="0" type="QString" name="IsMultiline"/>
+                <Option value="0" type="QString" name="UseHtml"/>
               </Option>
             </config>
           </editWidget>
@@ -5130,43 +4646,41 @@ def my_form_open(dialog, layer, feature):
           <editWidget type="TextEdit">
             <config>
               <Option type="Map">
-                <Option value="0" name="IsMultiline" type="QString"/>
-                <Option value="0" name="UseHtml" type="QString"/>
+                <Option value="0" type="QString" name="IsMultiline"/>
+                <Option value="0" type="QString" name="UseHtml"/>
               </Option>
             </config>
           </editWidget>
         </field>
       </fieldConfiguration>
       <aliases>
-        <alias name="" index="0" field="cat"/>
-        <alias name="" index="1" field="F_CODEDESC"/>
-        <alias name="" index="2" field="NAM"/>
-        <alias name="" index="3" field="F_CODE"/>
+        <alias name="" field="cat" index="0"/>
+        <alias name="" field="F_CODEDESC" index="1"/>
+        <alias name="" field="NAM" index="2"/>
+        <alias name="" field="F_CODE" index="3"/>
       </aliases>
       <excludeAttributesWMS/>
       <excludeAttributesWFS/>
       <defaults>
-        <default field="cat" applyOnUpdate="0" expression=""/>
-        <default field="F_CODEDESC" applyOnUpdate="0" expression=""/>
-        <default field="NAM" applyOnUpdate="0" expression=""/>
-        <default field="F_CODE" applyOnUpdate="0" expression=""/>
+        <default field="cat" expression="" applyOnUpdate="0"/>
+        <default field="F_CODEDESC" expression="" applyOnUpdate="0"/>
+        <default field="NAM" expression="" applyOnUpdate="0"/>
+        <default field="F_CODE" expression="" applyOnUpdate="0"/>
       </defaults>
       <constraints>
-        <constraint field="cat" notnull_strength="0" constraints="0" unique_strength="0" exp_strength="0"/>
-        <constraint field="F_CODEDESC" notnull_strength="0" constraints="0" unique_strength="0" exp_strength="0"/>
-        <constraint field="NAM" notnull_strength="0" constraints="0" unique_strength="0" exp_strength="0"/>
-        <constraint field="F_CODE" notnull_strength="0" constraints="0" unique_strength="0" exp_strength="0"/>
+        <constraint notnull_strength="0" exp_strength="0" field="cat" unique_strength="0" constraints="0"/>
+        <constraint notnull_strength="0" exp_strength="0" field="F_CODEDESC" unique_strength="0" constraints="0"/>
+        <constraint notnull_strength="0" exp_strength="0" field="NAM" unique_strength="0" constraints="0"/>
+        <constraint notnull_strength="0" exp_strength="0" field="F_CODE" unique_strength="0" constraints="0"/>
       </constraints>
       <constraintExpressions>
-        <constraint field="cat" exp="" desc=""/>
-        <constraint field="F_CODEDESC" exp="" desc=""/>
-        <constraint field="NAM" exp="" desc=""/>
-        <constraint field="F_CODE" exp="" desc=""/>
+        <constraint field="cat" desc="" exp=""/>
+        <constraint field="F_CODEDESC" desc="" exp=""/>
+        <constraint field="NAM" desc="" exp=""/>
+        <constraint field="F_CODE" desc="" exp=""/>
       </constraintExpressions>
       <expressionfields/>
-      <attributeactions>
-        <defaultAction value="{00000000-0000-0000-0000-000000000000}" key="Canvas"/>
-      </attributeactions>
+      <attributeactions/>
       <attributetableconfig sortExpression="" actionWidgetStyle="dropDown" sortOrder="0">
         <columns/>
       </attributetableconfig>
@@ -5174,7 +4688,6 @@ def my_form_open(dialog, layer, feature):
         <rowstyles/>
         <fieldstyles/>
       </conditionalstyles>
-      <storedexpressions/>
       <editform tolerant="1"></editform>
       <editforminit/>
       <editforminitcodesource>0</editforminitcodesource>
@@ -5204,7 +4717,7 @@ def my_form_open(dialog, layer, feature):
       <previewExpression>"cat"</previewExpression>
       <mapTip></mapTip>
     </maplayer>
-    <maplayer simplifyDrawingHints="1" simplifyAlgorithm="0" labelsEnabled="1" refreshOnNotifyMessage="" wkbType="MultiLineString" minScale="1e+8" readOnly="0" refreshOnNotifyEnabled="0" type="vector" maxScale="-4.65661e-10" simplifyLocal="1" autoRefreshTime="0" hasScaleBasedVisibilityFlag="0" geometry="Line" styleCategories="AllStyleCategories" autoRefreshEnabled="0" simplifyDrawingTol="1" simplifyMaxScale="1">
+    <maplayer refreshOnNotifyEnabled="0" refreshOnNotifyMessage="" styleCategories="AllStyleCategories" maxScale="-4.65661e-10" hasScaleBasedVisibilityFlag="0" simplifyAlgorithm="0" type="vector" labelsEnabled="1" minScale="1e+8" simplifyLocal="1" simplifyDrawingHints="1" autoRefreshTime="0" readOnly="0" geometry="Line" simplifyDrawingTol="1" autoRefreshEnabled="0" simplifyMaxScale="1" wkbType="MultiLineString">
       <extent>
         <xmin>-2007180.32812365726567805</xmin>
         <ymin>2451582.79989858577027917</ymin>
@@ -5219,7 +4732,6 @@ def my_form_open(dialog, layer, feature):
       <layername>rivers</layername>
       <srs>
         <spatialrefsys>
-          <wkt>PROJCS["NAD27 / Alaska Albers",GEOGCS["NAD27",DATUM["North_American_Datum_1927",SPHEROID["Clarke 1866",6378206.4,294.9786982138982,AUTHORITY["EPSG","7008"]],AUTHORITY["EPSG","6267"]],PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9122"]],AUTHORITY["EPSG","4267"]],PROJECTION["Albers_Conic_Equal_Area"],PARAMETER["standard_parallel_1",55],PARAMETER["standard_parallel_2",65],PARAMETER["latitude_of_center",50],PARAMETER["longitude_of_center",-154],PARAMETER["false_easting",0],PARAMETER["false_northing",0],UNIT["US survey foot",0.3048006096012192,AUTHORITY["EPSG","9003"]],AXIS["X",EAST],AXIS["Y",NORTH],AUTHORITY["EPSG","2964"]]</wkt>
           <proj4>+proj=aea +lat_1=55 +lat_2=65 +lat_0=50 +lon_0=-154 +x_0=0 +y_0=0 +datum=NAD27 +units=us-ft +no_defs</proj4>
           <srsid>932</srsid>
           <srid>2964</srid>
@@ -5237,21 +4749,11 @@ def my_form_open(dialog, layer, feature):
         <type></type>
         <title></title>
         <abstract></abstract>
-        <contact>
-          <name></name>
-          <organization></organization>
-          <position></position>
-          <voice></voice>
-          <fax></fax>
-          <email></email>
-          <role></role>
-        </contact>
         <links/>
         <fees></fees>
         <encoding></encoding>
         <crs>
           <spatialrefsys>
-            <wkt></wkt>
             <proj4></proj4>
             <srsid>0</srsid>
             <srid>0</srid>
@@ -5259,18 +4761,10 @@ def my_form_open(dialog, layer, feature):
             <description></description>
             <projectionacronym></projectionacronym>
             <ellipsoidacronym></ellipsoidacronym>
-            <geographicflag>false</geographicflag>
+            <geographicflag>true</geographicflag>
           </spatialrefsys>
         </crs>
-        <extent>
-          <spatial maxy="0" crs="" minz="0" minx="0" maxx="0" maxz="0" miny="0" dimensions="2"/>
-          <temporal>
-            <period>
-              <start></start>
-              <end></end>
-            </period>
-          </temporal>
-        </extent>
+        <extent/>
       </resourceMetadata>
       <provider encoding="UTF-8">ogr</provider>
       <vectorjoins/>
@@ -5287,301 +4781,301 @@ def my_form_open(dialog, layer, feature):
         <Removable>1</Removable>
         <Searchable>1</Searchable>
       </flags>
-      <renderer-v2 attr="NAM" symbollevels="0" type="categorizedSymbol" forceraster="0" enableorderby="0">
+      <renderer-v2 type="categorizedSymbol" symbollevels="0" forceraster="0" attr="NAM" enableorderby="0">
         <categories>
-          <category value="AGASHASHOK RIVER" label="AGASHASHOK RIVER" render="true" symbol="0"/>
-          <category value="AGIAPUK RIVER" label="AGIAPUK RIVER" render="true" symbol="1"/>
-          <category value="AKLUMAYUAK CREEK" label="AKLUMAYUAK CREEK" render="true" symbol="2"/>
-          <category value="ALAGNAK RIVER" label="ALAGNAK RIVER" render="true" symbol="3"/>
-          <category value="ALATNA RIVER" label="ALATNA RIVER" render="true" symbol="4"/>
-          <category value="AMBLER RIVER" label="AMBLER RIVER" render="true" symbol="5"/>
-          <category value="AMERICAN RIVER" label="AMERICAN RIVER" render="true" symbol="6"/>
-          <category value="ANCHOR RIVER" label="ANCHOR RIVER" render="true" symbol="7"/>
-          <category value="ANDREAFSKY RIVER" label="ANDREAFSKY RIVER" render="true" symbol="8"/>
-          <category value="ANIAK RIVER" label="ANIAK RIVER" render="true" symbol="9"/>
-          <category value="ANVIK RIVER" label="ANVIK RIVER" render="true" symbol="10"/>
-          <category value="ARCTIC RIVER" label="ARCTIC RIVER" render="true" symbol="11"/>
-          <category value="BEAR CREEK" label="BEAR CREEK" render="true" symbol="12"/>
-          <category value="BEAVER CREEK" label="BEAVER CREEK" render="true" symbol="13"/>
-          <category value="BIG RIVER" label="BIG RIVER" render="true" symbol="14"/>
-          <category value="BILLY CREEK" label="BILLY CREEK" render="true" symbol="15"/>
-          <category value="BIRCH CREEK" label="BIRCH CREEK" render="true" symbol="16"/>
-          <category value="BLACK RIVER" label="BLACK RIVER" render="true" symbol="17"/>
-          <category value="BONASILA RIVER" label="BONASILA RIVER" render="true" symbol="18"/>
-          <category value="BONEY CREEK" label="BONEY CREEK" render="true" symbol="19"/>
-          <category value="BOX RIVER" label="BOX RIVER" render="true" symbol="20"/>
-          <category value="BREMNER RIVER" label="BREMNER RIVER" render="true" symbol="21"/>
-          <category value="BUCKLAND RIVER" label="BUCKLAND RIVER" render="true" symbol="22"/>
-          <category value="CANYON CREEK" label="CANYON CREEK" render="true" symbol="23"/>
-          <category value="CHAKACHATNA RIVER" label="CHAKACHATNA RIVER" render="true" symbol="24"/>
-          <category value="CHANDALAR RIVER" label="CHANDALAR RIVER" render="true" symbol="25"/>
-          <category value="CHARLEY RIVER" label="CHARLEY RIVER" render="true" symbol="26"/>
-          <category value="CHATANIKA RIVER" label="CHATANIKA RIVER" render="true" symbol="27"/>
-          <category value="CHENA RIVER" label="CHENA RIVER" render="true" symbol="28"/>
-          <category value="CHICHITNOK RIVER" label="CHICHITNOK RIVER" render="true" symbol="29"/>
-          <category value="CHILIKADROTNA RIVER" label="CHILIKADROTNA RIVER" render="true" symbol="30"/>
-          <category value="CHISANA RIVER" label="CHISANA RIVER" render="true" symbol="31"/>
-          <category value="CHISTOCHINA RIVER" label="CHISTOCHINA RIVER" render="true" symbol="32"/>
-          <category value="CHITANANA RIVER" label="CHITANANA RIVER" render="true" symbol="33"/>
-          <category value="CHOKOTONK RIVER" label="CHOKOTONK RIVER" render="true" symbol="34"/>
-          <category value="CHRISTIAN RIVER" label="CHRISTIAN RIVER" render="true" symbol="35"/>
-          <category value="CHUILNAK RIVER" label="CHUILNAK RIVER" render="true" symbol="36"/>
-          <category value="CHULITNA RIVER" label="CHULITNA RIVER" render="true" symbol="37"/>
-          <category value="CHULTINA RIVER" label="CHULTINA RIVER" render="true" symbol="38"/>
-          <category value="CHUNILNA CREEK" label="CHUNILNA CREEK" render="true" symbol="39"/>
-          <category value="CLEAR CREEK" label="CLEAR CREEK" render="true" symbol="40"/>
-          <category value="COLEEN RIVER" label="COLEEN RIVER" render="true" symbol="41"/>
-          <category value="COLEENI RIVER" label="COLEENI RIVER" render="true" symbol="42"/>
-          <category value="COPPER RIVER" label="COPPER RIVER" render="true" symbol="43"/>
-          <category value="COSNA RIVER" label="COSNA RIVER" render="true" symbol="44"/>
-          <category value="CUTLER RIVER" label="CUTLER RIVER" render="true" symbol="45"/>
-          <category value="DADINA RIVER" label="DADINA RIVER" render="true" symbol="46"/>
-          <category value="DAGO CREEK" label="DAGO CREEK" render="true" symbol="47"/>
-          <category value="DALL RIVER" label="DALL RIVER" render="true" symbol="48"/>
-          <category value="DELTA CREEK" label="DELTA CREEK" render="true" symbol="49"/>
-          <category value="DELTA RIVER" label="DELTA RIVER" render="true" symbol="50"/>
-          <category value="DERBY CREEK" label="DERBY CREEK" render="true" symbol="51"/>
-          <category value="DESHKA RIVER" label="DESHKA RIVER" render="true" symbol="52"/>
-          <category value="DISHNA RIVER" label="DISHNA RIVER" render="true" symbol="53"/>
-          <category value="DOG SALMON RIVER" label="DOG SALMON RIVER" render="true" symbol="54"/>
-          <category value="DULBI RIVER" label="DULBI RIVER" render="true" symbol="55"/>
-          <category value="EAGLE CREEK" label="EAGLE CREEK" render="true" symbol="56"/>
-          <category value="EAST FORK" label="EAST FORK" render="true" symbol="57"/>
-          <category value="EAST FORK ANDREAFSKY RIVER" label="EAST FORK ANDREAFSKY RIVER" render="true" symbol="58"/>
-          <category value="EAST FORK CHANDALAR RIVER" label="EAST FORK CHANDALAR RIVER" render="true" symbol="59"/>
-          <category value="EAST FORK KOYUK RIVER" label="EAST FORK KOYUK RIVER" render="true" symbol="60"/>
-          <category value="EEK RIVER" label="EEK RIVER" render="true" symbol="61"/>
-          <category value="ELDORADO RIVER" label="ELDORADO RIVER" render="true" symbol="62"/>
-          <category value="ELI RIVER" label="ELI RIVER" render="true" symbol="63"/>
-          <category value="FISH RIVER" label="FISH RIVER" render="true" symbol="64"/>
-          <category value="FOG CREEK" label="FOG CREEK" render="true" symbol="65"/>
-          <category value="FORAKER RIVER" label="FORAKER RIVER" render="true" symbol="66"/>
-          <category value="FORTYMILE RIVER" label="FORTYMILE RIVER" render="true" symbol="67"/>
-          <category value="FOX RIVER" label="FOX RIVER" render="true" symbol="68"/>
-          <category value="GAKONA RIVER" label="GAKONA RIVER" render="true" symbol="69"/>
-          <category value="GARDINER CREEK" label="GARDINER CREEK" render="true" symbol="70"/>
-          <category value="GEORGE RIVER" label="GEORGE RIVER" render="true" symbol="71"/>
-          <category value="GERSTLE RIVER" label="GERSTLE RIVER" render="true" symbol="72"/>
-          <category value="GISASA RIVER" label="GISASA RIVER" render="true" symbol="73"/>
-          <category value="GOODHOPE RIVER" label="GOODHOPE RIVER" render="true" symbol="74"/>
-          <category value="GOODNEWS RIVER" label="GOODNEWS RIVER" render="true" symbol="75"/>
-          <category value="GOODPASTER RIVER" label="GOODPASTER RIVER" render="true" symbol="76"/>
-          <category value="GRANITE CREEK" label="GRANITE CREEK" render="true" symbol="77"/>
-          <category value="GRASS RIVER" label="GRASS RIVER" render="true" symbol="78"/>
-          <category value="GRAYLING FORK" label="GRAYLING FORK" render="true" symbol="79"/>
-          <category value="GULKANA RIVER" label="GULKANA RIVER" render="true" symbol="80"/>
-          <category value="GWEEK RIVER" label="GWEEK RIVER" render="true" symbol="81"/>
-          <category value="HANAGITA RIVER" label="HANAGITA RIVER" render="true" symbol="82"/>
-          <category value="HAPPY RIVER" label="HAPPY RIVER" render="true" symbol="83"/>
-          <category value="HERRON RIVER" label="HERRON RIVER" render="true" symbol="84"/>
-          <category value="HESS CREEK" label="HESS CREEK" render="true" symbol="85"/>
-          <category value="HIGHPOWER CREEK" label="HIGHPOWER CREEK" render="true" symbol="86"/>
-          <category value="HODZANA RIVER" label="HODZANA RIVER" render="true" symbol="87"/>
-          <category value="HOGATZA RIVER" label="HOGATZA RIVER" render="true" symbol="88"/>
-          <category value="HOHOLITNA RIVER" label="HOHOLITNA RIVER" render="true" symbol="89"/>
-          <category value="HONHOSA RIVER" label="HONHOSA RIVER" render="true" symbol="90"/>
-          <category value="HUNT RIVER" label="HUNT RIVER" render="true" symbol="91"/>
-          <category value="HUSLIA RIVER" label="HUSLIA RIVER" render="true" symbol="92"/>
-          <category value="HUSLIO RIVER" label="HUSLIO RIVER" render="true" symbol="93"/>
-          <category value="IDITAROD RIVER" label="IDITAROD RIVER" render="true" symbol="94"/>
-          <category value="ILIAMNA RIVER" label="ILIAMNA RIVER" render="true" symbol="95"/>
-          <category value="INDIAN RIVER" label="INDIAN RIVER" render="true" symbol="96"/>
-          <category value="INGLUTALIC RIVER" label="INGLUTALIC RIVER" render="true" symbol="97"/>
-          <category value="INNOKO RIVER" label="INNOKO RIVER" render="true" symbol="98"/>
-          <category value="IZAVIKNEK RIVER" label="IZAVIKNEK RIVER" render="true" symbol="99"/>
-          <category value="JOHN RIVER" label="JOHN RIVER" render="true" symbol="100"/>
-          <category value="KAHILTNA RIVER" label="KAHILTNA RIVER" render="true" symbol="101"/>
-          <category value="KALIAKH RIVER" label="KALIAKH RIVER" render="true" symbol="102"/>
-          <category value="KAMISHAK RIVER" label="KAMISHAK RIVER" render="true" symbol="103"/>
-          <category value="KANDIK RIVER" label="KANDIK RIVER" render="true" symbol="104"/>
-          <category value="KANTISHNA RIVER" label="KANTISHNA RIVER" render="true" symbol="105"/>
-          <category value="KANUTI CHALATNA CREEK" label="KANUTI CHALATNA CREEK" render="true" symbol="106"/>
-          <category value="KANUTI RIVER" label="KANUTI RIVER" render="true" symbol="107"/>
-          <category value="KASHUNUK RIVER" label="KASHUNUK RIVER" render="true" symbol="108"/>
-          <category value="KASHWITNA RIVER" label="KASHWITNA RIVER" render="true" symbol="109"/>
-          <category value="KATEEL RIVER" label="KATEEL RIVER" render="true" symbol="110"/>
-          <category value="KATLITNA RIVER" label="KATLITNA RIVER" render="true" symbol="111"/>
-          <category value="KAUK RIVER" label="KAUK RIVER" render="true" symbol="112"/>
-          <category value="KAVIRUK RIVER" label="KAVIRUK RIVER" render="true" symbol="113"/>
-          <category value="KEJULIK RIVER" label="KEJULIK RIVER" render="true" symbol="114"/>
-          <category value="KELLY RIVER" label="KELLY RIVER" render="true" symbol="115"/>
-          <category value="KELSALL RIVER" label="KELSALL RIVER" render="true" symbol="116"/>
-          <category value="KHOTOL RIVER" label="KHOTOL RIVER" render="true" symbol="117"/>
-          <category value="KIAGNA RIVER" label="KIAGNA RIVER" render="true" symbol="118"/>
-          <category value="KICHATNA RIVER" label="KICHATNA RIVER" render="true" symbol="119"/>
-          <category value="KING SALMON CREEK" label="KING SALMON CREEK" render="true" symbol="120"/>
-          <category value="KING SALMON RIVER" label="KING SALMON RIVER" render="true" symbol="121"/>
-          <category value="KISARALIK RIVER" label="KISARALIK RIVER" render="true" symbol="122"/>
-          <category value="KIVALINA RIVER" label="KIVALINA RIVER" render="true" symbol="123"/>
-          <category value="KIWALIK RIVER" label="KIWALIK RIVER" render="true" symbol="124"/>
-          <category value="KLEHINI RIVER" label="KLEHINI RIVER" render="true" symbol="125"/>
-          <category value="KLUKLAKLATNA RIVER" label="KLUKLAKLATNA RIVER" render="true" symbol="126"/>
-          <category value="KLUTINA RIVER" label="KLUTINA RIVER" render="true" symbol="127"/>
-          <category value="KLUTUK CREEK" label="KLUTUK CREEK" render="true" symbol="128"/>
-          <category value="KOBUK RIVER" label="KOBUK RIVER" render="true" symbol="129"/>
-          <category value="KOGOLUKTUK RIVER" label="KOGOLUKTUK RIVER" render="true" symbol="130"/>
-          <category value="KOGRUKLUK RIVER" label="KOGRUKLUK RIVER" render="true" symbol="131"/>
-          <category value="KOKWOK RIVER" label="KOKWOK RIVER" render="true" symbol="132"/>
-          <category value="KOSINA CREEK" label="KOSINA CREEK" render="true" symbol="133"/>
-          <category value="KOUGAROK CREEK" label="KOUGAROK CREEK" render="true" symbol="134"/>
-          <category value="KOYUK RIVER" label="KOYUK RIVER" render="true" symbol="135"/>
-          <category value="KOYUKUK RIVER" label="KOYUKUK RIVER" render="true" symbol="136"/>
-          <category value="KUGARAK RIVER" label="KUGARAK RIVER" render="true" symbol="137"/>
-          <category value="KUGRUK RIVER" label="KUGRUK RIVER" render="true" symbol="138"/>
-          <category value="KUGRUPAGA RIVER" label="KUGRUPAGA RIVER" render="true" symbol="139"/>
-          <category value="KUGURURCK RIVER" label="KUGURURCK RIVER" render="true" symbol="140"/>
-          <category value="KUGURUROK RIVER" label="KUGURUROK RIVER" render="true" symbol="141"/>
-          <category value="KUZITRIN RIVER" label="KUZITRIN RIVER" render="true" symbol="142"/>
-          <category value="KWETHLUK RIVER" label="KWETHLUK RIVER" render="true" symbol="143"/>
-          <category value="KWINIUK RIVER" label="KWINIUK RIVER" render="true" symbol="144"/>
-          <category value="LADUE RIVER" label="LADUE RIVER" render="true" symbol="145"/>
-          <category value="LAVA FORK" label="LAVA FORK" render="true" symbol="146"/>
-          <category value="LITTLE BLACK RIVER" label="LITTLE BLACK RIVER" render="true" symbol="147"/>
-          <category value="LITTLE DELTA RIVER" label="LITTLE DELTA RIVER" render="true" symbol="148"/>
-          <category value="LITTLE MELOZITNA RIVER" label="LITTLE MELOZITNA RIVER" render="true" symbol="149"/>
-          <category value="LITTLE MUD RIVER" label="LITTLE MUD RIVER" render="true" symbol="150"/>
-          <category value="LITTLE UNDERHILL CREEK" label="LITTLE UNDERHILL CREEK" render="true" symbol="151"/>
-          <category value="LOST CREEK" label="LOST CREEK" render="true" symbol="152"/>
-          <category value="LOST RIVER" label="LOST RIVER" render="true" symbol="153"/>
-          <category value="MACLAREN RIVER" label="MACLAREN RIVER" render="true" symbol="154"/>
-          <category value="MANGOAK RIVER" label="MANGOAK RIVER" render="true" symbol="155"/>
-          <category value="MATANUSKA RIVER" label="MATANUSKA RIVER" render="true" symbol="156"/>
-          <category value="MAUNELUK RIVER" label="MAUNELUK RIVER" render="true" symbol="157"/>
-          <category value="MCKINLEY RIVER" label="MCKINLEY RIVER" render="true" symbol="158"/>
-          <category value="MELOZITNA RIVER" label="MELOZITNA RIVER" render="true" symbol="159"/>
-          <category value="MELVIN CHANNEL" label="MELVIN CHANNEL" render="true" symbol="160"/>
-          <category value="MESHIK RIVER" label="MESHIK RIVER" render="true" symbol="161"/>
-          <category value="METTENPHERG CREEK" label="METTENPHERG CREEK" render="true" symbol="162"/>
-          <category value="MIDDLE FORK" label="MIDDLE FORK" render="true" symbol="163"/>
-          <category value="MIDDLE FORK CHANDALAR RIVER" label="MIDDLE FORK CHANDALAR RIVER" render="true" symbol="164"/>
-          <category value="MIDDLE FORK EEK RIVER" label="MIDDLE FORK EEK RIVER" render="true" symbol="165"/>
-          <category value="MIDDLE FORK FORTYMILE RIVER" label="MIDDLE FORK FORTYMILE RIVER" render="true" symbol="166"/>
-          <category value="MIDDLE FORK KOYUKUK RIVER" label="MIDDLE FORK KOYUKUK RIVER" render="true" symbol="167"/>
-          <category value="MINT RIVER" label="MINT RIVER" render="true" symbol="168"/>
-          <category value="MIRROR CREEK" label="MIRROR CREEK" render="true" symbol="169"/>
-          <category value="MOSQUITO FORK" label="MOSQUITO FORK" render="true" symbol="170"/>
-          <category value="MULCHATNA RIVER" label="MULCHATNA RIVER" render="true" symbol="171"/>
-          <category value="NAGEETHLUK RIVER" label="NAGEETHLUK RIVER" render="true" symbol="172"/>
-          <category value="NATION RIVER" label="NATION RIVER" render="true" symbol="173"/>
-          <category value="NEACOLA RIVER" label="NEACOLA RIVER" render="true" symbol="174"/>
-          <category value="NELLIE JUAN RIVER" label="NELLIE JUAN RIVER" render="true" symbol="175"/>
-          <category value="NENANA RIVER" label="NENANA RIVER" render="true" symbol="176"/>
-          <category value="NIUKLUK RIVER" label="NIUKLUK RIVER" render="true" symbol="177"/>
-          <category value="NIXON RIVER" label="NIXON RIVER" render="true" symbol="178"/>
-          <category value="NIZINA RIVER" label="NIZINA RIVER" render="true" symbol="179"/>
-          <category value="NOATAK RIVER" label="NOATAK RIVER" render="true" symbol="180"/>
-          <category value="NORTH FORK" label="NORTH FORK" render="true" symbol="181"/>
-          <category value="NORTH FORK INNOKO RIVER" label="NORTH FORK INNOKO RIVER" render="true" symbol="182"/>
-          <category value="NORTH FORK KOYUKUK RIVER" label="NORTH FORK KOYUKUK RIVER" render="true" symbol="183"/>
-          <category value="NORTH FORK KUSKOKWIM RIVER" label="NORTH FORK KUSKOKWIM RIVER" render="true" symbol="184"/>
-          <category value="NORTH FORK UNALAKLEET RIVER" label="NORTH FORK UNALAKLEET RIVER" render="true" symbol="185"/>
-          <category value="NORTH FORTYMILE RIVER" label="NORTH FORTYMILE RIVER" render="true" symbol="186"/>
-          <category value="NORTH RIVER" label="NORTH RIVER" render="true" symbol="187"/>
-          <category value="NOWITNA RIVER" label="NOWITNA RIVER" render="true" symbol="188"/>
-          <category value="NOXAPAGA RIVER" label="NOXAPAGA RIVER" render="true" symbol="189"/>
-          <category value="NUGNUGALURTUK RIVER" label="NUGNUGALURTUK RIVER" render="true" symbol="190"/>
-          <category value="NULATO RIVER" label="NULATO RIVER" render="true" symbol="191"/>
-          <category value="NULUK RIVER" label="NULUK RIVER" render="true" symbol="192"/>
-          <category value="NUSHAGAK RIVER" label="NUSHAGAK RIVER" render="true" symbol="193"/>
-          <category value="OMAR RIVER" label="OMAR RIVER" render="true" symbol="194"/>
-          <category value="OMIKVIOROK RIVER" label="OMIKVIOROK RIVER" render="true" symbol="195"/>
-          <category value="OOKAHLIKSOOK CREEK" label="OOKAHLIKSOOK CREEK" render="true" symbol="196"/>
-          <category value="OSHETNA RIVER" label="OSHETNA RIVER" render="true" symbol="197"/>
-          <category value="OSKAWALIK RIVER" label="OSKAWALIK RIVER" render="true" symbol="198"/>
-          <category value="PASTOLIK RIVER" label="PASTOLIK RIVER" render="true" symbol="199"/>
-          <category value="PEACE RIVER" label="PEACE RIVER" render="true" symbol="200"/>
-          <category value="PILE RIVER" label="PILE RIVER" render="true" symbol="201"/>
-          <category value="PILGRIM RIVER" label="PILGRIM RIVER" render="true" symbol="202"/>
-          <category value="PINGUK RIVER" label="PINGUK RIVER" render="true" symbol="203"/>
-          <category value="PISH RIVER" label="PISH RIVER" render="true" symbol="204"/>
-          <category value="PITNA FORK" label="PITNA FORK" render="true" symbol="205"/>
-          <category value="PORTAGE CREEK" label="PORTAGE CREEK" render="true" symbol="206"/>
-          <category value="PREACHER CREEK" label="PREACHER CREEK" render="true" symbol="207"/>
-          <category value="RAY RIVER" label="RAY RIVER" render="true" symbol="208"/>
-          <category value="REINDEER RIVER" label="REINDEER RIVER" render="true" symbol="209"/>
-          <category value="ROBERTSON RIVER" label="ROBERTSON RIVER" render="true" symbol="210"/>
-          <category value="SALCHA RIVER" label="SALCHA RIVER" render="true" symbol="211"/>
-          <category value="SALMON FORK" label="SALMON FORK" render="true" symbol="212"/>
-          <category value="SALMON RIVER" label="SALMON RIVER" render="true" symbol="213"/>
-          <category value="SAND CREEK" label="SAND CREEK" render="true" symbol="214"/>
-          <category value="SAVONOSKI RIVER" label="SAVONOSKI RIVER" render="true" symbol="215"/>
-          <category value="SELAWIK RIVER" label="SELAWIK RIVER" render="true" symbol="216"/>
-          <category value="SERPENTINE RIVER" label="SERPENTINE RIVER" render="true" symbol="217"/>
-          <category value="SETHKOKNA RIVER" label="SETHKOKNA RIVER" render="true" symbol="218"/>
-          <category value="SEVENTYMILE RIVER" label="SEVENTYMILE RIVER" render="true" symbol="219"/>
-          <category value="SHADE CREEK" label="SHADE CREEK" render="true" symbol="220"/>
-          <category value="SHAKTOOLIK RIVER" label="SHAKTOOLIK RIVER" render="true" symbol="221"/>
-          <category value="SHAW CREEK" label="SHAW CREEK" render="true" symbol="222"/>
-          <category value="SHEEP CREEK" label="SHEEP CREEK" render="true" symbol="223"/>
-          <category value="SHEERJEI RIVER" label="SHEERJEI RIVER" render="true" symbol="224"/>
-          <category value="SINONA CREEK" label="SINONA CREEK" render="true" symbol="225"/>
-          <category value="SINUK RIVER" label="SINUK RIVER" render="true" symbol="226"/>
-          <category value="SKWENTNA RIVER" label="SKWENTNA RIVER" render="true" symbol="227"/>
-          <category value="SLANA RIVER" label="SLANA RIVER" render="true" symbol="228"/>
-          <category value="SLIPPERY CREEK" label="SLIPPERY CREEK" render="true" symbol="229"/>
-          <category value="SOUTH FORK" label="SOUTH FORK" render="true" symbol="230"/>
-          <category value="SOUTH FORK HUSLIA RIVER" label="SOUTH FORK HUSLIA RIVER" render="true" symbol="231"/>
-          <category value="SOUTH FORK KOYUKUK RIVER" label="SOUTH FORK KOYUKUK RIVER" render="true" symbol="232"/>
-          <category value="SOUTH FORK KUSKOKWIM RIVER" label="SOUTH FORK KUSKOKWIM RIVER" render="true" symbol="233"/>
-          <category value="SOUTH FORK NULATO  RIVER" label="SOUTH FORK NULATO  RIVER" render="true" symbol="234"/>
-          <category value="SOUTH FORK SERPENTINE RIVER" label="SOUTH FORK SERPENTINE RIVER" render="true" symbol="235"/>
-          <category value="SPEEL RIVER" label="SPEEL RIVER" render="true" symbol="236"/>
-          <category value="SQUIRREL RIVER" label="SQUIRREL RIVER" render="true" symbol="237"/>
-          <category value="STONY RIVER" label="STONY RIVER" render="true" symbol="238"/>
-          <category value="STUYAHOK RIVER" label="STUYAHOK RIVER" render="true" symbol="239"/>
-          <category value="SUCKER RIVER" label="SUCKER RIVER" render="true" symbol="240"/>
-          <category value="SULATNA RIVER" label="SULATNA RIVER" render="true" symbol="241"/>
-          <category value="SULUKNA RIVER" label="SULUKNA RIVER" render="true" symbol="242"/>
-          <category value="SUSITNA RIVER" label="SUSITNA RIVER" render="true" symbol="243"/>
-          <category value="SUSULATNA RIVER" label="SUSULATNA RIVER" render="true" symbol="244"/>
-          <category value="SWIFT RIVER" label="SWIFT RIVER" render="true" symbol="245"/>
-          <category value="TAGAGAWIK RIVER" label="TAGAGAWIK RIVER" render="true" symbol="246"/>
-          <category value="TAKOTNA RIVER" label="TAKOTNA RIVER" render="true" symbol="247"/>
-          <category value="TALKEENTA RIVER" label="TALKEENTA RIVER" render="true" symbol="248"/>
-          <category value="TALKEETNA RIVER" label="TALKEETNA RIVER" render="true" symbol="249"/>
-          <category value="TANANA RIVER" label="TANANA RIVER" render="true" symbol="250"/>
-          <category value="TATALINA RIVER" label="TATALINA RIVER" render="true" symbol="251"/>
-          <category value="TATLWIKSUK RIVER" label="TATLWIKSUK RIVER" render="true" symbol="252"/>
-          <category value="TAZLINA RIVER" label="TAZLINA RIVER" render="true" symbol="253"/>
-          <category value="TEBAY RIVER" label="TEBAY RIVER" render="true" symbol="254"/>
-          <category value="TEKLANIKA RIVER" label="TEKLANIKA RIVER" render="true" symbol="255"/>
-          <category value="TETLIN RIVER" label="TETLIN RIVER" render="true" symbol="256"/>
-          <category value="TIEKEL RIVER" label="TIEKEL RIVER" render="true" symbol="257"/>
-          <category value="TIKCHIK RIVER" label="TIKCHIK RIVER" render="true" symbol="258"/>
-          <category value="TIMBER CREEK" label="TIMBER CREEK" render="true" symbol="259"/>
-          <category value="TINAYGUK RIVER" label="TINAYGUK RIVER" render="true" symbol="260"/>
-          <category value="TISUK RIVER" label="TISUK RIVER" render="true" symbol="261"/>
-          <category value="TITNUK CREEK" label="TITNUK CREEK" render="true" symbol="262"/>
-          <category value="TLIKAKILA RIVER" label="TLIKAKILA RIVER" render="true" symbol="263"/>
-          <category value="TOGIAK RIVER" label="TOGIAK RIVER" render="true" symbol="264"/>
-          <category value="TOK RIVER" label="TOK RIVER" render="true" symbol="265"/>
-          <category value="TOKLAT RIVER" label="TOKLAT RIVER" render="true" symbol="266"/>
-          <category value="TOLOVANA RIVER" label="TOLOVANA RIVER" render="true" symbol="267"/>
-          <category value="TONSINA RIVER" label="TONSINA RIVER" render="true" symbol="268"/>
-          <category value="TONZONA RIVER" label="TONZONA RIVER" render="true" symbol="269"/>
-          <category value="TOZITNA RIVER" label="TOZITNA RIVER" render="true" symbol="270"/>
-          <category value="TSINA RIVER" label="TSINA RIVER" render="true" symbol="271"/>
-          <category value="TSIRKU RIVER" label="TSIRKU RIVER" render="true" symbol="272"/>
-          <category value="TUBUTULIK RIVER" label="TUBUTULIK RIVER" render="true" symbol="273"/>
-          <category value="TUTUKSUK RIVER" label="TUTUKSUK RIVER" render="true" symbol="274"/>
-          <category value="TYONE RIVER" label="TYONE RIVER" render="true" symbol="275"/>
-          <category value="UNALAKLEET RIVER" label="UNALAKLEET RIVER" render="true" symbol="276"/>
-          <category value="UNGALIK RIVER" label="UNGALIK RIVER" render="true" symbol="277"/>
-          <category value="UNUK RIVER" label="UNUK RIVER" render="true" symbol="278"/>
-          <category value="WEARY RIVER" label="WEARY RIVER" render="true" symbol="279"/>
-          <category value="WEST FORK" label="WEST FORK" render="true" symbol="280"/>
-          <category value="WEST FORK GULKANA RIVER" label="WEST FORK GULKANA RIVER" render="true" symbol="281"/>
-          <category value="WHITING RIVER" label="WHITING RIVER" render="true" symbol="282"/>
-          <category value="WINDY FORK" label="WINDY FORK" render="true" symbol="283"/>
-          <category value="WOOD RIVER" label="WOOD RIVER" render="true" symbol="284"/>
-          <category value="WULIK RIVER" label="WULIK RIVER" render="true" symbol="285"/>
-          <category value="YENTNA RIVER" label="YENTNA RIVER" render="true" symbol="286"/>
-          <category value="YUKI RIVER" label="YUKI RIVER" render="true" symbol="287"/>
-          <category value="YUKON CREEK" label="YUKON CREEK" render="true" symbol="288"/>
-          <category value="" label="" render="true" symbol="289"/>
+          <category value="AGASHASHOK RIVER" label="AGASHASHOK RIVER" symbol="0" render="true"/>
+          <category value="AGIAPUK RIVER" label="AGIAPUK RIVER" symbol="1" render="true"/>
+          <category value="AKLUMAYUAK CREEK" label="AKLUMAYUAK CREEK" symbol="2" render="true"/>
+          <category value="ALAGNAK RIVER" label="ALAGNAK RIVER" symbol="3" render="true"/>
+          <category value="ALATNA RIVER" label="ALATNA RIVER" symbol="4" render="true"/>
+          <category value="AMBLER RIVER" label="AMBLER RIVER" symbol="5" render="true"/>
+          <category value="AMERICAN RIVER" label="AMERICAN RIVER" symbol="6" render="true"/>
+          <category value="ANCHOR RIVER" label="ANCHOR RIVER" symbol="7" render="true"/>
+          <category value="ANDREAFSKY RIVER" label="ANDREAFSKY RIVER" symbol="8" render="true"/>
+          <category value="ANIAK RIVER" label="ANIAK RIVER" symbol="9" render="true"/>
+          <category value="ANVIK RIVER" label="ANVIK RIVER" symbol="10" render="true"/>
+          <category value="ARCTIC RIVER" label="ARCTIC RIVER" symbol="11" render="true"/>
+          <category value="BEAR CREEK" label="BEAR CREEK" symbol="12" render="true"/>
+          <category value="BEAVER CREEK" label="BEAVER CREEK" symbol="13" render="true"/>
+          <category value="BIG RIVER" label="BIG RIVER" symbol="14" render="true"/>
+          <category value="BILLY CREEK" label="BILLY CREEK" symbol="15" render="true"/>
+          <category value="BIRCH CREEK" label="BIRCH CREEK" symbol="16" render="true"/>
+          <category value="BLACK RIVER" label="BLACK RIVER" symbol="17" render="true"/>
+          <category value="BONASILA RIVER" label="BONASILA RIVER" symbol="18" render="true"/>
+          <category value="BONEY CREEK" label="BONEY CREEK" symbol="19" render="true"/>
+          <category value="BOX RIVER" label="BOX RIVER" symbol="20" render="true"/>
+          <category value="BREMNER RIVER" label="BREMNER RIVER" symbol="21" render="true"/>
+          <category value="BUCKLAND RIVER" label="BUCKLAND RIVER" symbol="22" render="true"/>
+          <category value="CANYON CREEK" label="CANYON CREEK" symbol="23" render="true"/>
+          <category value="CHAKACHATNA RIVER" label="CHAKACHATNA RIVER" symbol="24" render="true"/>
+          <category value="CHANDALAR RIVER" label="CHANDALAR RIVER" symbol="25" render="true"/>
+          <category value="CHARLEY RIVER" label="CHARLEY RIVER" symbol="26" render="true"/>
+          <category value="CHATANIKA RIVER" label="CHATANIKA RIVER" symbol="27" render="true"/>
+          <category value="CHENA RIVER" label="CHENA RIVER" symbol="28" render="true"/>
+          <category value="CHICHITNOK RIVER" label="CHICHITNOK RIVER" symbol="29" render="true"/>
+          <category value="CHILIKADROTNA RIVER" label="CHILIKADROTNA RIVER" symbol="30" render="true"/>
+          <category value="CHISANA RIVER" label="CHISANA RIVER" symbol="31" render="true"/>
+          <category value="CHISTOCHINA RIVER" label="CHISTOCHINA RIVER" symbol="32" render="true"/>
+          <category value="CHITANANA RIVER" label="CHITANANA RIVER" symbol="33" render="true"/>
+          <category value="CHOKOTONK RIVER" label="CHOKOTONK RIVER" symbol="34" render="true"/>
+          <category value="CHRISTIAN RIVER" label="CHRISTIAN RIVER" symbol="35" render="true"/>
+          <category value="CHUILNAK RIVER" label="CHUILNAK RIVER" symbol="36" render="true"/>
+          <category value="CHULITNA RIVER" label="CHULITNA RIVER" symbol="37" render="true"/>
+          <category value="CHULTINA RIVER" label="CHULTINA RIVER" symbol="38" render="true"/>
+          <category value="CHUNILNA CREEK" label="CHUNILNA CREEK" symbol="39" render="true"/>
+          <category value="CLEAR CREEK" label="CLEAR CREEK" symbol="40" render="true"/>
+          <category value="COLEEN RIVER" label="COLEEN RIVER" symbol="41" render="true"/>
+          <category value="COLEENI RIVER" label="COLEENI RIVER" symbol="42" render="true"/>
+          <category value="COPPER RIVER" label="COPPER RIVER" symbol="43" render="true"/>
+          <category value="COSNA RIVER" label="COSNA RIVER" symbol="44" render="true"/>
+          <category value="CUTLER RIVER" label="CUTLER RIVER" symbol="45" render="true"/>
+          <category value="DADINA RIVER" label="DADINA RIVER" symbol="46" render="true"/>
+          <category value="DAGO CREEK" label="DAGO CREEK" symbol="47" render="true"/>
+          <category value="DALL RIVER" label="DALL RIVER" symbol="48" render="true"/>
+          <category value="DELTA CREEK" label="DELTA CREEK" symbol="49" render="true"/>
+          <category value="DELTA RIVER" label="DELTA RIVER" symbol="50" render="true"/>
+          <category value="DERBY CREEK" label="DERBY CREEK" symbol="51" render="true"/>
+          <category value="DESHKA RIVER" label="DESHKA RIVER" symbol="52" render="true"/>
+          <category value="DISHNA RIVER" label="DISHNA RIVER" symbol="53" render="true"/>
+          <category value="DOG SALMON RIVER" label="DOG SALMON RIVER" symbol="54" render="true"/>
+          <category value="DULBI RIVER" label="DULBI RIVER" symbol="55" render="true"/>
+          <category value="EAGLE CREEK" label="EAGLE CREEK" symbol="56" render="true"/>
+          <category value="EAST FORK" label="EAST FORK" symbol="57" render="true"/>
+          <category value="EAST FORK ANDREAFSKY RIVER" label="EAST FORK ANDREAFSKY RIVER" symbol="58" render="true"/>
+          <category value="EAST FORK CHANDALAR RIVER" label="EAST FORK CHANDALAR RIVER" symbol="59" render="true"/>
+          <category value="EAST FORK KOYUK RIVER" label="EAST FORK KOYUK RIVER" symbol="60" render="true"/>
+          <category value="EEK RIVER" label="EEK RIVER" symbol="61" render="true"/>
+          <category value="ELDORADO RIVER" label="ELDORADO RIVER" symbol="62" render="true"/>
+          <category value="ELI RIVER" label="ELI RIVER" symbol="63" render="true"/>
+          <category value="FISH RIVER" label="FISH RIVER" symbol="64" render="true"/>
+          <category value="FOG CREEK" label="FOG CREEK" symbol="65" render="true"/>
+          <category value="FORAKER RIVER" label="FORAKER RIVER" symbol="66" render="true"/>
+          <category value="FORTYMILE RIVER" label="FORTYMILE RIVER" symbol="67" render="true"/>
+          <category value="FOX RIVER" label="FOX RIVER" symbol="68" render="true"/>
+          <category value="GAKONA RIVER" label="GAKONA RIVER" symbol="69" render="true"/>
+          <category value="GARDINER CREEK" label="GARDINER CREEK" symbol="70" render="true"/>
+          <category value="GEORGE RIVER" label="GEORGE RIVER" symbol="71" render="true"/>
+          <category value="GERSTLE RIVER" label="GERSTLE RIVER" symbol="72" render="true"/>
+          <category value="GISASA RIVER" label="GISASA RIVER" symbol="73" render="true"/>
+          <category value="GOODHOPE RIVER" label="GOODHOPE RIVER" symbol="74" render="true"/>
+          <category value="GOODNEWS RIVER" label="GOODNEWS RIVER" symbol="75" render="true"/>
+          <category value="GOODPASTER RIVER" label="GOODPASTER RIVER" symbol="76" render="true"/>
+          <category value="GRANITE CREEK" label="GRANITE CREEK" symbol="77" render="true"/>
+          <category value="GRASS RIVER" label="GRASS RIVER" symbol="78" render="true"/>
+          <category value="GRAYLING FORK" label="GRAYLING FORK" symbol="79" render="true"/>
+          <category value="GULKANA RIVER" label="GULKANA RIVER" symbol="80" render="true"/>
+          <category value="GWEEK RIVER" label="GWEEK RIVER" symbol="81" render="true"/>
+          <category value="HANAGITA RIVER" label="HANAGITA RIVER" symbol="82" render="true"/>
+          <category value="HAPPY RIVER" label="HAPPY RIVER" symbol="83" render="true"/>
+          <category value="HERRON RIVER" label="HERRON RIVER" symbol="84" render="true"/>
+          <category value="HESS CREEK" label="HESS CREEK" symbol="85" render="true"/>
+          <category value="HIGHPOWER CREEK" label="HIGHPOWER CREEK" symbol="86" render="true"/>
+          <category value="HODZANA RIVER" label="HODZANA RIVER" symbol="87" render="true"/>
+          <category value="HOGATZA RIVER" label="HOGATZA RIVER" symbol="88" render="true"/>
+          <category value="HOHOLITNA RIVER" label="HOHOLITNA RIVER" symbol="89" render="true"/>
+          <category value="HONHOSA RIVER" label="HONHOSA RIVER" symbol="90" render="true"/>
+          <category value="HUNT RIVER" label="HUNT RIVER" symbol="91" render="true"/>
+          <category value="HUSLIA RIVER" label="HUSLIA RIVER" symbol="92" render="true"/>
+          <category value="HUSLIO RIVER" label="HUSLIO RIVER" symbol="93" render="true"/>
+          <category value="IDITAROD RIVER" label="IDITAROD RIVER" symbol="94" render="true"/>
+          <category value="ILIAMNA RIVER" label="ILIAMNA RIVER" symbol="95" render="true"/>
+          <category value="INDIAN RIVER" label="INDIAN RIVER" symbol="96" render="true"/>
+          <category value="INGLUTALIC RIVER" label="INGLUTALIC RIVER" symbol="97" render="true"/>
+          <category value="INNOKO RIVER" label="INNOKO RIVER" symbol="98" render="true"/>
+          <category value="IZAVIKNEK RIVER" label="IZAVIKNEK RIVER" symbol="99" render="true"/>
+          <category value="JOHN RIVER" label="JOHN RIVER" symbol="100" render="true"/>
+          <category value="KAHILTNA RIVER" label="KAHILTNA RIVER" symbol="101" render="true"/>
+          <category value="KALIAKH RIVER" label="KALIAKH RIVER" symbol="102" render="true"/>
+          <category value="KAMISHAK RIVER" label="KAMISHAK RIVER" symbol="103" render="true"/>
+          <category value="KANDIK RIVER" label="KANDIK RIVER" symbol="104" render="true"/>
+          <category value="KANTISHNA RIVER" label="KANTISHNA RIVER" symbol="105" render="true"/>
+          <category value="KANUTI CHALATNA CREEK" label="KANUTI CHALATNA CREEK" symbol="106" render="true"/>
+          <category value="KANUTI RIVER" label="KANUTI RIVER" symbol="107" render="true"/>
+          <category value="KASHUNUK RIVER" label="KASHUNUK RIVER" symbol="108" render="true"/>
+          <category value="KASHWITNA RIVER" label="KASHWITNA RIVER" symbol="109" render="true"/>
+          <category value="KATEEL RIVER" label="KATEEL RIVER" symbol="110" render="true"/>
+          <category value="KATLITNA RIVER" label="KATLITNA RIVER" symbol="111" render="true"/>
+          <category value="KAUK RIVER" label="KAUK RIVER" symbol="112" render="true"/>
+          <category value="KAVIRUK RIVER" label="KAVIRUK RIVER" symbol="113" render="true"/>
+          <category value="KEJULIK RIVER" label="KEJULIK RIVER" symbol="114" render="true"/>
+          <category value="KELLY RIVER" label="KELLY RIVER" symbol="115" render="true"/>
+          <category value="KELSALL RIVER" label="KELSALL RIVER" symbol="116" render="true"/>
+          <category value="KHOTOL RIVER" label="KHOTOL RIVER" symbol="117" render="true"/>
+          <category value="KIAGNA RIVER" label="KIAGNA RIVER" symbol="118" render="true"/>
+          <category value="KICHATNA RIVER" label="KICHATNA RIVER" symbol="119" render="true"/>
+          <category value="KING SALMON CREEK" label="KING SALMON CREEK" symbol="120" render="true"/>
+          <category value="KING SALMON RIVER" label="KING SALMON RIVER" symbol="121" render="true"/>
+          <category value="KISARALIK RIVER" label="KISARALIK RIVER" symbol="122" render="true"/>
+          <category value="KIVALINA RIVER" label="KIVALINA RIVER" symbol="123" render="true"/>
+          <category value="KIWALIK RIVER" label="KIWALIK RIVER" symbol="124" render="true"/>
+          <category value="KLEHINI RIVER" label="KLEHINI RIVER" symbol="125" render="true"/>
+          <category value="KLUKLAKLATNA RIVER" label="KLUKLAKLATNA RIVER" symbol="126" render="true"/>
+          <category value="KLUTINA RIVER" label="KLUTINA RIVER" symbol="127" render="true"/>
+          <category value="KLUTUK CREEK" label="KLUTUK CREEK" symbol="128" render="true"/>
+          <category value="KOBUK RIVER" label="KOBUK RIVER" symbol="129" render="true"/>
+          <category value="KOGOLUKTUK RIVER" label="KOGOLUKTUK RIVER" symbol="130" render="true"/>
+          <category value="KOGRUKLUK RIVER" label="KOGRUKLUK RIVER" symbol="131" render="true"/>
+          <category value="KOKWOK RIVER" label="KOKWOK RIVER" symbol="132" render="true"/>
+          <category value="KOSINA CREEK" label="KOSINA CREEK" symbol="133" render="true"/>
+          <category value="KOUGAROK CREEK" label="KOUGAROK CREEK" symbol="134" render="true"/>
+          <category value="KOYUK RIVER" label="KOYUK RIVER" symbol="135" render="true"/>
+          <category value="KOYUKUK RIVER" label="KOYUKUK RIVER" symbol="136" render="true"/>
+          <category value="KUGARAK RIVER" label="KUGARAK RIVER" symbol="137" render="true"/>
+          <category value="KUGRUK RIVER" label="KUGRUK RIVER" symbol="138" render="true"/>
+          <category value="KUGRUPAGA RIVER" label="KUGRUPAGA RIVER" symbol="139" render="true"/>
+          <category value="KUGURURCK RIVER" label="KUGURURCK RIVER" symbol="140" render="true"/>
+          <category value="KUGURUROK RIVER" label="KUGURUROK RIVER" symbol="141" render="true"/>
+          <category value="KUZITRIN RIVER" label="KUZITRIN RIVER" symbol="142" render="true"/>
+          <category value="KWETHLUK RIVER" label="KWETHLUK RIVER" symbol="143" render="true"/>
+          <category value="KWINIUK RIVER" label="KWINIUK RIVER" symbol="144" render="true"/>
+          <category value="LADUE RIVER" label="LADUE RIVER" symbol="145" render="true"/>
+          <category value="LAVA FORK" label="LAVA FORK" symbol="146" render="true"/>
+          <category value="LITTLE BLACK RIVER" label="LITTLE BLACK RIVER" symbol="147" render="true"/>
+          <category value="LITTLE DELTA RIVER" label="LITTLE DELTA RIVER" symbol="148" render="true"/>
+          <category value="LITTLE MELOZITNA RIVER" label="LITTLE MELOZITNA RIVER" symbol="149" render="true"/>
+          <category value="LITTLE MUD RIVER" label="LITTLE MUD RIVER" symbol="150" render="true"/>
+          <category value="LITTLE UNDERHILL CREEK" label="LITTLE UNDERHILL CREEK" symbol="151" render="true"/>
+          <category value="LOST CREEK" label="LOST CREEK" symbol="152" render="true"/>
+          <category value="LOST RIVER" label="LOST RIVER" symbol="153" render="true"/>
+          <category value="MACLAREN RIVER" label="MACLAREN RIVER" symbol="154" render="true"/>
+          <category value="MANGOAK RIVER" label="MANGOAK RIVER" symbol="155" render="true"/>
+          <category value="MATANUSKA RIVER" label="MATANUSKA RIVER" symbol="156" render="true"/>
+          <category value="MAUNELUK RIVER" label="MAUNELUK RIVER" symbol="157" render="true"/>
+          <category value="MCKINLEY RIVER" label="MCKINLEY RIVER" symbol="158" render="true"/>
+          <category value="MELOZITNA RIVER" label="MELOZITNA RIVER" symbol="159" render="true"/>
+          <category value="MELVIN CHANNEL" label="MELVIN CHANNEL" symbol="160" render="true"/>
+          <category value="MESHIK RIVER" label="MESHIK RIVER" symbol="161" render="true"/>
+          <category value="METTENPHERG CREEK" label="METTENPHERG CREEK" symbol="162" render="true"/>
+          <category value="MIDDLE FORK" label="MIDDLE FORK" symbol="163" render="true"/>
+          <category value="MIDDLE FORK CHANDALAR RIVER" label="MIDDLE FORK CHANDALAR RIVER" symbol="164" render="true"/>
+          <category value="MIDDLE FORK EEK RIVER" label="MIDDLE FORK EEK RIVER" symbol="165" render="true"/>
+          <category value="MIDDLE FORK FORTYMILE RIVER" label="MIDDLE FORK FORTYMILE RIVER" symbol="166" render="true"/>
+          <category value="MIDDLE FORK KOYUKUK RIVER" label="MIDDLE FORK KOYUKUK RIVER" symbol="167" render="true"/>
+          <category value="MINT RIVER" label="MINT RIVER" symbol="168" render="true"/>
+          <category value="MIRROR CREEK" label="MIRROR CREEK" symbol="169" render="true"/>
+          <category value="MOSQUITO FORK" label="MOSQUITO FORK" symbol="170" render="true"/>
+          <category value="MULCHATNA RIVER" label="MULCHATNA RIVER" symbol="171" render="true"/>
+          <category value="NAGEETHLUK RIVER" label="NAGEETHLUK RIVER" symbol="172" render="true"/>
+          <category value="NATION RIVER" label="NATION RIVER" symbol="173" render="true"/>
+          <category value="NEACOLA RIVER" label="NEACOLA RIVER" symbol="174" render="true"/>
+          <category value="NELLIE JUAN RIVER" label="NELLIE JUAN RIVER" symbol="175" render="true"/>
+          <category value="NENANA RIVER" label="NENANA RIVER" symbol="176" render="true"/>
+          <category value="NIUKLUK RIVER" label="NIUKLUK RIVER" symbol="177" render="true"/>
+          <category value="NIXON RIVER" label="NIXON RIVER" symbol="178" render="true"/>
+          <category value="NIZINA RIVER" label="NIZINA RIVER" symbol="179" render="true"/>
+          <category value="NOATAK RIVER" label="NOATAK RIVER" symbol="180" render="true"/>
+          <category value="NORTH FORK" label="NORTH FORK" symbol="181" render="true"/>
+          <category value="NORTH FORK INNOKO RIVER" label="NORTH FORK INNOKO RIVER" symbol="182" render="true"/>
+          <category value="NORTH FORK KOYUKUK RIVER" label="NORTH FORK KOYUKUK RIVER" symbol="183" render="true"/>
+          <category value="NORTH FORK KUSKOKWIM RIVER" label="NORTH FORK KUSKOKWIM RIVER" symbol="184" render="true"/>
+          <category value="NORTH FORK UNALAKLEET RIVER" label="NORTH FORK UNALAKLEET RIVER" symbol="185" render="true"/>
+          <category value="NORTH FORTYMILE RIVER" label="NORTH FORTYMILE RIVER" symbol="186" render="true"/>
+          <category value="NORTH RIVER" label="NORTH RIVER" symbol="187" render="true"/>
+          <category value="NOWITNA RIVER" label="NOWITNA RIVER" symbol="188" render="true"/>
+          <category value="NOXAPAGA RIVER" label="NOXAPAGA RIVER" symbol="189" render="true"/>
+          <category value="NUGNUGALURTUK RIVER" label="NUGNUGALURTUK RIVER" symbol="190" render="true"/>
+          <category value="NULATO RIVER" label="NULATO RIVER" symbol="191" render="true"/>
+          <category value="NULUK RIVER" label="NULUK RIVER" symbol="192" render="true"/>
+          <category value="NUSHAGAK RIVER" label="NUSHAGAK RIVER" symbol="193" render="true"/>
+          <category value="OMAR RIVER" label="OMAR RIVER" symbol="194" render="true"/>
+          <category value="OMIKVIOROK RIVER" label="OMIKVIOROK RIVER" symbol="195" render="true"/>
+          <category value="OOKAHLIKSOOK CREEK" label="OOKAHLIKSOOK CREEK" symbol="196" render="true"/>
+          <category value="OSHETNA RIVER" label="OSHETNA RIVER" symbol="197" render="true"/>
+          <category value="OSKAWALIK RIVER" label="OSKAWALIK RIVER" symbol="198" render="true"/>
+          <category value="PASTOLIK RIVER" label="PASTOLIK RIVER" symbol="199" render="true"/>
+          <category value="PEACE RIVER" label="PEACE RIVER" symbol="200" render="true"/>
+          <category value="PILE RIVER" label="PILE RIVER" symbol="201" render="true"/>
+          <category value="PILGRIM RIVER" label="PILGRIM RIVER" symbol="202" render="true"/>
+          <category value="PINGUK RIVER" label="PINGUK RIVER" symbol="203" render="true"/>
+          <category value="PISH RIVER" label="PISH RIVER" symbol="204" render="true"/>
+          <category value="PITNA FORK" label="PITNA FORK" symbol="205" render="true"/>
+          <category value="PORTAGE CREEK" label="PORTAGE CREEK" symbol="206" render="true"/>
+          <category value="PREACHER CREEK" label="PREACHER CREEK" symbol="207" render="true"/>
+          <category value="RAY RIVER" label="RAY RIVER" symbol="208" render="true"/>
+          <category value="REINDEER RIVER" label="REINDEER RIVER" symbol="209" render="true"/>
+          <category value="ROBERTSON RIVER" label="ROBERTSON RIVER" symbol="210" render="true"/>
+          <category value="SALCHA RIVER" label="SALCHA RIVER" symbol="211" render="true"/>
+          <category value="SALMON FORK" label="SALMON FORK" symbol="212" render="true"/>
+          <category value="SALMON RIVER" label="SALMON RIVER" symbol="213" render="true"/>
+          <category value="SAND CREEK" label="SAND CREEK" symbol="214" render="true"/>
+          <category value="SAVONOSKI RIVER" label="SAVONOSKI RIVER" symbol="215" render="true"/>
+          <category value="SELAWIK RIVER" label="SELAWIK RIVER" symbol="216" render="true"/>
+          <category value="SERPENTINE RIVER" label="SERPENTINE RIVER" symbol="217" render="true"/>
+          <category value="SETHKOKNA RIVER" label="SETHKOKNA RIVER" symbol="218" render="true"/>
+          <category value="SEVENTYMILE RIVER" label="SEVENTYMILE RIVER" symbol="219" render="true"/>
+          <category value="SHADE CREEK" label="SHADE CREEK" symbol="220" render="true"/>
+          <category value="SHAKTOOLIK RIVER" label="SHAKTOOLIK RIVER" symbol="221" render="true"/>
+          <category value="SHAW CREEK" label="SHAW CREEK" symbol="222" render="true"/>
+          <category value="SHEEP CREEK" label="SHEEP CREEK" symbol="223" render="true"/>
+          <category value="SHEERJEI RIVER" label="SHEERJEI RIVER" symbol="224" render="true"/>
+          <category value="SINONA CREEK" label="SINONA CREEK" symbol="225" render="true"/>
+          <category value="SINUK RIVER" label="SINUK RIVER" symbol="226" render="true"/>
+          <category value="SKWENTNA RIVER" label="SKWENTNA RIVER" symbol="227" render="true"/>
+          <category value="SLANA RIVER" label="SLANA RIVER" symbol="228" render="true"/>
+          <category value="SLIPPERY CREEK" label="SLIPPERY CREEK" symbol="229" render="true"/>
+          <category value="SOUTH FORK" label="SOUTH FORK" symbol="230" render="true"/>
+          <category value="SOUTH FORK HUSLIA RIVER" label="SOUTH FORK HUSLIA RIVER" symbol="231" render="true"/>
+          <category value="SOUTH FORK KOYUKUK RIVER" label="SOUTH FORK KOYUKUK RIVER" symbol="232" render="true"/>
+          <category value="SOUTH FORK KUSKOKWIM RIVER" label="SOUTH FORK KUSKOKWIM RIVER" symbol="233" render="true"/>
+          <category value="SOUTH FORK NULATO  RIVER" label="SOUTH FORK NULATO  RIVER" symbol="234" render="true"/>
+          <category value="SOUTH FORK SERPENTINE RIVER" label="SOUTH FORK SERPENTINE RIVER" symbol="235" render="true"/>
+          <category value="SPEEL RIVER" label="SPEEL RIVER" symbol="236" render="true"/>
+          <category value="SQUIRREL RIVER" label="SQUIRREL RIVER" symbol="237" render="true"/>
+          <category value="STONY RIVER" label="STONY RIVER" symbol="238" render="true"/>
+          <category value="STUYAHOK RIVER" label="STUYAHOK RIVER" symbol="239" render="true"/>
+          <category value="SUCKER RIVER" label="SUCKER RIVER" symbol="240" render="true"/>
+          <category value="SULATNA RIVER" label="SULATNA RIVER" symbol="241" render="true"/>
+          <category value="SULUKNA RIVER" label="SULUKNA RIVER" symbol="242" render="true"/>
+          <category value="SUSITNA RIVER" label="SUSITNA RIVER" symbol="243" render="true"/>
+          <category value="SUSULATNA RIVER" label="SUSULATNA RIVER" symbol="244" render="true"/>
+          <category value="SWIFT RIVER" label="SWIFT RIVER" symbol="245" render="true"/>
+          <category value="TAGAGAWIK RIVER" label="TAGAGAWIK RIVER" symbol="246" render="true"/>
+          <category value="TAKOTNA RIVER" label="TAKOTNA RIVER" symbol="247" render="true"/>
+          <category value="TALKEENTA RIVER" label="TALKEENTA RIVER" symbol="248" render="true"/>
+          <category value="TALKEETNA RIVER" label="TALKEETNA RIVER" symbol="249" render="true"/>
+          <category value="TANANA RIVER" label="TANANA RIVER" symbol="250" render="true"/>
+          <category value="TATALINA RIVER" label="TATALINA RIVER" symbol="251" render="true"/>
+          <category value="TATLWIKSUK RIVER" label="TATLWIKSUK RIVER" symbol="252" render="true"/>
+          <category value="TAZLINA RIVER" label="TAZLINA RIVER" symbol="253" render="true"/>
+          <category value="TEBAY RIVER" label="TEBAY RIVER" symbol="254" render="true"/>
+          <category value="TEKLANIKA RIVER" label="TEKLANIKA RIVER" symbol="255" render="true"/>
+          <category value="TETLIN RIVER" label="TETLIN RIVER" symbol="256" render="true"/>
+          <category value="TIEKEL RIVER" label="TIEKEL RIVER" symbol="257" render="true"/>
+          <category value="TIKCHIK RIVER" label="TIKCHIK RIVER" symbol="258" render="true"/>
+          <category value="TIMBER CREEK" label="TIMBER CREEK" symbol="259" render="true"/>
+          <category value="TINAYGUK RIVER" label="TINAYGUK RIVER" symbol="260" render="true"/>
+          <category value="TISUK RIVER" label="TISUK RIVER" symbol="261" render="true"/>
+          <category value="TITNUK CREEK" label="TITNUK CREEK" symbol="262" render="true"/>
+          <category value="TLIKAKILA RIVER" label="TLIKAKILA RIVER" symbol="263" render="true"/>
+          <category value="TOGIAK RIVER" label="TOGIAK RIVER" symbol="264" render="true"/>
+          <category value="TOK RIVER" label="TOK RIVER" symbol="265" render="true"/>
+          <category value="TOKLAT RIVER" label="TOKLAT RIVER" symbol="266" render="true"/>
+          <category value="TOLOVANA RIVER" label="TOLOVANA RIVER" symbol="267" render="true"/>
+          <category value="TONSINA RIVER" label="TONSINA RIVER" symbol="268" render="true"/>
+          <category value="TONZONA RIVER" label="TONZONA RIVER" symbol="269" render="true"/>
+          <category value="TOZITNA RIVER" label="TOZITNA RIVER" symbol="270" render="true"/>
+          <category value="TSINA RIVER" label="TSINA RIVER" symbol="271" render="true"/>
+          <category value="TSIRKU RIVER" label="TSIRKU RIVER" symbol="272" render="true"/>
+          <category value="TUBUTULIK RIVER" label="TUBUTULIK RIVER" symbol="273" render="true"/>
+          <category value="TUTUKSUK RIVER" label="TUTUKSUK RIVER" symbol="274" render="true"/>
+          <category value="TYONE RIVER" label="TYONE RIVER" symbol="275" render="true"/>
+          <category value="UNALAKLEET RIVER" label="UNALAKLEET RIVER" symbol="276" render="true"/>
+          <category value="UNGALIK RIVER" label="UNGALIK RIVER" symbol="277" render="true"/>
+          <category value="UNUK RIVER" label="UNUK RIVER" symbol="278" render="true"/>
+          <category value="WEARY RIVER" label="WEARY RIVER" symbol="279" render="true"/>
+          <category value="WEST FORK" label="WEST FORK" symbol="280" render="true"/>
+          <category value="WEST FORK GULKANA RIVER" label="WEST FORK GULKANA RIVER" symbol="281" render="true"/>
+          <category value="WHITING RIVER" label="WHITING RIVER" symbol="282" render="true"/>
+          <category value="WINDY FORK" label="WINDY FORK" symbol="283" render="true"/>
+          <category value="WOOD RIVER" label="WOOD RIVER" symbol="284" render="true"/>
+          <category value="WULIK RIVER" label="WULIK RIVER" symbol="285" render="true"/>
+          <category value="YENTNA RIVER" label="YENTNA RIVER" symbol="286" render="true"/>
+          <category value="YUKI RIVER" label="YUKI RIVER" symbol="287" render="true"/>
+          <category value="YUKON CREEK" label="YUKON CREEK" symbol="288" render="true"/>
+          <category value="" label="" symbol="289" render="true"/>
         </categories>
         <symbols>
-          <symbol force_rhr="0" name="0" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="0" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -5601,14 +5095,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="1" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="1" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -5628,14 +5122,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="10" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="10" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -5655,14 +5149,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="100" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="100" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -5682,14 +5176,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="101" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="101" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -5709,14 +5203,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="102" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="102" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -5736,14 +5230,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="103" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="103" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -5763,14 +5257,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="104" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="104" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -5790,14 +5284,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="105" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="105" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -5817,14 +5311,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="106" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="106" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -5844,14 +5338,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="107" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="107" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -5871,14 +5365,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="108" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="108" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -5898,14 +5392,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="109" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="109" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -5925,14 +5419,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="11" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="11" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -5952,14 +5446,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="110" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="110" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -5979,14 +5473,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="111" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="111" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -6006,14 +5500,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="112" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="112" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -6033,14 +5527,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="113" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="113" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -6060,14 +5554,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="114" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="114" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -6087,14 +5581,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="115" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="115" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -6114,14 +5608,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="116" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="116" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -6141,14 +5635,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="117" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="117" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -6168,14 +5662,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="118" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="118" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -6195,14 +5689,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="119" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="119" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -6222,14 +5716,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="12" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="12" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -6249,14 +5743,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="120" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="120" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -6276,14 +5770,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="121" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="121" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -6303,14 +5797,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="122" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="122" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -6330,14 +5824,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="123" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="123" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -6357,14 +5851,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="124" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="124" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -6384,14 +5878,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="125" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="125" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -6411,14 +5905,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="126" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="126" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -6438,14 +5932,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="127" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="127" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -6465,14 +5959,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="128" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="128" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -6492,14 +5986,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="129" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="129" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -6519,14 +6013,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="13" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="13" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -6546,14 +6040,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="130" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="130" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -6573,14 +6067,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="131" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="131" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -6600,14 +6094,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="132" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="132" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -6627,14 +6121,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="133" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="133" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -6654,14 +6148,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="134" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="134" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -6681,14 +6175,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="135" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="135" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -6708,14 +6202,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="136" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="136" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -6735,14 +6229,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="137" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="137" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -6762,14 +6256,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="138" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="138" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -6789,14 +6283,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="139" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="139" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -6816,14 +6310,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="14" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="14" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -6843,14 +6337,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="140" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="140" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -6870,14 +6364,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="141" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="141" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -6897,14 +6391,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="142" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="142" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -6924,14 +6418,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="143" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="143" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -6951,14 +6445,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="144" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="144" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -6978,14 +6472,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="145" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="145" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -7005,14 +6499,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="146" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="146" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -7032,14 +6526,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="147" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="147" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -7059,14 +6553,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="148" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="148" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -7086,14 +6580,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="149" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="149" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -7113,14 +6607,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="15" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="15" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -7140,14 +6634,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="150" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="150" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -7167,14 +6661,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="151" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="151" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -7194,14 +6688,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="152" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="152" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -7221,14 +6715,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="153" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="153" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -7248,14 +6742,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="154" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="154" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -7275,14 +6769,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="155" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="155" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -7302,14 +6796,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="156" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="156" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -7329,14 +6823,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="157" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="157" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -7356,14 +6850,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="158" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="158" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -7383,14 +6877,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="159" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="159" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -7410,14 +6904,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="16" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="16" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -7437,14 +6931,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="160" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="160" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -7464,14 +6958,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="161" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="161" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -7491,14 +6985,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="162" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="162" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -7518,14 +7012,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="163" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="163" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -7545,14 +7039,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="164" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="164" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -7572,20 +7066,20 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
-                  <Option name="properties" type="Map">
-                    <Option name="outlineWidth" type="Map">
-                      <Option value="true" name="active" type="bool"/>
-                      <Option value="coalesce(scale_exp(cat, 1, 4262, 1, 10, 0.57), 0)" name="expression" type="QString"/>
-                      <Option value="3" name="type" type="int"/>
+                  <Option value="" type="QString" name="name"/>
+                  <Option type="Map" name="properties">
+                    <Option type="Map" name="outlineWidth">
+                      <Option value="true" type="bool" name="active"/>
+                      <Option value="coalesce(scale_exp(cat, 1, 4262, 1, 10, 0.57), 0)" type="QString" name="expression"/>
+                      <Option value="3" type="int" name="type"/>
                     </Option>
                   </Option>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="165" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="165" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -7605,14 +7099,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="166" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="166" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -7632,14 +7126,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="167" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="167" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -7659,14 +7153,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="168" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="168" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -7686,14 +7180,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="169" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="169" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -7713,14 +7207,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="17" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="17" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -7740,14 +7234,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="170" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="170" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -7767,14 +7261,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="171" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="171" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -7794,14 +7288,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="172" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="172" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -7821,14 +7315,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="173" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="173" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -7848,14 +7342,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="174" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="174" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -7875,14 +7369,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="175" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="175" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -7902,14 +7396,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="176" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="176" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -7929,14 +7423,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="177" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="177" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -7956,14 +7450,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="178" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="178" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -7983,14 +7477,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="179" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="179" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -8010,14 +7504,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="18" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="18" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -8037,14 +7531,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="180" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="180" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -8064,14 +7558,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="181" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="181" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -8091,14 +7585,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="182" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="182" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -8118,14 +7612,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="183" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="183" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -8145,14 +7639,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="184" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="184" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -8172,14 +7666,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="185" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="185" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -8199,14 +7693,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="186" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="186" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -8226,14 +7720,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="187" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="187" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -8253,14 +7747,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="188" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="188" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -8280,14 +7774,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="189" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="189" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -8307,14 +7801,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="19" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="19" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -8334,14 +7828,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="190" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="190" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -8361,14 +7855,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="191" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="191" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -8388,14 +7882,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="192" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="192" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -8415,14 +7909,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="193" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="193" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -8442,14 +7936,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="194" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="194" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -8469,14 +7963,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="195" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="195" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -8496,14 +7990,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="196" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="196" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -8523,14 +8017,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="197" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="197" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -8550,14 +8044,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="198" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="198" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -8577,14 +8071,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="199" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="199" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -8604,14 +8098,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="2" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="2" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -8631,14 +8125,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="20" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="20" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -8658,14 +8152,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="200" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="200" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -8685,14 +8179,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="201" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="201" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -8712,14 +8206,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="202" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="202" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -8739,14 +8233,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="203" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="203" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -8766,14 +8260,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="204" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="204" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -8793,14 +8287,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="205" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="205" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -8820,14 +8314,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="206" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="206" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -8847,14 +8341,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="207" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="207" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -8874,14 +8368,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="208" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="208" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -8901,14 +8395,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="209" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="209" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -8928,14 +8422,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="21" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="21" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -8955,14 +8449,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="210" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="210" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -8982,14 +8476,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="211" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="211" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -9009,14 +8503,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="212" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="212" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -9036,14 +8530,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="213" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="213" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -9063,14 +8557,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="214" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="214" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -9090,14 +8584,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="215" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="215" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -9117,14 +8611,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="216" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="216" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -9144,14 +8638,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="217" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="217" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -9171,14 +8665,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="218" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="218" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -9198,14 +8692,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="219" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="219" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -9225,14 +8719,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="22" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="22" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -9252,14 +8746,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="220" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="220" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -9279,14 +8773,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="221" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="221" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -9306,14 +8800,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="222" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="222" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -9333,14 +8827,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="223" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="223" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -9360,14 +8854,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="224" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="224" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -9387,14 +8881,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="225" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="225" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -9414,14 +8908,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="226" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="226" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -9441,14 +8935,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="227" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="227" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -9468,14 +8962,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="228" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="228" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -9495,14 +8989,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="229" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="229" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -9522,14 +9016,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="23" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="23" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -9549,14 +9043,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="230" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="230" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -9576,14 +9070,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="231" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="231" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -9603,14 +9097,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="232" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="232" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -9630,14 +9124,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="233" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="233" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -9657,14 +9151,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="234" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="234" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -9684,14 +9178,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="235" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="235" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -9711,14 +9205,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="236" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="236" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -9738,14 +9232,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="237" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="237" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -9765,14 +9259,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="238" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="238" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -9792,14 +9286,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="239" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="239" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -9819,14 +9313,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="24" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="24" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -9846,14 +9340,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="240" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="240" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -9873,14 +9367,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="241" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="241" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -9900,14 +9394,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="242" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="242" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -9927,14 +9421,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="243" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="243" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -9954,14 +9448,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="244" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="244" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -9981,14 +9475,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="245" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="245" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -10008,14 +9502,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="246" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="246" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -10035,14 +9529,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="247" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="247" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -10062,14 +9556,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="248" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="248" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -10089,14 +9583,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="249" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="249" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -10116,14 +9610,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="25" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="25" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -10143,14 +9637,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="250" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="250" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -10170,14 +9664,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="251" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="251" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -10197,14 +9691,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="252" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="252" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -10224,14 +9718,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="253" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="253" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -10251,14 +9745,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="254" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="254" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -10278,14 +9772,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="255" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="255" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -10305,14 +9799,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="256" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="256" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -10332,14 +9826,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="257" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="257" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -10359,14 +9853,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="258" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="258" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -10386,14 +9880,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="259" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="259" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -10413,14 +9907,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="26" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="26" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -10440,14 +9934,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="260" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="260" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -10467,14 +9961,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="261" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="261" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -10494,14 +9988,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="262" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="262" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -10521,14 +10015,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="263" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="263" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -10548,14 +10042,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="264" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="264" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -10575,14 +10069,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="265" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="265" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -10602,14 +10096,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="266" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="266" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -10629,14 +10123,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="267" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="267" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -10656,14 +10150,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="268" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="268" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -10683,14 +10177,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="269" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="269" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -10710,14 +10204,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="27" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="27" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -10737,14 +10231,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="270" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="270" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -10764,14 +10258,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="271" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="271" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -10791,14 +10285,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="272" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="272" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -10818,14 +10312,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="273" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="273" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -10845,14 +10339,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="274" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="274" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -10872,14 +10366,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="275" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="275" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -10899,14 +10393,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="276" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="276" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -10926,14 +10420,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="277" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="277" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -10953,14 +10447,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="278" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="278" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -10980,14 +10474,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="279" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="279" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -11007,14 +10501,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="28" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="28" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -11034,14 +10528,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="280" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="280" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -11061,14 +10555,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="281" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="281" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -11088,14 +10582,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="282" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="282" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -11115,14 +10609,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="283" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="283" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -11142,14 +10636,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="284" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="284" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -11169,14 +10663,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="285" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="285" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -11196,14 +10690,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="286" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="286" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -11223,14 +10717,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="287" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="287" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -11250,14 +10744,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="288" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="288" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -11277,14 +10771,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="289" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="289" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -11304,14 +10798,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="29" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="29" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -11331,14 +10825,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="3" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="3" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -11358,14 +10852,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="30" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="30" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -11385,14 +10879,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="31" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="31" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -11412,14 +10906,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="32" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="32" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -11439,14 +10933,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="33" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="33" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -11466,14 +10960,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="34" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="34" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -11493,14 +10987,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="35" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="35" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -11520,14 +11014,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="36" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="36" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -11547,14 +11041,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="37" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="37" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -11574,14 +11068,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="38" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="38" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -11601,14 +11095,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="39" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="39" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -11628,14 +11122,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="4" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="4" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -11655,14 +11149,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="40" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="40" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -11682,14 +11176,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="41" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="41" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -11709,14 +11203,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="42" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="42" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -11736,14 +11230,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="43" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="43" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -11763,14 +11257,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="44" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="44" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -11790,14 +11284,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="45" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="45" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -11817,14 +11311,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="46" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="46" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -11844,14 +11338,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="47" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="47" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -11871,14 +11365,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="48" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="48" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -11898,14 +11392,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="49" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="49" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -11925,14 +11419,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="5" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="5" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -11952,14 +11446,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="50" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="50" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -11979,14 +11473,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="51" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="51" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -12006,14 +11500,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="52" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="52" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -12033,14 +11527,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="53" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="53" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -12060,14 +11554,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="54" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="54" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -12087,14 +11581,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="55" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="55" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -12114,14 +11608,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="56" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="56" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -12141,14 +11635,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="57" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="57" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -12168,14 +11662,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="58" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="58" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -12195,14 +11689,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="59" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="59" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -12222,14 +11716,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="6" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="6" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -12249,14 +11743,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="60" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="60" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -12276,14 +11770,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="61" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="61" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -12303,14 +11797,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="62" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="62" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -12330,14 +11824,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="63" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="63" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -12357,14 +11851,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="64" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="64" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -12384,14 +11878,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="65" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="65" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -12411,14 +11905,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="66" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="66" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -12438,14 +11932,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="67" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="67" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -12465,14 +11959,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="68" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="68" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -12492,14 +11986,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="69" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="69" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -12519,14 +12013,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="7" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="7" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -12546,14 +12040,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="70" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="70" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -12573,14 +12067,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="71" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="71" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -12600,14 +12094,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="72" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="72" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -12627,14 +12121,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="73" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="73" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -12654,14 +12148,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="74" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="74" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -12681,14 +12175,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="75" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="75" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -12708,14 +12202,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="76" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="76" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -12735,14 +12229,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="77" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="77" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -12762,14 +12256,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="78" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="78" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -12789,14 +12283,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="79" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="79" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -12816,14 +12310,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="8" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="8" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -12843,14 +12337,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="80" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="80" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -12870,14 +12364,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="81" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="81" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -12897,14 +12391,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="82" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="82" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -12924,14 +12418,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="83" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="83" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -12951,14 +12445,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="84" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="84" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -12978,14 +12472,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="85" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="85" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -13005,14 +12499,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="86" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="86" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -13032,14 +12526,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="87" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="87" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -13059,14 +12553,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="88" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="88" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -13086,14 +12580,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="89" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="89" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -13113,14 +12607,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="9" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="9" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -13140,14 +12634,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="90" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="90" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -13167,14 +12661,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="91" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="91" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -13194,14 +12688,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="92" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="92" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -13221,14 +12715,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="93" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="93" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -13248,14 +12742,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="94" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="94" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -13275,14 +12769,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="95" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="95" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -13302,14 +12796,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="96" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="96" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -13329,14 +12823,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="97" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="97" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -13356,14 +12850,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="98" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="98" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -13383,14 +12877,14 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol force_rhr="0" name="99" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="99" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -13410,16 +12904,16 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
         </symbols>
         <source-symbol>
-          <symbol force_rhr="0" name="0" clip_to_extent="1" alpha="1" type="line">
+          <symbol clip_to_extent="1" force_rhr="0" type="line" name="0" alpha="1">
             <layer enabled="1" pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -13439,9 +12933,9 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
@@ -13451,114 +12945,54 @@ def my_form_open(dialog, layer, feature):
         <sizescale/>
       </renderer-v2>
       <labeling type="simple">
-        <settings calloutType="simple">
-          <text-style fontSize="11" textOpacity="1" fontFamily="Ubuntu" fontItalic="1" fontCapitals="2" textOrientation="horizontal" fontStrikeout="0" blendMode="0" fieldName="NAM" previewBkgrdColor="255,255,255,255" fontUnderline="0" fontWordSpacing="5" fontSizeUnit="Point" namedStyle="Bold Italic" fontKerning="1" isExpression="0" useSubstitutions="0" textColor="0,87,168,255" fontSizeMapUnitScale="3x:0,0,0,0,0,0" multilineHeight="1" fontLetterSpacing="0" fontWeight="75">
-            <text-buffer bufferSizeUnits="MM" bufferDraw="0" bufferNoFill="0" bufferColor="255,255,255,255" bufferOpacity="1" bufferBlendMode="0" bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferJoinStyle="64" bufferSize="1"/>
-            <background shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeOpacity="1" shapeSizeX="0" shapeRadiiX="0" shapeSVGFile="" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeOffsetX="0" shapeType="0" shapeBlendMode="0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeJoinStyle="64" shapeDraw="0" shapeSizeUnit="MM" shapeSizeType="0" shapeRotationType="0" shapeRotation="0" shapeOffsetUnit="MM" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeBorderWidthUnit="MM" shapeSizeY="0" shapeBorderWidth="0" shapeRadiiY="0" shapeOffsetY="0" shapeBorderColor="128,128,128,255" shapeRadiiUnit="MM" shapeFillColor="255,255,255,255">
-              <symbol force_rhr="0" name="markerSymbol" clip_to_extent="1" alpha="1" type="marker">
-                <layer enabled="1" pass="0" class="SimpleMarker" locked="0">
-                  <prop k="angle" v="0"/>
-                  <prop k="color" v="183,72,75,255"/>
-                  <prop k="horizontal_anchor_point" v="1"/>
-                  <prop k="joinstyle" v="bevel"/>
-                  <prop k="name" v="circle"/>
-                  <prop k="offset" v="0,0"/>
-                  <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-                  <prop k="offset_unit" v="MM"/>
-                  <prop k="outline_color" v="35,35,35,255"/>
-                  <prop k="outline_style" v="solid"/>
-                  <prop k="outline_width" v="0"/>
-                  <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-                  <prop k="outline_width_unit" v="MM"/>
-                  <prop k="scale_method" v="diameter"/>
-                  <prop k="size" v="2"/>
-                  <prop k="size_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-                  <prop k="size_unit" v="MM"/>
-                  <prop k="vertical_anchor_point" v="1"/>
-                  <data_defined_properties>
-                    <Option type="Map">
-                      <Option value="" name="name" type="QString"/>
-                      <Option name="properties"/>
-                      <Option value="collection" name="type" type="QString"/>
-                    </Option>
-                  </data_defined_properties>
-                </layer>
-              </symbol>
-            </background>
-            <shadow shadowDraw="0" shadowOffsetUnit="MM" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowRadiusUnit="MM" shadowScale="100" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowRadiusAlphaOnly="0" shadowBlendMode="6" shadowOffsetAngle="135" shadowOffsetDist="1" shadowOffsetGlobal="1" shadowUnder="0" shadowRadius="1.5" shadowColor="0,0,0,255" shadowOpacity="0.7"/>
-            <dd_properties>
-              <Option type="Map">
-                <Option value="" name="name" type="QString"/>
-                <Option name="properties"/>
-                <Option value="collection" name="type" type="QString"/>
-              </Option>
-            </dd_properties>
+        <settings>
+          <text-style namedStyle="Bold Italic" fieldName="NAM" fontWeight="75" fontWordSpacing="5" fontSizeUnit="Point" fontItalic="1" fontSizeMapUnitScale="3x:0,0,0,0,0,0" fontCapitals="2" fontFamily="Ubuntu" textColor="0,87,168,255" fontSize="11" fontLetterSpacing="0" previewBkgrdColor="255,255,255,255" fontStrikeout="0" multilineHeight="1" useSubstitutions="0" textOpacity="1" isExpression="0" blendMode="0" fontUnderline="0">
+            <text-buffer bufferDraw="0" bufferNoFill="0" bufferBlendMode="0" bufferSize="1" bufferSizeUnits="MM" bufferColor="255,255,255,255" bufferJoinStyle="64" bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferOpacity="1"/>
+            <background shapeRadiiX="0" shapeSizeUnit="MM" shapeOffsetY="0" shapeRadiiUnit="MM" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeBlendMode="0" shapeRotation="0" shapeSizeX="0" shapeSizeY="0" shapeDraw="0" shapeRadiiY="0" shapeOffsetX="0" shapeRotationType="0" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeOffsetUnit="MM" shapeBorderWidth="0" shapeBorderWidthUnit="MM" shapeJoinStyle="64" shapeBorderColor="128,128,128,255" shapeFillColor="255,255,255,255" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeType="0" shapeSVGFile="" shapeSizeType="0" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeOpacity="1"/>
+            <shadow shadowDraw="0" shadowOffsetGlobal="1" shadowOffsetAngle="135" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowColor="0,0,0,255" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowOpacity="0.7" shadowRadiusUnit="MM" shadowUnder="0" shadowOffsetUnit="MM" shadowScale="100" shadowBlendMode="6" shadowRadiusAlphaOnly="0" shadowOffsetDist="1" shadowRadius="1.5"/>
             <substitutions/>
           </text-style>
-          <text-format addDirectionSymbol="0" rightDirectionSymbol=">" plussign="0" reverseDirectionSymbol="0" placeDirectionSymbol="0" multilineAlign="0" leftDirectionSymbol="&lt;" formatNumbers="0" wrapChar="" autoWrapLength="0" useMaxLineLengthForAutoWrap="1" decimals="3"/>
-          <placement geometryGeneratorEnabled="0" fitInPolygonOnly="0" maxCurvedCharAngleOut="-20" rotationAngle="0" priority="5" geometryGeneratorType="PointGeometry" predefinedPositionOrder="TR,TL,BR,BL,R,L,TSR,BSR" distUnits="MM" repeatDistance="0" xOffset="0" centroidWhole="0" preserveRotation="1" offsetUnits="MapUnit" overrunDistance="0" repeatDistanceMapUnitScale="3x:0,0,0,0,0,0" placement="3" repeatDistanceUnits="MM" labelOffsetMapUnitScale="3x:0,0,0,0,0,0" layerType="LineGeometry" distMapUnitScale="3x:0,0,0,0,0,0" yOffset="0" offsetType="0" quadOffset="4" dist="1" overrunDistanceMapUnitScale="3x:0,0,0,0,0,0" placementFlags="2" maxCurvedCharAngleIn="20" overrunDistanceUnit="MM" geometryGenerator="" centroidInside="0"/>
-          <rendering obstacle="1" drawLabels="1" fontMaxPixelSize="10000" maxNumLabels="2000" minFeatureSize="0" scaleVisibility="0" mergeLines="1" scaleMin="1" zIndex="0" fontMinPixelSize="3" upsidedownLabels="0" obstacleType="0" obstacleFactor="1" limitNumLabels="0" labelPerPart="0" scaleMax="10000000" displayAll="0" fontLimitPixelSize="0"/>
+          <text-format formatNumbers="0" useMaxLineLengthForAutoWrap="1" rightDirectionSymbol=">" leftDirectionSymbol="&lt;" wrapChar="" autoWrapLength="0" addDirectionSymbol="0" decimals="3" plussign="0" reverseDirectionSymbol="0" multilineAlign="0" placeDirectionSymbol="0"/>
+          <placement fitInPolygonOnly="0" geometryGenerator="" geometryGeneratorEnabled="0" geometryGeneratorType="PointGeometry" priority="5" repeatDistanceUnits="MM" placementFlags="2" dist="1" maxCurvedCharAngleOut="-20" distUnits="MM" predefinedPositionOrder="TR,TL,BR,BL,R,L,TSR,BSR" repeatDistanceMapUnitScale="3x:0,0,0,0,0,0" labelOffsetMapUnitScale="3x:0,0,0,0,0,0" centroidWhole="0" centroidInside="0" rotationAngle="0" preserveRotation="1" offsetUnits="MapUnit" xOffset="0" quadOffset="4" distMapUnitScale="3x:0,0,0,0,0,0" repeatDistance="0" yOffset="0" placement="3" maxCurvedCharAngleIn="20" layerType="UnknownGeometry" offsetType="0"/>
+          <rendering obstacle="1" minFeatureSize="0" labelPerPart="0" maxNumLabels="2000" upsidedownLabels="0" drawLabels="1" fontMaxPixelSize="10000" fontMinPixelSize="3" scaleMax="10000000" zIndex="0" scaleVisibility="0" fontLimitPixelSize="0" obstacleFactor="1" limitNumLabels="0" mergeLines="1" scaleMin="1" obstacleType="0" displayAll="0"/>
           <dd_properties>
             <Option type="Map">
-              <Option value="" name="name" type="QString"/>
+              <Option value="" type="QString" name="name"/>
               <Option name="properties"/>
-              <Option value="collection" name="type" type="QString"/>
+              <Option value="collection" type="QString" name="type"/>
             </Option>
           </dd_properties>
-          <callout type="simple">
-            <Option type="Map">
-              <Option value="pole_of_inaccessibility" name="anchorPoint" type="QString"/>
-              <Option name="ddProperties" type="Map">
-                <Option value="" name="name" type="QString"/>
-                <Option name="properties"/>
-                <Option value="collection" name="type" type="QString"/>
-              </Option>
-              <Option value="false" name="drawToAllParts" type="bool"/>
-              <Option value="0" name="enabled" type="QString"/>
-              <Option value="&lt;symbol force_rhr=&quot;0&quot; name=&quot;symbol&quot; clip_to_extent=&quot;1&quot; alpha=&quot;1&quot; type=&quot;line&quot;>&lt;layer enabled=&quot;1&quot; pass=&quot;0&quot; class=&quot;SimpleLine&quot; locked=&quot;0&quot;>&lt;prop k=&quot;capstyle&quot; v=&quot;square&quot;/>&lt;prop k=&quot;customdash&quot; v=&quot;5;2&quot;/>&lt;prop k=&quot;customdash_map_unit_scale&quot; v=&quot;3x:0,0,0,0,0,0&quot;/>&lt;prop k=&quot;customdash_unit&quot; v=&quot;MM&quot;/>&lt;prop k=&quot;draw_inside_polygon&quot; v=&quot;0&quot;/>&lt;prop k=&quot;joinstyle&quot; v=&quot;bevel&quot;/>&lt;prop k=&quot;line_color&quot; v=&quot;60,60,60,255&quot;/>&lt;prop k=&quot;line_style&quot; v=&quot;solid&quot;/>&lt;prop k=&quot;line_width&quot; v=&quot;0.3&quot;/>&lt;prop k=&quot;line_width_unit&quot; v=&quot;MM&quot;/>&lt;prop k=&quot;offset&quot; v=&quot;0&quot;/>&lt;prop k=&quot;offset_map_unit_scale&quot; v=&quot;3x:0,0,0,0,0,0&quot;/>&lt;prop k=&quot;offset_unit&quot; v=&quot;MM&quot;/>&lt;prop k=&quot;ring_filter&quot; v=&quot;0&quot;/>&lt;prop k=&quot;use_custom_dash&quot; v=&quot;0&quot;/>&lt;prop k=&quot;width_map_unit_scale&quot; v=&quot;3x:0,0,0,0,0,0&quot;/>&lt;data_defined_properties>&lt;Option type=&quot;Map&quot;>&lt;Option value=&quot;&quot; name=&quot;name&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;properties&quot;/>&lt;Option value=&quot;collection&quot; name=&quot;type&quot; type=&quot;QString&quot;/>&lt;/Option>&lt;/data_defined_properties>&lt;/layer>&lt;/symbol>" name="lineSymbol" type="QString"/>
-              <Option value="0" name="minLength" type="double"/>
-              <Option value="3x:0,0,0,0,0,0" name="minLengthMapUnitScale" type="QString"/>
-              <Option value="MM" name="minLengthUnit" type="QString"/>
-              <Option value="0" name="offsetFromAnchor" type="double"/>
-              <Option value="3x:0,0,0,0,0,0" name="offsetFromAnchorMapUnitScale" type="QString"/>
-              <Option value="MM" name="offsetFromAnchorUnit" type="QString"/>
-              <Option value="0" name="offsetFromLabel" type="double"/>
-              <Option value="3x:0,0,0,0,0,0" name="offsetFromLabelMapUnitScale" type="QString"/>
-              <Option value="MM" name="offsetFromLabelUnit" type="QString"/>
-            </Option>
-          </callout>
         </settings>
       </labeling>
       <customproperties>
-        <property value="0" key="embeddedWidgets/count"/>
-        <property key="variableNames"/>
-        <property key="variableValues"/>
+        <property key="variableNames" value="_fields_"/>
+        <property key="variableValues" value=""/>
       </customproperties>
       <blendMode>0</blendMode>
       <featureBlendMode>0</featureBlendMode>
       <layerOpacity>1</layerOpacity>
-      <SingleCategoryDiagramRenderer diagramType="Pie" attributeLegend="1">
-        <DiagramCategory backgroundAlpha="255" sizeScale="3x:0,0,0,0,0,0" opacity="1" scaleBasedVisibility="0" width="15" backgroundColor="#ffffff" minScaleDenominator="-4.65661e-10" rotationOffset="270" minimumSize="0" penAlpha="255" lineSizeScale="3x:0,0,0,0,0,0" scaleDependency="Area" penWidth="0" barWidth="5" height="15" labelPlacementMethod="XHeight" lineSizeType="MM" diagramOrientation="Up" enabled="0" sizeType="MM" penColor="#000000" maxScaleDenominator="1e+8">
+      <SingleCategoryDiagramRenderer attributeLegend="1" diagramType="Pie">
+        <DiagramCategory minScaleDenominator="-4.65661e-10" diagramOrientation="Up" backgroundColor="#ffffff" penWidth="0" barWidth="5" penColor="#000000" opacity="1" maxScaleDenominator="1e+8" rotationOffset="270" scaleBasedVisibility="0" penAlpha="255" scaleDependency="Area" labelPlacementMethod="XHeight" enabled="0" width="15" sizeType="MM" lineSizeScale="3x:0,0,0,0,0,0" height="15" lineSizeType="MM" backgroundAlpha="255" sizeScale="3x:0,0,0,0,0,0" minimumSize="0">
           <fontProperties description="Ubuntu,11,-1,5,50,0,0,0,0,0" style=""/>
-          <attribute field="" label="" color="#000000"/>
+          <attribute label="" color="#000000" field=""/>
         </DiagramCategory>
       </SingleCategoryDiagramRenderer>
-      <DiagramLayerSettings priority="0" obstacle="0" zIndex="0" showAll="1" placement="2" dist="0" linePlacementFlags="2">
+      <DiagramLayerSettings showAll="1" priority="0" placement="2" linePlacementFlags="10" zIndex="0" dist="0" obstacle="0">
         <properties>
           <Option type="Map">
-            <Option value="" name="name" type="QString"/>
-            <Option name="properties" type="Map">
-              <Option name="show" type="Map">
-                <Option value="true" name="active" type="bool"/>
-                <Option value="cat" name="field" type="QString"/>
-                <Option value="2" name="type" type="int"/>
+            <Option value="" type="QString" name="name"/>
+            <Option type="Map" name="properties">
+              <Option type="Map" name="show">
+                <Option value="true" type="bool" name="active"/>
+                <Option value="cat" type="QString" name="field"/>
+                <Option value="2" type="int" name="type"/>
               </Option>
             </Option>
-            <Option value="collection" name="type" type="QString"/>
+            <Option value="collection" type="QString" name="type"/>
           </Option>
         </properties>
       </DiagramLayerSettings>
-      <geometryOptions removeDuplicateNodes="0" geometryPrecision="0">
+      <geometryOptions geometryPrecision="0" removeDuplicateNodes="0">
         <activeChecks/>
         <checkConfiguration/>
       </geometryOptions>
@@ -13567,8 +13001,8 @@ def my_form_open(dialog, layer, feature):
           <editWidget type="TextEdit">
             <config>
               <Option type="Map">
-                <Option value="0" name="IsMultiline" type="QString"/>
-                <Option value="0" name="UseHtml" type="QString"/>
+                <Option value="0" type="QString" name="IsMultiline"/>
+                <Option value="0" type="QString" name="UseHtml"/>
               </Option>
             </config>
           </editWidget>
@@ -13577,8 +13011,8 @@ def my_form_open(dialog, layer, feature):
           <editWidget type="TextEdit">
             <config>
               <Option type="Map">
-                <Option value="0" name="IsMultiline" type="QString"/>
-                <Option value="0" name="UseHtml" type="QString"/>
+                <Option value="0" type="QString" name="IsMultiline"/>
+                <Option value="0" type="QString" name="UseHtml"/>
               </Option>
             </config>
           </editWidget>
@@ -13587,8 +13021,8 @@ def my_form_open(dialog, layer, feature):
           <editWidget type="TextEdit">
             <config>
               <Option type="Map">
-                <Option value="0" name="IsMultiline" type="QString"/>
-                <Option value="0" name="UseHtml" type="QString"/>
+                <Option value="0" type="QString" name="IsMultiline"/>
+                <Option value="0" type="QString" name="UseHtml"/>
               </Option>
             </config>
           </editWidget>
@@ -13597,57 +13031,48 @@ def my_form_open(dialog, layer, feature):
           <editWidget type="TextEdit">
             <config>
               <Option type="Map">
-                <Option value="0" name="IsMultiline" type="QString"/>
-                <Option value="0" name="UseHtml" type="QString"/>
+                <Option value="0" type="QString" name="IsMultiline"/>
+                <Option value="0" type="QString" name="UseHtml"/>
               </Option>
             </config>
           </editWidget>
         </field>
       </fieldConfiguration>
       <aliases>
-        <alias name="" index="0" field="cat"/>
-        <alias name="" index="1" field="F_CODEDESC"/>
-        <alias name="" index="2" field="NAM"/>
-        <alias name="" index="3" field="F_CODE"/>
+        <alias name="" field="cat" index="0"/>
+        <alias name="" field="F_CODEDESC" index="1"/>
+        <alias name="" field="NAM" index="2"/>
+        <alias name="" field="F_CODE" index="3"/>
       </aliases>
       <excludeAttributesWMS/>
       <excludeAttributesWFS/>
       <defaults>
-        <default field="cat" applyOnUpdate="0" expression=""/>
-        <default field="F_CODEDESC" applyOnUpdate="0" expression=""/>
-        <default field="NAM" applyOnUpdate="0" expression=""/>
-        <default field="F_CODE" applyOnUpdate="0" expression=""/>
+        <default field="cat" expression="" applyOnUpdate="0"/>
+        <default field="F_CODEDESC" expression="" applyOnUpdate="0"/>
+        <default field="NAM" expression="" applyOnUpdate="0"/>
+        <default field="F_CODE" expression="" applyOnUpdate="0"/>
       </defaults>
       <constraints>
-        <constraint field="cat" notnull_strength="0" constraints="0" unique_strength="0" exp_strength="0"/>
-        <constraint field="F_CODEDESC" notnull_strength="0" constraints="0" unique_strength="0" exp_strength="0"/>
-        <constraint field="NAM" notnull_strength="0" constraints="0" unique_strength="0" exp_strength="0"/>
-        <constraint field="F_CODE" notnull_strength="0" constraints="0" unique_strength="0" exp_strength="0"/>
+        <constraint notnull_strength="0" exp_strength="0" field="cat" unique_strength="0" constraints="0"/>
+        <constraint notnull_strength="0" exp_strength="0" field="F_CODEDESC" unique_strength="0" constraints="0"/>
+        <constraint notnull_strength="0" exp_strength="0" field="NAM" unique_strength="0" constraints="0"/>
+        <constraint notnull_strength="0" exp_strength="0" field="F_CODE" unique_strength="0" constraints="0"/>
       </constraints>
       <constraintExpressions>
-        <constraint field="cat" exp="" desc=""/>
-        <constraint field="F_CODEDESC" exp="" desc=""/>
-        <constraint field="NAM" exp="" desc=""/>
-        <constraint field="F_CODE" exp="" desc=""/>
+        <constraint field="cat" desc="" exp=""/>
+        <constraint field="F_CODEDESC" desc="" exp=""/>
+        <constraint field="NAM" desc="" exp=""/>
+        <constraint field="F_CODE" desc="" exp=""/>
       </constraintExpressions>
       <expressionfields/>
-      <attributeactions>
-        <defaultAction value="{00000000-0000-0000-0000-000000000000}" key="Canvas"/>
-      </attributeactions>
+      <attributeactions/>
       <attributetableconfig sortExpression="" actionWidgetStyle="dropDown" sortOrder="0">
-        <columns>
-          <column hidden="0" name="cat" type="field" width="-1"/>
-          <column hidden="0" name="F_CODEDESC" type="field" width="-1"/>
-          <column hidden="0" name="NAM" type="field" width="-1"/>
-          <column hidden="0" name="F_CODE" type="field" width="-1"/>
-          <column hidden="1" type="actions" width="-1"/>
-        </columns>
+        <columns/>
       </attributetableconfig>
       <conditionalstyles>
         <rowstyles/>
         <fieldstyles/>
       </conditionalstyles>
-      <storedexpressions/>
       <editform tolerant="1"></editform>
       <editforminit/>
       <editforminitcodesource>0</editforminitcodesource>
@@ -13671,23 +13096,13 @@ def my_form_open(dialog, layer, feature):
 ]]></editforminitcode>
       <featformsuppress>0</featformsuppress>
       <editorlayout>generatedlayout</editorlayout>
-      <editable>
-        <field name="F_CODE" editable="1"/>
-        <field name="F_CODEDESC" editable="1"/>
-        <field name="NAM" editable="1"/>
-        <field name="cat" editable="1"/>
-      </editable>
-      <labelOnTop>
-        <field name="F_CODE" labelOnTop="0"/>
-        <field name="F_CODEDESC" labelOnTop="0"/>
-        <field name="NAM" labelOnTop="0"/>
-        <field name="cat" labelOnTop="0"/>
-      </labelOnTop>
+      <editable/>
+      <labelOnTop/>
       <widgets/>
-      <previewExpression>cat</previewExpression>
+      <previewExpression>"cat"</previewExpression>
       <mapTip></mapTip>
     </maplayer>
-    <maplayer simplifyDrawingHints="1" simplifyAlgorithm="0" labelsEnabled="1" refreshOnNotifyMessage="" wkbType="Point" minScale="1e+8" readOnly="0" refreshOnNotifyEnabled="0" type="vector" maxScale="0" simplifyLocal="1" autoRefreshTime="0" hasScaleBasedVisibilityFlag="0" geometry="Point" styleCategories="AllStyleCategories" autoRefreshEnabled="0" simplifyDrawingTol="1" simplifyMaxScale="1">
+    <maplayer refreshOnNotifyEnabled="0" refreshOnNotifyMessage="" styleCategories="AllStyleCategories" maxScale="0" hasScaleBasedVisibilityFlag="0" simplifyAlgorithm="0" type="vector" labelsEnabled="1" minScale="1e+8" simplifyLocal="1" simplifyDrawingHints="1" autoRefreshTime="0" readOnly="0" geometry="Point" simplifyDrawingTol="1" autoRefreshEnabled="0" simplifyMaxScale="1" wkbType="Point">
       <extent>
         <xmin>-1633123.84234515647403896</xmin>
         <ymin>2842321.16874827956780791</ymin>
@@ -13702,7 +13117,6 @@ def my_form_open(dialog, layer, feature):
       <layername>storagep</layername>
       <srs>
         <spatialrefsys>
-          <wkt>PROJCS["NAD27 / Alaska Albers",GEOGCS["NAD27",DATUM["North_American_Datum_1927",SPHEROID["Clarke 1866",6378206.4,294.9786982138982,AUTHORITY["EPSG","7008"]],AUTHORITY["EPSG","6267"]],PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9122"]],AUTHORITY["EPSG","4267"]],PROJECTION["Albers_Conic_Equal_Area"],PARAMETER["standard_parallel_1",55],PARAMETER["standard_parallel_2",65],PARAMETER["latitude_of_center",50],PARAMETER["longitude_of_center",-154],PARAMETER["false_easting",0],PARAMETER["false_northing",0],UNIT["US survey foot",0.3048006096012192,AUTHORITY["EPSG","9003"]],AXIS["X",EAST],AXIS["Y",NORTH],AUTHORITY["EPSG","2964"]]</wkt>
           <proj4>+proj=aea +lat_1=55 +lat_2=65 +lat_0=50 +lon_0=-154 +x_0=0 +y_0=0 +datum=NAD27 +units=us-ft +no_defs</proj4>
           <srsid>932</srsid>
           <srid>2964</srid>
@@ -13725,7 +13139,6 @@ def my_form_open(dialog, layer, feature):
         <encoding></encoding>
         <crs>
           <spatialrefsys>
-            <wkt></wkt>
             <proj4></proj4>
             <srsid>0</srsid>
             <srid>0</srid>
@@ -13733,7 +13146,7 @@ def my_form_open(dialog, layer, feature):
             <description></description>
             <projectionacronym></projectionacronym>
             <ellipsoidacronym></ellipsoidacronym>
-            <geographicflag>false</geographicflag>
+            <geographicflag>true</geographicflag>
           </spatialrefsys>
         </crs>
         <extent/>
@@ -13753,9 +13166,9 @@ def my_form_open(dialog, layer, feature):
         <Removable>1</Removable>
         <Searchable>1</Searchable>
       </flags>
-      <renderer-v2 symbollevels="0" type="singleSymbol" forceraster="0" enableorderby="0">
+      <renderer-v2 type="singleSymbol" symbollevels="0" forceraster="0" enableorderby="0">
         <symbols>
-          <symbol force_rhr="0" name="0" clip_to_extent="1" alpha="1" type="marker">
+          <symbol clip_to_extent="1" force_rhr="0" type="marker" name="0" alpha="1">
             <layer enabled="1" pass="0" class="SimpleMarker" locked="0">
               <prop k="angle" v="0"/>
               <prop k="color" v="123,141,186,255"/>
@@ -13777,9 +13190,9 @@ def my_form_open(dialog, layer, feature):
               <prop k="vertical_anchor_point" v="1"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
@@ -13792,7 +13205,7 @@ def my_form_open(dialog, layer, feature):
       <blendMode>0</blendMode>
       <featureBlendMode>0</featureBlendMode>
       <layerOpacity>1</layerOpacity>
-      <geometryOptions removeDuplicateNodes="0" geometryPrecision="0">
+      <geometryOptions geometryPrecision="0" removeDuplicateNodes="0">
         <activeChecks/>
         <checkConfiguration/>
       </geometryOptions>
@@ -13801,8 +13214,8 @@ def my_form_open(dialog, layer, feature):
           <editWidget type="TextEdit">
             <config>
               <Option type="Map">
-                <Option value="0" name="IsMultiline" type="QString"/>
-                <Option value="0" name="UseHtml" type="QString"/>
+                <Option value="0" type="QString" name="IsMultiline"/>
+                <Option value="0" type="QString" name="UseHtml"/>
               </Option>
             </config>
           </editWidget>
@@ -13811,8 +13224,8 @@ def my_form_open(dialog, layer, feature):
           <editWidget type="TextEdit">
             <config>
               <Option type="Map">
-                <Option value="0" name="IsMultiline" type="QString"/>
-                <Option value="0" name="UseHtml" type="QString"/>
+                <Option value="0" type="QString" name="IsMultiline"/>
+                <Option value="0" type="QString" name="UseHtml"/>
               </Option>
             </config>
           </editWidget>
@@ -13821,8 +13234,8 @@ def my_form_open(dialog, layer, feature):
           <editWidget type="TextEdit">
             <config>
               <Option type="Map">
-                <Option value="0" name="IsMultiline" type="QString"/>
-                <Option value="0" name="UseHtml" type="QString"/>
+                <Option value="0" type="QString" name="IsMultiline"/>
+                <Option value="0" type="QString" name="UseHtml"/>
               </Option>
             </config>
           </editWidget>
@@ -13831,43 +13244,41 @@ def my_form_open(dialog, layer, feature):
           <editWidget type="TextEdit">
             <config>
               <Option type="Map">
-                <Option value="0" name="IsMultiline" type="QString"/>
-                <Option value="0" name="UseHtml" type="QString"/>
+                <Option value="0" type="QString" name="IsMultiline"/>
+                <Option value="0" type="QString" name="UseHtml"/>
               </Option>
             </config>
           </editWidget>
         </field>
       </fieldConfiguration>
       <aliases>
-        <alias name="" index="0" field="cat"/>
-        <alias name="" index="1" field="F_CODEDESC"/>
-        <alias name="" index="2" field="F_CODE"/>
-        <alias name="" index="3" field="TYPE"/>
+        <alias name="" field="cat" index="0"/>
+        <alias name="" field="F_CODEDESC" index="1"/>
+        <alias name="" field="F_CODE" index="2"/>
+        <alias name="" field="TYPE" index="3"/>
       </aliases>
       <excludeAttributesWMS/>
       <excludeAttributesWFS/>
       <defaults>
-        <default field="cat" applyOnUpdate="0" expression=""/>
-        <default field="F_CODEDESC" applyOnUpdate="0" expression=""/>
-        <default field="F_CODE" applyOnUpdate="0" expression=""/>
-        <default field="TYPE" applyOnUpdate="0" expression=""/>
+        <default field="cat" expression="" applyOnUpdate="0"/>
+        <default field="F_CODEDESC" expression="" applyOnUpdate="0"/>
+        <default field="F_CODE" expression="" applyOnUpdate="0"/>
+        <default field="TYPE" expression="" applyOnUpdate="0"/>
       </defaults>
       <constraints>
-        <constraint field="cat" notnull_strength="0" constraints="0" unique_strength="0" exp_strength="0"/>
-        <constraint field="F_CODEDESC" notnull_strength="0" constraints="0" unique_strength="0" exp_strength="0"/>
-        <constraint field="F_CODE" notnull_strength="0" constraints="0" unique_strength="0" exp_strength="0"/>
-        <constraint field="TYPE" notnull_strength="0" constraints="0" unique_strength="0" exp_strength="0"/>
+        <constraint notnull_strength="0" exp_strength="0" field="cat" unique_strength="0" constraints="0"/>
+        <constraint notnull_strength="0" exp_strength="0" field="F_CODEDESC" unique_strength="0" constraints="0"/>
+        <constraint notnull_strength="0" exp_strength="0" field="F_CODE" unique_strength="0" constraints="0"/>
+        <constraint notnull_strength="0" exp_strength="0" field="TYPE" unique_strength="0" constraints="0"/>
       </constraints>
       <constraintExpressions>
-        <constraint field="cat" exp="" desc=""/>
-        <constraint field="F_CODEDESC" exp="" desc=""/>
-        <constraint field="F_CODE" exp="" desc=""/>
-        <constraint field="TYPE" exp="" desc=""/>
+        <constraint field="cat" desc="" exp=""/>
+        <constraint field="F_CODEDESC" desc="" exp=""/>
+        <constraint field="F_CODE" desc="" exp=""/>
+        <constraint field="TYPE" desc="" exp=""/>
       </constraintExpressions>
       <expressionfields/>
-      <attributeactions>
-        <defaultAction value="{00000000-0000-0000-0000-000000000000}" key="Canvas"/>
-      </attributeactions>
+      <attributeactions/>
       <attributetableconfig sortExpression="" actionWidgetStyle="dropDown" sortOrder="0">
         <columns/>
       </attributetableconfig>
@@ -13875,7 +13286,6 @@ def my_form_open(dialog, layer, feature):
         <rowstyles/>
         <fieldstyles/>
       </conditionalstyles>
-      <storedexpressions/>
       <editform tolerant="1"></editform>
       <editforminit/>
       <editforminitcodesource>0</editforminitcodesource>
@@ -13889,7 +13299,7 @@ def my_form_open(dialog, layer, feature):
       <previewExpression>cat</previewExpression>
       <mapTip></mapTip>
     </maplayer>
-    <maplayer simplifyDrawingHints="1" simplifyAlgorithm="0" labelsEnabled="1" refreshOnNotifyMessage="" wkbType="MultiPolygon" minScale="1e+8" readOnly="0" refreshOnNotifyEnabled="0" type="vector" maxScale="0" simplifyLocal="1" autoRefreshTime="0" hasScaleBasedVisibilityFlag="0" geometry="Polygon" styleCategories="AllStyleCategories" autoRefreshEnabled="0" simplifyDrawingTol="1" simplifyMaxScale="1">
+    <maplayer refreshOnNotifyEnabled="0" refreshOnNotifyMessage="" styleCategories="AllStyleCategories" maxScale="0" hasScaleBasedVisibilityFlag="0" simplifyAlgorithm="0" type="vector" labelsEnabled="1" minScale="1e+8" simplifyLocal="1" simplifyDrawingHints="1" autoRefreshTime="0" readOnly="0" geometry="Polygon" simplifyDrawingTol="1" autoRefreshEnabled="0" simplifyMaxScale="1" wkbType="MultiPolygon">
       <extent>
         <xmin>-1953285.65190167212858796</xmin>
         <ymin>3759429.09873354947194457</ymin>
@@ -13904,7 +13314,6 @@ def my_form_open(dialog, layer, feature):
       <layername>swamp</layername>
       <srs>
         <spatialrefsys>
-          <wkt>PROJCS["NAD27 / Alaska Albers",GEOGCS["NAD27",DATUM["North_American_Datum_1927",SPHEROID["Clarke 1866",6378206.4,294.9786982138982,AUTHORITY["EPSG","7008"]],AUTHORITY["EPSG","6267"]],PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9122"]],AUTHORITY["EPSG","4267"]],PROJECTION["Albers_Conic_Equal_Area"],PARAMETER["standard_parallel_1",55],PARAMETER["standard_parallel_2",65],PARAMETER["latitude_of_center",50],PARAMETER["longitude_of_center",-154],PARAMETER["false_easting",0],PARAMETER["false_northing",0],UNIT["US survey foot",0.3048006096012192,AUTHORITY["EPSG","9003"]],AXIS["X",EAST],AXIS["Y",NORTH],AUTHORITY["EPSG","2964"]]</wkt>
           <proj4>+proj=aea +lat_1=55 +lat_2=65 +lat_0=50 +lon_0=-154 +x_0=0 +y_0=0 +datum=NAD27 +units=us-ft +no_defs</proj4>
           <srsid>932</srsid>
           <srid>2964</srid>
@@ -13927,7 +13336,6 @@ def my_form_open(dialog, layer, feature):
         <encoding></encoding>
         <crs>
           <spatialrefsys>
-            <wkt></wkt>
             <proj4></proj4>
             <srsid>0</srsid>
             <srid>0</srid>
@@ -13935,7 +13343,7 @@ def my_form_open(dialog, layer, feature):
             <description></description>
             <projectionacronym></projectionacronym>
             <ellipsoidacronym></ellipsoidacronym>
-            <geographicflag>false</geographicflag>
+            <geographicflag>true</geographicflag>
           </spatialrefsys>
         </crs>
         <extent/>
@@ -13955,9 +13363,9 @@ def my_form_open(dialog, layer, feature):
         <Removable>1</Removable>
         <Searchable>1</Searchable>
       </flags>
-      <renderer-v2 symbollevels="0" type="singleSymbol" forceraster="0" enableorderby="0">
+      <renderer-v2 type="singleSymbol" symbollevels="0" forceraster="0" enableorderby="0">
         <symbols>
-          <symbol force_rhr="0" name="0" clip_to_extent="1" alpha="1" type="fill">
+          <symbol clip_to_extent="1" force_rhr="0" type="fill" name="0" alpha="1">
             <layer enabled="1" pass="0" class="SimpleFill" locked="0">
               <prop k="border_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <prop k="color" v="50,18,132,255"/>
@@ -13972,9 +13380,9 @@ def my_form_open(dialog, layer, feature):
               <prop k="style" v="solid"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
@@ -13987,7 +13395,7 @@ def my_form_open(dialog, layer, feature):
       <blendMode>0</blendMode>
       <featureBlendMode>0</featureBlendMode>
       <layerOpacity>1</layerOpacity>
-      <geometryOptions removeDuplicateNodes="0" geometryPrecision="0">
+      <geometryOptions geometryPrecision="0" removeDuplicateNodes="0">
         <activeChecks/>
         <checkConfiguration/>
       </geometryOptions>
@@ -13996,8 +13404,8 @@ def my_form_open(dialog, layer, feature):
           <editWidget type="TextEdit">
             <config>
               <Option type="Map">
-                <Option value="0" name="IsMultiline" type="QString"/>
-                <Option value="0" name="UseHtml" type="QString"/>
+                <Option value="0" type="QString" name="IsMultiline"/>
+                <Option value="0" type="QString" name="UseHtml"/>
               </Option>
             </config>
           </editWidget>
@@ -14006,8 +13414,8 @@ def my_form_open(dialog, layer, feature):
           <editWidget type="TextEdit">
             <config>
               <Option type="Map">
-                <Option value="0" name="IsMultiline" type="QString"/>
-                <Option value="0" name="UseHtml" type="QString"/>
+                <Option value="0" type="QString" name="IsMultiline"/>
+                <Option value="0" type="QString" name="UseHtml"/>
               </Option>
             </config>
           </editWidget>
@@ -14016,8 +13424,8 @@ def my_form_open(dialog, layer, feature):
           <editWidget type="TextEdit">
             <config>
               <Option type="Map">
-                <Option value="0" name="IsMultiline" type="QString"/>
-                <Option value="0" name="UseHtml" type="QString"/>
+                <Option value="0" type="QString" name="IsMultiline"/>
+                <Option value="0" type="QString" name="UseHtml"/>
               </Option>
             </config>
           </editWidget>
@@ -14026,38 +13434,38 @@ def my_form_open(dialog, layer, feature):
           <editWidget type="TextEdit">
             <config>
               <Option type="Map">
-                <Option value="0" name="IsMultiline" type="QString"/>
-                <Option value="0" name="UseHtml" type="QString"/>
+                <Option value="0" type="QString" name="IsMultiline"/>
+                <Option value="0" type="QString" name="UseHtml"/>
               </Option>
             </config>
           </editWidget>
         </field>
       </fieldConfiguration>
       <aliases>
-        <alias name="" index="0" field="cat"/>
-        <alias name="" index="1" field="F_CODEDESC"/>
-        <alias name="" index="2" field="F_CODE"/>
-        <alias name="" index="3" field="AREAKM2"/>
+        <alias name="" field="cat" index="0"/>
+        <alias name="" field="F_CODEDESC" index="1"/>
+        <alias name="" field="F_CODE" index="2"/>
+        <alias name="" field="AREAKM2" index="3"/>
       </aliases>
       <excludeAttributesWMS/>
       <excludeAttributesWFS/>
       <defaults>
-        <default field="cat" applyOnUpdate="0" expression=""/>
-        <default field="F_CODEDESC" applyOnUpdate="0" expression=""/>
-        <default field="F_CODE" applyOnUpdate="0" expression=""/>
-        <default field="AREAKM2" applyOnUpdate="0" expression=""/>
+        <default field="cat" expression="" applyOnUpdate="0"/>
+        <default field="F_CODEDESC" expression="" applyOnUpdate="0"/>
+        <default field="F_CODE" expression="" applyOnUpdate="0"/>
+        <default field="AREAKM2" expression="" applyOnUpdate="0"/>
       </defaults>
       <constraints>
-        <constraint field="cat" notnull_strength="0" constraints="0" unique_strength="0" exp_strength="0"/>
-        <constraint field="F_CODEDESC" notnull_strength="0" constraints="0" unique_strength="0" exp_strength="0"/>
-        <constraint field="F_CODE" notnull_strength="0" constraints="0" unique_strength="0" exp_strength="0"/>
-        <constraint field="AREAKM2" notnull_strength="0" constraints="0" unique_strength="0" exp_strength="0"/>
+        <constraint notnull_strength="0" exp_strength="0" field="cat" unique_strength="0" constraints="0"/>
+        <constraint notnull_strength="0" exp_strength="0" field="F_CODEDESC" unique_strength="0" constraints="0"/>
+        <constraint notnull_strength="0" exp_strength="0" field="F_CODE" unique_strength="0" constraints="0"/>
+        <constraint notnull_strength="0" exp_strength="0" field="AREAKM2" unique_strength="0" constraints="0"/>
       </constraints>
       <constraintExpressions>
-        <constraint field="cat" exp="" desc=""/>
-        <constraint field="F_CODEDESC" exp="" desc=""/>
-        <constraint field="F_CODE" exp="" desc=""/>
-        <constraint field="AREAKM2" exp="" desc=""/>
+        <constraint field="cat" desc="" exp=""/>
+        <constraint field="F_CODEDESC" desc="" exp=""/>
+        <constraint field="F_CODE" desc="" exp=""/>
+        <constraint field="AREAKM2" desc="" exp=""/>
       </constraintExpressions>
       <expressionfields/>
       <attributeactions/>
@@ -14068,7 +13476,6 @@ def my_form_open(dialog, layer, feature):
         <rowstyles/>
         <fieldstyles/>
       </conditionalstyles>
-      <storedexpressions/>
       <editform tolerant="1"></editform>
       <editforminit/>
       <editforminitcodesource>0</editforminitcodesource>
@@ -14266,20 +13673,15 @@ def closeProject():&#xd;
     </Measurement>
     <PAL>
       <CandidatesLine type="int">50</CandidatesLine>
-      <CandidatesLinePerCM type="double">5</CandidatesLinePerCM>
       <CandidatesPoint type="int">16</CandidatesPoint>
       <CandidatesPolygon type="int">30</CandidatesPolygon>
-      <CandidatesPolygonPerCM type="double">2.5</CandidatesPolygonPerCM>
       <DrawOutlineLabels type="bool">true</DrawOutlineLabels>
       <DrawRectOnly type="bool">false</DrawRectOnly>
-      <DrawUnplaced type="bool">false</DrawUnplaced>
-      <PlacementEngineVersion type="int">0</PlacementEngineVersion>
       <SearchMethod type="int">0</SearchMethod>
       <ShowingAllLabels type="bool">false</ShowingAllLabels>
       <ShowingCandidates type="bool">false</ShowingCandidates>
       <ShowingPartialsLabels type="bool">true</ShowingPartialsLabels>
       <TextFormat type="int">0</TextFormat>
-      <UnplacedColor type="QString">255,0,0,255</UnplacedColor>
     </PAL>
     <Paths>
       <Absolute type="bool">false</Absolute>
@@ -14346,39 +13748,37 @@ def closeProject():&#xd;
   </properties>
   <visibility-presets>
     <visibility-preset name="composer_map_main_map">
-      <layer id="popp20130517221648651"/>
-      <layer id="majrivers_copy20141004123744134"/>
-      <layer id="alaska20130517221648216"/>
       <layer id="lakes20130517221648410"/>
+      <layer id="alaska20130517221648216"/>
       <layer id="airports20130517221648088"/>
+      <layer id="majrivers_copy20141004123744134"/>
+      <layer id="popp20130517221648651"/>
       <layer id="regions20130517221648766"/>
     </visibility-preset>
     <visibility-preset name="composer_overview">
       <layer id="alaska20130517221648216"/>
     </visibility-preset>
     <visibility-preset name="data_defined_labels" has-expanded-info="1">
-      <layer style="default" expanded="1" id="majrivers_copy20141004123744134"/>
-      <expanded-legend-nodes id="majrivers_copy20141004123744134"/>
-      <layer style="default" expanded="1" id="alaska20130517221648216"/>
-      <expanded-legend-nodes id="alaska20130517221648216"/>
-      <layer style="default" expanded="1" id="airports_copy20140330175838921"/>
-      <expanded-legend-nodes id="airports_copy20140330175838921"/>
-      <layer style="default" expanded="1" id="lakes20130517221648410"/>
+      <layer expanded="1" style="default" id="lakes20130517221648410"/>
       <expanded-legend-nodes id="lakes20130517221648410"/>
-      <layer style="default" expanded="0" id="regions20130517221648766"/>
+      <layer expanded="1" style="default" id="airports_copy20140330175838921"/>
+      <expanded-legend-nodes id="airports_copy20140330175838921"/>
+      <layer expanded="1" style="default" id="alaska20130517221648216"/>
+      <expanded-legend-nodes id="alaska20130517221648216"/>
+      <layer expanded="1" style="default" id="majrivers_copy20141004123744134"/>
+      <expanded-legend-nodes id="majrivers_copy20141004123744134"/>
+      <layer expanded="0" style="default" id="regions20130517221648766"/>
       <expanded-legend-nodes id="regions20130517221648766"/>
       <expanded-group-nodes>
-        <expanded-group-node id="group1"/>
-        <expanded-group-node id="Boundaries Group"/>
         <expanded-group-node id="Water Group"/>
         <expanded-group-node id="Style_menu_properties_Scr"/>
+        <expanded-group-node id="group1"/>
         <expanded-group-node id="Labels"/>
+        <expanded-group-node id="Boundaries Group"/>
       </expanded-group-nodes>
     </visibility-preset>
   </visibility-presets>
-  <transformContext>
-    <srcDest dest="EPSG:2964" sourceTransform="" source="EPSG:4326" destTransform="+towgs84=2.478,149.752,197.726,0.526,0.498,-0.501,0.685"/>
-  </transformContext>
+  <transformContext/>
   <projectMetadata>
     <identifier></identifier>
     <parentidentifier></parentidentifier>
@@ -14392,11 +13792,11 @@ def closeProject():&#xd;
   </projectMetadata>
   <Annotations/>
   <Layouts>
-    <Layout worldFileMap="" printResolution="300" name="alaska1" units="mm">
-      <Snapper tolerance="5" snapToGrid="0" snapToGuides="1" snapToItems="1"/>
-      <Grid offsetY="0" resolution="10" offsetX="0" resUnits="mm" offsetUnits="mm"/>
+    <Layout units="mm" printResolution="300" worldFileMap="" name="alaska1">
+      <Snapper snapToGuides="1" tolerance="5" snapToItems="1" snapToGrid="0"/>
+      <Grid resolution="10" offsetX="0" offsetY="0" resUnits="mm" offsetUnits="mm"/>
       <PageCollection>
-        <symbol force_rhr="0" name="" clip_to_extent="1" alpha="1" type="fill">
+        <symbol clip_to_extent="1" force_rhr="0" type="fill" name="" alpha="1">
           <layer enabled="1" pass="0" class="SimpleFill" locked="0">
             <prop k="border_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
             <prop k="color" v="255,255,255,255"/>
@@ -14411,123 +13811,101 @@ def closeProject():&#xd;
             <prop k="style" v="solid"/>
             <data_defined_properties>
               <Option type="Map">
-                <Option value="" name="name" type="QString"/>
+                <Option value="" type="QString" name="name"/>
                 <Option name="properties"/>
-                <Option value="collection" name="type" type="QString"/>
+                <Option value="collection" type="QString" name="type"/>
               </Option>
             </data_defined_properties>
           </layer>
         </symbol>
-        <LayoutItem size="420,297,mm" id="" visibility="1" positionOnPage="0,0,mm" opacity="1" blendMode="0" outlineWidthM="0.3,mm" groupUuid="" type="65638" frame="false" referencePoint="0" templateUuid="{77dfd27d-9758-46db-955e-e73ebaac3767}" background="true" uuid="{77dfd27d-9758-46db-955e-e73ebaac3767}" zValue="0" positionLock="false" itemRotation="0" excludeFromExports="0" frameJoinStyle="miter" position="0,0,mm">
-          <FrameColor green="0" red="0" blue="0" alpha="255"/>
-          <BackgroundColor green="255" red="255" blue="255" alpha="255"/>
+        <LayoutItem visibility="1" excludeFromExports="0" outlineWidthM="0.3,mm" positionOnPage="0,0,mm" type="65638" opacity="1" templateUuid="{77dfd27d-9758-46db-955e-e73ebaac3767}" background="true" frameJoinStyle="miter" id="" referencePoint="0" zValue="0" position="0,0,mm" itemRotation="0" frame="false" positionLock="false" uuid="{77dfd27d-9758-46db-955e-e73ebaac3767}" blendMode="0" groupUuid="" size="420,297,mm">
+          <FrameColor green="0" blue="0" red="0" alpha="255"/>
+          <BackgroundColor green="255" blue="255" red="255" alpha="255"/>
           <LayoutObject>
             <dataDefinedProperties>
               <Option type="Map">
-                <Option value="" name="name" type="QString"/>
+                <Option value="" type="QString" name="name"/>
                 <Option name="properties"/>
-                <Option value="collection" name="type" type="QString"/>
+                <Option value="collection" type="QString" name="type"/>
               </Option>
             </dataDefinedProperties>
             <customproperties/>
           </LayoutObject>
-          <symbol force_rhr="0" name="" clip_to_extent="1" alpha="1" type="fill">
-            <layer enabled="1" pass="0" class="SimpleFill" locked="0">
-              <prop k="border_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-              <prop k="color" v="255,255,255,255"/>
-              <prop k="joinstyle" v="miter"/>
-              <prop k="offset" v="0,0"/>
-              <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-              <prop k="offset_unit" v="MM"/>
-              <prop k="outline_color" v="35,35,35,255"/>
-              <prop k="outline_style" v="no"/>
-              <prop k="outline_width" v="0.26"/>
-              <prop k="outline_width_unit" v="MM"/>
-              <prop k="style" v="solid"/>
-              <data_defined_properties>
-                <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
-                  <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
-                </Option>
-              </data_defined_properties>
-            </layer>
-          </symbol>
         </LayoutItem>
         <GuideCollection visible="1"/>
       </PageCollection>
-      <LayoutItem size="94.4937,112.1,mm" id="" sectionY="0" visibility="1" positionOnPage="320.852,121.523,mm" opacity="1" hideBackgroundIfEmpty="0" blendMode="0" multiFrame="{73a89e82-fc28-4e77-bbcd-75e6c3f7700f}" outlineWidthM="0.3,mm" groupUuid="" type="65647" frame="false" referencePoint="0" templateUuid="{648a1f51-c720-4e96-be57-e11adc6ca8be}" background="false" sectionX="0" sectionWidth="94.4937" uuid="{648a1f51-c720-4e96-be57-e11adc6ca8be}" multiFrameTemplateUuid="{73a89e82-fc28-4e77-bbcd-75e6c3f7700f}" zValue="13" positionLock="false" itemRotation="0" excludeFromExports="0" sectionHeight="112.1" hidePageIfEmpty="0" frameJoinStyle="miter" position="320.852,121.523,mm">
-        <FrameColor green="0" red="0" blue="0" alpha="255"/>
-        <BackgroundColor green="255" red="255" blue="255" alpha="255"/>
+      <LayoutItem visibility="1" excludeFromExports="0" outlineWidthM="0.3,mm" multiFrameTemplateUuid="{73a89e82-fc28-4e77-bbcd-75e6c3f7700f}" sectionWidth="94.4937" positionOnPage="320.852,121.523,mm" type="65647" opacity="1" sectionHeight="112.1" templateUuid="{648a1f51-c720-4e96-be57-e11adc6ca8be}" background="false" frameJoinStyle="miter" id="" referencePoint="0" zValue="13" position="320.852,121.523,mm" itemRotation="0" multiFrame="{73a89e82-fc28-4e77-bbcd-75e6c3f7700f}" sectionX="0" frame="false" positionLock="false" sectionY="0" hideBackgroundIfEmpty="0" uuid="{648a1f51-c720-4e96-be57-e11adc6ca8be}" blendMode="0" hidePageIfEmpty="0" groupUuid="" size="94.4937,112.1,mm">
+        <FrameColor green="0" blue="0" red="0" alpha="255"/>
+        <BackgroundColor green="255" blue="255" red="255" alpha="255"/>
         <LayoutObject>
           <dataDefinedProperties>
             <Option type="Map">
-              <Option value="" name="name" type="QString"/>
+              <Option value="" type="QString" name="name"/>
               <Option name="properties"/>
-              <Option value="collection" name="type" type="QString"/>
+              <Option value="collection" type="QString" name="type"/>
             </Option>
           </dataDefinedProperties>
           <customproperties/>
         </LayoutObject>
       </LayoutItem>
-      <LayoutItem size="77.1778,152.26,mm" id="" sectionY="0" visibility="1" positionOnPage="16,127.74,mm" opacity="1" hideBackgroundIfEmpty="0" blendMode="0" multiFrame="{efc33b86-db2d-400f-9c25-709e67c55b9d}" outlineWidthM="0,mm" groupUuid="" type="65647" frame="true" referencePoint="0" templateUuid="{570970e1-7c34-492e-9a3e-7e37387cd3f8}" background="true" sectionX="0" sectionWidth="77.1778" uuid="{570970e1-7c34-492e-9a3e-7e37387cd3f8}" multiFrameTemplateUuid="{efc33b86-db2d-400f-9c25-709e67c55b9d}" zValue="12" positionLock="false" itemRotation="0" excludeFromExports="0" sectionHeight="152.26" hidePageIfEmpty="0" frameJoinStyle="miter" position="16,127.74,mm">
-        <FrameColor green="0" red="13" blue="157" alpha="255"/>
-        <BackgroundColor green="255" red="255" blue="255" alpha="255"/>
+      <LayoutItem visibility="1" excludeFromExports="0" outlineWidthM="0,mm" multiFrameTemplateUuid="{efc33b86-db2d-400f-9c25-709e67c55b9d}" sectionWidth="77.1778" positionOnPage="16,127.74,mm" type="65647" opacity="1" sectionHeight="152.26" templateUuid="{570970e1-7c34-492e-9a3e-7e37387cd3f8}" background="true" frameJoinStyle="miter" id="" referencePoint="0" zValue="12" position="16,127.74,mm" itemRotation="0" multiFrame="{efc33b86-db2d-400f-9c25-709e67c55b9d}" sectionX="0" frame="true" positionLock="false" sectionY="0" hideBackgroundIfEmpty="0" uuid="{570970e1-7c34-492e-9a3e-7e37387cd3f8}" blendMode="0" hidePageIfEmpty="0" groupUuid="" size="77.1778,152.26,mm">
+        <FrameColor green="0" blue="157" red="13" alpha="255"/>
+        <BackgroundColor green="255" blue="255" red="255" alpha="255"/>
         <LayoutObject>
           <dataDefinedProperties>
             <Option type="Map">
-              <Option value="" name="name" type="QString"/>
+              <Option value="" type="QString" name="name"/>
               <Option name="properties"/>
-              <Option value="collection" name="type" type="QString"/>
+              <Option value="collection" type="QString" name="type"/>
             </Option>
           </dataDefinedProperties>
           <customproperties/>
         </LayoutObject>
       </LayoutItem>
-      <LayoutItem size="0.352246,0,mm" id="" sectionY="0" visibility="1" positionOnPage="123.286,95.1064,mm" opacity="1" hideBackgroundIfEmpty="0" blendMode="0" multiFrame="{60855bfd-b5ce-4a6c-a90a-644dc971bf70}" outlineWidthM="0.3,mm" groupUuid="" type="65647" frame="false" referencePoint="0" templateUuid="{0e2ae97d-4224-4dde-b484-d5338a39b1ce}" background="true" sectionX="0" sectionWidth="0.352246" uuid="{0e2ae97d-4224-4dde-b484-d5338a39b1ce}" multiFrameTemplateUuid="{60855bfd-b5ce-4a6c-a90a-644dc971bf70}" zValue="11" positionLock="false" itemRotation="0" excludeFromExports="0" sectionHeight="0" hidePageIfEmpty="0" frameJoinStyle="miter" position="123.286,95.1064,mm">
-        <FrameColor green="0" red="0" blue="0" alpha="255"/>
-        <BackgroundColor green="255" red="255" blue="255" alpha="255"/>
+      <LayoutItem visibility="1" excludeFromExports="0" outlineWidthM="0.3,mm" multiFrameTemplateUuid="{60855bfd-b5ce-4a6c-a90a-644dc971bf70}" sectionWidth="0.352246" positionOnPage="123.286,95.1064,mm" type="65647" opacity="1" sectionHeight="0" templateUuid="{0e2ae97d-4224-4dde-b484-d5338a39b1ce}" background="true" frameJoinStyle="miter" id="" referencePoint="0" zValue="11" position="123.286,95.1064,mm" itemRotation="0" multiFrame="{60855bfd-b5ce-4a6c-a90a-644dc971bf70}" sectionX="0" frame="false" positionLock="false" sectionY="0" hideBackgroundIfEmpty="0" uuid="{0e2ae97d-4224-4dde-b484-d5338a39b1ce}" blendMode="0" hidePageIfEmpty="0" groupUuid="" size="0.352246,0,mm">
+        <FrameColor green="0" blue="0" red="0" alpha="255"/>
+        <BackgroundColor green="255" blue="255" red="255" alpha="255"/>
         <LayoutObject>
           <dataDefinedProperties>
             <Option type="Map">
-              <Option value="" name="name" type="QString"/>
+              <Option value="" type="QString" name="name"/>
               <Option name="properties"/>
-              <Option value="collection" name="type" type="QString"/>
+              <Option value="collection" type="QString" name="type"/>
             </Option>
           </dataDefinedProperties>
           <customproperties/>
         </LayoutObject>
       </LayoutItem>
-      <LayoutItem size="71.6871,18.1135,mm" id="" marginX="0" visibility="1" positionOnPage="328.08,103.409,mm" opacity="1" blendMode="0" outlineWidthM="0.3,mm" groupUuid="" type="65641" frame="false" referencePoint="0" templateUuid="{0d0b0ce0-3fab-4d45-a21b-2c8077393893}" background="true" uuid="{0d0b0ce0-3fab-4d45-a21b-2c8077393893}" zValue="10" positionLock="false" itemRotation="0" excludeFromExports="0" halign="4" htmlState="0" valign="128" frameJoinStyle="miter" position="328.08,103.409,mm" labelText="Nome Region Nearby airports" marginY="0">
-        <FrameColor green="0" red="0" blue="0" alpha="255"/>
-        <BackgroundColor green="255" red="255" blue="255" alpha="255"/>
+      <LayoutItem visibility="1" excludeFromExports="0" marginY="0" outlineWidthM="0.3,mm" positionOnPage="328.08,103.409,mm" labelText="Nome Region Nearby airports" type="65641" opacity="1" templateUuid="{0d0b0ce0-3fab-4d45-a21b-2c8077393893}" background="true" frameJoinStyle="miter" id="" referencePoint="0" zValue="10" position="328.08,103.409,mm" valign="128" itemRotation="0" frame="false" htmlState="0" positionLock="false" marginX="0" uuid="{0d0b0ce0-3fab-4d45-a21b-2c8077393893}" halign="4" blendMode="0" groupUuid="" size="71.6871,18.1135,mm">
+        <FrameColor green="0" blue="0" red="0" alpha="255"/>
+        <BackgroundColor green="255" blue="255" red="255" alpha="255"/>
         <LayoutObject>
           <dataDefinedProperties>
             <Option type="Map">
-              <Option value="" name="name" type="QString"/>
+              <Option value="" type="QString" name="name"/>
               <Option name="properties"/>
-              <Option value="collection" name="type" type="QString"/>
+              <Option value="collection" type="QString" name="type"/>
             </Option>
           </dataDefinedProperties>
           <customproperties/>
         </LayoutObject>
         <LabelFont description="Ubuntu,14,-1,5,50,0,0,0,0,0" style=""/>
-        <FontColor green="0" red="0" blue="0" alpha="255"/>
+        <FontColor green="0" blue="0" red="0" alpha="255"/>
       </LayoutItem>
-      <LayoutItem size="130.424,9.572,mm" id="" arrowHeadOutlineColor="0,0,147,255" arrowHeadWidth="2" visibility="1" positionOnPage="83.241,181.039,mm" opacity="1" blendMode="0" arrowHeadFillColor="0,0,147,255" outlineWidthM="0,mm" groupUuid="" type="65645" frame="false" referencePoint="0" templateUuid="{8cf61af7-d6d2-42a8-8be7-73aabd67f33f}" background="false" uuid="{8cf61af7-d6d2-42a8-8be7-73aabd67f33f}" endMarkerFile="" markerMode="1" zValue="9" positionLock="false" itemRotation="0" startMarkerFile="" excludeFromExports="0" startMarkerMode="0" outlineWidth="1" frameJoinStyle="miter" position="83.241,181.039,mm">
-        <FrameColor green="255" red="255" blue="255" alpha="0"/>
-        <BackgroundColor green="255" red="255" blue="255" alpha="0"/>
+      <LayoutItem visibility="1" excludeFromExports="0" outlineWidth="1" startMarkerFile="" markerMode="1" outlineWidthM="0,mm" startMarkerMode="0" positionOnPage="83.241,181.039,mm" type="65645" opacity="1" templateUuid="{8cf61af7-d6d2-42a8-8be7-73aabd67f33f}" arrowHeadFillColor="0,0,147,255" endMarkerFile="" background="false" frameJoinStyle="miter" id="" referencePoint="0" zValue="9" position="83.241,181.039,mm" itemRotation="0" arrowHeadWidth="2" frame="false" positionLock="false" uuid="{8cf61af7-d6d2-42a8-8be7-73aabd67f33f}" arrowHeadOutlineColor="0,0,147,255" blendMode="0" groupUuid="" size="130.424,9.572,mm">
+        <FrameColor green="255" blue="255" red="255" alpha="0"/>
+        <BackgroundColor green="255" blue="255" red="255" alpha="0"/>
         <LayoutObject>
           <dataDefinedProperties>
             <Option type="Map">
-              <Option value="" name="name" type="QString"/>
+              <Option value="" type="QString" name="name"/>
               <Option name="properties"/>
-              <Option value="collection" name="type" type="QString"/>
+              <Option value="collection" type="QString" name="type"/>
             </Option>
           </dataDefinedProperties>
           <customproperties/>
         </LayoutObject>
-        <symbol force_rhr="0" name="" clip_to_extent="1" alpha="1" type="line">
+        <symbol clip_to_extent="1" force_rhr="0" type="line" name="" alpha="1">
           <layer enabled="1" pass="0" class="SimpleLine" locked="0">
             <prop k="capstyle" v="flat"/>
             <prop k="customdash" v="5;2"/>
@@ -14547,38 +13925,38 @@ def closeProject():&#xd;
             <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
             <data_defined_properties>
               <Option type="Map">
-                <Option value="" name="name" type="QString"/>
+                <Option value="" type="QString" name="name"/>
                 <Option name="properties"/>
-                <Option value="collection" name="type" type="QString"/>
+                <Option value="collection" type="QString" name="type"/>
               </Option>
             </data_defined_properties>
           </layer>
         </symbol>
         <nodes>
-          <node y="9.572" x="0"/>
-          <node y="0" x="130.424"/>
+          <node x="0" y="9.572"/>
+          <node x="130.424" y="0"/>
         </nodes>
       </LayoutItem>
-      <LayoutItem size="98.9359,79.6604,mm" keepLayerSet="true" id="" visibility="1" positionOnPage="315.64,29.2011,mm" opacity="1" mapFlags="0" blendMode="0" outlineWidthM="0.3,mm" groupUuid="" type="65639" followPresetName="" frame="false" referencePoint="0" templateUuid="{216419ed-5a57-4229-a79b-7201f7543e14}" background="true" uuid="{216419ed-5a57-4229-a79b-7201f7543e14}" followPreset="false" zValue="8" positionLock="false" itemRotation="0" excludeFromExports="0" mapRotation="0" labelMargin="0,mm" frameJoinStyle="miter" drawCanvasItems="true" position="315.64,29.2011,mm">
-        <FrameColor green="0" red="0" blue="0" alpha="255"/>
-        <BackgroundColor green="255" red="255" blue="255" alpha="255"/>
+      <LayoutItem visibility="1" excludeFromExports="0" outlineWidthM="0.3,mm" positionOnPage="315.64,29.2011,mm" type="65639" opacity="1" templateUuid="{216419ed-5a57-4229-a79b-7201f7543e14}" mapFlags="0" background="true" followPresetName="" frameJoinStyle="miter" drawCanvasItems="true" id="" referencePoint="0" zValue="8" keepLayerSet="true" position="315.64,29.2011,mm" itemRotation="0" followPreset="false" frame="false" positionLock="false" uuid="{216419ed-5a57-4229-a79b-7201f7543e14}" mapRotation="0" labelMargin="0,mm" blendMode="0" groupUuid="" size="98.9359,79.6604,mm">
+        <FrameColor green="0" blue="0" red="0" alpha="255"/>
+        <BackgroundColor green="255" blue="255" red="255" alpha="255"/>
         <LayoutObject>
           <dataDefinedProperties>
             <Option type="Map">
-              <Option value="" name="name" type="QString"/>
+              <Option value="" type="QString" name="name"/>
               <Option name="properties"/>
-              <Option value="collection" name="type" type="QString"/>
+              <Option value="collection" type="QString" name="type"/>
             </Option>
           </dataDefinedProperties>
           <customproperties/>
         </LayoutObject>
-        <Extent ymax="9764399.56700823828577995" xmin="-7540262.7803887752816081" xmax="5320629.60806266870349646" ymin="-590828.73759097512811422"/>
+        <Extent ymax="9764399.56700823828577995" xmin="-7540262.7803887752816081" ymin="-590828.73759097512811422" xmax="5320629.60806266870349646"/>
         <LayerSet>
-          <Layer name="alaska" provider="ogr" source="/home/aneto/QGIS/qgis_sample_data/shapefiles/alaska.shp">alaska20130517221648216</Layer>
+          <Layer name="alaska" provider="ogr" source="/media/TRAVAIL/dev/github/qgis_sample_data/shapefiles/alaska.shp">alaska20130517221648216</Layer>
         </LayerSet>
-        <ComposerMapGrid annotationFormat="0" gridFramePenThickness="0.5" gridFrameWidth="2" show="0" leftFrameDivisions="0" topFrameDivisions="0" bottomAnnotationDisplay="0" name="Grid 1" bottomAnnotationPosition="1" rightAnnotationPosition="1" rightAnnotationDirection="0" topAnnotationPosition="1" frameFillColor2="0,0,0,255" annotationFontColor="0,0,0,255" unit="0" minimumIntervalWidth="50" annotationPrecision="3" rightAnnotationDisplay="0" bottomFrameDivisions="0" annotationExpression="" frameAnnotationDistance="1" gridFrameStyle="0" intervalX="0" frameFillColor1="255,255,255,255" leftAnnotationPosition="1" offsetX="0" leftAnnotationDisplay="0" crossLength="3" gridFramePenColor="0,0,0,255" showAnnotation="0" gridFrameSideFlags="15" leftAnnotationDirection="0" topAnnotationDisplay="0" blendMode="0" rightFrameDivisions="0" intervalY="0" position="3" uuid="{18ae7177-443f-47b3-b221-13ccc18e6158}" maximumIntervalWidth="100" bottomAnnotationDirection="0" topAnnotationDirection="0" gridStyle="0" gridFrameMargin="0" offsetY="0">
+        <ComposerMapGrid offsetX="0" leftAnnotationDisplay="0" offsetY="0" gridFrameMargin="0" annotationFormat="0" bottomAnnotationDirection="0" gridFramePenColor="0,0,0,255" uuid="{18ae7177-443f-47b3-b221-13ccc18e6158}" topAnnotationDirection="0" annotationExpression="" topFrameDivisions="0" topAnnotationDisplay="0" annotationPrecision="3" bottomFrameDivisions="0" intervalY="0" rightAnnotationPosition="1" unit="0" topAnnotationPosition="1" position="3" frameAnnotationDistance="1" rightAnnotationDisplay="0" gridFrameWidth="2" rightAnnotationDirection="0" show="0" annotationFontColor="0,0,0,255" rightFrameDivisions="0" gridFramePenThickness="0.5" frameFillColor1="255,255,255,255" leftFrameDivisions="0" bottomAnnotationDisplay="0" intervalX="0" crossLength="3" gridFrameSideFlags="15" leftAnnotationDirection="0" name="Grid 1" gridFrameStyle="0" bottomAnnotationPosition="1" frameFillColor2="0,0,0,255" leftAnnotationPosition="1" blendMode="0" gridStyle="0" showAnnotation="0">
           <lineStyle>
-            <symbol force_rhr="0" name="" clip_to_extent="1" alpha="1" type="line">
+            <symbol clip_to_extent="1" force_rhr="0" type="line" name="" alpha="1">
               <layer enabled="1" pass="0" class="SimpleLine" locked="0">
                 <prop k="capstyle" v="flat"/>
                 <prop k="customdash" v="5;2"/>
@@ -14598,16 +13976,16 @@ def closeProject():&#xd;
                 <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
                 <data_defined_properties>
                   <Option type="Map">
-                    <Option value="" name="name" type="QString"/>
+                    <Option value="" type="QString" name="name"/>
                     <Option name="properties"/>
-                    <Option value="collection" name="type" type="QString"/>
+                    <Option value="collection" type="QString" name="type"/>
                   </Option>
                 </data_defined_properties>
               </layer>
             </symbol>
           </lineStyle>
           <markerStyle>
-            <symbol force_rhr="0" name="" clip_to_extent="1" alpha="1" type="marker">
+            <symbol clip_to_extent="1" force_rhr="0" type="marker" name="" alpha="1">
               <layer enabled="1" pass="0" class="SimpleMarker" locked="0">
                 <prop k="angle" v="0"/>
                 <prop k="color" v="0,0,0,255"/>
@@ -14629,28 +14007,18 @@ def closeProject():&#xd;
                 <prop k="vertical_anchor_point" v="1"/>
                 <data_defined_properties>
                   <Option type="Map">
-                    <Option value="" name="name" type="QString"/>
+                    <Option value="" type="QString" name="name"/>
                     <Option name="properties"/>
-                    <Option value="collection" name="type" type="QString"/>
+                    <Option value="collection" type="QString" name="type"/>
                   </Option>
                 </data_defined_properties>
               </layer>
             </symbol>
           </markerStyle>
           <annotationFontProperties description="Ubuntu,11,-1,5,50,0,0,0,0,0" style=""/>
-          <LayoutObject>
-            <dataDefinedProperties>
-              <Option type="Map">
-                <Option value="" name="name" type="QString"/>
-                <Option name="properties"/>
-                <Option value="collection" name="type" type="QString"/>
-              </Option>
-            </dataDefinedProperties>
-            <customproperties/>
-          </LayoutObject>
         </ComposerMapGrid>
-        <ComposerMapOverview frameMap="{7ec4114b-93d8-4982-b461-ad4c834c2a7c}" uuid="{216af386-3df7-44c2-afa0-c105d61aa740}" position="3" show="1" name="Overview 1" inverted="0" centered="0" blendMode="0">
-          <symbol force_rhr="0" name="" clip_to_extent="1" alpha="1" type="fill">
+        <ComposerMapOverview position="3" name="Overview 1" show="1" centered="0" blendMode="0" inverted="0" frameMap="{7ec4114b-93d8-4982-b461-ad4c834c2a7c}" uuid="{216af386-3df7-44c2-afa0-c105d61aa740}">
+          <symbol clip_to_extent="1" force_rhr="0" type="fill" name="" alpha="1">
             <layer enabled="1" pass="0" class="SimpleFill" locked="0">
               <prop k="border_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <prop k="color" v="255,0,0,75"/>
@@ -14665,77 +14033,67 @@ def closeProject():&#xd;
               <prop k="style" v="solid"/>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <LayoutObject>
-            <dataDefinedProperties>
-              <Option type="Map">
-                <Option value="" name="name" type="QString"/>
-                <Option name="properties"/>
-                <Option value="collection" name="type" type="QString"/>
-              </Option>
-            </dataDefinedProperties>
-            <customproperties/>
-          </LayoutObject>
         </ComposerMapOverview>
-        <AtlasMap scalingMode="2" atlasDriven="0" margin="0.10000000000000001"/>
+        <AtlasMap atlasDriven="0" scalingMode="2" margin="0.10000000000000001"/>
         <labelBlockingItems/>
       </LayoutItem>
-      <LayoutItem size="6.30585,4.11082,mm" id="" marginX="1" visibility="1" positionOnPage="20.303,15.8929,mm" opacity="1" blendMode="0" outlineWidthM="0.3,mm" groupUuid="" type="65641" frame="false" referencePoint="0" templateUuid="{fec87e29-d5fd-448c-acbe-906e1498a1dc}" background="true" uuid="{fec87e29-d5fd-448c-acbe-906e1498a1dc}" zValue="7" positionLock="false" itemRotation="0" excludeFromExports="0" halign="4" htmlState="0" valign="128" frameJoinStyle="miter" position="20.303,15.8929,mm" labelText="N" marginY="1">
-        <FrameColor green="0" red="0" blue="0" alpha="255"/>
-        <BackgroundColor green="255" red="255" blue="255" alpha="255"/>
+      <LayoutItem visibility="1" excludeFromExports="0" marginY="1" outlineWidthM="0.3,mm" positionOnPage="20.303,15.8929,mm" labelText="N" type="65641" opacity="1" templateUuid="{fec87e29-d5fd-448c-acbe-906e1498a1dc}" background="true" frameJoinStyle="miter" id="" referencePoint="0" zValue="7" position="20.303,15.8929,mm" valign="128" itemRotation="0" frame="false" htmlState="0" positionLock="false" marginX="1" uuid="{fec87e29-d5fd-448c-acbe-906e1498a1dc}" halign="4" blendMode="0" groupUuid="" size="6.30585,4.11082,mm">
+        <FrameColor green="0" blue="0" red="0" alpha="255"/>
+        <BackgroundColor green="255" blue="255" red="255" alpha="255"/>
         <LayoutObject>
           <dataDefinedProperties>
             <Option type="Map">
-              <Option value="" name="name" type="QString"/>
+              <Option value="" type="QString" name="name"/>
               <Option name="properties"/>
-              <Option value="collection" name="type" type="QString"/>
+              <Option value="collection" type="QString" name="type"/>
             </Option>
           </dataDefinedProperties>
           <customproperties/>
         </LayoutObject>
         <LabelFont description="Ubuntu,14,-1,5,75,0,0,0,0,0" style=""/>
-        <FontColor green="0" red="0" blue="0" alpha="255"/>
+        <FontColor green="0" blue="0" red="0" alpha="255"/>
       </LayoutItem>
-      <LayoutItem size="16.4859,17.8731,mm" id="" visibility="1" positionOnPage="15.2129,20.2645,mm" opacity="1" blendMode="0" northOffset="0" outlineWidthM="0.3,mm" groupUuid="" type="65640" file="arrows/NorthArrow_07.svg" northMode="0" frame="false" referencePoint="0" templateUuid="{2b30c648-da5e-4a74-887d-1f3eac770c26}" background="true" uuid="{2b30c648-da5e-4a74-887d-1f3eac770c26}" resizeMode="0" pictureWidth="16.4859" svgBorderWidth="0.2" pictureHeight="16.4859" anchorPoint="4" svgFillColor="0,0,0,255" zValue="6" positionLock="false" itemRotation="0" excludeFromExports="0" mapUuid="" pictureRotation="0" frameJoinStyle="miter" svgBorderColor="0,0,0,255" position="15.2129,20.2645,mm">
-        <FrameColor green="0" red="0" blue="0" alpha="255"/>
-        <BackgroundColor green="255" red="255" blue="255" alpha="255"/>
+      <LayoutItem visibility="1" excludeFromExports="0" pictureHeight="16.4859" outlineWidthM="0.3,mm" northMode="0" positionOnPage="15.2129,20.2645,mm" type="65640" opacity="1" resizeMode="0" pictureRotation="0" templateUuid="{2b30c648-da5e-4a74-887d-1f3eac770c26}" anchorPoint="4" background="true" frameJoinStyle="miter" id="" referencePoint="0" zValue="6" file="arrows/NorthArrow_07.svg" mapUuid="" position="15.2129,20.2645,mm" itemRotation="0" svgBorderWidth="0.2" frame="false" positionLock="false" uuid="{2b30c648-da5e-4a74-887d-1f3eac770c26}" northOffset="0" pictureWidth="16.4859" blendMode="0" svgFillColor="0,0,0,255" svgBorderColor="0,0,0,255" groupUuid="" size="16.4859,17.8731,mm">
+        <FrameColor green="0" blue="0" red="0" alpha="255"/>
+        <BackgroundColor green="255" blue="255" red="255" alpha="255"/>
         <LayoutObject>
           <dataDefinedProperties>
             <Option type="Map">
-              <Option value="" name="name" type="QString"/>
-              <Option name="properties" type="Map">
-                <Option name="dataDefinedSource" type="Map">
-                  <Option value="false" name="active" type="bool"/>
-                  <Option value="" name="expression" type="QString"/>
-                  <Option value="3" name="type" type="int"/>
+              <Option value="" type="QString" name="name"/>
+              <Option type="Map" name="properties">
+                <Option type="Map" name="dataDefinedSource">
+                  <Option value="false" type="bool" name="active"/>
+                  <Option value="" type="QString" name="expression"/>
+                  <Option value="3" type="int" name="type"/>
                 </Option>
               </Option>
-              <Option value="collection" name="type" type="QString"/>
+              <Option value="collection" type="QString" name="type"/>
             </Option>
           </dataDefinedProperties>
           <customproperties/>
         </LayoutObject>
       </LayoutItem>
-      <LayoutItem size="10,10,mm" id="" visibility="1" positionOnPage="216.309,175.525,mm" shapeType="0" opacity="1" blendMode="0" outlineWidthM="0,mm" cornerRadiusMeasure="0,mm" groupUuid="" type="65643" frame="false" referencePoint="0" templateUuid="{b610fb1a-5932-4342-a0bf-d1a70ebdde45}" background="false" uuid="{b610fb1a-5932-4342-a0bf-d1a70ebdde45}" zValue="5" positionLock="false" itemRotation="0" excludeFromExports="0" frameJoinStyle="miter" position="216.309,175.525,mm">
-        <FrameColor green="0" red="6" blue="190" alpha="255"/>
-        <BackgroundColor green="255" red="255" blue="255" alpha="255"/>
+      <LayoutItem visibility="1" excludeFromExports="0" outlineWidthM="0,mm" positionOnPage="216.309,175.525,mm" type="65643" opacity="1" templateUuid="{b610fb1a-5932-4342-a0bf-d1a70ebdde45}" background="false" frameJoinStyle="miter" id="" referencePoint="0" zValue="5" position="216.309,175.525,mm" itemRotation="0" frame="false" cornerRadiusMeasure="0,mm" shapeType="0" positionLock="false" uuid="{b610fb1a-5932-4342-a0bf-d1a70ebdde45}" blendMode="0" groupUuid="" size="10,10,mm">
+        <FrameColor green="0" blue="190" red="6" alpha="255"/>
+        <BackgroundColor green="255" blue="255" red="255" alpha="255"/>
         <LayoutObject>
           <dataDefinedProperties>
             <Option type="Map">
-              <Option value="" name="name" type="QString"/>
+              <Option value="" type="QString" name="name"/>
               <Option name="properties"/>
-              <Option value="collection" name="type" type="QString"/>
+              <Option value="collection" type="QString" name="type"/>
             </Option>
           </dataDefinedProperties>
           <customproperties/>
         </LayoutObject>
-        <symbol force_rhr="0" name="" clip_to_extent="1" alpha="1" type="fill">
+        <symbol clip_to_extent="1" force_rhr="0" type="fill" name="" alpha="1">
           <layer enabled="1" pass="0" class="SimpleFill" locked="0">
             <prop k="border_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
             <prop k="color" v="255,255,255,255"/>
@@ -14750,143 +14108,136 @@ def closeProject():&#xd;
             <prop k="style" v="no"/>
             <data_defined_properties>
               <Option type="Map">
-                <Option value="" name="name" type="QString"/>
+                <Option value="" type="QString" name="name"/>
                 <Option name="properties"/>
-                <Option value="collection" name="type" type="QString"/>
+                <Option value="collection" type="QString" name="type"/>
               </Option>
             </data_defined_properties>
           </layer>
         </symbol>
       </LayoutItem>
-      <LayoutItem numSegments="2" outlineWidth="1" labelVerticalPlacement="0" segmentMillimeters="45.0154" id="" numMapUnitsPerScaleBarUnit="1000" frame="false" boxContentSpace="1" lineJoinStyle="miter" numUnitsPerSegment="90000" lineCapStyle="square" templateUuid="{19b60a4e-f314-4282-8aea-175f38f98373}" unitLabel="km" outlineWidthM="0.3,mm" size="105.545,12.5,mm" labelHorizontalPlacement="0" segmentSizeMode="1" background="true" frameJoinStyle="miter" height="3" mapUuid="{7ec4114b-93d8-4982-b461-ad4c834c2a7c}" visibility="1" opacity="1" groupUuid="" itemRotation="0" blendMode="0" alignment="0" position="314.455,274,mm" uuid="{19b60a4e-f314-4282-8aea-175f38f98373}" minBarWidth="50" zValue="4" labelBarSpace="3" unitType="meters" maxBarWidth="100" positionLock="false" type="65646" style="Line Ticks Up" excludeFromExports="0" positionOnPage="314.455,274,mm" numSegmentsLeft="0" referencePoint="0">
-        <FrameColor green="0" red="0" blue="0" alpha="255"/>
-        <BackgroundColor green="255" red="255" blue="255" alpha="255"/>
+      <LayoutItem alignment="0" segmentMillimeters="45.0154" lineCapStyle="square" type="65646" uuid="{19b60a4e-f314-4282-8aea-175f38f98373}" labelBarSpace="3" positionLock="false" numSegmentsLeft="0" segmentSizeMode="1" numUnitsPerSegment="90000" groupUuid="" referencePoint="0" excludeFromExports="0" templateUuid="{19b60a4e-f314-4282-8aea-175f38f98373}" maxBarWidth="100" frameJoinStyle="miter" unitLabel="km" zValue="4" size="105.545,12.2,mm" position="314.455,274,mm" opacity="1" itemRotation="0" frame="false" positionOnPage="314.455,274,mm" background="true" height="3" outlineWidthM="0.3,mm" numSegments="2" style="Line Ticks Up" outlineWidth="1" mapUuid="{7ec4114b-93d8-4982-b461-ad4c834c2a7c}" id="" boxContentSpace="1" minBarWidth="50" lineJoinStyle="miter" unitType="meters" numMapUnitsPerScaleBarUnit="1000" visibility="1" blendMode="0">
+        <FrameColor green="0" blue="0" red="0" alpha="255"/>
+        <BackgroundColor green="255" blue="255" red="255" alpha="255"/>
         <LayoutObject>
           <dataDefinedProperties>
             <Option type="Map">
-              <Option value="" name="name" type="QString"/>
+              <Option value="" type="QString" name="name"/>
               <Option name="properties"/>
-              <Option value="collection" name="type" type="QString"/>
+              <Option value="collection" type="QString" name="type"/>
             </Option>
           </dataDefinedProperties>
           <customproperties/>
         </LayoutObject>
-        <text-style fontSize="12" textOpacity="1" fontFamily="Ubuntu" fontItalic="0" fontCapitals="0" textOrientation="horizontal" fontStrikeout="0" blendMode="0" previewBkgrdColor="255,255,255,255" fontUnderline="0" fontWordSpacing="0" fontSizeUnit="Point" namedStyle="" fontKerning="1" textColor="0,0,0,255" fontSizeMapUnitScale="3x:0,0,0,0,0,0" multilineHeight="1" fontLetterSpacing="0" fontWeight="50">
-          <text-buffer bufferSizeUnits="MM" bufferDraw="0" bufferNoFill="1" bufferColor="255,255,255,255" bufferOpacity="1" bufferBlendMode="0" bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferJoinStyle="128" bufferSize="1"/>
-          <background shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeOpacity="1" shapeSizeX="0" shapeRadiiX="0" shapeSVGFile="" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeOffsetX="0" shapeType="0" shapeBlendMode="0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeJoinStyle="64" shapeDraw="0" shapeSizeUnit="MM" shapeSizeType="0" shapeRotationType="0" shapeRotation="0" shapeOffsetUnit="MM" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeBorderWidthUnit="MM" shapeSizeY="0" shapeBorderWidth="0" shapeRadiiY="0" shapeOffsetY="0" shapeBorderColor="128,128,128,255" shapeRadiiUnit="MM" shapeFillColor="255,255,255,255"/>
-          <shadow shadowDraw="0" shadowOffsetUnit="MM" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowRadiusUnit="MM" shadowScale="100" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowRadiusAlphaOnly="0" shadowBlendMode="6" shadowOffsetAngle="135" shadowOffsetDist="1" shadowOffsetGlobal="1" shadowUnder="0" shadowRadius="1.5" shadowColor="0,0,0,255" shadowOpacity="0.7"/>
-          <dd_properties>
-            <Option type="Map">
-              <Option value="" name="name" type="QString"/>
-              <Option name="properties"/>
-              <Option value="collection" name="type" type="QString"/>
-            </Option>
-          </dd_properties>
+        <text-style multilineHeight="1" fontWordSpacing="0" fontSize="12" fontSizeUnit="Point" textOpacity="1" fontFamily="Ubuntu" fontWeight="50" fontStrikeout="0" namedStyle="" fontItalic="0" fontSizeMapUnitScale="3x:0,0,0,0,0,0" fontCapitals="0" fontLetterSpacing="0" fontUnderline="0" blendMode="0" textColor="0,0,0,255" previewBkgrdColor="255,255,255,255">
+          <text-buffer bufferDraw="0" bufferNoFill="1" bufferBlendMode="0" bufferSize="1" bufferSizeUnits="MM" bufferColor="255,255,255,255" bufferJoinStyle="128" bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferOpacity="1"/>
+          <background shapeRadiiX="0" shapeSizeUnit="MM" shapeOffsetY="0" shapeRadiiUnit="MM" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeBlendMode="0" shapeRotation="0" shapeSizeX="0" shapeSizeY="0" shapeDraw="0" shapeRadiiY="0" shapeOffsetX="0" shapeRotationType="0" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeOffsetUnit="MM" shapeBorderWidth="0" shapeBorderWidthUnit="MM" shapeJoinStyle="64" shapeBorderColor="128,128,128,255" shapeFillColor="255,255,255,255" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeType="0" shapeSVGFile="" shapeSizeType="0" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeOpacity="1"/>
+          <shadow shadowDraw="0" shadowOffsetGlobal="1" shadowOffsetAngle="135" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowColor="0,0,0,255" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowOpacity="0.7" shadowRadiusUnit="MM" shadowUnder="0" shadowOffsetUnit="MM" shadowScale="100" shadowBlendMode="6" shadowRadiusAlphaOnly="0" shadowOffsetDist="1" shadowRadius="1.5"/>
         </text-style>
-        <fillColor green="0" red="0" blue="0" alpha="255"/>
-        <fillColor2 green="255" red="255" blue="255" alpha="255"/>
-        <strokeColor green="0" red="0" blue="0" alpha="255"/>
+        <fillColor green="0" blue="0" red="0" alpha="255"/>
+        <fillColor2 green="255" blue="255" red="255" alpha="255"/>
+        <strokeColor green="0" blue="0" red="0" alpha="255"/>
       </LayoutItem>
-      <LayoutItem rasterBorderWidth="0" resizeToContents="1" id="" title="Legend" frame="false" equalColumnWidth="1" symbolAlignment="1" wmsLegendHeight="25" columnCount="3" legendFilterByMap="1" rasterBorder="1" map_uuid="{7ec4114b-93d8-4982-b461-ad4c834c2a7c}" rasterBorderColor="0,0,0,255" wrapChar="" templateUuid="{8b76e5e5-d2e7-4bde-a4ba-8672a887d75a}" outlineWidthM="0.3,mm" legendFilterByAtlas="0" lineSpacing="1" size="91.3219,24.4,mm" wmsLegendWidth="50" background="true" frameJoinStyle="miter" symbolWidth="7" boxSpace="2" visibility="1" opacity="1" groupUuid="" itemRotation="0" fontColor="#000000" blendMode="0" position="320.526,239.075,mm" uuid="{8b76e5e5-d2e7-4bde-a4ba-8672a887d75a}" zValue="3" symbolHeight="4" titleAlignment="4" positionLock="false" columnSpace="4" type="65642" excludeFromExports="0" positionOnPage="320.526,239.075,mm" splitLayer="0" referencePoint="0">
-        <FrameColor green="0" red="0" blue="0" alpha="255"/>
-        <BackgroundColor green="255" red="255" blue="255" alpha="255"/>
+      <LayoutItem rasterBorderColor="0,0,0,255" resizeToContents="1" type="65642" uuid="{8b76e5e5-d2e7-4bde-a4ba-8672a887d75a}" titleAlignment="4" positionLock="false" legendFilterByMap="1" fontColor="#000000" groupUuid="" referencePoint="0" excludeFromExports="0" templateUuid="{8b76e5e5-d2e7-4bde-a4ba-8672a887d75a}" columnCount="3" symbolWidth="7" frameJoinStyle="miter" zValue="3" size="81.6672,24.4,mm" position="320.526,239.075,mm" columnSpace="4" opacity="1" itemRotation="0" wmsLegendWidth="50" symbolHeight="4" frame="false" lineSpacing="1" positionOnPage="320.526,239.075,mm" background="true" legendFilterByAtlas="0" wmsLegendHeight="25" outlineWidthM="0.3,mm" splitLayer="0" boxSpace="2" map_uuid="{7ec4114b-93d8-4982-b461-ad4c834c2a7c}" id="" title="Legend" rasterBorderWidth="0" rasterBorder="1" wrapChar="" equalColumnWidth="1" visibility="1" blendMode="0">
+        <FrameColor green="0" blue="0" red="0" alpha="255"/>
+        <BackgroundColor green="255" blue="255" red="255" alpha="255"/>
         <LayoutObject>
           <dataDefinedProperties>
             <Option type="Map">
-              <Option value="" name="name" type="QString"/>
+              <Option value="" type="QString" name="name"/>
               <Option name="properties"/>
-              <Option value="collection" name="type" type="QString"/>
+              <Option value="collection" type="QString" name="type"/>
             </Option>
           </dataDefinedProperties>
           <customproperties/>
         </LayoutObject>
         <styles>
-          <style alignment="1" name="title" marginBottom="2">
+          <style marginBottom="2" name="title">
             <styleFont description="Ubuntu,16,-1,5,50,0,0,0,0,0" style=""/>
           </style>
-          <style alignment="1" name="group" marginTop="2">
+          <style name="group" marginTop="2">
             <styleFont description="Ubuntu,14,-1,5,50,0,0,0,0,0" style=""/>
           </style>
-          <style alignment="1" name="subgroup" marginTop="2">
+          <style name="subgroup" marginTop="2">
             <styleFont description="Ubuntu,12,-1,5,50,0,0,0,0,0" style=""/>
           </style>
-          <style alignment="1" name="symbol" marginTop="2">
+          <style name="symbol" marginTop="2">
             <styleFont description="Ubuntu,11,-1,5,50,0,0,0,0,0" style=""/>
           </style>
-          <style alignment="1" name="symbolLabel" marginTop="2" marginLeft="2">
+          <style name="symbolLabel" marginLeft="2" marginTop="2">
             <styleFont description="Ubuntu,12,-1,5,50,0,0,0,0,0" style=""/>
           </style>
         </styles>
         <layer-tree-group>
           <customproperties/>
-          <layer-tree-layer providerKey="ogr" checked="Qt::Checked" name="popp" expanded="1" source="../../../qgis_sample_data/shapefiles/popp.shp" id="popp20130517221648651">
+          <layer-tree-layer name="popp" checked="Qt::Checked" expanded="1" providerKey="ogr" id="popp20130517221648651" source="../../../qgis_sample_data/shapefiles/popp.shp">
             <customproperties/>
           </layer-tree-layer>
-          <layer-tree-layer providerKey="ogr" checked="Qt::Checked" name="airports" expanded="1" source="../../../qgis_sample_data/shapefiles/airports.shp" id="airports20130517221648088">
+          <layer-tree-layer name="airports" checked="Qt::Checked" expanded="1" providerKey="ogr" id="airports20130517221648088" source="../../../qgis_sample_data/shapefiles/airports.shp">
             <customproperties/>
           </layer-tree-layer>
-          <layer-tree-layer providerKey="ogr" checked="Qt::Checked" name="majrivers" expanded="1" source="../../../qgis_sample_data/shapefiles/majrivers.shp" id="majrivers_copy20141004123744134">
+          <layer-tree-layer name="majrivers" checked="Qt::Checked" expanded="1" providerKey="ogr" id="majrivers_copy20141004123744134" source="../../../qgis_sample_data/shapefiles/majrivers.shp">
             <customproperties/>
           </layer-tree-layer>
-          <layer-tree-layer providerKey="ogr" checked="Qt::Checked" name="regions" expanded="0" source="../../../qgis_sample_data/shapefiles/regions.shp" id="regions20130517221648766">
+          <layer-tree-layer name="regions" checked="Qt::Checked" expanded="0" providerKey="ogr" id="regions20130517221648766" source="../../../qgis_sample_data/shapefiles/regions.shp">
             <customproperties/>
           </layer-tree-layer>
-          <layer-tree-layer providerKey="ogr" checked="Qt::Checked" name="alaska" expanded="1" source="../../../qgis_sample_data/shapefiles/alaska.shp" id="alaska20130517221648216">
+          <layer-tree-layer name="alaska" checked="Qt::Checked" expanded="1" providerKey="ogr" id="alaska20130517221648216" source="../../../qgis_sample_data/shapefiles/alaska.shp">
             <customproperties/>
           </layer-tree-layer>
-          <layer-tree-layer providerKey="ogr" checked="Qt::Checked" name="lakes" expanded="0" source="../../../qgis_sample_data/shapefiles/lakes.shp" id="lakes20130517221648410">
+          <layer-tree-layer name="lakes" checked="Qt::Checked" expanded="0" providerKey="ogr" id="lakes20130517221648410" source="../../../qgis_sample_data/shapefiles/lakes.shp">
             <customproperties/>
           </layer-tree-layer>
-          <layer-tree-layer providerKey="ogr" checked="Qt::Unchecked" name="swamp" expanded="0" source="../../../qgis_sample_data/shapefiles/swamp.shp" id="swamp20130517232331437">
+          <layer-tree-layer name="swamp" checked="Qt::Unchecked" expanded="0" providerKey="ogr" id="swamp20130517232331437" source="../../../qgis_sample_data/shapefiles/swamp.shp">
             <customproperties/>
           </layer-tree-layer>
-          <layer-tree-layer providerKey="ogr" checked="Qt::Unchecked" name="storagep" expanded="1" source="../../../qgis_sample_data/shapefiles/storagep.shp" id="storagep20130517221648873">
+          <layer-tree-layer name="storagep" checked="Qt::Unchecked" expanded="1" providerKey="ogr" id="storagep20130517221648873" source="../../../qgis_sample_data/shapefiles/storagep.shp">
             <customproperties/>
           </layer-tree-layer>
           <custom-order enabled="0"/>
         </layer-tree-group>
       </LayoutItem>
-      <LayoutItem size="71.6871,18.1135,mm" id="" marginX="0" visibility="1" positionOnPage="329.264,8.9018,mm" opacity="1" blendMode="0" outlineWidthM="0.3,mm" groupUuid="" type="65641" frame="false" referencePoint="0" templateUuid="{0c5381d9-8446-43b0-b1ea-b77214de1702}" background="true" uuid="{0c5381d9-8446-43b0-b1ea-b77214de1702}" zValue="2" positionLock="false" itemRotation="0" excludeFromExports="0" halign="4" htmlState="0" valign="128" frameJoinStyle="miter" position="329.264,8.9018,mm" labelText="West Alaska&#xa;Nome Region" marginY="0">
-        <FrameColor green="0" red="0" blue="0" alpha="255"/>
-        <BackgroundColor green="255" red="255" blue="255" alpha="255"/>
+      <LayoutItem visibility="1" excludeFromExports="0" marginY="0" outlineWidthM="0.3,mm" positionOnPage="329.264,8.9018,mm" labelText="West Alaska&#xa;Nome Region" type="65641" opacity="1" templateUuid="{0c5381d9-8446-43b0-b1ea-b77214de1702}" background="true" frameJoinStyle="miter" id="" referencePoint="0" zValue="2" position="329.264,8.9018,mm" valign="128" itemRotation="0" frame="false" htmlState="0" positionLock="false" marginX="0" uuid="{0c5381d9-8446-43b0-b1ea-b77214de1702}" halign="4" blendMode="0" groupUuid="" size="71.6871,18.1135,mm">
+        <FrameColor green="0" blue="0" red="0" alpha="255"/>
+        <BackgroundColor green="255" blue="255" red="255" alpha="255"/>
         <LayoutObject>
           <dataDefinedProperties>
             <Option type="Map">
-              <Option value="" name="name" type="QString"/>
+              <Option value="" type="QString" name="name"/>
               <Option name="properties"/>
-              <Option value="collection" name="type" type="QString"/>
+              <Option value="collection" type="QString" name="type"/>
             </Option>
           </dataDefinedProperties>
           <customproperties/>
         </LayoutObject>
         <LabelFont description="Ubuntu,14,-1,5,75,1,0,0,0,0" style=""/>
-        <FontColor green="0" red="0" blue="0" alpha="255"/>
+        <FontColor green="0" blue="0" red="0" alpha="255"/>
       </LayoutItem>
-      <LayoutItem size="295.101,277,mm" keepLayerSet="true" id="" visibility="1" positionOnPage="10.3522,10,mm" opacity="1" mapFlags="0" blendMode="0" outlineWidthM="0.3,mm" groupUuid="" type="65639" followPresetName="" frame="true" referencePoint="0" templateUuid="{7ec4114b-93d8-4982-b461-ad4c834c2a7c}" background="true" uuid="{7ec4114b-93d8-4982-b461-ad4c834c2a7c}" followPreset="false" zValue="1" positionLock="true" itemRotation="0" excludeFromExports="0" mapRotation="0" labelMargin="0,mm" frameJoinStyle="miter" drawCanvasItems="true" position="10.3522,10,mm">
-        <FrameColor green="0" red="0" blue="0" alpha="255"/>
-        <BackgroundColor green="255" red="255" blue="255" alpha="255"/>
+      <LayoutItem visibility="1" excludeFromExports="0" outlineWidthM="0.3,mm" positionOnPage="10.3522,10,mm" type="65639" opacity="1" templateUuid="{7ec4114b-93d8-4982-b461-ad4c834c2a7c}" mapFlags="0" background="true" followPresetName="" frameJoinStyle="miter" drawCanvasItems="true" id="" referencePoint="0" zValue="1" keepLayerSet="true" position="10.3522,10,mm" itemRotation="0" followPreset="false" frame="true" positionLock="true" uuid="{7ec4114b-93d8-4982-b461-ad4c834c2a7c}" mapRotation="0" labelMargin="0,mm" blendMode="0" groupUuid="" size="295.101,277,mm">
+        <FrameColor green="0" blue="0" red="0" alpha="255"/>
+        <BackgroundColor green="255" blue="255" red="255" alpha="255"/>
         <LayoutObject>
           <dataDefinedProperties>
             <Option type="Map">
-              <Option value="" name="name" type="QString"/>
+              <Option value="" type="QString" name="name"/>
               <Option name="properties"/>
-              <Option value="collection" name="type" type="QString"/>
+              <Option value="collection" type="QString" name="type"/>
             </Option>
           </dataDefinedProperties>
           <customproperties/>
         </LayoutObject>
-        <Extent ymax="7411068.44179885927587748" xmin="-2226464.67337579280138016" xmax="-290769.13531805016100407" ymin="5594105.21889553219079971"/>
+        <Extent ymax="6250200.40000202413648367" xmin="-2477244.76902887132018805" ymin="4433237.17709869705140591" xmax="-541549.23097112867981195"/>
         <LayerSet>
-          <Layer name="popp" provider="ogr" source="/home/aneto/QGIS/qgis_sample_data/shapefiles/popp.shp">popp20130517221648651</Layer>
-          <Layer name="airports" provider="ogr" source="/home/aneto/QGIS/qgis_sample_data/shapefiles/airports.shp">airports20130517221648088</Layer>
-          <Layer name="regions" provider="ogr" source="/home/aneto/QGIS/qgis_sample_data/shapefiles/regions.shp">regions20130517221648766</Layer>
-          <Layer name="lakes" provider="ogr" source="/home/aneto/QGIS/qgis_sample_data/shapefiles/lakes.shp">lakes20130517221648410</Layer>
-          <Layer name="alaska" provider="ogr" source="/home/aneto/QGIS/qgis_sample_data/shapefiles/alaska.shp">alaska20130517221648216</Layer>
-          <Layer name="majrivers" provider="ogr" source="/home/aneto/QGIS/qgis_sample_data/shapefiles/majrivers.shp">majrivers_copy20141004123744134</Layer>
+          <Layer name="popp" provider="ogr" source="/media/TRAVAIL/dev/github/qgis_sample_data/shapefiles/popp.shp">popp20130517221648651</Layer>
+          <Layer name="airports" provider="ogr" source="/media/TRAVAIL/dev/github/qgis_sample_data/shapefiles/airports.shp">airports20130517221648088</Layer>
+          <Layer name="regions" provider="ogr" source="/media/TRAVAIL/dev/github/qgis_sample_data/shapefiles/regions.shp">regions20130517221648766</Layer>
+          <Layer name="lakes" provider="ogr" source="/media/TRAVAIL/dev/github/qgis_sample_data/shapefiles/lakes.shp">lakes20130517221648410</Layer>
+          <Layer name="alaska" provider="ogr" source="/media/TRAVAIL/dev/github/qgis_sample_data/shapefiles/alaska.shp">alaska20130517221648216</Layer>
+          <Layer name="majrivers" provider="ogr" source="/media/TRAVAIL/dev/github/qgis_sample_data/shapefiles/majrivers.shp">majrivers_copy20141004123744134</Layer>
         </LayerSet>
-        <ComposerMapGrid annotationFormat="0" gridFramePenThickness="0.5" gridFrameWidth="2" show="1" leftFrameDivisions="0" topFrameDivisions="0" bottomAnnotationDisplay="0" name="Grid 1" bottomAnnotationPosition="1" rightAnnotationPosition="1" rightAnnotationDirection="1" topAnnotationPosition="1" frameFillColor2="0,0,0,255" annotationFontColor="0,0,0,255" unit="0" minimumIntervalWidth="50" annotationPrecision="0" rightAnnotationDisplay="0" bottomFrameDivisions="0" annotationExpression="" frameAnnotationDistance="1" gridFrameStyle="0" intervalX="500000" frameFillColor1="255,255,255,255" leftAnnotationPosition="1" offsetX="0" leftAnnotationDisplay="0" crossLength="3" gridFramePenColor="0,0,0,255" showAnnotation="1" gridFrameSideFlags="15" leftAnnotationDirection="1" topAnnotationDisplay="0" blendMode="0" rightFrameDivisions="0" intervalY="500000" position="3" uuid="{3dfeff49-7a78-44b0-9b7b-b865bc5759ed}" maximumIntervalWidth="100" bottomAnnotationDirection="0" topAnnotationDirection="0" gridStyle="0" gridFrameMargin="0" offsetY="0">
+        <ComposerMapGrid offsetX="0" leftAnnotationDisplay="0" offsetY="0" gridFrameMargin="0" annotationFormat="0" bottomAnnotationDirection="0" gridFramePenColor="0,0,0,255" uuid="{3dfeff49-7a78-44b0-9b7b-b865bc5759ed}" topAnnotationDirection="0" annotationExpression="" topFrameDivisions="0" topAnnotationDisplay="0" annotationPrecision="0" bottomFrameDivisions="0" intervalY="500000" rightAnnotationPosition="1" unit="0" topAnnotationPosition="1" position="3" frameAnnotationDistance="1" rightAnnotationDisplay="0" gridFrameWidth="2" rightAnnotationDirection="1" show="1" annotationFontColor="0,0,0,255" rightFrameDivisions="0" gridFramePenThickness="0.5" frameFillColor1="255,255,255,255" leftFrameDivisions="0" bottomAnnotationDisplay="0" intervalX="500000" crossLength="3" gridFrameSideFlags="15" leftAnnotationDirection="1" name="Grid 1" gridFrameStyle="0" bottomAnnotationPosition="1" frameFillColor2="0,0,0,255" leftAnnotationPosition="1" blendMode="0" gridStyle="0" showAnnotation="1">
           <lineStyle>
-            <symbol force_rhr="0" name="" clip_to_extent="1" alpha="1" type="line">
+            <symbol clip_to_extent="1" force_rhr="0" type="line" name="" alpha="1">
               <layer enabled="1" pass="0" class="SimpleLine" locked="0">
                 <prop k="capstyle" v="flat"/>
                 <prop k="customdash" v="5;2"/>
@@ -14906,16 +14257,16 @@ def closeProject():&#xd;
                 <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
                 <data_defined_properties>
                   <Option type="Map">
-                    <Option value="" name="name" type="QString"/>
+                    <Option value="" type="QString" name="name"/>
                     <Option name="properties"/>
-                    <Option value="collection" name="type" type="QString"/>
+                    <Option value="collection" type="QString" name="type"/>
                   </Option>
                 </data_defined_properties>
               </layer>
             </symbol>
           </lineStyle>
           <markerStyle>
-            <symbol force_rhr="0" name="" clip_to_extent="1" alpha="1" type="marker">
+            <symbol clip_to_extent="1" force_rhr="0" type="marker" name="" alpha="1">
               <layer enabled="1" pass="0" class="SimpleMarker" locked="0">
                 <prop k="angle" v="0"/>
                 <prop k="color" v="0,0,0,255"/>
@@ -14937,63 +14288,53 @@ def closeProject():&#xd;
                 <prop k="vertical_anchor_point" v="1"/>
                 <data_defined_properties>
                   <Option type="Map">
-                    <Option value="" name="name" type="QString"/>
+                    <Option value="" type="QString" name="name"/>
                     <Option name="properties"/>
-                    <Option value="collection" name="type" type="QString"/>
+                    <Option value="collection" type="QString" name="type"/>
                   </Option>
                 </data_defined_properties>
               </layer>
             </symbol>
           </markerStyle>
           <annotationFontProperties description="Ubuntu,11,-1,5,50,0,0,0,0,0" style=""/>
-          <LayoutObject>
-            <dataDefinedProperties>
-              <Option type="Map">
-                <Option value="" name="name" type="QString"/>
-                <Option name="properties"/>
-                <Option value="collection" name="type" type="QString"/>
-              </Option>
-            </dataDefinedProperties>
-            <customproperties/>
-          </LayoutObject>
         </ComposerMapGrid>
-        <AtlasMap scalingMode="0" atlasDriven="1" margin="0.10000000000000001"/>
+        <AtlasMap atlasDriven="1" scalingMode="0" margin="0.10000000000000001"/>
         <labelBlockingItems/>
       </LayoutItem>
-      <LayoutMultiFrame uuid="{60855bfd-b5ce-4a6c-a90a-644dc971bf70}" templateUuid="{60855bfd-b5ce-4a6c-a90a-644dc971bf70}" url="http://www.aviationwap.com/airportdata.php?a=US00436" useSmartBreaks="true" stylesheet="" maxBreakDistance="10" contentMode="0" evaluateExpressions="true" type="65648" stylesheetEnabled="false" html="" resizeMode="0">
-        <childFrame uuid="{0e2ae97d-4224-4dde-b484-d5338a39b1ce}" templateUuid="{0e2ae97d-4224-4dde-b484-d5338a39b1ce}"/>
+      <LayoutMultiFrame resizeMode="0" contentMode="0" type="65648" url="http://www.aviationwap.com/airportdata.php?a=US00436" useSmartBreaks="true" html="" evaluateExpressions="true" maxBreakDistance="10" stylesheetEnabled="false" templateUuid="{60855bfd-b5ce-4a6c-a90a-644dc971bf70}" uuid="{60855bfd-b5ce-4a6c-a90a-644dc971bf70}" stylesheet="">
+        <childFrame templateUuid="{0e2ae97d-4224-4dde-b484-d5338a39b1ce}" uuid="{0e2ae97d-4224-4dde-b484-d5338a39b1ce}"/>
         <LayoutObject>
           <dataDefinedProperties>
             <Option type="Map">
-              <Option value="" name="name" type="QString"/>
+              <Option value="" type="QString" name="name"/>
               <Option name="properties"/>
-              <Option value="collection" name="type" type="QString"/>
+              <Option value="collection" type="QString" name="type"/>
             </Option>
           </dataDefinedProperties>
           <customproperties/>
         </LayoutObject>
       </LayoutMultiFrame>
-      <LayoutMultiFrame uuid="{efc33b86-db2d-400f-9c25-709e67c55b9d}" templateUuid="{efc33b86-db2d-400f-9c25-709e67c55b9d}" url="file:///media/TRAVAIL/dev/github/QGIS-Documentation/qgis-projects/user_manual/unalakleet_airport.html" useSmartBreaks="true" stylesheet="" maxBreakDistance="10" contentMode="0" evaluateExpressions="true" type="65648" stylesheetEnabled="false" html="" resizeMode="0">
-        <childFrame uuid="{570970e1-7c34-492e-9a3e-7e37387cd3f8}" templateUuid="{570970e1-7c34-492e-9a3e-7e37387cd3f8}"/>
+      <LayoutMultiFrame resizeMode="0" contentMode="0" type="65648" url="file:///media/TRAVAIL/dev/github/QGIS-Documentation/qgis-projects/user_manual/unalakleet_airport.html" useSmartBreaks="true" html="" evaluateExpressions="true" maxBreakDistance="10" stylesheetEnabled="false" templateUuid="{efc33b86-db2d-400f-9c25-709e67c55b9d}" uuid="{efc33b86-db2d-400f-9c25-709e67c55b9d}" stylesheet="">
+        <childFrame templateUuid="{570970e1-7c34-492e-9a3e-7e37387cd3f8}" uuid="{570970e1-7c34-492e-9a3e-7e37387cd3f8}"/>
         <LayoutObject>
           <dataDefinedProperties>
             <Option type="Map">
-              <Option value="" name="name" type="QString"/>
+              <Option value="" type="QString" name="name"/>
               <Option name="properties"/>
-              <Option value="collection" name="type" type="QString"/>
+              <Option value="collection" type="QString" name="type"/>
             </Option>
           </dataDefinedProperties>
           <customproperties/>
         </LayoutObject>
       </LayoutMultiFrame>
-      <LayoutMultiFrame vectorLayerName="airports" emptyTableMessage="" maxFeatures="30" wrapString="" showUniqueRowsOnly="0" headerHAlignment="0" relationId="" wrapBehavior="0" source="0" showGrid="1" showEmptyRows="0" backgroundColor="255,255,255,255" showOnlyVisibleFeatures="1" verticalGrid="1" headerMode="0" emptyTableMode="0" type="65649" templateUuid="{73a89e82-fc28-4e77-bbcd-75e6c3f7700f}" featureFilter="" uuid="{73a89e82-fc28-4e77-bbcd-75e6c3f7700f}" resizeMode="0" headerFontColor="0,0,0,255" vectorLayerSource="/home/aneto/QGIS/qgis_sample_data/shapefiles/airports.shp" contentFontColor="0,0,0,255" gridColor="0,0,0,255" filterFeatures="true" gridStrokeWidth="0.5" vectorLayer="airports20130517221648088" horizontalGrid="1" mapUuid="{7ec4114b-93d8-4982-b461-ad4c834c2a7c}" filterToAtlasIntersection="0" cellMargin="1" vectorLayerProvider="ogr">
-        <childFrame uuid="{648a1f51-c720-4e96-be57-e11adc6ca8be}" templateUuid="{648a1f51-c720-4e96-be57-e11adc6ca8be}"/>
+      <LayoutMultiFrame backgroundColor="255,255,255,255" vectorLayerProvider="ogr" horizontalGrid="1" filterToAtlasIntersection="0" filterFeatures="false" gridColor="0,0,0,255" showGrid="1" wrapBehavior="0" vectorLayerName="airports" maxFeatures="30" type="65649" emptyTableMode="0" resizeMode="0" emptyTableMessage="" templateUuid="{73a89e82-fc28-4e77-bbcd-75e6c3f7700f}" source="0" showOnlyVisibleFeatures="1" wrapString="" showEmptyRows="0" contentFontColor="0,0,0,255" headerHAlignment="0" mapUuid="{7ec4114b-93d8-4982-b461-ad4c834c2a7c}" vectorLayer="airports20130517221648088" vectorLayerSource="/media/TRAVAIL/dev/github/qgis_sample_data/shapefiles/airports.shp" gridStrokeWidth="0.5" headerMode="0" cellMargin="1" showUniqueRowsOnly="0" uuid="{73a89e82-fc28-4e77-bbcd-75e6c3f7700f}" relationId="" verticalGrid="1" featureFilter="" headerFontColor="0,0,0,255">
+        <childFrame templateUuid="{648a1f51-c720-4e96-be57-e11adc6ca8be}" uuid="{648a1f51-c720-4e96-be57-e11adc6ca8be}"/>
         <LayoutObject>
           <dataDefinedProperties>
             <Option type="Map">
-              <Option value="" name="name" type="QString"/>
+              <Option value="" type="QString" name="name"/>
               <Option name="properties"/>
-              <Option value="collection" name="type" type="QString"/>
+              <Option value="collection" type="QString" name="type"/>
             </Option>
           </dataDefinedProperties>
           <customproperties/>
@@ -15001,14 +14342,14 @@ def closeProject():&#xd;
         <headerFontProperties description="Ubuntu,11,-1,5,50,0,0,0,0,0" style=""/>
         <contentFontProperties description="Ubuntu,11,-1,5,50,0,0,0,0,0" style=""/>
         <displayColumns>
-          <column attribute="NAME" sortByRank="1" heading="Name" hAlignment="1" width="0" vAlignment="128" sortOrder="0">
-            <backgroundColor green="0" red="0" blue="0" alpha="0"/>
+          <column hAlignment="1" width="0" sortOrder="0" vAlignment="128" heading="Name" attribute="NAME" sortByRank="1">
+            <backgroundColor green="0" blue="0" red="0" alpha="0"/>
           </column>
-          <column attribute="USE" sortByRank="0" heading="Use" hAlignment="1" width="0" vAlignment="128" sortOrder="0">
-            <backgroundColor green="0" red="0" blue="0" alpha="0"/>
+          <column hAlignment="1" width="0" sortOrder="0" vAlignment="128" heading="Use" attribute="USE" sortByRank="0">
+            <backgroundColor green="0" blue="0" red="0" alpha="0"/>
           </column>
-          <column attribute="ELEV" sortByRank="0" heading="Elevation" hAlignment="1" width="0" vAlignment="128" sortOrder="0">
-            <backgroundColor green="0" red="0" blue="0" alpha="0"/>
+          <column hAlignment="1" width="0" sortOrder="0" vAlignment="128" heading="Elevation" attribute="ELEV" sortByRank="0">
+            <backgroundColor green="0" blue="0" red="0" alpha="0"/>
           </column>
         </displayColumns>
         <cellStyles>
@@ -15024,15 +14365,15 @@ def closeProject():&#xd;
         </cellStyles>
       </LayoutMultiFrame>
       <customproperties>
-        <property value="png" key="atlasRasterFormat"/>
+        <property key="atlasRasterFormat" value="png"/>
       </customproperties>
-      <Atlas enabled="1" sortFeatures="0" coverageLayerName="airports" hideCoverage="0" filenamePattern="'output_'||$feature" pageNameExpression="" coverageLayer="airports20130517221648088" coverageLayerSource="/home/aneto/QGIS/qgis_sample_data/shapefiles/airports.shp" filterFeatures="0" coverageLayerProvider="ogr"/>
+      <Atlas coverageLayer="airports20130517221648088" filenamePattern="'output_'||$feature" coverageLayerSource="/media/TRAVAIL/dev/github/qgis_sample_data/shapefiles/airports.shp" enabled="1" pageNameExpression="" hideCoverage="0" sortFeatures="0" coverageLayerName="airports" coverageLayerProvider="ogr" filterFeatures="0"/>
     </Layout>
-    <Layout worldFileMap="" printResolution="300" name="alaska2 - A4" units="mm">
-      <Snapper tolerance="5" snapToGrid="0" snapToGuides="1" snapToItems="1"/>
-      <Grid offsetY="0" resolution="10" offsetX="0" resUnits="mm" offsetUnits="mm"/>
+    <Layout units="mm" printResolution="300" worldFileMap="" name="alaska2 - A4">
+      <Snapper snapToGuides="1" tolerance="5" snapToItems="1" snapToGrid="0"/>
+      <Grid resolution="10" offsetX="0" offsetY="0" resUnits="mm" offsetUnits="mm"/>
       <PageCollection>
-        <symbol force_rhr="0" name="" clip_to_extent="1" alpha="1" type="fill">
+        <symbol clip_to_extent="1" force_rhr="0" type="fill" name="" alpha="1">
           <layer enabled="1" pass="0" class="SimpleFill" locked="0">
             <prop k="border_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
             <prop k="color" v="255,255,255,255"/>
@@ -15047,73 +14388,33 @@ def closeProject():&#xd;
             <prop k="style" v="solid"/>
             <data_defined_properties>
               <Option type="Map">
-                <Option value="" name="name" type="QString"/>
+                <Option value="" type="QString" name="name"/>
                 <Option name="properties"/>
-                <Option value="collection" name="type" type="QString"/>
+                <Option value="collection" type="QString" name="type"/>
               </Option>
             </data_defined_properties>
           </layer>
         </symbol>
-        <LayoutItem size="297,210,mm" id="" visibility="1" positionOnPage="0,0,mm" opacity="1" blendMode="0" outlineWidthM="0.3,mm" groupUuid="" type="65638" frame="false" referencePoint="0" templateUuid="{4d42dd46-7589-4c6a-9af5-b89d3fa776c5}" background="true" uuid="{4d42dd46-7589-4c6a-9af5-b89d3fa776c5}" zValue="0" positionLock="false" itemRotation="0" excludeFromExports="0" frameJoinStyle="miter" position="0,0,mm">
-          <FrameColor green="0" red="0" blue="0" alpha="255"/>
-          <BackgroundColor green="255" red="255" blue="255" alpha="255"/>
+        <LayoutItem visibility="1" excludeFromExports="0" outlineWidthM="0.3,mm" positionOnPage="0,0,mm" type="65638" opacity="1" templateUuid="{4d42dd46-7589-4c6a-9af5-b89d3fa776c5}" background="true" frameJoinStyle="miter" id="" referencePoint="0" zValue="0" position="0,0,mm" itemRotation="0" frame="false" positionLock="false" uuid="{4d42dd46-7589-4c6a-9af5-b89d3fa776c5}" blendMode="0" groupUuid="" size="297,210,mm">
+          <FrameColor green="0" blue="0" red="0" alpha="255"/>
+          <BackgroundColor green="255" blue="255" red="255" alpha="255"/>
           <LayoutObject>
             <dataDefinedProperties>
               <Option type="Map">
-                <Option value="" name="name" type="QString"/>
+                <Option value="" type="QString" name="name"/>
                 <Option name="properties"/>
-                <Option value="collection" name="type" type="QString"/>
+                <Option value="collection" type="QString" name="type"/>
               </Option>
             </dataDefinedProperties>
             <customproperties/>
           </LayoutObject>
-          <symbol force_rhr="0" name="" clip_to_extent="1" alpha="1" type="fill">
-            <layer enabled="1" pass="0" class="SimpleFill" locked="0">
-              <prop k="border_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-              <prop k="color" v="255,255,255,255"/>
-              <prop k="joinstyle" v="miter"/>
-              <prop k="offset" v="0,0"/>
-              <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-              <prop k="offset_unit" v="MM"/>
-              <prop k="outline_color" v="35,35,35,255"/>
-              <prop k="outline_style" v="no"/>
-              <prop k="outline_width" v="0.26"/>
-              <prop k="outline_width_unit" v="MM"/>
-              <prop k="style" v="solid"/>
-              <data_defined_properties>
-                <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
-                  <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
-                </Option>
-              </data_defined_properties>
-            </layer>
-          </symbol>
         </LayoutItem>
         <GuideCollection visible="1"/>
       </PageCollection>
       <customproperties>
-        <property value="png" key="atlasRasterFormat"/>
+        <property key="atlasRasterFormat" value="png"/>
       </customproperties>
-      <Atlas enabled="0" sortFeatures="0" hideCoverage="0" filenamePattern="'output_'||@atlas_featurenumber" pageNameExpression="" coverageLayer="" filterFeatures="0"/>
+      <Atlas coverageLayer="" filenamePattern="'output_'||@atlas_featurenumber" enabled="0" pageNameExpression="" hideCoverage="0" sortFeatures="0" filterFeatures="0"/>
     </Layout>
   </Layouts>
-  <Bookmarks>
-    <Bookmark name="New bookmark" extent="POLYGON((-1147760.66049999999813735 2493211.12939999997615814, 978975.45059999998193234 2493211.12939999997615814, 978975.45059999998193234 3992707.09720000019297004, -1147760.66049999999813735 3992707.09720000019297004, -1147760.66049999999813735 2493211.12939999997615814))" id="{18d58677-1a9e-4246-b0ce-dcaa307662f7}" group="">
-      <spatialrefsys>
-        <wkt>PROJCS["NAD27 / Alaska Albers",GEOGCS["NAD27",DATUM["North_American_Datum_1927",SPHEROID["Clarke 1866",6378206.4,294.9786982138982,AUTHORITY["EPSG","7008"]],AUTHORITY["EPSG","6267"]],PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9122"]],AUTHORITY["EPSG","4267"]],PROJECTION["Albers_Conic_Equal_Area"],PARAMETER["standard_parallel_1",55],PARAMETER["standard_parallel_2",65],PARAMETER["latitude_of_center",50],PARAMETER["longitude_of_center",-154],PARAMETER["false_easting",0],PARAMETER["false_northing",0],UNIT["US survey foot",0.3048006096012192,AUTHORITY["EPSG","9003"]],AXIS["X",EAST],AXIS["Y",NORTH],AUTHORITY["EPSG","2964"]]</wkt>
-        <proj4>+proj=aea +lat_1=55 +lat_2=65 +lat_0=50 +lon_0=-154 +x_0=0 +y_0=0 +datum=NAD27 +units=us-ft +no_defs</proj4>
-        <srsid>932</srsid>
-        <srid>2964</srid>
-        <authid>EPSG:2964</authid>
-        <description>NAD27 / Alaska Albers</description>
-        <projectionacronym>aea</projectionacronym>
-        <ellipsoidacronym>clrk66</ellipsoidacronym>
-        <geographicflag>false</geographicflag>
-      </spatialrefsys>
-    </Bookmark>
-  </Bookmarks>
-  <ProjectViewSettings UseProjectScales="0">
-    <Scales/>
-  </ProjectViewSettings>
 </qgis>


### PR DESCRIPTION
Goal: Revert the effect of #4896 

But it turns out that 3.4 "compatibility" of this project file was already lost (Jun 23, 2019):
https://github.com/qgis/QGIS-Documentation/commit/d162200b0d6e232cb862a6d6464c457c297bc7cf#diff-bcdf4885ad1dc8915d717bdb91c85ad3
Should we revert to the version preceding that commit?

Ticket(s): #4891
<!---
Indicate whether the fix should be backported to previous release.
Replace the space between square brackets by a `x` to make it checked.
-->
- [ ] Backport to LTR documentation is required

<!---
Reviewing is a process done by community members, mostly on a volunteer basis.
We try to keep the overhead as small as possible and appreciate if you help us.
Please read carefully and ensure you comply with our writing guidelines at
https://docs.qgis.org/testing/en/docs/documentation_guidelines/index.html.
Feel free to ask in a comment or the (qgis-community-team mailing list)
[https://lists.osgeo.org/mailman/listinfo/qgis-community-team] if you have troubles with any item.
--->
