### PR TITLE
Removed superfluous item of entry for parameter

### DIFF
--- a/docs/user_manual/processing_algs/qgis/vectorgeneral.rst
+++ b/docs/user_manual/processing_algs/qgis/vectorgeneral.rst
@@ -1972,8 +1972,6 @@ Truncates a layer, by deleting all features from within the layer.
 
 Parameters
 ..........
-``Input layer`` [vector: any]
-  Vector layer in input.
 
 .. list-table::
    :header-rows: 1


### PR DESCRIPTION
Line 1975 : mentioned entry for parameter which should have been inside a table.
                   The same entry inside a table is mentioned at line 1986

Goal: Display correct documentation

- [x] Backport to LTR documentation is required
