### PR TITLE
Add version (1.1.0) to WFS requests

### DIFF
--- a/docs/pyqgis_developer_cookbook/loadlayer.rst
+++ b/docs/pyqgis_developer_cookbook/loadlayer.rst
@@ -215,15 +215,15 @@ providers:
       QgsProject.instance().addMapLayer(vlayer)
 
 .. index::
-  pair: WFS vector; Loading
+  pair: WFS; Loading
 
 * WFS connection: the connection is defined with a URI and using the ``WFS`` provider:
 
   .. testcode:: loadlayer
 
-        uri = "https://demo.geo-solutions.it/geoserver/ows?service=WFS&request=GetFeature&typename=geosolutions:regioni"
-        vlayer = QgsVectorLayer(uri, "my wfs layer", "WFS")
-        QgsProject.instance().addMapLayer(vlayer)
+      uri = "https://demo.geo-solutions.it/geoserver/ows?service=WFS&version=1.1.0&request=GetFeature&typename=geosolutions:regioni"
+      vlayer = QgsVectorLayer(uri, "my wfs layer", "WFS")
+      QgsProject.instance().addMapLayer(vlayer)
 
   The uri can be created using the standard ``urllib`` library:
 
@@ -233,21 +233,21 @@ providers:
 
       params = {
           'service': 'WFS',
-          'version': '2.0.0',
+          'version': '1.1.0',
           'request': 'GetFeature',
           'typename': 'geosolutions:regioni',
           'srsname': "EPSG:4326"
       }
-      uri2 = 'https://demo.geo-solutions.it/geoserver/wfs?' + urllib.parse.unquote(urllib.parse.urlencode(params))
-
+      uri2 = 'https://demo.geo-solutions.it/geoserver/ows?' + urllib.parse.unquote(urllib.parse.urlencode(params))
 
 .. note:: You can change the data source of an existing layer by calling
    :meth:`setDataSource() <qgis.core.QgsVectorLayer.setDataSource>`
-   on a :class:`QgsVectorLayer <qgis.core.QgsVectorLayer>` instance, as in the following example:
+   on a :class:`QgsVectorLayer <qgis.core.QgsVectorLayer>` instance, as
+   in the following example:
 
    .. testcode:: loadlayer
 
-      uri = "https://demo.geo-solutions.it/geoserver/ows?service=WFS&request=GetFeature&typename=geosolutions:regioni"
+      uri = "https://demo.geo-solutions.it/geoserver/ows?service=WFS&version=1.1.0&request=GetFeature&typename=geosolutions:regioni"
       provider_options = QgsDataProvider.ProviderOptions()
       # Use project's transform context
       provider_options.transformContext = QgsProject.instance().transformContext()
@@ -260,7 +260,7 @@ providers:
 
 
 Raster Layers
-=============
+======================================================================
 
 For accessing raster files, GDAL library is used. It supports a wide range of
 file formats. In case you have troubles with opening some files, check whether


### PR DESCRIPTION
<!---
Include a few sentences describing the overall goals for this Pull Request.
 
A list of issues is at https://github.com/qgis/QGIS-Documentation/issues.
Add "fix #issuenumber" for each issue the PR fixes. The ticket(s) will be closed automatically.
If your PR doesn't fix entirely the ticket, only add the ticket(s) reference preceded by # character.
-->
Goal: Since QGIS does is not a fully compliant WFS 2 client, we should use WFS 1.1.0 in the
example requests (`version=1.1.0`).

Ticket(s): #5835
<!---
Indicate whether the fix should be backported to previous release.
Replace the space between square brackets by a `x` to make it checked.
-->
- [x] Backport to LTR documentation is required

<!---
Reviewing is a process done by community members, mostly on a volunteer basis.
We try to keep the overhead as small as possible and appreciate if you help us.
Please read carefully and ensure you comply with our writing guidelines at
https://docs.qgis.org/testing/en/docs/documentation_guidelines/index.html.
Feel free to ask in a comment or the (qgis-community-team mailing list)
[https://lists.osgeo.org/mailman/listinfo/qgis-community-team] if you have troubles with any item.
--->
