### PR TITLE
Update travis to most recent Python and linux distribution

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: python
 python:
-  - "3.5"
-
+  - "3.7"
+dist:
+  - bionic
 services:
   - docker
 


### PR DESCRIPTION
<!---
Include a few sentences describing the overall goals for this Pull Request.
 
A list of issues is at https://github.com/qgis/QGIS-Documentation/issues.
Add "fix #issuenumber" for each issue the PR fixes. The ticket(s) will be closed automatically.
If your PR doesn't fix entirely the ticket, only add the ticket(s) reference preceded by # character.
-->
Goal:

Trying to Update travis setup to a more recent version of python (3.5 --> 3.7) and ubuntu distribution(Xenial 16.04 --> Bionic 18.04).

Now, that we have moved to a more recent version of Sphinx, we should upgrade the testing infrastructure otherwise we will get problems like testing the usage of the newest libraries. Which is what is happening in here: #5729 

Notice that I don't know much about travis, just giving it a shot.

Ticket(s): #
<!---
Indicate whether the fix should be backported to previous release.
Replace the space between square brackets by a `x` to make it checked.
-->
- [x] Backport to LTR documentation is required

<!---
Reviewing is a process done by community members, mostly on a volunteer basis.
We try to keep the overhead as small as possible and appreciate if you help us.
Please read carefully and ensure you comply with our writing guidelines at
https://docs.qgis.org/testing/en/docs/documentation_guidelines/index.html.
Feel free to ask in a comment or the (qgis-community-team mailing list)
[https://lists.osgeo.org/mailman/listinfo/qgis-community-team] if you have troubles with any item.
--->
