### PR TITLE
information logarithmic scale

### DIFF
--- a/docs/user_manual/working_with_vector/vector_properties.rst
+++ b/docs/user_manual/working_with_vector/vector_properties.rst
@@ -497,8 +497,10 @@ available modes are:
 
 * Equal Interval: each class has the same size (e.g. values from 0 to 16 and
   4 classes, each class has a size of 4).
-* Quantile: each class will have the same number of element inside
+* Equal Count (Quantile): each class will have the same number of element inside
   (the idea of a boxplot).
+* Logarithmic scale: Computes classes for data with a wide range of values.
+  The low data can be distinguished very well by means of the classes.
 * Natural Breaks (Jenks): the variance within each class is minimal while the
   variance between classes is maximal.
 * Standard Deviation: classes are built depending on the standard deviation of

--- a/docs/user_manual/working_with_vector/vector_properties.rst
+++ b/docs/user_manual/working_with_vector/vector_properties.rst
@@ -495,20 +495,22 @@ Back to the Classes tab, you can specify the number of classes and also the
 mode for classifying features within the classes (using the Mode list). The
 available modes are:
 
-* Equal Interval: each class has the same size (e.g. values from 0 to 16 and
-  4 classes, each class has a size of 4).
-* Equal Count (Quantile): each class will have the same number of element inside
+* Equal Count (Quantile): each class will have the same number of elements
   (the idea of a boxplot).
-* Logarithmic scale: Computes classes for data with a wide range of values.
-  The low data can be distinguished very well by means of the classes.
-* Natural Breaks (Jenks): the variance within each class is minimal while the
-  variance between classes is maximal.
-* Standard Deviation: classes are built depending on the standard deviation of
-  the values.
-* Pretty Breaks: Computes a sequence of about n+1 equally spaced nice values
+* Equal Interval: each class will have the same size (e.g. with the values
+  from 1 to 16 and four classes, each class will have a size of four).
+* Logarithmic scale: suitable for data with a wide range of values.
+  Narrow classes for low values and wide classes for large values (e.g. for
+  decimal numbers with range [0..100] and two classes, the first class will
+  be from 0 to 10 and the second class from 10 to 100).
+* Natural Breaks (Jenks): the variance within each class is minimized while
+  the variance between classes is maximized.
+* Pretty Breaks: computes a sequence of about n+1 equally spaced nice values
   which cover the range of the values in x. The values are chosen so that they
   are 1, 2 or 5 times a power of 10. (based on pretty from the R statistical
-  environment https://astrostatistics.psu.edu/datasets/R/html/base/html/pretty.html)
+  environment https://www.rdocumentation.org/packages/base/topics/pretty).
+* Standard Deviation: classes are built depending on the standard deviation of
+  the values.
 
 The listbox in the center part of the :guilabel:`Symbology` tab lists the classes
 together with their ranges, labels and symbols that will be rendered.


### PR DESCRIPTION
The graduated renderer can use the classification mode logarithmic scale. It is useful for data with a wide range of values and represents the low data in detail.

<!--- 
 
A list of issues is at https://github.com/qgis/QGIS-Documentation/issues.
Add "fix #issuenumber" for each issue the PR fixes. The ticket(s) will be closed automatically.
If your PR doesn't fix entirely the ticket, only add the ticket(s) reference preceded by # character.
-->
Goal: Users shall be able to use the logarithmic scale classifier for graduated renderer.

Ticket(s): fix #4192
<!---
Indicate whether the fix should be backported to previous release.
Replace the space between square brackets by a `x` to make it checked.
-->
- [x] Backport to LTR documentation is required

<!---
Reviewing is a process done by community members, mostly on a volunteer basis.
We try to keep the overhead as small as possible and appreciate if you help us.
Please read carefully and ensure you comply with our writing guidelines at
https://docs.qgis.org/testing/en/docs/documentation_guidelines/index.html.
Feel free to ask in a comment or the (qgis-community-team mailing list)
[https://lists.osgeo.org/mailman/listinfo/qgis-community-team] if you have troubles with any item.
--->
