### PR TITLE
Match Makefile and conf.py to release 3.10

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,11 @@
 
 # You can set these variables from the command line.
 LANG            = en
+# currently we are building for the following languages, if you want yours to be build: ask!
+LANGUAGES       = en # bg cs de es fi fr id it ja ko nl pt_BR pt_PT ro ru tr zh_Hant zh_Hans
+# for transifex we need other codes for the chinese languages
+# a symbolic link is needed to be able to build them
+#LANGUAGES       = en bg cs de es fi fr id it ja ko nl pt_BR pt_PT ro ru tr zh-Hant zh-Hans
 SPHINXOPTS      =
 SPHINXINTLOPTS  = $(SPHINXOPTS) -D language=$(LANG)
 SPHINXBUILD     ?= sphinx-build
@@ -27,6 +32,15 @@ springclean:
 
 gettext:
 	@$(SPHINXBUILD) -M gettext "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+# this will build html-version of one language (defaults to english: en)
+# to build for example dutch on Linux:
+#  make LANG=nl html
+# on windows:
+#  set SPHINXOPTS=-D language=nl
+#  make.bat html
+# note that the translations/po files from git will be used
+# so if you want most up to date files, download or use 'tx' to get those first
 
 html:
 	echo "$(SPHINXOPTS) $(SPHINXINTLOPTS)"
@@ -56,6 +70,23 @@ pdf: latex
 site: html #pdf
 	rsync -az $(BUILDDIR)/html/$(LANG) $(SITEDIR)/
 	#rsync -az $(BUILDDIR)/pdf $(SITEDIR)/
+
+# this will build ALL languages, AND tries to rsync them to the web dir on qgis2
+# to be able to run this you will need a key on the server
+all:
+	@for LANG in $(LANGUAGES) ; do \
+		make LANG=$$LANG site; \
+	done
+
+# this will pull ALL translations (or at least from the languages we build for)
+# to your local disk, so it can be committed into github
+# in that way a build from git will contain those translation
+# tx is the python transifex cli client (pip install transifex-client)
+tx_force_pull_translations:
+	@for LANG in $(LANGUAGES) ; do \
+		tx pull -f --parallel -l $$LANG ; \
+	done
+
 
 doctest:
 	$(SPHINXBUILD) -b doctest . $(BUILDDIR)/doctest

--- a/conf.py
+++ b/conf.py
@@ -171,10 +171,10 @@ extlinks = {# api website: docs master branch points to '/' while x.y points to 
 
 context = {
     # 'READTHEDOCS': True,
-    'version_downloads': False,
+    'version_downloads': True,
     'versions': [ [v, docs_url+v] for v in version_list],
     'supported_languages': [ [l, docs_url+version+'/'+l] for l in supported_languages],
-    #'downloads': [ ['PDF', docs_url+version+'/pdf'] ], # ['HTML', '/builders.tgz'] ],
+    'downloads': [ ['PDF', docs_url+version+'/pdf'] ], # ['HTML', '/builders.tgz'] ],
 
     'display_github': not html_context['outdated'], # Do not display for outdated releases
     'github_user': 'qgis',
@@ -283,7 +283,6 @@ nitpick_ignore = [
 # Add doctest configuration
 
 doctest_path = ['/usr/share/qgis/python/plugins/', os.path.join(os.getcwd(), 'testdata', 'processing')]
-
 
 doctest_global_setup = '''
 import os


### PR DESCRIPTION
<!---
Include a few sentences describing the overall goals for this Pull Request.
 
A list of issues is at https://github.com/qgis/QGIS-Documentation/issues.
Add "fix #issuenumber" for each issue the PR fixes. The ticket(s) will be closed automatically.
If your PR doesn't fix entirely the ticket, only add the ticket(s) reference preceded by # character.
-->
Goal:

Release 3.10 and master building files have diverged a bit. When master gets to 3.16 release, we would need to catch up with everything we "hacked" on 3.10. Besides, we have been changing 3.10 and forward porting to master.

My idea with this PR, is to match the two, living the necessary commented lines to avoid building translations on testing.

This will allow us to work on these files the same way we do with all the others. We change master, and then backport to 3.10 (or in the future 3.16), and not the way around.
Ticket(s): #
<!---
Indicate whether the fix should be backported to previous release.
Replace the space between square brackets by a `x` to make it checked.
-->
- [ ] Backport to LTR documentation is required

<!---
Reviewing is a process done by community members, mostly on a volunteer basis.
We try to keep the overhead as small as possible and appreciate if you help us.
Please read carefully and ensure you comply with our writing guidelines at
https://docs.qgis.org/testing/en/docs/documentation_guidelines/index.html.
Feel free to ask in a comment or the (qgis-community-team mailing list)
[https://lists.osgeo.org/mailman/listinfo/qgis-community-team] if you have troubles with any item.
--->
