### PR TITLE
Rewording caption image Position and Size

### DIFF
--- a/docs/user_manual/print_composer/composer_items/composer_items_options.rst
+++ b/docs/user_manual/print_composer/composer_items/composer_items_options.rst
@@ -249,7 +249,7 @@ accurately.
 .. figure:: img/position_size.png
    :align: center
 
-   New Item properties dialog
+   Position and size
 
 * the actual number of the page to place the item on;
 * the reference point of the item;


### PR DESCRIPTION
Line 252 :  says "New item properties dialog" but is in fact the dialog Position and Size. Changed to "Position and Size"

Goal: Display correct documentation

- [x] Backport to LTR documentation is required
