### PR TITLE
Adds missing Processing Model inputs to the list

### DIFF
--- a/docs/user_manual/processing/console.rst
+++ b/docs/user_manual/processing/console.rst
@@ -482,33 +482,47 @@ functions are specified:
 There are a number of different parameter types available for
 input and output. Below is an alphabetically sorted list:
 
+* :class:`QgsProcessingParameterAggregate  <qgis.core.QgsProcessingParameterAggregate >`
+* :class:`QgsProcessingParameterAuthConfig <qgis.core.QgsProcessingParameterAuthConfig>`
 * :class:`QgsProcessingParameterBand <qgis.core.QgsProcessingParameterBand>`
 * :class:`QgsProcessingParameterBoolean <qgis.core.QgsProcessingParameterBoolean>`
 * :class:`QgsProcessingParameterColor <qgis.core.QgsProcessingParameterColor>`
+* :class:`QgsProcessingParameterCoordinateOperation <qgis.core.QgsProcessingParameterCoordinateOperation>`
 * :class:`QgsProcessingParameterCrs <qgis.core.QgsProcessingParameterCrs>`
+* :class:`QgsProcessingParameterDatabaseSchema <qgis.core.QgsProcessingParameterDatabaseSchema>`
+* :class:`QgsProcessingParameterDatabaseTable <qgis.core.QgsProcessingParameterDatabaseTable>`
+* :class:`QgsProcessingParameterDateTime <qgis.core.QgsProcessingParameterDateTime>`
 * :class:`QgsProcessingParameterDistance <qgis.core.QgsProcessingParameterDistance>`
 * :class:`QgsProcessingParameterEnum <qgis.core.QgsProcessingParameterEnum>`
 * :class:`QgsProcessingParameterExpression <qgis.core.QgsProcessingParameterExpression>`
 * :class:`QgsProcessingParameterExtent <qgis.core.QgsProcessingParameterExtent>`
 * :class:`QgsProcessingParameterFeatureSink <qgis.core.QgsProcessingParameterFeatureSink>`
 * :class:`QgsProcessingParameterFeatureSource <qgis.core.QgsProcessingParameterFeatureSource>`
-* :class:`QgsProcessingParameterField <qgis.core.QgsProcessingParameterField>` -
+* :class:`QgsProcessingParameterField <qgis.core.QgsProcessingParameterField>`
   A field in the attributes table of a vector layer. The name of the
   layer has to be specified.
+* :class:`QgsProcessingParameterFieldMapping  <qgis.core.QgsProcessingParameterFieldMapping>`
 * :class:`QgsProcessingParameterFile <qgis.core.QgsProcessingParameterFile>`
 * :class:`QgsProcessingParameterFileDestination <qgis.core.QgsProcessingParameterFileDestination>`
 * :class:`QgsProcessingParameterFolderDestination <qgis.core.QgsProcessingParameterFolderDestination>`
+* :class:`QgsProcessingParameterLayout <qgis.core.QgsProcessingParameterLayout>`
+* :class:`QgsProcessingParameterLayoutItem <qgis.core.QgsProcessingParameterLayoutItem>`
 * :class:`QgsProcessingParameterMapLayer <qgis.core.QgsProcessingParameterMapLayer>`
+* :class:`QgsProcessingParameterMapTheme <qgis.core.QgsProcessingParameterMapTheme>`
 * :class:`QgsProcessingParameterMatrix <qgis.core.QgsProcessingParameterMatrix>`
+* :class:`QgsProcessingParameterMeshLayer  <qgis.core.QgsProcessingParameterMeshLayer >`
 * :class:`QgsProcessingParameterMultipleLayers <qgis.core.QgsProcessingParameterMultipleLayers>`
 * :class:`QgsProcessingParameterNumber <qgis.core.QgsProcessingParameterNumber>`
 * :class:`QgsProcessingParameterPoint <qgis.core.QgsProcessingParameterPoint>`
+* :class:`QgsProcessingParameterProviderConnection <qgis.core.QgsProcessingParameterProviderConnection>`
 * :class:`QgsProcessingParameterRange <qgis.core.QgsProcessingParameterRange>`
 * :class:`QgsProcessingParameterRasterDestination <qgis.core.QgsProcessingParameterRasterDestination>`
 * :class:`QgsProcessingParameterRasterLayer <qgis.core.QgsProcessingParameterRasterLayer>`
+* :class:`QgsProcessingParameterScale <qgis.core.QgsProcessingParameterScale>`
 * :class:`QgsProcessingParameterString <qgis.core.QgsProcessingParameterString>`
 * :class:`QgsProcessingParameterVectorDestination <qgis.core.QgsProcessingParameterVectorDestination>`
 * :class:`QgsProcessingParameterVectorLayer <qgis.core.QgsProcessingParameterVectorLayer>`
