### PR TITLE
Move notions' index from training manual to main repo first page

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -16,4 +16,5 @@ Please have a look into one of the documents below.
    Developers Guide <developers_guide/index>
    Training Manual <training_manual/index>
    A Gentle Introduction to GIS <gentle_gis_introduction/index>
-
+   
+* :ref:`genindex`

--- a/docs/training_manual/index.rst
+++ b/docs/training_manual/index.rst
@@ -31,10 +31,3 @@ QGIS Training Manual
    appendix/contribute
 
    answers/answers
-
-Indices and tables
-==================
-
-* :ref:`genindex`
-* :ref:`modindex`
-* :ref:`search`


### PR DESCRIPTION
refs #5543 
I'm not convinced that indices list is worth a place in the bottom left menu