### PR TITLE
Broken format due to superfluous colon and missing parenthesis

### DIFF
--- a/docs/training_manual/map_composer/dynamic_layout.rst
+++ b/docs/training_manual/map_composer/dynamic_layout.rst
@@ -110,7 +110,7 @@ Also, the date of creation will adapt dynamically.
 
            @layout_pagewidth -  @sw_layout_margin * 3 - 53.5
 
-   #. For the first vertical line::
+   #. For the first vertical line:
 
       #. Set the expression for :guilabel:`X` to::
 
@@ -178,7 +178,7 @@ Also, the date of creation will adapt dynamically.
      printed on: [%format_date(now(),'dd.MM.yyyy')%]
 
    Here we used two ``Date and Time`` functions (``now`` and
-   ``format_date``.
+   ``format_date``).
 
    Set the position of the label.
 


### PR DESCRIPTION
Line 113 : "#. For the first vertical line::" -->> double colon at the end breaks the format of the list that follows it. Removed one instance to correct the format
Line 181 : closing parenthesis is missing. Added

Goal: Display cerrect documentation

- [x] Backport to LTR documentation is required
