### PR TITLE
Add QGIS Server missing environment variables

### DIFF
--- a/docs/server_manual/config.rst
+++ b/docs/server_manual/config.rst
@@ -44,168 +44,161 @@ several ways to define these variables. This is fully described in
 :ref:`httpserver`.
 
 
-QGIS_OPTIONS_PATH
-^^^^^^^^^^^^^^^^^
+.. list-table::
+   :header-rows: 1
+   :widths: auto
 
-Specifies the path to the directory with settings. It works the same way as
-QGIS application ``--optionspath`` option. It is looking for settings file in
-``<QGIS_OPTIONS_PATH>/QGIS/QGIS3.ini``.
+   * - Name
+     - Description
+     - Default
+     - Services
 
+   * - QGIS_OPTIONS_PATH
+     - Specifies the path to the directory with settings. It works the same way as
+       QGIS application ``--optionspath`` option. It is looking for settings file in
+       ``<QGIS_OPTIONS_PATH>/QGIS/QGIS3.ini``.
+     - ''
+     - All
 
-QUERY_STRING
-^^^^^^^^^^^^
+   * - QUERY_STRING
+     - The query string, normally passed by the web server. This variable can be
+       useful while testing QGIS server binary from the command line.
 
-The query string, normally passed by the web server. This variable can be
-useful while testing QGIS server binary from the command line.
+       For example for testing a GetCapabilities request on the command line
+       to a project that also requires a PostgreSQL connection defined in a
+       pg_service.conf file:
 
-For example for testing a GetCapabilities request on the command line
-to a project that also requires a PostgreSQL connection defined in a
-pg_service.conf file:
+       .. code-block:: bash
+		
+        PGSERVICEFILE=/etc/pg_service.conf \
+	QUERY_STRING="MAP=/home/qgis/projects/world.qgs&SERVICE=WMS&REQUEST=GetCapabilities" \
+	/usr/lib/cgi-bin/qgis_mapserv.fcgi
 
-.. code-block:: bash
+       The result should be either the content of the GetCapabilities response or,
+       if something is wrong, an error message.
+     - ''
+     - All
 
- PGSERVICEFILE=/etc/pg_service.conf QUERY_STRING="MAP=/home/qgis/projects/world.qgs&SERVICE=WMS&REQUEST=GetCapabilities" /usr/lib/cgi-bin/qgis_mapserv.fcgi
+   * - QGIS_PROJECT_FILE
+     - The ``.qgs`` or ``.qgz`` project file, normally passed as a parameter in the
+       query string (with *MAP*), you can also set it as an environment variable (for
+       example by using ``mod_rewrite`` Apache module).
 
-The result should be either the content of the GetCapabilities response or,
-if something is wrong, an error message.
+       Note that you may also indicate a project stored in PostgreSQL, e.g.
+       ``postgresql://localhost:5432?sslmode=disable&dbname=mydb&schema=myschema&project=myproject``.
+     - ''
+     - All
 
-QGIS_PROJECT_FILE
-^^^^^^^^^^^^^^^^^
+   * - QGIS_SERVER_LOG_FILE
+     - Specify path and filename. Make sure that server has proper permissions for
+       writing to file. File should be created automatically, just send some requests
+       to server. If it's not there, check permissions.
 
-The ``.qgs`` or ``.qgz`` project file, normally passed as a parameter in the
-query string (with *MAP*), you can also set it as an environment variable (for
-example by using ``mod_rewrite`` Apache module).
+       QGIS_SERVER_LOG_FILE is deprecated since QGIS 3.4. File logging support will
+       be removed in QGIS 4.0.
+     - ''
+     - All
 
-Note that you may also indicate a project stored in PostgreSQL, e.g.
-``postgresql://localhost:5432?sslmode=disable&dbname=mydb&schema=myschema&project=myproject``.
+   * - QGIS_SERVER_LOG_STDERR
+     - Activate logging to stderr. This variable  has no effect when ``QGIS_SERVER_LOG_FILE``
+       is set.
 
+       * ``0`` or ``false`` (case insensitive)
+       * ``1`` or ``true`` (case insensitive)
+     - false
+     - All
 
-QGIS_SERVER_LOG_FILE
-^^^^^^^^^^^^^^^^^^^^
+   * - MAX_CACHE_LAYERS
+     - Specify the maximum number of cached layers (default: ``100``).
+     - 100
+     - All
 
-Specify path and filename. Make sure that server has proper permissions for
-writing to file. File should be created automatically, just send some requests
-to server. If it's not there, check permissions.
+   * - DISPLAY
+     - This is used to pass (fake) X server display number (needed on Unix-like systems).
+     - ''
+     - All
 
-QGIS_SERVER_LOG_FILE is deprecated since QGIS 3.4. File logging support will
-be removed in QGIS 4.0.
+   * - QGIS_PLUGINPATH
+     - Useful if you are using Python plugins for the server, this sets the folder
+       that is searched for Python plugins.
+     - ''
+     - All
 
