### PR TITLE
Overrun distance labels

### DIFF
--- a/docs/user_manual/style_library/label_settings.rst
+++ b/docs/user_manual/style_library/label_settings.rst
@@ -426,7 +426,9 @@ angle between curved characters` when selecting the |radioButtonOff|
 
 For all three placement options, in :guilabel:`Repeat`, you can set up a
 minimum distance for repeating labels. The distance can be in ``mm`` or in
-``map units``.
+``map units``. Also, in :guilabel:`Overrun feature` you can specify the
+maximal allowable distance a label may run past the end (or start) of
+line features.
 
 Placement for polygon layers
 ----------------------------


### PR DESCRIPTION
<!---
Description of the overrun feature for line labels.
 
A list of issues is at https://github.com/qgis/QGIS-Documentation/issues.
Add "fix #issuenumber" for each issue the PR fixes. The ticket(s) will be closed automatically.
If your PR doesn't fix entirely the ticket, only add the ticket(s) reference preceded by # character.
-->
Goal: Users shall be able to find the settings for the overrun feature which is available for line layers.

Ticket(s): fix #4036
<!---
Indicate whether the fix should be backported to previous release.
Replace the space between square brackets by a `x` to make it checked.
-->
- [x] Backport to LTR documentation is required

<!---
Reviewing is a process done by community members, mostly on a volunteer basis.
We try to keep the overhead as small as possible and appreciate if you help us.
Please read carefully and ensure you comply with our writing guidelines at
https://docs.qgis.org/testing/en/docs/documentation_guidelines/index.html.
Feel free to ask in a comment or the (qgis-community-team mailing list)
[https://lists.osgeo.org/mailman/listinfo/qgis-community-team] if you have troubles with any item.
--->
