### PR TITLE
Fix typo in user manual doc (be also be)

### DIFF
--- a/docs/user_manual/introduction/project_files.rst
+++ b/docs/user_manual/introduction/project_files.rst
@@ -129,7 +129,7 @@ implementations (PostgreSQL and GeoPackage).
 Clicking the action will open a dialog to pick a GeoPackage connection
 and project or a PostgreSQL connection, schema and project.
 
-Projects stored in Geopackage or PostgreSQL can be also be loaded
+Projects stored in Geopackage or PostgreSQL can also be loaded
 through the QGIS browser panel, either by double-clicking them or by
 dragging them to the map canvas.
 


### PR DESCRIPTION
<!---
Include a few sentences describing the overall goals for this Pull Request.
 
A list of issues is at https://github.com/qgis/QGIS-Documentation/issues.
Add "fix #issuenumber" for each issue the PR fixes. The ticket(s) will be closed automatically.
If your PR doesn't fix entirely the ticket, only add the ticket(s) reference preceded by # character.
-->
Goal: Improving User Guide/Manual by fixing detected typos while studying

Ticket(s): #
<!---
Indicate whether the fix should be backported to previous release.
Replace the space between square brackets by a `x` to make it checked.
-->
- [ ] Backport to LTR documentation is required

<!---
Reviewing is a process done by community members, mostly on a volunteer basis.
We try to keep the overhead as small as possible and appreciate if you help us.
Please read carefully and ensure you comply with our writing guidelines at
https://docs.qgis.org/testing/en/docs/documentation_guidelines/index.html.
Feel free to ask in a comment or the (qgis-community-team mailing list)
[https://lists.osgeo.org/mailman/listinfo/qgis-community-team] if you have troubles with any item.
--->