-QGIS_SERVER_LOG_STDERR
-^^^^^^^^^^^^^^^^^^^^^^
+   * - QGIS_SERVER_LOG_LEVEL
+     - Specify desired log level. Available values are:
 
-Activate logging to stderr. It's disabled by default. This variable
-has no effect when ``QGIS_SERVER_LOG_FILE`` is set.
+       * ``0`` or ``INFO`` (log all requests)
+       * ``1`` or ``WARNING``
+       * ``2`` or ``CRITICAL`` (log just critical errors, suitable for production purposes)
+     - 0
+     - All
 
-* ``0`` or ``false`` (case insensitive)
-* ``1`` or ``true`` (case insensitive)
+   * - QGIS_SERVER_PARALLEL_RENDERING
+     - Activates parallel rendering for WMS GetMap requests. It's disabled (``false``)
+       by default. Available values are:
 
-MAX_CACHE_LAYERS
-^^^^^^^^^^^^^^^^
+       * ``0`` or ``false`` (case insensitive)
+       * ``1`` or ``true`` (case insensitive)
+     - false
+     - WMS
 
-Specify the maximum number of cached layers (default: ``100``).
+   * - QGIS_SERVER_MAX_THREADS
+     - Number of threads to use when parallel rendering is activated. If value is ``-1`` it
+       uses the number of processor cores.
+     - -1
+     - All
 
+   * - QGIS_SERVER_CACHE_DIRECTORY
+     - Specifies the network cache directory on the filesystem. 
+     - ``cache`` in profile directory
+     - All
 
-DISPLAY
-^^^^^^^
+   * - QGIS_SERVER_CACHE_SIZE
+     - Sets the network cache size in MB.
+     - 50 MB
+     - All
 
-This is used to pass (fake) X server display number (needed on Unix-like systems).
+   * - QGIS_SERVER_OVERRIDE_SYSTEM_LOCALE
+     - Sets LOCALE to be used by QGIS server. The default value is empty (no override).
 
+       Example: ``de_CH.utf8``
+     - ''
+     - All
 
-QGIS_PLUGINPATH
-^^^^^^^^^^^^^^^
+   * - QGIS_SERVER_SHOW_GROUP_SEPARATOR
+     - Defines whether a group separator (e.g. thousand separator) should be used for
+       numeric values (e.g. in GetFeatureInfo responses). The default value is ``0``.
 
-Useful if you are using Python plugins for the server, this sets the folder
-that is searched for Python plugins.
+       * ``0`` or ``false`` (case insensitive)
+       * ``1`` or ``true`` (case insensitive)
+     - false
+     - WMS
 
+   * - QGIS_SERVER_IGNORE_BAD_LAYERS
+     - "Bad" layers are layers that cannot be loaded. The default behavior of QGIS Server
+       is to consider the project as not available if it contains a bad layer.
 
-QGIS_SERVER_LOG_LEVEL
-^^^^^^^^^^^^^^^^^^^^^
+       The default behavior can be overridden by setting this variable to ``1`` or ``true``.
+       In this case, "bad" layers will just be ignored, and the project will be considered
+       valid and available.
+     - false
+     - All
 
-Specify desired log level. Available values are:
+   * - QGIS_SERVER_WMS_MAX_HEIGHT / QGIS_SERVER_WMS_MAX_WIDTH
+     - Maximum height/width for a WMS request. The most conservative between this and the project one is used.
+       If the value is ``-1``, it means that there is no maximum set.
+     - -1
+     - WMS
 
-* ``0`` or ``INFO`` (log all requests)
-* ``1`` or ``WARNING``
-* ``2`` or ``CRITICAL`` (log just critical errors, suitable for production purposes)
+   * - QGIS_SERVER_API_RESOURCES_DIRECTORY
+     - Base directory for all WFS3 static resources (HTML templates, CSS, JS etc.)
+     - depends on packaging
+     - WFS
 
