### PR TITLE
Removed superfluous dot at end of sentence

### DIFF
--- a/docs/training_manual/create_vector_data/topo_editing.rst
+++ b/docs/training_manual/create_vector_data/topo_editing.rst
@@ -204,7 +204,7 @@ Extending:
    :sup:`Select Features by area or single click` tool.
 #. Left-click inside the polygon to start drawing.
 #. Draw a shape outside the polygon. The last vertex should be back
-   inside the polygon..
+   inside the polygon.
 #. Right-click to finish the shape:
 
    .. figure:: img/reshape_step_one.png


### PR DESCRIPTION
Line 207  :  "inside the polygon.." should probably be  "inside the polygon." 
               Removed last instance of the dot (.)

<!---
Include a few sentences describing the overall goals for this Pull Request.
 
A list of issues is at https://github.com/qgis/QGIS-Documentation/issues.
Add "fix #issuenumber" for each issue the PR fixes. The ticket(s) will be closed automatically.
If your PR doesn't fix entirely the ticket, only add the ticket(s) reference preceded by # character.
-->
Goal: Display correct documentation

- [x] Backport to LTR documentation is required