+* :class:`QgsProcessingParameterVectorTileWriterLayers <qgis.core.QgsProcessingParameterVectorTileWriterLayers>`
 
 The first parameter to the constructors is the name of the parameter,
 and the second is the description of the parameter (for the user

--- a/docs/user_manual/processing/console.rst
+++ b/docs/user_manual/processing/console.rst
@@ -482,7 +482,7 @@ functions are specified:
 There are a number of different parameter types available for
 input and output. Below is an alphabetically sorted list:
 
-* :class:`QgsProcessingParameterAggregate  <qgis.core.QgsProcessingParameterAggregate >`
+* :class:`QgsProcessingParameterAggregate <qgis.core.QgsProcessingParameterAggregate>`
 * :class:`QgsProcessingParameterAuthConfig <qgis.core.QgsProcessingParameterAuthConfig>`
 * :class:`QgsProcessingParameterBand <qgis.core.QgsProcessingParameterBand>`
 * :class:`QgsProcessingParameterBoolean <qgis.core.QgsProcessingParameterBoolean>`
@@ -510,7 +510,7 @@ input and output. Below is an alphabetically sorted list:
 * :class:`QgsProcessingParameterMapLayer <qgis.core.QgsProcessingParameterMapLayer>`
 * :class:`QgsProcessingParameterMapTheme <qgis.core.QgsProcessingParameterMapTheme>`
 * :class:`QgsProcessingParameterMatrix <qgis.core.QgsProcessingParameterMatrix>`
-* :class:`QgsProcessingParameterMeshLayer  <qgis.core.QgsProcessingParameterMeshLayer >`
+* :class:`QgsProcessingParameterMeshLayer <qgis.core.QgsProcessingParameterMeshLayer>`
 * :class:`QgsProcessingParameterMultipleLayers <qgis.core.QgsProcessingParameterMultipleLayers>`
 * :class:`QgsProcessingParameterNumber <qgis.core.QgsProcessingParameterNumber>`
 * :class:`QgsProcessingParameterPoint <qgis.core.QgsProcessingParameterPoint>`

--- a/docs/user_manual/processing/modeler.rst
+++ b/docs/user_manual/processing/modeler.rst
@@ -87,7 +87,7 @@ the left side of the modeler window:
 * Vector Layer
 * Vector Tile Writer Layers
 
-.. note:: Hovering with the mouse on the inputs will show a tooltip with 
+.. note:: Hovering with the mouse over the inputs will show a tooltip with 
   additional information.
 
 When double-clicking on an element, a dialog is shown that lets

--- a/docs/user_manual/processing/modeler.rst
+++ b/docs/user_manual/processing/modeler.rst
@@ -51,8 +51,7 @@ Definition of inputs
 
 The first step is to define the inputs for the model.
 The following elements are found in the :guilabel:`Inputs` tab on
-the left side of the modeler window. Hoovering with the mouse on the inputs will 
-show a tooltip with additional information:
+the left side of the modeler window:
 
 * Authentication Configuration
 * Boolean
@@ -87,6 +86,9 @@ show a tooltip with additional information:
 * Vector Field
 * Vector Layer
 * Vector Tile Writer Layers
+
+.. note:: Hovering with the mouse on the inputs will show a tooltip with 
+  additional information.
 
 When double-clicking on an element, a dialog is shown that lets
 you define its characteristics.

--- a/docs/user_manual/processing/modeler.rst
+++ b/docs/user_manual/processing/modeler.rst
@@ -51,28 +51,42 @@ Definition of inputs
 
 The first step is to define the inputs for the model.
 The following elements are found in the :guilabel:`Inputs` tab on
-the left side of the modeler window:
+the left side of the modeler window. Hoovering with the mouse on the inputs will 
+show a tooltip with additional information:
 
+* Authentication Configuration
 * Boolean
+* Color
+* Connection Name
+* Coordinate Operation
 * CRS
+* Database Schema
+* Database Table
+* Datetime
 * Distance
 * Enum
 * Expression
 * Extent
+* Fields Aggregate
 * Fields Mapper
 * File/Folder
 * Map Layer
+* Map Theme
 * Matrix
 * Multiple Input
 * Number
 * Point
+* Print Layout
+* Print Layout Item
 * Range
 * Raster Band
 * Raster Layer
+* Scale
 * String
 * Vector Features
 * Vector Field
 * Vector Layer
+* Vector Tile Writer Layers
 
 When double-clicking on an element, a dialog is shown that lets
 you define its characteristics.


### PR DESCRIPTION
Goal: first PR of the Processing Model chapter. It just adds the list of the new inputs. Not backportable to 3.10 because of some very new inputs 

Ticket(s): fixes #2316 (I couldn't find other issues)
<!---
Indicate whether the fix should be backported to previous release.
Replace the space between square brackets by a `x` to make it checked.
-->
- [ ] Backport to LTR documentation is required