-
-QGIS_SERVER_PARALLEL_RENDERING
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-Activates parallel rendering for WMS GetMap requests. It's disabled (``false``)
-by default. Available values are:
-
-* ``0`` or ``false`` (case insensitive)
-* ``1`` or ``true`` (case insensitive)
-
-
-QGIS_SERVER_MAX_THREADS
-^^^^^^^^^^^^^^^^^^^^^^^
-
-Number of threads to use when parallel rendering is activated. Default value
-is ``-1`` to use the number of processor cores.
-
-
-QGIS_SERVER_CACHE_DIRECTORY
-^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-Specifies the network cache directory on the filesystem. The default
-directory is named ``cache`` and located in the profile directory.
-
-
-QGIS_SERVER_CACHE_SIZE
-^^^^^^^^^^^^^^^^^^^^^^
-
-Sets the network cache size in MB. The default value is ``50`` MB.
-
-
-QGIS_SERVER_OVERRIDE_SYSTEM_LOCALE
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-Sets LOCALE to be used by QGIS server. The default value is empty (no override).
-
-Example: ``de_CH.utf8``
-
-
-QGIS_SERVER_SHOW_GROUP_SEPARATOR
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-Defines whether a group separator (e.g. thousand separator) should be used for
-numeric values (e.g. in GetFeatureInfo responses). The default value is ``0``.
-
-* ``0`` or ``false`` (case insensitive)
-* ``1`` or ``true`` (case insensitive)
-
-
-QGIS_SERVER_IGNORE_BAD_LAYERS
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-"Bad" layers are layers that cannot be loaded. The default behavior of QGIS Server
-is to consider the project as not available if it contains a bad layer.
-
-The default behavior can be overridden by setting this variable to ``1`` or ``true``.
-In this case, "bad" layers will just be ignored, and the project will be considered
-valid and available.
-
-QGIS_SERVER_WMS_MAX_HEIGHT / QGIS_SERVER_WMS_MAX_WIDTH
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-Maximum height/width for a WMS request. The most conservative between this and the project one is used
-
-Default value is ``-1``, meaning that there is no maximum set.
-
-QGIS_SERVER_API_RESOURCES_DIRECTORY
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^	
-
-Base directory for all WFS3 static resources (HTML templates, CSS, JS etc.)
-	
-The default value depends on packaging.
-
-.. _`server_wfs3_max_limit_settings`:
-
-QGIS_SERVER_API_WFS3_MAX_LIMIT
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-Maximum value for ``limit`` in a features request. The default value is ``10000``
+   * - QGIS_SERVER_API_WFS3_MAX_LIMIT
+     - Maximum value for ``limit`` in a features request.
+     - 10000
+     - WFS
 
 
 Settings summary

--- a/docs/server_manual/config.rst
+++ b/docs/server_manual/config.rst
@@ -46,7 +46,7 @@ several ways to define these variables. This is fully described in
 
 .. list-table::
    :header-rows: 1
-   :widths: auto
+   :widths: 30 40 15 15
 
    * - Name
      - Description

--- a/docs/server_manual/config.rst
+++ b/docs/server_manual/config.rst
@@ -186,6 +186,27 @@ The default behavior can be overridden by setting this variable to ``1`` or ``tr
 In this case, "bad" layers will just be ignored, and the project will be considered
 valid and available.
 
+QGIS_SERVER_WMS_MAX_HEIGHT / QGIS_SERVER_WMS_MAX_WIDTH
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Maximum height/width for a WMS request. The most conservative between this and the project one is used
+
+Default value is ``-1``, meaning that there is no maximum set.
+
+QGIS_SERVER_API_RESOURCES_DIRECTORY
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^	
+
+Base directory for all WFS3 static resources (HTML templates, CSS, JS etc.)
+	
+The default value depends on packaging.
+
+.. _`server_wfs3_max_limit_settings`:
+
+QGIS_SERVER_API_WFS3_MAX_LIMIT
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Maximum value for ``limit`` in a features request. The default value is ``10000``
+
 
 Settings summary
 ================

--- a/docs/server_manual/services.rst
+++ b/docs/server_manual/services.rst
@@ -1773,7 +1773,7 @@ URL example:
 
     The maximum acceptable value for ``limit`` can be configured with
     the ``QGIS_SERVER_API_WFS3_MAX_LIMIT`` server configuration setting
-    (see: :ref:`server_wfs3_max_limit_settings`).
+    (see: :ref:`qgis-server-envvar`).
 
 
 Feature filtering

--- a/docs/server_manual/services.rst
+++ b/docs/server_manual/services.rst
@@ -1773,7 +1773,7 @@ URL example:
 
     The maximum acceptable value for ``limit`` can be configured with
     the ``QGIS_SERVER_API_WFS3_MAX_LIMIT`` server configuration setting
-    (see: :ref:`server_wfs3_settings`).
+    (see: :ref:`server_wfs3_max_limit_settings`).
 
 
 Feature filtering
@@ -1911,24 +1911,6 @@ returns only the ``name`` attribute
 .. code-block:: none
 
     http://localhost/qgisserver/wfs3/collection_one/items.json?properties=name
-
-
-.. _`server_wfs3_settings`:
-
-Configuration and settings
---------------------------
-
-Server settings recognized by the QGIS WFS3 implementation are:
-
-.. csv-table::
-   :header: "Name", "Description", "Default"
-   :widths: auto
-
-   "``QGIS_SERVER_API_RESOURCES_DIRECTORY``", "Base directory for all WFS3
-   static resources (HTML templates, CSS, JS etc.)", "depends on packaging"
-   "``QGIS_SERVER_API_WFS3_MAX_LIMIT``", "Maximum value for ``limit``
-   in a features request", "10000"
-
 
 
 The HTML template language


### PR DESCRIPTION
I complete some missing QGIS Server environment variables.

WFS environment variables were already described [here](https://github.com/qgis/QGIS-Documentation/blob/master/docs/user_manual/working_with_ogc/server/services.rst#configuration-and-settings), but I think it's good to have all in one place, so I move them in **Environment variables** chapter

- [x] Backport to LTR documentation is required

