### PR TITLE
More info on GetFeatureInfo WITH_GEOMETRY parameter

### DIFF
--- a/docs/server_manual/getting_started.rst
+++ b/docs/server_manual/getting_started.rst
@@ -756,8 +756,8 @@ You can receive requested GetFeatureInfo as plain text, XML and GML. Default is 
 text or GML format depends the output format chosen for the GetFeatureInfo request.
 
 If you wish, you can check |checkbox| :guilabel:`Add geometry to feature response`.
-This will include bounding box for every feature in the GetFeatureInfo response.
-See :ref:`WITH_GEOMETRY <server_wms_getfeatureinfo>` parameter to receive geometries in text format.
+This will include the bounding box for each feature in the GetFeatureInfo response.
+See also the :ref:`WITH_GEOMETRY <server_wms_getfeatureinfo>` parameter.
 
 As many web clients can’t display circular arcs in geometries you have the option
 to segmentize the geometry before sending it to the client in a GetFeatureInfo

--- a/docs/server_manual/getting_started.rst
+++ b/docs/server_manual/getting_started.rst
@@ -756,8 +756,8 @@ You can receive requested GetFeatureInfo as plain text, XML and GML. Default is 
 text or GML format depends the output format chosen for the GetFeatureInfo request.
 
 If you wish, you can check |checkbox| :guilabel:`Add geometry to feature response`.
-This will include in the GetFeatureInfo response the geometries of the
-features in a text format.
+This will include bounding box for every feature in the GetFeatureInfo response.
+See :ref:`WITH_GEOMETRY <server_wms_getfeatureinfo>` parameter to receive geometries in text format.
 
 As many web clients can’t display circular arcs in geometries you have the option
 to segmentize the geometry before sending it to the client in a GetFeatureInfo

--- a/docs/server_manual/services.rst
+++ b/docs/server_manual/services.rst
@@ -708,8 +708,8 @@ WITH_GEOMETRY
 ^^^^^^^^^^^^^
 
 This parameter specifies whether to add geometries to the output. To use
-this feature you must first enable :guilabel:`Add geometry to feature response`
-option in QGIS project. See :ref:`Configure your project <Creatingwmsfromproject>`.
+this feature you must first enable the :guilabel:`Add geometry to feature response`
+option in the QGIS project. See :ref:`Configure your project <Creatingwmsfromproject>`.
 
 Available values are (not case sensitive):
 

--- a/docs/server_manual/services.rst
+++ b/docs/server_manual/services.rst
@@ -707,7 +707,9 @@ Available values are (not case sensitive):
 WITH_GEOMETRY
 ^^^^^^^^^^^^^
 
-This parameter specifies whether to add geometries to the output.
+This parameter specifies whether to add geometries to the output. To use
+this feature you must first enable :guilabel:`Add geometry to feature response`
+option in QGIS project. See :ref:`Configure your project <Creatingwmsfromproject>`.
 
 Available values are (not case sensitive):
 


### PR DESCRIPTION
Geometries are not added by default to GetFeatureInfo response. Explaining need for WITH_GEOMETRY parameter and related QGIS project setting.

Manual Backport to LTR documentation