### PR TITLE
"Labe name" should be "Layer name"

### DIFF
--- a/docs/training_manual/vector_analysis/basic_analysis.rst
+++ b/docs/training_manual/vector_analysis/basic_analysis.rst
@@ -295,7 +295,7 @@ You can find it in :menuselection:`Vector Overlay` group in the
 
 #. Use the two buffer layers as :guilabel:`Input layer` and
    :guilabel:`Overlay layer`, choose :file:`vector_analysis.gpkg`
-   GeoPackage in :guilabel:`Intersection` with :guilabel:`Labe name`
+   GeoPackage in :guilabel:`Intersection` with :guilabel:`Layer name`
    ``road_school_buffers_intersect``.
    Leave the rest as suggested (default).
 


### PR DESCRIPTION
Line  298 ; ":guilabel:`Labe name`  should probably be ":guilabel:`Layer name`", since name of layer is meant, not the name of a label


Goal:  Display correct information

- [x] Backport to LTR documentation is required

