### PR TITLE
Explain RULELABEL AUTO option in GetLegendGraphics

### DIFF
--- a/docs/server_manual/services.rst
+++ b/docs/server_manual/services.rst
@@ -1342,8 +1342,8 @@ the default format PNG is used instead.
 TILEMATRIXSET
 ^^^^^^^^^^^^^
 
-This parameter allows to define the CRS to use to compute the
-underlying pyramid and has to be formed like ``EPSG:XXXX``.
+This parameter defines the CRS to use when computing the underlying
+pyramid. Format: ``EPSG:XXXX``.
 
 
 TILEMATRIX

--- a/docs/server_manual/services.rst
+++ b/docs/server_manual/services.rst
@@ -461,7 +461,7 @@ return the next error:
   word / special character is mandatory. Allowed Keywords and special
   characters are 'AND','OR','IN','=','<','>=','>','>=','!=*,'(',')'.
   Semicolons in string expressions are not allowed.
-  
+
 
 URL example:
 
@@ -920,8 +920,11 @@ labels:
 * **LAYERFONTITALIC / ITEMFONTITALIC** ``TRUE`` to use italic font
 * **LAYERFONTCOLOR / ITEMFONTCOLOR** Hex color code (e.g. ``#FF0000``
   for red)
-* **LAYERTITLE / RULELABEL** set them to ``FALSE`` to get only
-  the legend graphics without labels
+* **LAYERTITLE** ``FALSE`` to get only the legend graphics without layer title
+* **RULELABEL**:
+
+    * ``FALSE`` get only the legend graphics without item labels
+    * ``AUTO`` hide item label for single legend and display item labels for any other legend type. This is useful to avoid having duplicated layer title and item label in case of single legend.
 
 Content based legend. These parameters let the client request a legend
 showing only the symbols for the features falling into the requested
@@ -1339,7 +1342,7 @@ the default format PNG is used instead.
 TILEMATRIXSET
 ^^^^^^^^^^^^^
 
-This parameter allows to define the CRS to use to compute the 
+This parameter allows to define the CRS to use to compute the
 underlying pyramid and has to be formed like ``EPSG:XXXX``.
 
 
@@ -1529,7 +1532,7 @@ WFS3 (OGC API Features)
 
 WFS3 is the first implementation of the new generation of OGC
 protocols.
-It is described by the `OGC API - Features - Part 1: Core 
+It is described by the `OGC API - Features - Part 1: Core
 <http://docs.opengeospatial.org/is/17-069r3/17-069r3.html>`_ document.
 
 Here is a quick informal summary of the most important differences
@@ -1882,7 +1885,7 @@ Feature sorting |316|
 ---------------------
 
 It is possible to order the result set by field value using the ``sortby``
-query parameter. 
+query parameter.
 
 The results are sorted in ascending order by default.
 To sort the results in descending order, a boolean flag (``sortdesc``) can be set:
@@ -1890,7 +1893,7 @@ To sort the results in descending order, a boolean flag (``sortdesc``) can be se
 .. code-block:: none
 
   http://localhost/qgisserver/wfs3/collection_one/items.json?sortby=name&sortdesc=1
-  
+
 
 Attribute selection
 -------------------
@@ -1933,7 +1936,7 @@ The HTML representation uses a set of HTML templates to generate the
 response.
 The template is parsed by a template engine called
 `inja <https://github.com/pantor/inja#tutorial>`_.
-The templates can be customized by overriding them (see: 
+The templates can be customized by overriding them (see:
 :ref:`server_wfs3_template_override`).
 The template has access to the same data that are available to the
 ``JSON`` representation and a few additional functions are available to

--- a/docs/server_manual/services.rst
+++ b/docs/server_manual/services.rst
@@ -923,8 +923,8 @@ labels:
 * **LAYERTITLE** ``FALSE`` to get only the legend graphics without layer title
 * **RULELABEL**:
 
-    * ``FALSE`` get only the legend graphics without item labels
-    * ``AUTO`` hide item label for single legend and display item labels for any other legend type. This is useful to avoid having duplicated layer title and item label in case of single legend.
+    * ``FALSE`` legend graphics without item labels
+    * ``AUTO`` hide item label for layers with :guilabel:`Single symbol` rendering
 
 Content based legend. These parameters let the client request a legend
 showing only the symbols for the features falling into the requested


### PR DESCRIPTION
GetLegendGraphics request for setting legend labels (RULELABEL) to TRUE or FALSE now also supports AUTO value which is explained with this commit.
fix #5506 

- [ ] Backport to LTR documentation is required
