### PR TITLE
[3.10] backport documentation for OTB provider 

### DIFF
--- a/docs/user_manual/processing/3rdParty.rst
+++ b/docs/user_manual/processing/3rdParty.rst
@@ -608,3 +608,83 @@ LAStools is activated and configured in the Processing options
 location of LAStools (:guilabel:`LAStools folder`) and Wine
 (:guilabel:`Wine folder`).
 On Ubuntu, the default Wine folder is :file:`/usr/bin`.
+
+.. index:: OTB
+.. _otb_configure:
+
+OTB Applications
+-----------------
+
+OTB applications are fully supported within QGIS Processing framework. 
+Note that OTB is not distributed with QGIS and needs to be installed 
+separately. Binary packages for OTB can be found on the 
+`download page <https://www.orfeo-toolbox.org/download>`_.
+
+QGIS processing should be configured to find the OTB library:
+
+#. Open processing settings: *Settings -> Options -> Processing (left panel)*
+
+#. You can see OTB under "Providers":
+
+   #. Expand OTB tab
+   #. Tick Activate option
+   #. Set OTB folder. This is location of your OTB installation.
+   #. Set OTB application folder. This is location of your OTB applications ( <PATH_TO_OTB_INSTALLATION>/lib/otb/applications)
+   #. Click "ok" to save settings and close dialog. 
+   
+If settings are correct, you will have OTB algorithms loaded in 
+Processing toolbox.
+
+Documentation of OTB settings available in QGIS Processing
+...........................................................
+
+
+* **Activate**: This is a checkbox to activate or deactivate OTB provider. Any invalid settings in OTB folder will uncheck this when saved.
+
+* **OTB folder**: This is the directory where OTB is available. 
+
+* **OTB application folder**: This is the location(s) of OTB applications. 
+
+Multiple paths are allowed to use custom/proprietary OTB applications.
+
+* **Logger level** (optional): Level of logger to use by OTB applications. 
+
+The level of logging controls the amount of details printed during 
+algorithm execution. Possible values for logger level are INFO, 
+WARNING, CRITICAL, DEBUG.  This value is INFO by default. This is an 
+advanced user configuration.
+
+* **Maximum RAM to use** (optional): by default OTB applications use 
+  system RAM as available. 
+
+You can however instruct OTB to use a specific amount of RAM (in Mb) 
+from available using this option. A value of 256 is ignored by OTB 
+processing provider. This is an advanced user configuration.
+
+* **Geoid file** (optional): Path to geoid file. 
+
+Value of this options is set for elev.dem.geoid and elev.geoid 
+parameters in OTB applications.
+Setting this value globally help users to share it across multiple 
+processing algorithms. This value is empty by default.
+
+* **SRTM tiles folder** (optional): Directory where SRTM tiles are 
+  available. 
+
+SRTM data can be stored locally to avoid connecting to downloading of 
+files during processing. Value of this options is set for elev.dem.path 
+and elev.dem parameters in OTB applications. Setting this value 
+globally help users to share it across multiple processing algorithms. 
+This value is empty by default.
+
+Compatibility between QGIS and OTB versions
+...........................................
+
+All versions of OTB from OTB 6.6.1 to latest (currently 7.1.0) are 
+compatible with latest QGIS version. 
+
+Troubleshoot
+............
+If you have any issue with OTB applications into QGIS Processing, please 
+open an issue on `OTB bug tracker <https://gitlab.orfeo-toolbox.org/orfeotoolbox/otb/-/issues>`_ 
+with qgis label.

--- a/docs/user_manual/processing/3rdParty.rst
+++ b/docs/user_manual/processing/3rdParty.rst
@@ -680,8 +680,10 @@ This value is empty by default.
 Compatibility between QGIS and OTB versions
 ...........................................
 
-All versions of OTB from OTB 6.6.1 to latest (currently 7.1.0) are 
-compatible with latest QGIS version. 
+Any version of OTB compiled with GDAL 3.X is not compatible with QGIS 
+3.10. This is the case for the binary packages of OTB 7.1 and above. 
+Therefore QGIS 3.10 is only compatible with OTB official binary 
+packages 6.6.1 and 7.0.0.
 
 Troubleshoot
 ............

--- a/docs/user_manual/processing_algs/index.rst
+++ b/docs/user_manual/processing_algs/index.rst
@@ -18,3 +18,4 @@ are documented here.
      gdal/index
      lidartools/lastools
      taudem/index
+     otb/index

--- a/docs/user_manual/processing_algs/otb/index.rst
+++ b/docs/user_manual/processing_algs/otb/index.rst
@@ -1,0 +1,9 @@
+*************************
+OTB applications provider
+*************************
+
+`OTB <https://www.orfeo-toolbox.org>`_ (Orfeo ToolBox) is image  
+processing library for remote sensing data. It also provide a set of 
+applications which provides a set of image processing functionnalities. 
+The list and the documentation of this applications are available in 
+`OTB CookBook <https://www.orfeo-toolbox.org/CookBook/Applications.html>`_


### PR DESCRIPTION
<!---
Include a few sentences describing the overall goals for this Pull Request.
 
A list of issues is at https://github.com/qgis/QGIS-Documentation/issues.
Add "fix #issuenumber" for each issue the PR fixes. The ticket(s) will be closed automatically.
If your PR doesn't fix entirely the ticket, only add the ticket(s) reference preceded by # character.
-->
Goal: Add documentation for OTB provider in QGSI 3.10 documentation

fix #3454 

Ticket(s): #3454
<!---
Indicate whether the fix should be backported to previous release.
Replace the space between square brackets by a `x` to make it checked.
-->
- [ ] Backport to LTR documentation is required

<!---
Reviewing is a process done by community members, mostly on a volunteer basis.
We try to keep the overhead as small as possible and appreciate if you help us.
Please read carefully and ensure you comply with our writing guidelines at
https://docs.qgis.org/testing/en/docs/documentation_guidelines/index.html.
Feel free to ask in a comment or the (qgis-community-team mailing list)
[https://lists.osgeo.org/mailman/listinfo/qgis-community-team] if you have troubles with any item.
--->
