### PR TITLE
Warn about using QObjects in tasks

### DIFF
--- a/docs/pyqgis_developer_cookbook/tasks.rst
+++ b/docs/pyqgis_developer_cookbook/tasks.rst
@@ -86,10 +86,13 @@ There are several ways to create a QGIS task:
 
 .. warning::
    Any background task (regardless of how it is created) must NEVER
-   perform any GUI based operations, such as creating new widgets or
-   interacting with existing widgets. Qt widgets must only be
-   accessed or modified from the main thread. Attempting to use
-   them from background threads will result in crashes.
+   use any QObject that live on the main thread, such as accessing
+   QgsVectorLayer, QgsProject or perform any GUI based operations
+   like creating new widgets or interacting with existing widgets.
+   Qt widgets must only be accessed or modified from the main thread.
+   Data that is used in a task must be copied before the task is started.
+   Attempting to use them from background threads will result in
+   crashes.
 
 Dependencies between tasks can be described using the :meth:`addSubTask <qgis.core.QgsTask.addSubTask>`
 function of :class:`QgsTask <qgis.core.QgsTask>`.

--- a/docs/pyqgis_developer_cookbook/tasks.rst
+++ b/docs/pyqgis_developer_cookbook/tasks.rst
@@ -86,7 +86,7 @@ There are several ways to create a QGIS task:
 
 .. warning::
    Any background task (regardless of how it is created) must NEVER
-   use any QObject that live on the main thread, such as accessing
+   use any QObject that lives on the main thread, such as accessing
    QgsVectorLayer, QgsProject or perform any GUI based operations
    like creating new widgets or interacting with existing widgets.
    Qt widgets must only be accessed or modified from the main thread.


### PR DESCRIPTION
<!---
Include a few sentences describing the overall goals for this Pull Request.
 
A list of issues is at https://github.com/qgis/QGIS-Documentation/issues.
Add "fix #issuenumber" for each issue the PR fixes. The ticket(s) will be closed automatically.
If your PR doesn't fix entirely the ticket, only add the ticket(s) reference preceded by # character.
-->
Goal:

Be clear that GUI objects *AND* other QObjects that live on the main thread must not be accessed from a task.