### PR TITLE
Make links to Sample Dataset consistent in testing docs

### DIFF
--- a/docs/user_manual/introduction/getting_started.rst
+++ b/docs/user_manual/introduction/getting_started.rst
@@ -78,7 +78,8 @@ you may do one of the following:
 
 * Use GIS data that you already have
 * Download sample data from
-  https://qgis.org/downloads/data/qgis_sample_data.zip
+  https://github.com/qgis/QGIS-Sample-Data/archive/master.zip and unzip the archive
+  on any convenient location on your system.
 * Uninstall QGIS and reinstall with the data download option checked (only
   recommended if the above solutions are unsuccessful)
 


### PR DESCRIPTION
<!---
Include a few sentences describing the overall goals for this Pull Request.
 
A list of issues is at https://github.com/qgis/QGIS-Documentation/issues.
Add "fix #issuenumber" for each issue the PR fixes. The ticket(s) will be closed automatically.
If your PR doesn't fix entirely the ticket, only add the ticket(s) reference preceded by # character.
-->
Goal:
Make links to Sample Dataset consistent in testing docs.

In the "[Downloading sample data](https://docs.qgis.org/testing/en/docs/user_manual/introduction/getting_started.html#downloading-sample-data)" paragraph of the "Getting Starter" chapter in the "User Guide/Manual" there are separate instructions for Windows and GNU/Linux/macOS.

The current situation is that there are different link for the same sample dataset to download:
_ | Window | GNU/Linux/macOS
-------- | ---------- |------
testing | https://qgis.org/downloads/data/qgis_sample_data.zip | https://github.com/qgis/QGIS-Sample-Data/archive/master.zip
3.10 | https://github.com/qgis/QGIS-Sample-Data/archive/release_3.10.zip | https://qgis.org/downloads/data/qgis_sample_data.zip
3.4 | https://qgis.org/downloads/data/qgis_sample_data.zip | https://qgis.org/downloads/data/qgis_sample_data.zip

'testing' docs now:
![image](https://user-images.githubusercontent.com/16253859/83908877-1e006080-a768-11ea-8b59-dcf4ab286a83.png)


With this PR I propose to use the same link https://github.com/qgis/QGIS-Sample-Data/archive/master.zip in both Windows and GNU/Linux/macOS instructions for testing docs  using the full url for consistency with the remaining part of the page

or alternatively, using "here" with a link to  https://github.com/qgis/QGIS-Sample-Data/archive/master.zip
(https://github.com/agiudiceandrea/QGIS-Documentation/commit/30e1d848ba0296dbe325808ab090e98b2ff9cc9f)

Similar change should be made to 3.10 docs, using the URL https://github.com/qgis/QGIS-Sample-Data/archive/release_3.10.zip.

To avoid having to manually change the URL for each QGIS/docs ltr release, it is possible to add an extlinks alias name to the URL in conf.py and use the alias name as a role in getting_started.rst in order to automatically inserts the link to https://github.com/qgis/QGIS-Sample-Data/archive/release_x.y.zip (provided a new branch will be created in qgis/QGIS-Sample-Data for each docs release).
See https://github.com/agiudiceandrea/QGIS-Documentation/commit/ea9f19a79b3a9e90c2c5fa96add92cf2970c2cb0

Ticket(s): #
<!---
Indicate whether the fix should be backported to previous release.
Replace the space between square brackets by a `x` to make it checked.
-->
- [ ] Backport to LTR documentation is required

<!---
Reviewing is a process done by community members, mostly on a volunteer basis.
We try to keep the overhead as small as possible and appreciate if you help us.
Please read carefully and ensure you comply with our writing guidelines at
https://docs.qgis.org/testing/en/docs/documentation_guidelines/index.html.
Feel free to ask in a comment or the (qgis-community-team mailing list)
[https://lists.osgeo.org/mailman/listinfo/qgis-community-team] if you have troubles with any item.
--->