### PR TITLE
Double wording "the"

### DIFF
--- a/docs/pyqgis_developer_cookbook/plugins/plugins.rst
+++ b/docs/pyqgis_developer_cookbook/plugins/plugins.rst
@@ -133,7 +133,7 @@ icon                   False     a file name or a relative path (relative to
 category               False     one of `Raster`, `Vector`, `Database` and `Web`
 plugin_dependencies    False     PIP-like comma separated list of other plugins to install
 server                 False     boolean flag, `True` or `False`, determines if the
-                                 the plugin has a server interface
+                                 plugin has a server interface
 hasProcessingProvider  False     boolean flag, `True` or `False`, determines if
                                  the plugin provides processing algorithms
 =====================  ========  =======================================


### PR DESCRIPTION
Line 135/136  :  determines if the
                          the plugin has a server interface
word "the" twice in same sentence, directly behind each other.

Goal: Display correct documentation

- [x] Backport to LTR documentation is required

