### PR TITLE
List 3.10 version in 3.4 docs bottom left panel

### DIFF
--- a/docs_conf.yml
+++ b/docs_conf.yml
@@ -1,4 +1,4 @@
 
-version_list: testing, latest, 3.4, 2.18, 2.14, 2.8, 2.6, 2.2, 2.0, 1.8
+version_list: testing, latest, 3.10, 3.4, 2.18, 2.14, 2.8, 2.6, 2.2, 2.0, 1.8
 # Fill this list based on languages that are actually pulled from transifex
 supported_languages: en, bg, cs, de, es, fi, fr, id, it, ja, ko, nl, pt_BR, pt_PT, ro, ru, tr, zh-Hant


### PR DESCRIPTION
<!---
Include a few sentences describing the overall goals for this Pull Request.
 
A list of issues is at https://github.com/qgis/QGIS-Documentation/issues.
Add "fix #issuenumber" for each issue the PR fixes. The ticket(s) will be closed automatically.
If your PR doesn't fix entirely the ticket, only add the ticket(s) reference preceded by # character.
-->
Goal:
Add the 3,10 version to the list of docs versions in the bottom left panel of 3.4 docs.

Current bottom left panel of 3.4 docs (3.10 version is missing)
![image](https://user-images.githubusercontent.com/16253859/86669540-fbc26280-bff3-11ea-9cc1-dd8728b34d59.png)

<!---
Indicate whether the fix should be backported to previous release.
Replace the space between square brackets by a `x` to make it checked.
-->
- [ ] Backport to LTR documentation is required

<!---
Reviewing is a process done by community members, mostly on a volunteer basis.
We try to keep the overhead as small as possible and appreciate if you help us.
Please read carefully and ensure you comply with our writing guidelines at
https://docs.qgis.org/testing/en/docs/documentation_guidelines/index.html.
Feel free to ask in a comment or the (qgis-community-team mailing list)
[https://lists.osgeo.org/mailman/listinfo/qgis-community-team] if you have troubles with any item.
--->
