### PR TITLE
Allows PDF creation to fail softly without breaking the build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,26 +64,33 @@ pdf: latex
 	# Compile the tex files into PDF, it runs 2x to fix hyperlinks
 	# notice that platex compiler needs an extra step to convert dvi to PDF
 	# using the dvipdfmx command
+	# -interaction=batchmode in latex compiler and -q im dvipdfmx will hide errors
+	# for debugging you need to remove them
 	cd $(BUILDDIR)/latex/$(LANG); \
 	$(LATEXCOMPILER) -interaction=batchmode -shell-escape QGISUserGuide.tex; \
 	$(LATEXCOMPILER) -interaction=batchmode -shell-escape QGISUserGuide.tex; \
-	if [ "$(LATEXCOMPILER)" != "xelatex" ]; then dvipdfmx QGISUserGuide.dvi; fi; \
+	if [ "$(LATEXCOMPILER)" != "xelatex" ] && [ -f "QGISUserGuide2.dvi" ]; then \
+		dvipdfmx -q QGISUserGuide.dvi; fi; \
 	$(LATEXCOMPILER) -interaction=batchmode -shell-escape PyQGISDeveloperCookbook.tex; \
 	$(LATEXCOMPILER) -interaction=batchmode -shell-escape PyQGISDeveloperCookbook.tex; \
-	if [ "$(LATEXCOMPILER)" != "xelatex" ]; then dvipdfmx PyQGISDeveloperCookbook.dvi; fi; \
+	if [ "$(LATEXCOMPILER)" != "xelatex" ] && [ -f "PyQGISDeveloperCookbook.dvi" ]; then \
+		dvipdfmx -q PyQGISDeveloperCookbook.dvi; fi; \
 	$(LATEXCOMPILER) -interaction=batchmode -shell-escape QGISTrainingManual.tex; \
 	$(LATEXCOMPILER) -interaction=batchmode -shell-escape QGISTrainingManual.tex; \
-	if [ "$(LATEXCOMPILER)" != "xelatex" ]; then dvipdfmx QGISTrainingManual.dvi; fi; \
+	if [ "$(LATEXCOMPILER)" != "xelatex" ] && [ -f "QGISTrainingManual.dvi" ]; then \
+		dvipdfmx -q QGISTrainingManual.dvi; fi; \
 	$(LATEXCOMPILER) -interaction=batchmode -shell-escape QGISDocumentationGuidelines.tex; \
 	$(LATEXCOMPILER) -interaction=batchmode -shell-escape QGISDocumentationGuidelines.tex; \
-	if [ "$(LATEXCOMPILER)" != "xelatex" ]; then dvipdfmx QGISDocumentationGuidelines.dvi; fi;
+	if [ "$(LATEXCOMPILER)" != "xelatex" ]  && [ -f "QGISDocumentationGuidelines.dvi" ]; then \
+		dvipdfmx -q QGISDocumentationGuidelines.dvi; fi;
 
 	# copy and rename PDF files to the pdf folder
+	# || true allows the job to continue even if one of the files is missing
 	mkdir -p $(BUILDDIR)/pdf/$(LANG);
-	mv $(BUILDDIR)/latex/$(LANG)/QGISUserGuide.pdf $(BUILDDIR)/pdf/$(LANG)/QGIS-$(VERSION)-UserGuide-$(LANG).pdf;
-	mv $(BUILDDIR)/latex/$(LANG)/PyQGISDeveloperCookbook.pdf $(BUILDDIR)/pdf/$(LANG)/QGIS-$(VERSION)-PyQGISDeveloperCookbook-$(LANG).pdf;
-	mv $(BUILDDIR)/latex/$(LANG)/QGISTrainingManual.pdf $(BUILDDIR)/pdf/$(LANG)/QGIS-$(VERSION)-TrainingManual-$(LANG).pdf;
-	mv $(BUILDDIR)/latex/$(LANG)/QGISDocumentationGuidelines.pdf $(BUILDDIR)/pdf/$(LANG)/QGIS-$(VERSION)-DocumentationGuidelines-$(LANG).pdf;
+	mv $(BUILDDIR)/latex/$(LANG)/QGISUserGuide.pdf $(BUILDDIR)/pdf/$(LANG)/QGIS-$(VERSION)-UserGuide-$(LANG).pdf || true;
+	mv $(BUILDDIR)/latex/$(LANG)/PyQGISDeveloperCookbook.pdf $(BUILDDIR)/pdf/$(LANG)/QGIS-$(VERSION)-PyQGISDeveloperCookbook-$(LANG).pdf || true;
+	mv $(BUILDDIR)/latex/$(LANG)/QGISTrainingManual.pdf $(BUILDDIR)/pdf/$(LANG)/QGIS-$(VERSION)-TrainingManual-$(LANG).pdf || true;
+	mv $(BUILDDIR)/latex/$(LANG)/QGISDocumentationGuidelines.pdf $(BUILDDIR)/pdf/$(LANG)/QGIS-$(VERSION)-DocumentationGuidelines-$(LANG).pdf || true;
 
 zip:
 	mkdir -p $(BUILDDIR)/zip;


### PR DESCRIPTION
<!---
Include a few sentences describing the overall goals for this Pull Request.
 
A list of issues is at https://github.com/qgis/QGIS-Documentation/issues.
Add "fix #issuenumber" for each issue the PR fixes. The ticket(s) will be closed automatically.
If your PR doesn't fix entirely the ticket, only add the ticket(s) reference preceded by # character.
-->
Goal:

In case anything goes wrong with one of the PDFs creation, the build will keep going and finish the rest of the jobs.

Ticket(s): #
<!---
Indicate whether the fix should be backported to previous release.
Replace the space between square brackets by a `x` to make it checked.
-->
- [ ] Backport to LTR documentation is required

This needs to be ported to master. I will do it once we confirm that this works with the current problems with JA.

<!---
Reviewing is a process done by community members, mostly on a volunteer basis.
We try to keep the overhead as small as possible and appreciate if you help us.
Please read carefully and ensure you comply with our writing guidelines at
https://docs.qgis.org/testing/en/docs/documentation_guidelines/index.html.
Feel free to ask in a comment or the (qgis-community-team mailing list)
[https://lists.osgeo.org/mailman/listinfo/qgis-community-team] if you have troubles with any item.
--->
