### PR TITLE
Update TM to reference a GeoPackage data source instead of Shapefile Format data sources

### DIFF
--- a/docs/training_manual/introduction/mapviewnavigation.rst
+++ b/docs/training_manual/introduction/mapviewnavigation.rst
@@ -14,8 +14,12 @@ Before learning how to navigate within the Map Canvas, let's add two additional
 layers that we can explore during this tutorial.
 
 #. Use the steps learnt in :ref:`Create a Map <tm_pepare_a_map>` lesson to add 
-   ESRI Shapefiles :file:`roads.shp` and :file:`buildings.shp` as layers to the 
-   current project.  The result view should look similiar to the snippet below:
+   the ``roads`` and ``buildings`` datasets from :file:`training_data.gpkg`
+   as layers to the current project.
+   These datasets are contained in a GeoPackage file, containing several
+   datasets, so the dialog in :guilabel:`Data Source Manager` is a bit
+   different from what you experienced for the ESRI Shapefile format datasets.
+   The result view should look similiar to the snippet below:
 
    .. figure:: img/roads_buildings_added.png
      :align: center

--- a/docs/training_manual/introduction/mapviewnavigation.rst
+++ b/docs/training_manual/introduction/mapviewnavigation.rst
@@ -16,7 +16,7 @@ layers that we can explore during this tutorial.
 #. Use the steps learnt in :ref:`Create a Map <tm_pepare_a_map>` lesson to add 
    the ``roads`` and ``buildings`` datasets from :file:`training_data.gpkg`
    as layers to the current project.
-   These datasets are contained in a GeoPackage file, containing several
+   These datasets are found in a *GeoPackage* file that contains several
    datasets, so the dialog in :guilabel:`Data Source Manager` is a bit
    different from what you experienced for the ESRI Shapefile format datasets.
    The result view should look similiar to the snippet below:

--- a/docs/training_manual/introduction/mapviewnavigation.rst
+++ b/docs/training_manual/introduction/mapviewnavigation.rst
@@ -19,7 +19,7 @@ layers that we can explore during this tutorial.
    These datasets are found in a *GeoPackage* file that contains several
    datasets, so the dialog in :guilabel:`Data Source Manager` is a bit
    different from what you experienced for the ESRI Shapefile format datasets.
-   The result view should look similiar to the snippet below:
+   The result view should look similar to the snippet below:
 
    .. figure:: img/roads_buildings_added.png
      :align: center


### PR DESCRIPTION
<!---
Include a few sentences describing the overall goals for this Pull Request.
 
A list of issues is at https://github.com/qgis/QGIS-Documentation/issues.
Add "fix #issuenumber" for each issue the PR fixes. The ticket(s) will be closed automatically.
If your PR doesn't fix entirely the ticket, only add the ticket(s) reference preceded by # character.
-->
Goal: Update TM to reference a GeoPackage data source instead of Shapefile Format data sources

Ticket(s): #5726
<!---
Indicate whether the fix should be backported to previous release.
Replace the space between square brackets by a `x` to make it checked.
-->
- [x] Backport to LTR documentation is required

<!---
Reviewing is a process done by community members, mostly on a volunteer basis.
We try to keep the overhead as small as possible and appreciate if you help us.
Please read carefully and ensure you comply with our writing guidelines at
https://docs.qgis.org/testing/en/docs/documentation_guidelines/index.html.
Feel free to ask in a comment or the (qgis-community-team mailing list)
[https://lists.osgeo.org/mailman/listinfo/qgis-community-team] if you have troubles with any item.
--->
