### PR TITLE
Typo corrected in the link to Aptana website

### DIFF
--- a/docs/pyqgis_developer_cookbook/plugins/ide_debugging.rst
+++ b/docs/pyqgis_developer_cookbook/plugins/ide_debugging.rst
@@ -93,7 +93,7 @@ Installation
 To use Eclipse, make sure you have installed the following
 
 * `Eclipse <https://www.eclipse.org>`_
-* `Aptana Studio 3 Plugin <https://www.aptana.com>`_ or `PyDev <https://www.pydev.org>`_
+* `Aptana Studio 3 Plugin <http://www.aptana.com>`_ or `PyDev <https://www.pydev.org>`_
 * QGIS 2.x
 * You may also want to install **Remote Debug**, a QGIS plugin. At the moment
   it's still experimental so enable |checkbox| :guilabel:`Experimental plugins`

--- a/docs/pyqgis_developer_cookbook/plugins/ide_debugging.rst
+++ b/docs/pyqgis_developer_cookbook/plugins/ide_debugging.rst
@@ -93,7 +93,7 @@ Installation
 To use Eclipse, make sure you have installed the following
 
 * `Eclipse <https://www.eclipse.org>`_
-* `Aptana Studio 3 Plugin <www.aptana.com>`_ or `PyDev <https://www.pydev.org>`_
+* `Aptana Studio 3 Plugin <https://www.aptana.com>`_ or `PyDev <https://www.pydev.org>`_
 * QGIS 2.x
 * You may also want to install **Remote Debug**, a QGIS plugin. At the moment
   it's still experimental so enable |checkbox| :guilabel:`Experimental plugins`


### PR DESCRIPTION
Aptana Studio 3 Plugin <www.aptana.com>
becomes
Aptana Studio 3 Plugin <https://www.aptana.com>

