### PR TITLE
Remove obsolete note on algorithm parameters name

### DIFF
--- a/docs/user_manual/processing_algs/index.rst
+++ b/docs/user_manual/processing_algs/index.rst
@@ -7,10 +7,6 @@ Processing providers and algorithms
 Processing algorithms and their parameters (as presented in the user interface)
 are documented here.
 
-.. note::
-   Parameter names (as used in Python scripts) are not yet included.
-   :ref:`processing_console` shows how to find them.
-
 .. toctree::
      :maxdepth: 2
 


### PR DESCRIPTION
Parameter name for Python use is also displayed in the tables