### PR TITLE
Auth config for OGR sources

### DIFF
--- a/docs/user_manual/managing_data_source/opening_data.rst
+++ b/docs/user_manual/managing_data_source/opening_data.rst
@@ -430,9 +430,7 @@ Layer` tabs allow loading of layers from source types other than :guilabel:`File
   * service supporting OGC ``WFS 3`` (still experimental),
     using ``GeoJSON`` or ``GEOJSON - Newline Delimited`` format or based on
     ``CouchDB`` database.
-    A :guilabel:`URI` is required, with optional authentication. See 
-    :ref:`authentication_index` for further details about the authentication 
-    methods.
+    A :guilabel:`URI` is required, with optional :ref:`authentication <authentication_index>`.
 
 .. _mesh_loading:
 

--- a/docs/user_manual/managing_data_source/opening_data.rst
+++ b/docs/user_manual/managing_data_source/opening_data.rst
@@ -422,8 +422,7 @@ Layer` tabs allow loading of layers from source types other than :guilabel:`File
   Supported protocol types are:
 
   * ``HTTP/HTTPS/FTP``, with a :guilabel:`URI` and, if required,
-    an authentication. See :ref:`authentication_index` for further details 
-    about the authentication methods.
+    an :ref:`authentication <authentication_index>`.
   * Cloud storage such as ``AWS S3``, ``Google Cloud Storage``, ``Microsoft
     Azure Blob``, ``Alibaba OSS Cloud``, ``Open Stack Swift Storage``.
     You need to fill in the :guilabel:`Bucket or container` and the

--- a/docs/user_manual/managing_data_source/opening_data.rst
+++ b/docs/user_manual/managing_data_source/opening_data.rst
@@ -422,7 +422,8 @@ Layer` tabs allow loading of layers from source types other than :guilabel:`File
   Supported protocol types are:
 
   * ``HTTP/HTTPS/FTP``, with a :guilabel:`URI` and, if required,
-    an authentication
+    an authentication. See :ref:`authentication_index` for further details 
+    about the authentication methods.
   * Cloud storage such as ``AWS S3``, ``Google Cloud Storage``, ``Microsoft
     Azure Blob``, ``Alibaba OSS Cloud``, ``Open Stack Swift Storage``.
     You need to fill in the :guilabel:`Bucket or container` and the
@@ -430,7 +431,9 @@ Layer` tabs allow loading of layers from source types other than :guilabel:`File
   * service supporting OGC ``WFS 3`` (still experimental),
     using ``GeoJSON`` or ``GEOJSON - Newline Delimited`` format or based on
     ``CouchDB`` database.
-    A :guilabel:`URI` is required, with optional authentication.
+    A :guilabel:`URI` is required, with optional authentication. See 
+    :ref:`authentication_index` for further details about the authentication 
+    methods.
 
 .. _mesh_loading:
 


### PR DESCRIPTION
Goal: adds the description of the auth methods to the ogr dataset

Ticket(s): fixes #2227

- [x] Backport to LTR documentation is required