### PR TITLE
add * in the project description

### DIFF
--- a/docs/user_manual/introduction/project_files.rst
+++ b/docs/user_manual/introduction/project_files.rst
@@ -31,8 +31,8 @@ or
 
 .. note::
 
-  If the project has been modified QGIS will, by default, ask you
-  if you would like to save the changes.
+  If the project has been modified the ``*`` symbol will appear in the top bar 
+  and QGIS will, by default, ask you if you would like to save the changes.
   This behavior is controlled by the |checkbox|
   :guilabel:`Prompt to save project and data source changes when required`
   setting under :menuselection:`Settings --> Options --> General`.


### PR DESCRIPTION
Goal: add the `*` when the project has some changes. Really a small enhancement.

- [x] Backport to LTR documentation is required

