### PR TITLE
Make the documentation wider

### DIFF
--- a/themes/rtd_qgis/static/css/qgis_docs.css
+++ b/themes/rtd_qgis/static/css/qgis_docs.css
@@ -42,6 +42,10 @@
   position: fixed
 }
 
+.wy-nav-content {
+	max-width: unset;
+}
+
 /* override table width restrictions 
 from https://rackerlabs.github.io/docs-rackspace/tools/rtd-tables.html */
 @media screen and (min-width: 767px) {

--- a/themes/rtd_qgis/static/css/qgis_docs.css
+++ b/themes/rtd_qgis/static/css/qgis_docs.css
@@ -43,7 +43,7 @@
 }
 
 .wy-nav-content {
-	max-width: unset;
+	max-width: 1260px;
 }
 
 /* override table width restrictions 


### PR DESCRIPTION
Goal: we discussed this small topic a long ago and actually I don't remember the conclusion (ping @DelazJ @havatv @rduivenvoorde), but given that the *fix* is simple it's more straightforward to make a PR and eventually closing it without merging.

I think that all the white space on the right side of the documentation is *waster*

I just took the same css rule of our big brother https://gdal.org/

Of course the panel is shrinkable on devices etc

![ezgif com-video-to-gif](https://user-images.githubusercontent.com/2884884/83233426-f53c0200-a18e-11ea-9197-5e1047a44b66.gif)

- [x] Backport to LTR documentation is required
