### PR TITLE
add doc for createAlgorithmDialog and execAlgorithmDialog

### DIFF
--- a/docs/user_manual/processing/console.rst
+++ b/docs/user_manual/processing/console.rst
@@ -333,10 +333,10 @@ the ``load()`` method.
 Or you could use ``runAndLoadResults()`` instead of ``run()`` to load
 them immediately.
 
-If you want to open an algorithm dialog from console you can use the 
-``createAlgorithmDialog``. The only mandatory parameter is the algorithm name
-but you can also define the dictionary of parameters so that the dialog will
-be filled automatically:
+If you want to open an algorithm dialog from the console you can use the 
+``createAlgorithmDialog`` method. The only mandatory parameter is the algorithm 
+name but you can also define the dictionary of parameters so that the dialog 
+will be filled automatically:
 
 ::
 

--- a/docs/user_manual/processing/console.rst
+++ b/docs/user_manual/processing/console.rst
@@ -335,7 +335,7 @@ them immediately.
 
 If you want to open an algorithm dialog from the console you can use the 
 ``createAlgorithmDialog`` method. The only mandatory parameter is the algorithm 
-name but you can also define the dictionary of parameters so that the dialog 
+name, but you can also define the dictionary of parameters so that the dialog 
 will be filled automatically:
 
 ::

--- a/docs/user_manual/processing/console.rst
+++ b/docs/user_manual/processing/console.rst
@@ -333,6 +333,39 @@ the ``load()`` method.
 Or you could use ``runAndLoadResults()`` instead of ``run()`` to load
 them immediately.
 
+If you want to open an algorithm dialog from console you can use the 
+``createAlgorithmDialog``. The only mandatory parameter is the algorithm name
+but you can also define the dictionary of parameters so that the dialog will
+be filled automatically:
+
+::
+
+    >>> my_dialog = processing.createAlgorithmDialog("native:buffer", {
+                  'INPUT': '/data/lines.shp',
+                  'DISTANCE': 100.0,
+                  'SEGMENTS': 10,
+                  'DISSOLVE': True,
+                  'END_CAP_STYLE': 0,
+                  'JOIN_STYLE': 0,
+                  'MITER_LIMIT': 10,
+                  'OUTPUT': '/data/buffers.shp'})
+    >>> my_dialog.show()
+
+The ``execAlgorithmDialog`` method opens the dialog immediately:
+
+::
+
+    >>> processing.execAlgorithmDialog("native:buffer", {
+                  'INPUT': '/data/lines.shp',
+                  'DISTANCE': 100.0,
+                  'SEGMENTS': 10,
+                  'DISSOLVE': True,
+                  'END_CAP_STYLE': 0,
+                  'JOIN_STYLE': 0,
+                  'MITER_LIMIT': 10,
+                  'OUTPUT': '/data/buffers.shp'})
+
+
 Creating scripts and running them from the toolbox
 --------------------------------------------------
 


### PR DESCRIPTION
Add the `createAlgorithmDialog` and `execAlgorithmDialog` processing methods to the manual.

p.s. not really really sure that the processing *scripts* section fits in the user manual, we can think to move the entire chapter to the pyqgis cookbook

Ticket(s): fixes #2294

- [x] Backport to LTR documentation is required