### PR TITLE
Fix typo native.buffer -> native:buffer

### DIFF
--- a/docs/user_manual/processing/console.rst
+++ b/docs/user_manual/processing/console.rst
@@ -259,7 +259,7 @@ list gives a quick review of how to introduce values for each type of input para
 * Enumeration. If an algorithm has an enumeration parameter, the value of that
   parameter should be entered using an integer value. To know the available
   options, you can use the ``algorithmHelp()`` command, as above.
-  For instance, the "native.buffer" algorithm has an enumeration called JOIN_STYLE:
+  For instance, the ``native:buffer`` algorithm has an enumeration called JOIN_STYLE:
 
   ::
 


### PR DESCRIPTION
<!---
Include a few sentences describing the overall goals for this Pull Request.
 
A list of issues is at https://github.com/qgis/QGIS-Documentation/issues.
Add "fix #issuenumber" for each issue the PR fixes. The ticket(s) will be closed automatically.
If your PR doesn't fix entirely the ticket, only add the ticket(s) reference preceded by # character.
-->
Goal:
Fixes a typo in https://docs.qgis.org/testing/en/docs/user_manual/processing/console.html

errata
> To know the available options, you can use the algorithmHelp() command, as above. For instance, the **“native.buffer”** algorithm has an enumeration called JOIN_STYLE:

corrige
> To know the available options, you can use the algorithmHelp() command, as above. For instance, the **native:buffer** algorithm has an enumeration called JOIN_STYLE:

This should be backported to 3.10 branch.

<!---
Indicate whether the fix should be backported to previous release.
Replace the space between square brackets by a `x` to make it checked.
-->
- [ ] Backport to LTR documentation is required

<!---
Reviewing is a process done by community members, mostly on a volunteer basis.
We try to keep the overhead as small as possible and appreciate if you help us.
Please read carefully and ensure you comply with our writing guidelines at
https://docs.qgis.org/testing/en/docs/documentation_guidelines/index.html.
Feel free to ask in a comment or the (qgis-community-team mailing list)
[https://lists.osgeo.org/mailman/listinfo/qgis-community-team] if you have troubles with any item.
--->
