### PR TITLE
Operator OR instead of AND for expression to work

### DIFF
--- a/docs/training_manual/vector_analysis/basic_analysis.rst
+++ b/docs/training_manual/vector_analysis/basic_analysis.rst
@@ -104,13 +104,13 @@ We first need to load the data to work with.
 #. In the dialog that pops up we filter these features with the
    following expression::
 
-     "highway" NOT IN ('footway', 'path', 'unclassified', 'track') AND "highway" != NULL
+     "highway" NOT IN ('footway', 'path', 'unclassified', 'track') OR "highway" != NULL
 
    The concatenation of the two operators ``NOT`` and ``IN`` excludes
    all the features that have these attribute values in the
    ``highway`` field.
 
-   ``!= NULL`` combined with the ``AND`` operator excludes roads with
+   ``!= NULL`` combined with the ``OR`` operator excludes roads with
    no value in the ``highway`` field.
 
    Note the |indicatorFilter| icon next to the :guilabel:`roads`


### PR DESCRIPTION
Line 107  :   The expression ""highway" NOT IN ('footway', 'path', 'unclassified', 'track') AND "highway" != NULL" does not work !
Result is zero because the excluded types of roads all have a value AND is nowhere NULL
Probably OR should be used to filter the excluded types AND the NULL, then the result is 466 rows, instead of 0 rows

line 113 :  "``!= NULL`` combined with the ``AND`` operator excludes roads with"  should probably be: "``!= NULL`` combined with the ``OR`` operator excludes roads with"
because the AND operator combines both clauses (to use as conditions for NOT IN) and makes the expression search for the four excluded types AND they should not have an empty value.
Well, that is probably never going to happen, which results to 0 rows found.
Using OR wil search for the four excluded types OR the ones with no value in the field 'highway', which are the ones we want to filter out of the dataset

Goal: Display correct information

- [x] Backport to LTR documentation is required

