### PR TITLE
Make pasting examples with quotes succesfull

### DIFF
--- a/docs/user_manual/working_with_vector/expression_help/Aggregates.rst
+++ b/docs/user_manual/working_with_vector/expression_help/Aggregates.rst
@@ -57,11 +57,11 @@ Returns an aggregate value calculated using features from another layer.
        * **concatenator** - optional string to use to join values for 'concatenate' aggregate
        * **order_by** - optional filter expression to order the features used for calculating the aggregate. Fields and geometry are from the features on the joined layer.
    * - Examples
-     - * aggregate(layer:='rail_stations',aggregate:='sum',expression:="passengers") → sum of all values from the passengers field in the rail_stations layer
-       * aggregate('rail_stations','sum', "passengers"/7) → calculates a daily average of "passengers" by dividing the "passengers" field by 7 before summing the values
-       * aggregate(layer:='rail_stations',aggregate:='sum',expression:="passengers",filter:="class">3) → sums up all values from the "passengers" field from features where the "class" attribute is greater than 3 only
-       * aggregate(layer:='rail_stations',aggregate:='concatenate', expression:="name", concatenator:=',') → comma separated list of the name field for all features in the rail_stations layer
-       * aggregate(layer:='countries', aggregate:='max', expression:="code", filter:=intersects( $geometry, geometry(@parent) ) ) → The country code of an intersecting country on the layer 'countries'
+     - * ``aggregate(layer:='rail_stations',aggregate:='sum',expression:="passengers")`` → sum of all values from the passengers field in the rail_stations layer
+       * ``aggregate('rail_stations','sum', "passengers"/7)`` → calculates a daily average of "passengers" by dividing the "passengers" field by 7 before summing the values
+       * ``aggregate(layer:='rail_stations',aggregate:='sum',expression:="passengers",filter:="class">3)`` → sums up all values from the "passengers" field from features where the "class" attribute is greater than 3 only
+       * ``aggregate(layer:='rail_stations',aggregate:='concatenate', expression:="name", concatenator:=',')`` → comma separated list of the name field for all features in the rail_stations layer
+       * ``aggregate(layer:='countries', aggregate:='max', expression:="code", filter:=intersects( $geometry, geometry(@parent) ) )`` → The country code of an intersecting country on the layer 'countries'
 
 
 .. end_aggregate_section
@@ -88,7 +88,7 @@ Returns an array of aggregated values from a field or expression.
        * **filter** - optional expression to use to filter features used to calculate aggregate
        * **order_by** - optional expression to use to order features used to calculate aggregate
    * - Examples
-     - * array_agg("name",group_by:="state") → list of name values, grouped by state field
+     - * ``array_agg("name",group_by:="state")`` → list of name values, grouped by state field
 
 
 .. end_array_agg_section
@@ -114,7 +114,7 @@ Returns the multipart geometry of aggregated geometries from an expression
        * **group_by** - optional expression to use to group aggregate calculations
        * **filter** - optional expression to use to filter features used to calculate aggregate
    * - Examples
-     - * collect( $geometry ) → multipart geometry of aggregated geometries
+     - * ``collect( $geometry )`` → multipart geometry of aggregated geometries
 
 
 .. end_collect_section
@@ -142,7 +142,7 @@ Returns all aggregated strings from a field or expression joined by a delimiter.
        * **concatenator** - optional string to use to join values
        * **order_by** - optional expression to use to order features used to calculate aggregate
    * - Examples
-     - * concatenate("town_name",group_by:="state",concatenator:=',') → comma separated list of town_names, grouped by state field
+     - * ``concatenate("town_name",group_by:="state",concatenator:=',')`` → comma separated list of town_names, grouped by state field
 
 
 .. end_concatenate_section
@@ -170,7 +170,7 @@ Returns all unique strings from a field or expression joined by a delimiter.
        * **concatenator** - optional string to use to join values
        * **order_by** - optional expression to use to order features used to calculate aggregate
    * - Examples
-     - * concatenate("town_name",group_by:="state",concatenator:=',') → comma separated list of unique town_names, grouped by state field
+     - * ``concatenate("town_name",group_by:="state",concatenator:=',')`` → comma separated list of unique town_names, grouped by state field
 
 
 .. end_concatenate_unique_section
@@ -196,7 +196,7 @@ Returns the count of matching features.
        * **group_by** - optional expression to use to group aggregate calculations
        * **filter** - optional expression to use to filter features used to calculate aggregate
    * - Examples
-     - * count("stations",group_by:="state") → count of stations, grouped by state field
+     - * ``count("stations",group_by:="state")`` → count of stations, grouped by state field
 
 
 .. end_count_section
@@ -222,7 +222,7 @@ Returns the count of distinct values.
        * **group_by** - optional expression to use to group aggregate calculations
        * **filter** - optional expression to use to filter features used to calculate aggregate
    * - Examples
-     - * count_distinct("stations",group_by:="state") → count of distinct stations values, grouped by state field
+     - * ``count_distinct("stations",group_by:="state")`` → count of distinct stations values, grouped by state field
 
 
 .. end_count_distinct_section
@@ -248,7 +248,7 @@ Returns the count of missing (NULL) values.
        * **group_by** - optional expression to use to group aggregate calculations
        * **filter** - optional expression to use to filter features used to calculate aggregate
    * - Examples
-     - * count_missing("stations",group_by:="state") → count of missing (NULL) station values, grouped by state field
+     - * ``count_missing("stations",group_by:="state")`` → count of missing (NULL) station values, grouped by state field
 
 
 .. end_count_missing_section
@@ -274,7 +274,7 @@ Returns the calculated inter quartile range from a field or expression.
        * **group_by** - optional expression to use to group aggregate calculations
        * **filter** - optional expression to use to filter features used to calculate aggregate
    * - Examples
-     - * iqr("population",group_by:="state") → inter quartile range of population value, grouped by state field
+     - * ``iqr("population",group_by:="state")`` → inter quartile range of population value, grouped by state field
 
 
 .. end_iqr_section
@@ -300,7 +300,7 @@ Returns the aggregate majority of values (most commonly occurring value) from a 
        * **group_by** - optional expression to use to group aggregate calculations
        * **filter** - optional expression to use to filter features used to calculate aggregate
    * - Examples
-     - * majority("class",group_by:="state") → most commonly occurring class value, grouped by state field
+     - * ``majority("class",group_by:="state")`` → most commonly occurring class value, grouped by state field
 
 
 .. end_majority_section
@@ -326,7 +326,7 @@ Returns the maximum length of strings from a field or expression.
        * **group_by** - optional expression to use to group aggregate calculations
        * **filter** - optional expression to use to filter features used to calculate aggregate
    * - Examples
-     - * max_length("town_name",group_by:="state") → maximum length of town_name, grouped by state field
+     - * ``max_length("town_name",group_by:="state")`` → maximum length of town_name, grouped by state field
 
 
 .. end_max_length_section
@@ -352,7 +352,7 @@ Returns the aggregate maximum value from a field or expression.
        * **group_by** - optional expression to use to group aggregate calculations
        * **filter** - optional expression to use to filter features used to calculate aggregate
    * - Examples
-     - * maximum("population",group_by:="state") → maximum population value, grouped by state field
+     - * ``maximum("population",group_by:="state")`` → maximum population value, grouped by state field
 
 
 .. end_maximum_section
@@ -378,7 +378,7 @@ Returns the aggregate mean value from a field or expression.
        * **group_by** - optional expression to use to group aggregate calculations
        * **filter** - optional expression to use to filter features used to calculate aggregate
    * - Examples
-     - * mean("population",group_by:="state") → mean population value, grouped by state field
+     - * ``mean("population",group_by:="state")`` → mean population value, grouped by state field
 
 
 .. end_mean_section
@@ -404,7 +404,7 @@ Returns the aggregate median value from a field or expression.
        * **group_by** - optional expression to use to group aggregate calculations
        * **filter** - optional expression to use to filter features used to calculate aggregate
    * - Examples
-     - * median("population",group_by:="state") → median population value, grouped by state field
+     - * ``median("population",group_by:="state")`` → median population value, grouped by state field
 
 
 .. end_median_section
@@ -430,7 +430,7 @@ Returns the minimum length of strings from a field or expression.
        * **group_by** - optional expression to use to group aggregate calculations
        * **filter** - optional expression to use to filter features used to calculate aggregate
    * - Examples
-     - * min_length("town_name",group_by:="state") → minimum length of town_name, grouped by state field
+     - * ``min_length("town_name",group_by:="state")`` → minimum length of town_name, grouped by state field
 
 
 .. end_min_length_section
@@ -456,7 +456,7 @@ Returns the aggregate minimum value from a field or expression.
        * **group_by** - optional expression to use to group aggregate calculations
        * **filter** - optional expression to use to filter features used to calculate aggregate
    * - Examples
-     - * minimum("population",group_by:="state") → minimum population value, grouped by state field
+     - * ``minimum("population",group_by:="state")`` → minimum population value, grouped by state field
 
 
 .. end_minimum_section
@@ -482,7 +482,7 @@ Returns the aggregate minority of values (least occurring value) from a field or
        * **group_by** - optional expression to use to group aggregate calculations
        * **filter** - optional expression to use to filter features used to calculate aggregate
    * - Examples
-     - * minority("class",group_by:="state") → least occurring class value, grouped by state field
+     - * ``minority("class",group_by:="state")`` → least occurring class value, grouped by state field
 
 
 .. end_minority_section
@@ -508,7 +508,7 @@ Returns the calculated first quartile from a field or expression.
        * **group_by** - optional expression to use to group aggregate calculations
        * **filter** - optional expression to use to filter features used to calculate aggregate
    * - Examples
-     - * q1("population",group_by:="state") → first quartile of population value, grouped by state field
+     - * ``q1("population",group_by:="state")`` → first quartile of population value, grouped by state field
 
 
 .. end_q1_section
@@ -534,7 +534,7 @@ Returns the calculated third quartile from a field or expression.
        * **group_by** - optional expression to use to group aggregate calculations
        * **filter** - optional expression to use to filter features used to calculate aggregate
    * - Examples
-     - * q3("population",group_by:="state") → third quartile of population value, grouped by state field
+     - * ``q3("population",group_by:="state")`` → third quartile of population value, grouped by state field
 
 
 .. end_q3_section
@@ -560,7 +560,7 @@ Returns the aggregate range of values (maximum - minimum) from a field or expres
        * **group_by** - optional expression to use to group aggregate calculations
        * **filter** - optional expression to use to filter features used to calculate aggregate
    * - Examples
-     - * range("population",group_by:="state") → range of population values, grouped by state field
+     - * ``range("population",group_by:="state")`` → range of population values, grouped by state field
 
 
 .. end_range_section
@@ -615,10 +615,10 @@ Returns an aggregate value calculated using all matching child features from a l
        * **concatenator** - optional string to use to join values for 'concatenate' aggregate
        * **order_by** - optional expression to order the features used for calculating the aggregate. Fields and geometry are from the features on the joined layer.
    * - Examples
-     - * relation_aggregate(relation:='my_relation',aggregate:='mean',expression:="passengers") → mean value of all matching child features using the 'my_relation' relation
-       * relation_aggregate('my_relation','sum', "passengers"/7) → sum of the passengers field divided by 7 for all matching child features using the 'my_relation' relation
-       * relation_aggregate('my_relation','concatenate', "towns", concatenator:=',') → comma separated list of the towns field for all matching child features using the 'my_relation' relation
-       * relation_aggregate('my_relation','array_agg', "id") → array of the id field from all matching child features using the 'my_relation' relation
+     - * ``relation_aggregate(relation:='my_relation',aggregate:='mean',expression:="passengers")`` → mean value of all matching child features using the 'my_relation' relation
+       * ``relation_aggregate('my_relation','sum', "passengers"/7)`` → sum of the passengers field divided by 7 for all matching child features using the 'my_relation' relation
+       * ``relation_aggregate('my_relation','concatenate', "towns", concatenator:=',')`` → comma separated list of the towns field for all matching child features using the 'my_relation' relation
+       * ``relation_aggregate('my_relation','array_agg', "id")`` → array of the id field from all matching child features using the 'my_relation' relation
 
 
 .. end_relation_aggregate_section
@@ -644,7 +644,7 @@ Returns the aggregate standard deviation value from a field or expression.
        * **group_by** - optional expression to use to group aggregate calculations
        * **filter** - optional expression to use to filter features used to calculate aggregate
    * - Examples
-     - * stdev("population",group_by:="state") → standard deviation of population value, grouped by state field
+     - * ``stdev("population",group_by:="state")`` → standard deviation of population value, grouped by state field
 
 
 .. end_stdev_section
@@ -670,7 +670,7 @@ Returns the aggregate summed value from a field or expression.
        * **group_by** - optional expression to use to group aggregate calculations
        * **filter** - optional expression to use to filter features used to calculate aggregate
    * - Examples
-     - * sum("population",group_by:="state") → summed population value, grouped by state field
+     - * ``sum("population",group_by:="state")`` → summed population value, grouped by state field
 
 
 .. end_sum_section

--- a/docs/user_manual/working_with_vector/expression_help/Arrays.rst
+++ b/docs/user_manual/working_with_vector/expression_help/Arrays.rst
@@ -23,7 +23,7 @@ Returns an array containing all the values passed as parameter.
    * - Arguments
      - * **value** - a value
    * - Examples
-     - * array(2,10) → [ 2, 10 ]
+     - * ``array(2,10)`` → [ 2, 10 ]
 
 
 .. end_array_section
@@ -46,8 +46,8 @@ Returns true if an array contains all the values of a given array.
      - * **array_a** - an array
        * **array_b** - the array of values to search
    * - Examples
-     - * array_all(array(1,2,3),array(2,3)) → true
-       * array_all(array(1,2,3),array(1,2,4)) → false
+     - * ``array_all(array(1,2,3),array(2,3))`` → true
+       * ``array_all(array(1,2,3),array(1,2,4))`` → false
 
 
 .. end_array_all_section
@@ -70,7 +70,7 @@ Returns an array with the given value added at the end.
      - * **array** - an array
        * **value** - the value to add
    * - Examples
-     - * array_append(array(1,2,3),4) → [ 1, 2, 3, 4 ]
+     - * ``array_append(array(1,2,3),4)`` → [ 1, 2, 3, 4 ]
 
 
 .. end_array_append_section
@@ -92,7 +92,7 @@ Returns an array containing all the given arrays concatenated.
    * - Arguments
      - * **array** - an array
    * - Examples
-     - * array_cat(array(1,2),array(2,3)) → [ 1, 2, 2, 3 ]
+     - * ``array_cat(array(1,2),array(2,3))`` → [ 1, 2, 2, 3 ]
 
 
 .. end_array_cat_section
@@ -115,7 +115,7 @@ Returns true if an array contains the given value.
      - * **array** - an array
        * **value** - the value to search
    * - Examples
-     - * array_contains(array(1,2,3),2) → true
+     - * ``array_contains(array(1,2,3),2)`` → true
 
 
 .. end_array_contains_section
@@ -137,7 +137,7 @@ Returns an array containing distinct values of the given array.
    * - Arguments
      - * **array** - an array
    * - Examples
-     - * array_distinct(array(1,2,3,2,1)) → [ 1, 2, 3 ]
+     - * ``array_distinct(array(1,2,3,2,1))`` → [ 1, 2, 3 ]
 
 
 .. end_array_distinct_section
@@ -160,7 +160,7 @@ Returns an array with only the items for which the expression evaluates to true.
      - * **array** - an array
        * **expression** - an expression to evaluate on each item. The variable `@element` will be replaced by the current value.
    * - Examples
-     - * array_filter(array(1,2,3),@element &lt; 3) → [ 1, 2 ]
+     - * ``array_filter(array(1,2,3),@element &lt; 3)`` → [ 1, 2 ]
 
 
 .. end_array_filter_section
@@ -183,7 +183,7 @@ Returns the index (0 for the first one) of a value within an array. Returns -1 i
      - * **array** - an array
        * **value** - the value to search
    * - Examples
-     - * array_find(array(1,2,3),2) → 1
+     - * ``array_find(array(1,2,3),2)`` → 1
 
 
 .. end_array_find_section
@@ -205,7 +205,7 @@ Returns the first value of an array.
    * - Arguments
      - * **array** - an array
    * - Examples
-     - * array_first(array('a','b','c')) → 'a'
+     - * ``array_first(array('a','b','c'))`` → 'a'
 
 
 .. end_array_first_section
@@ -228,8 +228,8 @@ Returns an array with the given expression evaluated on each item.
      - * **array** - an array
        * **expression** - an expression to evaluate on each item. The variable `@element` will be replaced by the current value.
    * - Examples
-     - * array_foreach(array('a','b','c'),upper(@element)) → [ 'A', 'B', 'C' ]
-       * array_foreach(array(1,2,3),@element + 10) → [ 11, 12, 13 ]
+     - * ``array_foreach(array('a','b','c'),upper(@element))`` → [ 'A', 'B', 'C' ]
+       * ``array_foreach(array(1,2,3),@element + 10)`` → [ 11, 12, 13 ]
 
 
 .. end_array_foreach_section
@@ -252,7 +252,7 @@ Returns the Nth value (0 for the first one) of an array.
      - * **array** - an array
        * **index** - the index to get (0 based)
    * - Examples
-     - * array_get(array('a','b','c'),1) → 'b'
+     - * ``array_get(array('a','b','c'),1)`` → 'b'
 
 
 .. end_array_get_section
@@ -276,7 +276,7 @@ Returns an array with the given value added at the given position.
        * **pos** - the position where to add (0 based)
        * **value** - the value to add
    * - Examples
-     - * array_insert(array(1,2,3),1,100) → [ 1, 100, 2, 3 ]
+     - * ``array_insert(array(1,2,3),1,100)`` → [ 1, 100, 2, 3 ]
 
 
 .. end_array_insert_section
@@ -299,7 +299,7 @@ Returns true if at least one element of array1 exists in array2.
      - * **array1** - an array
        * **array2** - another array
    * - Examples
-     - * array_intersect(array(1,2,3,4),array(4,0,2,5)) → true
+     - * ``array_intersect(array(1,2,3,4),array(4,0,2,5))`` → true
 
 
 .. end_array_intersect_section
@@ -321,7 +321,7 @@ Returns the last value of an array.
    * - Arguments
      - * **array** - an array
    * - Examples
-     - * array_last(array('a','b','c')) → 'c'
+     - * ``array_last(array('a','b','c'))`` → 'c'
 
 
 .. end_array_last_section
@@ -343,7 +343,7 @@ Returns the number of elements of an array.
    * - Arguments
      - * **array** - an array
    * - Examples
-     - * array_length(array(1,2,3)) → 3
+     - * ``array_length(array(1,2,3))`` → 3
 
 
 .. end_array_length_section
@@ -366,7 +366,7 @@ Returns an array with the given value added at the beginning.
      - * **array** - an array
        * **value** - the value to add
    * - Examples
-     - * array_prepend(array(1,2,3),0) → [ 0, 1, 2, 3 ]
+     - * ``array_prepend(array(1,2,3),0)`` → [ 0, 1, 2, 3 ]
 
 
 .. end_array_prepend_section
@@ -389,7 +389,7 @@ Returns an array with all the entries of the given value removed.
      - * **array** - an array
        * **value** - the values to remove
    * - Examples
-     - * array_remove_all(array('a','b','c','b'),'b') → [ 'a', 'c' ]
+     - * ``array_remove_all(array('a','b','c','b'),'b')`` → [ 'a', 'c' ]
 
 
 .. end_array_remove_all_section
@@ -412,7 +412,7 @@ Returns an array with the given index removed.
      - * **array** - an array
        * **pos** - the position to remove (0 based)
    * - Examples
-     - * array_remove_at(array(1,2,3),1) → [ 1, 3 ]
+     - * ``array_remove_at(array(1,2,3),1)`` → [ 1, 3 ]
 
 
 .. end_array_remove_at_section
@@ -434,7 +434,7 @@ Returns the given array with array values in reversed order.
    * - Arguments
      - * **array** - an array
    * - Examples
-     - * array_reverse(array(2,4,0,10)) → [ 10, 0, 4, 2 ]
+     - * ``array_reverse(array(2,4,0,10))`` → [ 10, 0, 4, 2 ]
 
 
 .. end_array_reverse_section
@@ -458,14 +458,14 @@ Returns a portion of the array. The slice is defined by the start_pos and end_po
        * **start_pos** - the index of the start position of the slice (0 based). The start_pos index is included in the slice. If you use a negative start_pos, the index is counted from the end of the list (-1 based).
        * **end_pos** - the index of the end position of the slice (0 based). The end_pos index is included in the slice. If you use a negative end_pos, the index is counted from the end of the list (-1 based).
    * - Examples
-     - * array_slice(array(1,2,3,4,5),0,3) → [ 1, 2, 3, 4 ]
-       * array_slice(array(1,2,3,4,5),0,-1) → [ 1, 2, 3, 4, 5 ]
-       * array_slice(array(1,2,3,4,5),-5,-1) → [ 1, 2, 3, 4, 5 ]
-       * array_slice(array(1,2,3,4,5),0,0) → [ 1 ]
-       * array_slice(array(1,2,3,4,5),-2,-1) → [ 4, 5 ]
-       * array_slice(array(1,2,3,4,5),-1,-1) → [ 5 ]
-       * array_slice(array('Dufour','Valmiera','Chugiak','Brighton'),1,2) → [ 'Valmiera', 'Chugiak' ]
-       * array_slice(array_slice(array('Dufour','Valmiera','Chugiak','Brighton'),-2,-1) → [ 'Chugiak', 'Brighton' ]
+     - * ``array_slice(array(1,2,3,4,5),0,3)`` → [ 1, 2, 3, 4 ]
+       * ``array_slice(array(1,2,3,4,5),0,-1)`` → [ 1, 2, 3, 4, 5 ]
+       * ``array_slice(array(1,2,3,4,5),-5,-1)`` → [ 1, 2, 3, 4, 5 ]
+       * ``array_slice(array(1,2,3,4,5),0,0)`` → [ 1 ]
+       * ``array_slice(array(1,2,3,4,5),-2,-1)`` → [ 4, 5 ]
+       * ``array_slice(array(1,2,3,4,5),-1,-1)`` → [ 5 ]
+       * ``array_slice(array('Dufour','Valmiera','Chugiak','Brighton'),1,2)`` → [ 'Valmiera', 'Chugiak' ]
+       * ``array_slice(array_slice(array('Dufour','Valmiera','Chugiak','Brighton'),-2,-1)`` → [ 'Chugiak', 'Brighton' ]
 
 
 .. end_array_slice_section
@@ -490,7 +490,7 @@ Returns the provided array with its elements sorted.
      - * **array** - an array
        * **ascending** - set this parameter to false to sort the array in descending order
    * - Examples
-     - * array_sort(array(3,2,1)) → [ 1, 2, 3 ]
+     - * ``array_sort(array(3,2,1))`` → [ 1, 2, 3 ]
 
 
 .. end_array_sort_section
@@ -516,9 +516,9 @@ Concatenates array elements into a string separated by a delimiter and using opt
        * **delimiter** - the string delimiter used to separate concatenated array elements
        * **empty_value** - the optional string to use as replacement for empty (zero length) matches
    * - Examples
-     - * array_to_string(array('1','2','3')) → '1,2,3'
-       * array_to_string(array(1,2,3),'-') → '1-2-3'
-       * array_to_string(array('1','','3'),',','0') → '1,0,3'
+     - * ``array_to_string(array('1','2','3'))`` → '1,2,3'
+       * ``array_to_string(array(1,2,3),'-')`` → '1-2-3'
+       * ``array_to_string(array('1','','3'),',','0')`` → '1,0,3'
 
 
 .. end_array_to_string_section
@@ -544,8 +544,8 @@ Creates an array containing a sequence of numbers.
        * **stop** - value that ends the sequence once reached
        * **step** - value used as the increment between values
    * - Examples
-     - * generate_series(1,5) → [ 1, 2, 3, 4, 5 ]
-       * generate_series(5,1,-1) → [ 5, 4, 3, 2, 1 ]
+     - * ``generate_series(1,5)`` → [ 1, 2, 3, 4, 5 ]
+       * ``generate_series(5,1,-1)`` → [ 5, 4, 3, 2, 1 ]
 
 
 .. end_generate_series_section
@@ -571,8 +571,8 @@ Returns an array of all strings captured by capturing groups, in the order the g
        * **regex** - the regular expression used to capture groups
        * **empty_value** - the optional string to use as replacement for empty (zero length) matches
    * - Examples
-     - * regexp_matches('QGIS=>rocks','(.*)=>(.*)') → [ 'QGIS', 'rocks' ]
-       * regexp_matches('key=>','(.*)=>(.*)','empty value') → [ 'key', 'empty value' ]
+     - * ``regexp_matches('QGIS=>rocks','(.*)=>(.*)')`` → [ 'QGIS', 'rocks' ]
+       * ``regexp_matches('key=>','(.*)=>(.*)','empty value')`` → [ 'key', 'empty value' ]
 
 
 .. end_regexp_matches_section
@@ -598,8 +598,8 @@ Splits string into an array using supplied delimiter and optional string for emp
        * **delimiter** - the string delimiter used to split the input string
        * **empty_value** - the optional string to use as replacement for empty (zero length) matches
    * - Examples
-     - * string_to_array('1,2,3',',') → [ '1', '2', '3' ]
-       * string_to_array('1,,3',',','0') → [ '1', '0', '3' ]
+     - * ``string_to_array('1,2,3',',')`` → [ '1', '2', '3' ]
+       * ``string_to_array('1,,3',',','0')`` → [ '1', '0', '3' ]
 
 
 .. end_string_to_array_section

--- a/docs/user_manual/working_with_vector/expression_help/Color.rst
+++ b/docs/user_manual/working_with_vector/expression_help/Color.rst
@@ -26,7 +26,7 @@ Returns a string representation of a color based on its cyan, magenta, yellow an
        * **yellow** - yellow component of the color, as a percentage integer value from 0 to 100
        * **black** - black component of the color, as a percentage integer value from 0 to 100
    * - Examples
-     - * color_cmyk(100,50,0,10) → '0,115,230'
+     - * ``color_cmyk(100,50,0,10)`` → '0,115,230'
 
 
 .. end_color_cmyk_section
@@ -52,7 +52,7 @@ Returns a string representation of a color based on its cyan, magenta, yellow, b
        * **black** - black component of the color, as a percentage integer value from 0 to 100
        * **alpha** - alpha component as an integer value from 0 (completely transparent) to 255 (opaque).
    * - Examples
-     - * color_cmyk(100,50,0,10,200) → '0,115,230,200'
+     - * ``color_cmyk(100,50,0,10,200)`` → '0,115,230,200'
 
 
 .. end_color_cmyka_section
@@ -74,7 +74,7 @@ Applies a grayscale filter and returns a string representation from a provided c
    * - Arguments
      - * **color** - a color string
    * - Examples
-     - * color_grayscale_average('255,100,50') → '135,135,135,255'
+     - * ``color_grayscale_average('255,100,50')`` → '135,135,135,255'
 
 
 .. end_color_grayscale_average_section
@@ -98,7 +98,7 @@ Returns a string representation of a color based on its hue, saturation, and lig
        * **saturation** - saturation percentage of the color as an integer value from 0 to 100
        * **lightness** - lightness percentage of the color as an integer value from 0 to 100
    * - Examples
-     - * color_hsl(100,50,70) → '166,217,140'
+     - * ``color_hsl(100,50,70)`` → '166,217,140'
 
 
 .. end_color_hsl_section
@@ -123,7 +123,7 @@ Returns a string representation of a color based on its hue, saturation, lightne
        * **lightness** - lightness percentage of the color as an integer value from 0 to 100
        * **alpha** - alpha component as an integer value from 0 (completely transparent) to 255 (opaque).
    * - Examples
-     - * color_hsla(100,50,70,200) → '166,217,140,200'
+     - * ``color_hsla(100,50,70,200)`` → '166,217,140,200'
 
 
 .. end_color_hsla_section
@@ -147,7 +147,7 @@ Returns a string representation of a color based on its hue, saturation, and val
        * **saturation** - saturation percentage of the color as an integer value from 0 to 100
        * **value** - value percentage of the color as an integer from 0 to 100
    * - Examples
-     - * color_hsv(40,100,100) → '255,170,0'
+     - * ``color_hsv(40,100,100)`` → '255,170,0'
 
 
 .. end_color_hsv_section
@@ -172,7 +172,7 @@ Returns a string representation of a color based on its hue, saturation, value a
        * **value** - value percentage of the color as an integer from 0 to 100
        * **alpha** - alpha component as an integer value from 0 (completely transparent) to 255 (opaque)
    * - Examples
-     - * color_hsva(40,100,100,200) → '255,170,0,200'
+     - * ``color_hsva(40,100,100,200)`` → '255,170,0,200'
 
 
 .. end_color_hsva_section
@@ -196,7 +196,7 @@ Returns a string representing a color mixing the red, green, blue, and alpha val
        * **color2** - a color string
        * **ratio** - a ratio
    * - Examples
-     - * color_mix_rgb('0,0,0','255,255,255',0.5) → '127,127,127,255'
+     - * ``color_mix_rgb('0,0,0','255,255,255',0.5)`` → '127,127,127,255'
 
 
 .. end_color_mix_rgb_section
@@ -238,7 +238,7 @@ Returns a specific component from a color string, e.g., the red component or alp
          
 
    * - Examples
-     - * color_part('200,10,30','green') → 10
+     - * ``color_part('200,10,30','green')`` → 10
 
 
 .. end_color_part_section
@@ -262,7 +262,7 @@ Returns a string representation of a color based on its red, green, and blue com
        * **green** - green component as an integer value from 0 to 255
        * **blue** - blue component as an integer value from 0 to 255
    * - Examples
-     - * color_rgb(255,127,0) → '255,127,0'
+     - * ``color_rgb(255,127,0)`` → '255,127,0'
 
 
 .. end_color_rgb_section
@@ -287,7 +287,7 @@ Returns a string representation of a color based on its red, green, blue, and al
        * **blue** - blue component as an integer value from 0 to 255
        * **alpha** - alpha component as an integer value from 0 (completely transparent) to 255 (opaque).
    * - Examples
-     - * color_rgba(255,127,0,200) → '255,127,0,200'
+     - * ``color_rgba(255,127,0,200)`` → '255,127,0,200'
 
 
 .. end_color_rgba_section
@@ -312,7 +312,7 @@ Returns a gradient ramp from a map of color strings and steps.
      - * **map** - a map of color strings and steps
        * **discrete** - set this parameter to true to create a discrete color ramp
    * - Examples
-     - * ramp_color(create_ramp(map(0,'0,0,0',1,'255,0,0')),1) → '255,0,0,255'
+     - * ``ramp_color(create_ramp(map(0,'0,0,0',1,'255,0,0')),1)`` → '255,0,0,255'
 
 
 .. end_create_ramp_section
@@ -341,7 +341,7 @@ Returns a darker (or lighter) color string
          
 
    * - Examples
-     - * darker('200,10,30',300) → '66,3,10,255'
+     - * ``darker('200,10,30',300)`` → '66,3,10,255'
 
 
 .. end_darker_section
@@ -370,7 +370,7 @@ Returns a lighter (or darker) color string
          
 
    * - Examples
-     - * lighter('200,10,30',200) → '255,158,168,255'
+     - * ``lighter('200,10,30',200)`` → '255,158,168,255'
 
 
 .. end_lighter_section
@@ -392,7 +392,7 @@ Returns a color from the project's color scheme.
    * - Arguments
      - * **name** - a color name
    * - Examples
-     - * project_color('Logo color') → '20,140,50'
+     - * ``project_color('Logo color')`` → '20,140,50'
 
 
 .. end_project_color_section
@@ -419,7 +419,7 @@ Returns a string representing a color from a saved ramp
      - * **ramp_name** - the name of the color ramp as a string, for example 'Spectral'
        * **value** - the position on the ramp to select the color from as a real number between 0 and 1
    * - Examples
-     - * ramp_color('Spectral',0.3) → '253,190,115,255'
+     - * ``ramp_color('Spectral',0.3)`` → '253,190,115,255'
 
 .. note:: The color ramps available vary between QGIS installations. This function may not give the expected results if you move your QGIS project between installations.
 
@@ -437,7 +437,7 @@ Returns a string representing a color from an expression-created ramp
      - * **ramp** - the color ramp
        * **value** - the position on the ramp to select the color from as a real number between 0 and 1
    * - Examples
-     - * ramp_color(create_ramp(map(0,'0,0,0',1,'255,0,0')),1) → '255,0,0,255'
+     - * ``ramp_color(create_ramp(map(0,'0,0,0',1,'255,0,0')),1)`` → '255,0,0,255'
 
 
 .. end_ramp_color_section
@@ -480,7 +480,7 @@ Sets a specific color component for a color string, e.g., the red component or a
 
        * **value** - new value for color component, respecting the ranges listed above
    * - Examples
-     - * set_color_part('200,10,30','green',50) → '200,50,30,255'
+     - * ``set_color_part('200,10,30','green',50)`` → '200,50,30,255'
 
 
 .. end_set_color_part_section

--- a/docs/user_manual/working_with_vector/expression_help/Conditionals.rst
+++ b/docs/user_manual/working_with_vector/expression_help/Conditionals.rst
@@ -39,8 +39,8 @@ END
        * **THEN result** - If *condition* evaluates to True then *result* is evaluated and returned.
        * **ELSE result** - If none of the above conditions evaluated to True then *result* is evaluated and returned.
    * - Examples
-     - * CASE WHEN "name" IS NULL THEN 'None' END →  Returns the string 'none' if the "name" field is NULL
-       * CASE WHEN $area > 10000 THEN 'Big property' WHEN $area > 5000 THEN 'Medium property' ELSE 'Small property' END →  Returns the string 'Big property' if the area is bigger than 10000, 'Medium property' if the area is between 5000 and 10000, and 'Small property' for others
+     - * ``CASE WHEN "name" IS NULL THEN 'None' END`` →  Returns the string 'none' if the "name" field is NULL
+       * ``CASE WHEN $area > 10000 THEN 'Big property' WHEN $area > 5000 THEN 'Medium property' ELSE 'Small property' END`` →  Returns the string 'Big property' if the area is bigger than 10000, 'Medium property' if the area is between 5000 and 10000, and 'Small property' for others
 
 
 .. end_CASE_section
@@ -64,10 +64,10 @@ This function can take any number of arguments.
    * - Arguments
      - * **expression** - any valid expression or value, regardless of type.
    * - Examples
-     - * coalesce(NULL, 2) → 2
-       * coalesce(NULL, 2, 3) → 2
-       * coalesce(7, NULL, 3*2) → 7
-       * coalesce("fieldA", "fallbackField", 'ERROR') → value of fieldA if it is non-NULL else the value of "fallbackField" or the string 'ERROR' if both are NULL
+     - * ``coalesce(NULL, 2)`` → 2
+       * ``coalesce(NULL, 2, 3)`` → 2
+       * ``coalesce(7, NULL, 3*2)`` → 7
+       * ``coalesce("fieldA", "fallbackField", 'ERROR')`` → value of fieldA if it is non-NULL else the value of "fallbackField" or the string 'ERROR' if both are NULL
 
 
 .. end_coalesce_section
@@ -91,13 +91,13 @@ Tests a condition and returns a different result depending on the conditional ch
        * **result_when_true** - the result which will be returned when the condition is true or another value that does not convert to false.
        * **result_when_false** - the result which will be returned when the condition is false or another value that converts to false like 0 or ''. NULL will also be converted to false.
    * - Examples
-     - * if( 1+1=2, 'Yes', 'No' ) → 'Yes'
-       * if( 1+1=3, 'Yes', 'No' ) → 'No'
-       * if( 5 > 3, 1, 0) → 1
-       * if( '', 'It is true (not empty)', 'It is false (empty)' ) → 'It is false (empty)'
-       * if( ' ', 'It is true (not empty)', 'It is false (empty)' ) → 'It is true (not empty)'
-       * if( 0, 'One', 'Zero' ) → 'Zero'
-       * if( 10, 'One', 'Zero' ) → 'One'
+     - * ``if( 1+1=2, 'Yes', 'No' )`` → 'Yes'
+       * ``if( 1+1=3, 'Yes', 'No' )`` → 'No'
+       * ``if( 5 > 3, 1, 0)`` → 1
+       * ``if( '', 'It is true (not empty)', 'It is false (empty)' )`` → 'It is false (empty)'
+       * ``if( ' ', 'It is true (not empty)', 'It is false (empty)' )`` → 'It is true (not empty)'
+       * ``if( 0, 'One', 'Zero' )`` → 'Zero'
+       * ``if( 10, 'One', 'Zero' )`` → 'One'
 
 
 .. end_if_section
@@ -120,9 +120,9 @@ Returns a NULL value if value1 equals value2; otherwise it returns value1. This 
      - * **value1** - The value that should either be used or substituted with NULL.
        * **value2** - The control value that will trigger the NULL substitution.
    * - Examples
-     - * nullif('(none)', '(none)') → NULL
-       * nullif('text', '(none)') → 'text'
-       * nullif("name", '') → NULL, if name is an empty string (or already NULL), the name in any other case.
+     - * ``nullif('(none)', '(none)')`` → NULL
+       * ``nullif('text', '(none)')`` → 'text'
+       * ``nullif("name", '')`` → NULL, if name is an empty string (or already NULL), the name in any other case.
 
 
 .. end_nullif_section
@@ -145,7 +145,7 @@ Return the first matching position matching a regular expression within a string
      - * **input_string** - the string to test against the regular expression
        * **regex** - The regular expression to test against. Backslash characters must be double escaped (e.g., "\\\\s" to match a white space character).
    * - Examples
-     - * regexp_match('QGIS ROCKS','\\\\sROCKS') → 4
+     - * ``regexp_match('QGIS ROCKS','\\\\sROCKS')`` → 4
 
 
 .. end_regexp_match_section
@@ -170,9 +170,9 @@ Tries an expression and returns its value if error-free. If the expression retur
      - * **expression** - the expression which should be run
        * **alternative** - the result which will be returned if the expression returns an error.
    * - Examples
-     - * try( to_int( '1' ), 0 ) → 1
-       * try( to_int( 'a' ), 0 ) → 0
-       * try( to_date( 'invalid_date' ) ) → NULL
+     - * ``try( to_int( '1' ), 0 )`` → 1
+       * ``try( to_int( 'a' ), 0 )`` → 0
+       * ``try( to_date( 'invalid_date' ) )`` → NULL
 
 
 .. end_try_section

--- a/docs/user_manual/working_with_vector/expression_help/Conversions.rst
+++ b/docs/user_manual/working_with_vector/expression_help/Conversions.rst
@@ -23,7 +23,7 @@ Decodes a string in the Base64 encoding into a binary value.
    * - Arguments
      - * **string** - the string to decode
    * - Examples
-     - * from_base64('UUdJUw==') → 'QGIS'
+     - * ``from_base64('UUdJUw==')`` → 'QGIS'
 
 
 .. end_from_base64_section
@@ -46,21 +46,21 @@ Creates a hash from a string with a given method. One byte (8 bits) is represent
      - * **string** - the string to hash
        * **method** - The hash method among 'md4', 'md5', 'sha1', 'sha224', 'sha384', 'sha512', 'sha3_224', 'sha3_256', 'sha3_384', 'sha3_512', 'keccak_224', 'keccak_256', 'keccak_384', 'keccak_512'
    * - Examples
-     - * hash('QGIS', md4) → 'c0fc71c241cdebb6e888cbac0e2b68eb'
-       * hash('QGIS', md5) → '57470aaa9e22adaefac7f5f342f1c6da'
-       * hash('QGIS', sha1) → 'f87cfb2b74cdd5867db913237024e7001e62b114'
-       * hash('QGIS', sha224) → '4093a619ada631c770f44bc643ead18fb393b93d6a6af1861fcfece0'
-       * hash('QGIS', sha256) → 'eb045cba7a797aaa06ac58830846e40c8e8c780bc0676d3393605fae50c05309'
-       * hash('QGIS', sha384) → '91c1de038cc3d09fdd512e99f9dd9922efadc39ed21d3922e69a4305cc25506033aee388e554b78714c8734f9cd7e610'
-       * hash('QGIS', sha512) → 'c2c092f2ab743bf8edbeb6d028a745f30fc720408465ed369421f0a4e20fa5e27f0c90ad72d3f1d836eaa5d25cd39897d4cf77e19984668ef58da6e3159f18ac'
-       * hash('QGIS', sha3_224) → '467f49a5039e7280d5d42fd433e80d203439e338eaabd701f0d6c17d'
-       * hash('QGIS', sha3_256) → '540f7354b6b8a6e735f2845250f15f4f3ba4f666c55574d9e9354575de0e980f'
-       * hash('QGIS', sha3_384) → '96052da1e77679e9a65f60d7ead961b287977823144786386eb43647b0901fd8516fa6f1b9d243fb3f28775e6dde6107'
-       * hash('QGIS', sha3_512) → '900d079dc69761da113980253aa8ac0414a8bd6d09879a916228f8743707c4758051c98445d6b8945ec854ff90655005e02aceb0a2ffc6a0ebf818745d665349'
-       * hash('QGIS', keccak_224) → '5b0ce6acef8b0a121d4ac4f3eaa8503c799ad4e26a3392d1fb201478'
-       * hash('QGIS', keccak_256) → '991c520aa6815392de24087f61b2ae0fd56abbfeee4a8ca019c1011d327c577e'
-       * hash('QGIS', keccak_384) → 'c57a3aed9d856fa04e5eeee9b62b6e027cca81ba574116d3cc1f0d48a1ef9e5886ff463ea8d0fac772ee473bf92f810d'
-       * keccak_512('QGIS') → '6f0f751776b505e317de222508fa5d3ed7099d8f07c74fed54ccee6e7cdc6b89b4a085e309f2ee5210c9'
+     - * ``hash('QGIS', md4)`` → 'c0fc71c241cdebb6e888cbac0e2b68eb'
+       * ``hash('QGIS', md5)`` → '57470aaa9e22adaefac7f5f342f1c6da'
+       * ``hash('QGIS', sha1)`` → 'f87cfb2b74cdd5867db913237024e7001e62b114'
+       * ``hash('QGIS', sha224)`` → '4093a619ada631c770f44bc643ead18fb393b93d6a6af1861fcfece0'
+       * ``hash('QGIS', sha256)`` → 'eb045cba7a797aaa06ac58830846e40c8e8c780bc0676d3393605fae50c05309'
+       * ``hash('QGIS', sha384)`` → '91c1de038cc3d09fdd512e99f9dd9922efadc39ed21d3922e69a4305cc25506033aee388e554b78714c8734f9cd7e610'
+       * ``hash('QGIS', sha512)`` → 'c2c092f2ab743bf8edbeb6d028a745f30fc720408465ed369421f0a4e20fa5e27f0c90ad72d3f1d836eaa5d25cd39897d4cf77e19984668ef58da6e3159f18ac'
+       * ``hash('QGIS', sha3_224)`` → '467f49a5039e7280d5d42fd433e80d203439e338eaabd701f0d6c17d'
+       * ``hash('QGIS', sha3_256)`` → '540f7354b6b8a6e735f2845250f15f4f3ba4f666c55574d9e9354575de0e980f'
+       * ``hash('QGIS', sha3_384)`` → '96052da1e77679e9a65f60d7ead961b287977823144786386eb43647b0901fd8516fa6f1b9d243fb3f28775e6dde6107'
+       * ``hash('QGIS', sha3_512)`` → '900d079dc69761da113980253aa8ac0414a8bd6d09879a916228f8743707c4758051c98445d6b8945ec854ff90655005e02aceb0a2ffc6a0ebf818745d665349'
+       * ``hash('QGIS', keccak_224)`` → '5b0ce6acef8b0a121d4ac4f3eaa8503c799ad4e26a3392d1fb201478'
+       * ``hash('QGIS', keccak_256)`` → '991c520aa6815392de24087f61b2ae0fd56abbfeee4a8ca019c1011d327c577e'
+       * ``hash('QGIS', keccak_384)`` → 'c57a3aed9d856fa04e5eeee9b62b6e027cca81ba574116d3cc1f0d48a1ef9e5886ff463ea8d0fac772ee473bf92f810d'
+       * ``keccak_512('QGIS')`` → '6f0f751776b505e317de222508fa5d3ed7099d8f07c74fed54ccee6e7cdc6b89b4a085e309f2ee5210c9'
 
 
 .. end_hash_section
@@ -82,7 +82,7 @@ Creates a md5 hash from a string.
    * - Arguments
      - * **string** - the string to hash
    * - Examples
-     - * md5('QGIS') → '57470aaa9e22adaefac7f5f342f1c6da'
+     - * ``md5('QGIS')`` → '57470aaa9e22adaefac7f5f342f1c6da'
 
 
 .. end_md5_section
@@ -104,7 +104,7 @@ Creates a sha256 hash from a string.
    * - Arguments
      - * **string** - the string to hash
    * - Examples
-     - * sha256('QGIS') → 'eb045cba7a797aaa06ac58830846e40c8e8c780bc0676d3393605fae50c05309'
+     - * ``sha256('QGIS')`` → 'eb045cba7a797aaa06ac58830846e40c8e8c780bc0676d3393605fae50c05309'
 
 
 .. end_sha256_section
@@ -126,7 +126,7 @@ Encodes a binary value into a string, using the Base64 encoding.
    * - Arguments
      - * **value** - the binary value to encode
    * - Examples
-     - * to_base64('QGIS') → 'UUdJUw=='
+     - * ``to_base64('QGIS')`` → 'UUdJUw=='
 
 
 .. end_to_base64_section
@@ -152,9 +152,9 @@ Converts a string into a date object. An optional format string can be provided 
        * **format** - format used to convert the string into a date
        * **language** - language (lowercase, two- or three-letter, ISO 639 language code) used to convert the string into a date
    * - Examples
-     - * to_date('2012-05-04') → 2012-05-04
-       * to_date('June 29, 2019','MMMM d, yyyy') → 2019-06-29
-       * to_date('29 juin, 2019','d MMMM, yyyy','fr') → 2019-06-29
+     - * ``to_date('2012-05-04')`` → 2012-05-04
+       * ``to_date('June 29, 2019','MMMM d, yyyy')`` → 2019-06-29
+       * ``to_date('29 juin, 2019','d MMMM, yyyy','fr')`` → 2019-06-29
 
 
 .. end_to_date_section
@@ -180,9 +180,9 @@ Converts a string into a datetime object. An optional format string can be provi
        * **format** - format used to convert the string into a datetime
        * **language** - language (lowercase, two- or three-letter, ISO 639 language code) used to convert the string into a datetime
    * - Examples
-     - * to_datetime('2012-05-04 12:50:00') → 2012-05-04T12:50:00
-       * to_datetime('June 29, 2019 @ 12:34','MMMM d, yyyy @ HH:mm') → 2019-06-29T12:34
-       * to_datetime('29 juin, 2019 @ 12:34','d MMMM, yyyy @ HH:mm','fr') → 2019-06-29T12:34
+     - * ``to_datetime('2012-05-04 12:50:00')`` → 2012-05-04T12:50:00
+       * ``to_datetime('June 29, 2019 @ 12:34','MMMM d, yyyy @ HH:mm')`` → 2019-06-29T12:34
+       * ``to_datetime('29 juin, 2019 @ 12:34','d MMMM, yyyy @ HH:mm','fr')`` → 2019-06-29T12:34
 
 
 .. end_to_datetime_section
@@ -204,7 +204,7 @@ Converts a degree, minute, second coordinate to its decimal equivalent.
    * - Arguments
      - * **value** - A degree, minute, second string.
    * - Examples
-     - * to_decimal('6°21\'16.445') → 6.3545680555
+     - * ``to_decimal('6°21\'16.445')`` → 6.3545680555
 
 
 .. end_to_decimal_section
@@ -231,8 +231,8 @@ Convert a coordinate to degree, minute.
        * **precision** - Number of decimals.
        * **formatting** - Designates the formatting type. Acceptable values are NULL, 'aligned' or 'suffix'.
    * - Examples
-     - * to_dm(6.3545681, 'x', 3) → 6°21.274′
-       * to_dm(6.3545681, 'y', 4, 'suffix') → 6°21.2741′N
+     - * ``to_dm(6.3545681, 'x', 3)`` → 6°21.274′
+       * ``to_dm(6.3545681, 'y', 4, 'suffix')`` → 6°21.2741′N
 
 
 .. end_to_dm_section
@@ -259,8 +259,8 @@ Convert a coordinate to degree, minute, second.
        * **precision** - Number of decimals.
        * **formatting** - Designates the formatting type. Acceptable values are NULL, 'aligned' or 'suffix'.
    * - Examples
-     - * to_dms(6.3545681, 'x', 3) → 6°21′16.445″
-       * to_dms(6.3545681, 'y', 4, 'suffix') → 6°21′16.4452″N
+     - * ``to_dms(6.3545681, 'x', 3)`` → 6°21′16.445″
+       * ``to_dms(6.3545681, 'y', 4, 'suffix')`` → 6°21′16.4452″N
 
 
 .. end_to_dms_section
@@ -282,7 +282,7 @@ Converts a string to integer number. Nothing is returned if a value cannot be co
    * - Arguments
      - * **string** - string to convert to integer number
    * - Examples
-     - * to_int('123') → 123
+     - * ``to_int('123')`` → 123
 
 
 .. end_to_int_section
@@ -304,7 +304,7 @@ Converts a string to a interval type. Can be used to take days, hours, month, et
    * - Arguments
      - * **string** - a string representing an interval. Allowable formats include {n} days {n} hours {n} months.
    * - Examples
-     - * to_datetime('2012-05-05 12:00:00') - to_interval('1 day 2 hours') → 2012-05-04T10:00:00
+     - * ``to_datetime('2012-05-05 12:00:00') - to_interval('1 day 2 hours')`` → 2012-05-04T10:00:00
 
 
 .. end_to_interval_section
@@ -326,7 +326,7 @@ Converts a string to a real number. Nothing is returned if a value cannot be con
    * - Arguments
      - * **string** - string to convert to real number
    * - Examples
-     - * to_real('123.45') → 123.45
+     - * ``to_real('123.45')`` → 123.45
 
 
 .. end_to_real_section
@@ -348,7 +348,7 @@ Converts a number to string.
    * - Arguments
      - * **number** - Integer or real value. The number to convert to string.
    * - Examples
-     - * to_string(123) → '123'
+     - * ``to_string(123)`` → '123'
 
 
 .. end_to_string_section
@@ -374,9 +374,9 @@ Converts a string into a time object. An optional format string can be provided 
        * **format** - format used to convert the string into a time
        * **language** - language (lowercase, two- or three-letter, ISO 639 language code) used to convert the string into a time
    * - Examples
-     - * to_time('12:30:01') → 12:30:01
-       * to_time('12:34','HH:mm') → 12:34:00
-       * to_time('12:34','HH:mm','fr') → 12:34:00
+     - * ``to_time('12:30:01')`` → 12:30:01
+       * ``to_time('12:34','HH:mm')`` → 12:34:00
+       * ``to_time('12:34','HH:mm','fr')`` → 12:34:00
 
 
 .. end_to_time_section

--- a/docs/user_manual/working_with_vector/expression_help/Date_and_Time.rst
+++ b/docs/user_manual/working_with_vector/expression_help/Date_and_Time.rst
@@ -38,8 +38,8 @@ The difference is returned as an ``Interval`` and needs to be used with one of t
      - * **datetime1** - a string, date or datetime representing the later date
        * **datetime2** - a string, date or datetime representing the earlier date
    * - Examples
-     - * day(age('2012-05-12','2012-05-02')) → 10
-       * hour(age('2012-05-12','2012-05-02')) → 240
+     - * ``day(age('2012-05-12','2012-05-02'))`` → 10
+       * ``hour(age('2012-05-12','2012-05-02'))`` → 240
 
 
 .. end_age_section
@@ -61,7 +61,7 @@ Returns a datetime whose date and time are the number of milliseconds, msecs, th
    * - Arguments
      - * **int** - number (milliseconds)
    * - Examples
-     - * datetime_from_epoch(1483225200000) → 2017-01-01T00:00:00
+     - * ``datetime_from_epoch(1483225200000)`` → 2017-01-01T00:00:00
 
 
 .. end_datetime_from_epoch_section
@@ -87,7 +87,7 @@ Extracts the day from a date or datetime.
    * - Arguments
      - * **date** - a date or datetime value
    * - Examples
-     - * day('2012-05-12') → 12
+     - * ``day('2012-05-12')`` → 12
 
 
 **Interval variant**
@@ -102,9 +102,9 @@ Calculates the length in days of an interval.
    * - Arguments
      - * **interval** - interval value to return number of days from
    * - Examples
-     - * day(to_interval('3 days')) → 3
-       * day(to_interval('3 weeks 2 days')) → 23
-       * day(age('2012-01-01','2010-01-01')) → 730
+     - * ``day(to_interval('3 days'))`` → 3
+       * ``day(to_interval('3 weeks 2 days'))`` → 23
+       * ``day(age('2012-01-01','2010-01-01'))`` → 730
 
 
 .. end_day_section
@@ -126,7 +126,7 @@ Returns the day of the week for a specified date or datetime. The returned value
    * - Arguments
      - * **date** - date or datetime value
    * - Examples
-     - * day_of_week(to_date('2015-09-21')) → 1
+     - * ``day_of_week(to_date('2015-09-21'))`` → 1
 
 
 .. end_day_of_week_section
@@ -148,7 +148,7 @@ Returns the interval in milliseconds between the unix epoch and a given date val
    * - Arguments
      - * **date** - a date or datetime value
    * - Examples
-     - * epoch(to_date('2017-01-01')) → 1483203600000
+     - * ``epoch(to_date('2017-01-01'))`` → 1483203600000
 
 
 .. end_epoch_section
@@ -213,8 +213,8 @@ Formats a date type or string into a custom string format. Uses Qt date/time for
 
        * **language** - language (lowercase, two- or three-letter, ISO 639 language code) used to format the date into a custom string
    * - Examples
-     - * format_date('2012-05-15','dd.MM.yyyy') → '15.05.2012'
-       * format_date('2012-05-15','d MMMM yyyy','fr') → '15 juin 2012'
+     - * ``format_date('2012-05-15','dd.MM.yyyy')`` → '15.05.2012'
+       * ``format_date('2012-05-15','d MMMM yyyy','fr')`` → '15 juin 2012'
 
 
 .. end_format_date_section
@@ -240,7 +240,7 @@ Extracts the hour part from a time or datetime.
    * - Arguments
      - * **datetime** - a time or datetime value
    * - Examples
-     - * hour('2012-07-22T13:24:57') → 13
+     - * ``hour('2012-07-22T13:24:57')`` → 13
 
 
 **Interval variant**
@@ -255,9 +255,9 @@ Calculates the length in hours of an interval.
    * - Arguments
      - * **interval** - interval value to return number of hours from
    * - Examples
-     - * hour(tointerval('3 hours')) → 3
-       * hour(age('2012-07-22T13:00:00','2012-07-22T10:00:00')) → 3
-       * hour(age('2012-01-01','2010-01-01')) → 17520
+     - * ``hour(tointerval('3 hours'))`` → 3
+       * ``hour(age('2012-07-22T13:00:00','2012-07-22T10:00:00'))`` → 3
+       * ``hour(age('2012-01-01','2010-01-01'))`` → 17520
 
 
 .. end_hour_section
@@ -281,7 +281,7 @@ Creates a date value from year, month and day numbers.
        * **month** - Month number, where 1=January
        * **day** - Day number, beginning with 1 for the first day in the month
    * - Examples
-     - * make_date(2020,5,4) → date value 2020-05-04
+     - * ``make_date(2020,5,4)`` → date value 2020-05-04
 
 
 .. end_make_date_section
@@ -308,7 +308,7 @@ Creates a datetime value from year, month, day, hour, minute and second numbers.
        * **minute** - Minutes
        * **second** - Seconds (fractional values include milliseconds)
    * - Examples
-     - * make_datetime(2020,5,4,13,45,30.5) → datetime value 2020-05-04 13:45:30.500
+     - * ``make_datetime(2020,5,4,13,45,30.5)`` → datetime value 2020-05-04 13:45:30.500
 
 
 .. end_make_datetime_section
@@ -338,8 +338,8 @@ Creates an interval value from year, month, weeks, days, hours, minute and secon
        * **minutes** - Number of minutes
        * **seconds** - Number of seconds
    * - Examples
-     - * make_interval(hours:=3) → 3 hour interval
-       * make_interval(days:=2, hours:=3) → 2 day, 3 hour interval
+     - * ``make_interval(hours:=3)`` → 3 hour interval
+       * ``make_interval(days:=2, hours:=3)`` → 2 day, 3 hour interval
 
 
 .. end_make_interval_section
@@ -363,7 +363,7 @@ Creates a time value from hour, minute and second numbers.
        * **minute** - Minutes
        * **second** - Seconds (fractional values include milliseconds)
    * - Examples
-     - * make_time(13,45,30.5) → time value 13:45:30.500
+     - * ``make_time(13,45,30.5)`` → time value 13:45:30.500
 
 
 .. end_make_time_section
@@ -389,7 +389,7 @@ Extracts the minutes part from a time or datetime.
    * - Arguments
      - * **datetime** - a time or datetime value
    * - Examples
-     - * minute('2012-07-22T13:24:57') → 24
+     - * ``minute('2012-07-22T13:24:57')`` → 24
 
 
 **Interval variant**
@@ -404,9 +404,9 @@ Calculates the length in minutes of an interval.
    * - Arguments
      - * **interval** - interval value to return number of minutes from
    * - Examples
-     - * minute(tointerval('3 minutes')) → 3
-       * minute(age('2012-07-22T00:20:00','2012-07-22T00:00:00')) → 20
-       * minute(age('2012-01-01','2010-01-01')) → 1051200
+     - * ``minute(tointerval('3 minutes'))`` → 3
+       * ``minute(age('2012-07-22T00:20:00','2012-07-22T00:00:00'))`` → 20
+       * ``minute(age('2012-01-01','2010-01-01'))`` → 1051200
 
 
 .. end_minute_section
@@ -432,7 +432,7 @@ Extracts the month part from a date or datetime.
    * - Arguments
      - * **date** - a date or datetime value
    * - Examples
-     - * month('2012-05-12') → 05
+     - * ``month('2012-05-12')`` → 05
 
 
 **Interval variant**
@@ -447,8 +447,8 @@ Calculates the length in months of an interval.
    * - Arguments
      - * **interval** - interval value to return number of months from
    * - Examples
-     - * month(to_interval('3 months')) → 3
-       * month(age('2012-01-01','2010-01-01')) → 4.03333
+     - * ``month(to_interval('3 months'))`` → 3
+       * ``month(age('2012-01-01','2010-01-01'))`` → 4.03333
 
 
 .. end_month_section
@@ -468,7 +468,7 @@ Returns the current date and time. The function is static and will return consis
    * - Syntax
      - now()
    * - Examples
-     - * now() → 2012-07-22T13:24:57
+     - * ``now()`` → 2012-07-22T13:24:57
 
 
 .. end_now_section
@@ -494,7 +494,7 @@ Extracts the seconds part from a time or datetime.
    * - Arguments
      - * **datetime** - a time or datetime value
    * - Examples
-     - * second('2012-07-22T13:24:57') → 57
+     - * ``second('2012-07-22T13:24:57')`` → 57
 
 
 **Interval variant**
@@ -509,8 +509,8 @@ Calculates the length in seconds of an interval.
    * - Arguments
      - * **interval** - interval value to return number of seconds from
    * - Examples
-     - * second(age('2012-07-22T00:20:00','2012-07-22T00:00:00')) → 1200
-       * second(age('2012-01-01','2010-01-01')) → 63072000
+     - * ``second(age('2012-07-22T00:20:00','2012-07-22T00:00:00'))`` → 1200
+       * ``second(age('2012-01-01','2010-01-01'))`` → 63072000
 
 
 .. end_second_section
@@ -536,9 +536,9 @@ Converts a string into a date object. An optional format string can be provided 
        * **format** - format used to convert the string into a date
        * **language** - language (lowercase, two- or three-letter, ISO 639 language code) used to convert the string into a date
    * - Examples
-     - * to_date('2012-05-04') → 2012-05-04
-       * to_date('June 29, 2019','MMMM d, yyyy') → 2019-06-29
-       * to_date('29 juin, 2019','d MMMM, yyyy','fr') → 2019-06-29
+     - * ``to_date('2012-05-04')`` → 2012-05-04
+       * ``to_date('June 29, 2019','MMMM d, yyyy')`` → 2019-06-29
+       * ``to_date('29 juin, 2019','d MMMM, yyyy','fr')`` → 2019-06-29
 
 
 .. end_to_date_section
@@ -564,9 +564,9 @@ Converts a string into a datetime object. An optional format string can be provi
        * **format** - format used to convert the string into a datetime
        * **language** - language (lowercase, two- or three-letter, ISO 639 language code) used to convert the string into a datetime
    * - Examples
-     - * to_datetime('2012-05-04 12:50:00') → 2012-05-04T12:50:00
-       * to_datetime('June 29, 2019 @ 12:34','MMMM d, yyyy @ HH:mm') → 2019-06-29T12:34
-       * to_datetime('29 juin, 2019 @ 12:34','d MMMM, yyyy @ HH:mm','fr') → 2019-06-29T12:34
+     - * ``to_datetime('2012-05-04 12:50:00')`` → 2012-05-04T12:50:00
+       * ``to_datetime('June 29, 2019 @ 12:34','MMMM d, yyyy @ HH:mm')`` → 2019-06-29T12:34
+       * ``to_datetime('29 juin, 2019 @ 12:34','d MMMM, yyyy @ HH:mm','fr')`` → 2019-06-29T12:34
 
 
 .. end_to_datetime_section
@@ -588,7 +588,7 @@ Converts a string to a interval type. Can be used to take days, hours, month, et
    * - Arguments
      - * **string** - a string representing an interval. Allowable formats include {n} days {n} hours {n} months.
    * - Examples
-     - * to_datetime('2012-05-05 12:00:00') - to_interval('1 day 2 hours') → 2012-05-04T10:00:00
+     - * ``to_datetime('2012-05-05 12:00:00') - to_interval('1 day 2 hours')`` → 2012-05-04T10:00:00
 
 
 .. end_to_interval_section
@@ -614,9 +614,9 @@ Converts a string into a time object. An optional format string can be provided 
        * **format** - format used to convert the string into a time
        * **language** - language (lowercase, two- or three-letter, ISO 639 language code) used to convert the string into a time
    * - Examples
-     - * to_time('12:30:01') → 12:30:01
-       * to_time('12:34','HH:mm') → 12:34:00
-       * to_time('12:34','HH:mm','fr') → 12:34:00
+     - * ``to_time('12:30:01')`` → 12:30:01
+       * ``to_time('12:34','HH:mm')`` → 12:34:00
+       * ``to_time('12:34','HH:mm','fr')`` → 12:34:00
 
 
 .. end_to_time_section
@@ -642,7 +642,7 @@ Extracts the week number from a date or datetime.
    * - Arguments
      - * **date** - a date or datetime value
    * - Examples
-     - * week('2012-05-12') → 19
+     - * ``week('2012-05-12')`` → 19
 
 
 **Interval variant**
@@ -657,8 +657,8 @@ Calculates the length in weeks of an interval.
    * - Arguments
      - * **interval** - interval value to return number of months from
    * - Examples
-     - * week(to_interval('3 weeks')) → 3
-       * week(age('2012-01-01','2010-01-01')) → 104.285
+     - * ``week(to_interval('3 weeks'))`` → 3
+       * ``week(age('2012-01-01','2010-01-01'))`` → 104.285
 
 
 .. end_week_section
@@ -684,7 +684,7 @@ Extracts the year part from a date or datetime.
    * - Arguments
      - * **date** - a date or datetime value
    * - Examples
-     - * year('2012-05-12') → 2012
+     - * ``year('2012-05-12')`` → 2012
 
 
 **Interval variant**
@@ -699,8 +699,8 @@ Calculates the length in years of an interval.
    * - Arguments
      - * **interval** - interval value to return number of years from
    * - Examples
-     - * year(to_interval('3 years')) → 3
-       * year(age('2012-01-01','2010-01-01')) → 1.9986
+     - * ``year(to_interval('3 years'))`` → 3
+       * ``year(age('2012-01-01','2010-01-01'))`` → 1.9986
 
 
 .. end_year_section

--- a/docs/user_manual/working_with_vector/expression_help/Files_and_Paths.rst
+++ b/docs/user_manual/working_with_vector/expression_help/Files_and_Paths.rst
@@ -23,7 +23,7 @@ Returns the base name of the file without the directory or file suffix.
    * - Arguments
      - * **path** - a file path
    * - Examples
-     - * base_file_name('/home/qgis/data/country_boundaries.shp') → 'country_boundaries'
+     - * ``base_file_name('/home/qgis/data/country_boundaries.shp')`` → 'country_boundaries'
 
 
 .. end_base_file_name_section
@@ -45,7 +45,7 @@ Returns true if a file path exists.
    * - Arguments
      - * **path** - a file path
    * - Examples
-     - * file_exists('/home/qgis/data/country_boundaries.shp') → true
+     - * ``file_exists('/home/qgis/data/country_boundaries.shp')`` → true
 
 
 .. end_file_exists_section
@@ -67,7 +67,7 @@ Returns the name of a file (including the file extension), excluding the directo
    * - Arguments
      - * **path** - a file path
    * - Examples
-     - * file_name('/home/qgis/data/country_boundaries.shp') → 'country_boundaries.shp'
+     - * ``file_name('/home/qgis/data/country_boundaries.shp')`` → 'country_boundaries.shp'
 
 
 .. end_file_name_section
@@ -89,7 +89,7 @@ Returns the directory component of a file path. This does not include the file n
    * - Arguments
      - * **path** - a file path
    * - Examples
-     - * file_path('/home/qgis/data/country_boundaries.shp') → '/home/qgis/data'
+     - * ``file_path('/home/qgis/data/country_boundaries.shp')`` → '/home/qgis/data'
 
 
 .. end_file_path_section
@@ -111,7 +111,7 @@ Returns the size (in bytes) of a file.
    * - Arguments
      - * **path** - a file path
    * - Examples
-     - * file_size('/home/qgis/data/country_boundaries.geojson') → 5674
+     - * ``file_size('/home/qgis/data/country_boundaries.geojson')`` → 5674
 
 
 .. end_file_size_section
@@ -133,7 +133,7 @@ Returns the file suffix (extension) from a file path.
    * - Arguments
      - * **path** - a file path
    * - Examples
-     - * file_suffix('/home/qgis/data/country_boundaries.shp') → 'shp'
+     - * ``file_suffix('/home/qgis/data/country_boundaries.shp')`` → 'shp'
 
 
 .. end_file_suffix_section
@@ -155,8 +155,8 @@ Returns true if a path corresponds to a directory.
    * - Arguments
      - * **path** - a file path
    * - Examples
-     - * is_directory('/home/qgis/data/country_boundaries.shp') → false
-       * is_directory('/home/qgis/data/') → true
+     - * ``is_directory('/home/qgis/data/country_boundaries.shp')`` → false
+       * ``is_directory('/home/qgis/data/')`` → true
 
 
 .. end_is_directory_section
@@ -178,8 +178,8 @@ Returns true if a path corresponds to a file.
    * - Arguments
      - * **path** - a file path
    * - Examples
-     - * is_file('/home/qgis/data/country_boundaries.shp') → true
-       * is_file('/home/qgis/data/') → false
+     - * ``is_file('/home/qgis/data/country_boundaries.shp')`` → true
+       * ``is_file('/home/qgis/data/')`` → false
 
 
 .. end_is_file_section

--- a/docs/user_manual/working_with_vector/expression_help/Form.rst
+++ b/docs/user_manual/working_with_vector/expression_help/Form.rst
@@ -23,7 +23,7 @@ Only usable in an embedded form context, this function returns the current, unsa
    * - Arguments
      - * **field_name** - a field name in the current parent form
    * - Examples
-     - * current_parent_value( 'FIELD_NAME' ) → The current value of a field 'FIELD_NAME' in the parent form.
+     - * ``current_parent_value( 'FIELD_NAME' )`` → The current value of a field 'FIELD_NAME' in the parent form.
 
 
 .. end_current_parent_value_section
@@ -45,7 +45,7 @@ Returns the current, unsaved value of a field in the form or table row currently
    * - Arguments
      - * **field_name** - a field name in the current form or table row
    * - Examples
-     - * current_value( 'FIELD_NAME' ) → The current value of field 'FIELD_NAME'.
+     - * ``current_value( 'FIELD_NAME' )`` → The current value of field 'FIELD_NAME'.
 
 
 .. end_current_value_section

--- a/docs/user_manual/working_with_vector/expression_help/Fuzzy_Matching.rst
+++ b/docs/user_manual/working_with_vector/expression_help/Fuzzy_Matching.rst
@@ -24,9 +24,9 @@ Returns the Hamming distance between two strings. This equates to the number of 
      - * **string1** - a string
        * **string2** - a string
    * - Examples
-     - * hamming_distance('abc','xec') → 2
-       * hamming_distance('abc','ABc') → 2
-       * hamming_distance(upper('abc'),upper('ABC')) → 0
+     - * ``hamming_distance('abc','xec')`` → 2
+       * ``hamming_distance('abc','ABc')`` → 2
+       * ``hamming_distance(upper('abc'),upper('ABC'))`` → 0
 
 
 .. end_hamming_distance_section
@@ -51,9 +51,9 @@ The Levenshtein distance is a measure of the similarity between two strings. Sma
      - * **string1** - a string
        * **string2** - a string
    * - Examples
-     - * levenshtein('kittens','mitten') → 2
-       * levenshtein('Kitten','kitten') → 1
-       * levenshtein(upper('Kitten'),upper('kitten')) → 0
+     - * ``levenshtein('kittens','mitten')`` → 2
+       * ``levenshtein('Kitten','kitten')`` → 1
+       * ``levenshtein(upper('Kitten'),upper('kitten'))`` → 0
 
 
 .. end_levenshtein_section
@@ -76,9 +76,9 @@ Returns the longest common substring between two strings. This substring is the 
      - * **string1** - a string
        * **string2** - a string
    * - Examples
-     - * longest_common_substring('ABABC','BABCA') → 'ABC'
-       * longest_common_substring('abcDeF','abcdef') → 'abc'
-       * longest_common_substring(upper('abcDeF'),upper('abcdex')) → 'ABCDE'
+     - * ``longest_common_substring('ABABC','BABCA')`` → 'ABC'
+       * ``longest_common_substring('abcDeF','abcdef')`` → 'abc'
+       * ``longest_common_substring(upper('abcDeF'),upper('abcdex'))`` → 'ABCDE'
 
 
 .. end_longest_common_substring_section
@@ -100,9 +100,9 @@ Returns the Soundex representation of a string. Soundex is a phonetic matching a
    * - Arguments
      - * **string** - a string
    * - Examples
-     - * soundex('robert') → 'R163'
-       * soundex('rupert') → 'R163'
-       * soundex('rubin') → 'R150'
+     - * ``soundex('robert')`` → 'R163'
+       * ``soundex('rupert')`` → 'R163'
+       * ``soundex('rubin')`` → 'R150'
 
 
 .. end_soundex_section

--- a/docs/user_manual/working_with_vector/expression_help/General.rst
+++ b/docs/user_manual/working_with_vector/expression_help/General.rst
@@ -23,9 +23,9 @@ Gets an environment variable and returns its content as a string. If the variabl
    * - Arguments
      - * **name** - The name of the environment variable which should be retrieved.
    * - Examples
-     - * env( 'LANG' ) → 'en_US.UTF-8'
-       * env( 'MY_OWN_PREFIX_VAR' ) → 'Z:'
-       * env( 'I_DO_NOT_EXIST' ) → NULL
+     - * ``env( 'LANG' )`` → 'en_US.UTF-8'
+       * ``env( 'MY_OWN_PREFIX_VAR' )`` → 'Z:'
+       * ``env( 'I_DO_NOT_EXIST' )`` → NULL
 
 
 .. end_env_section
@@ -47,8 +47,8 @@ Evaluates an expression which is passed in a string. Useful to expand dynamic pa
    * - Arguments
      - * **expression** - an expression string
    * - Examples
-     - * eval('\'nice\'') → 'nice'
-       * eval(@expression_var) → [whatever the result of evaluating @expression_var might be…]
+     - * ``eval('\'nice\'')`` → 'nice'
+       * ``eval(@expression_var)`` → [whatever the result of evaluating @expression_var might be…]
 
 
 .. end_eval_section
@@ -70,7 +70,7 @@ Evaluates a template which is passed in a string. Useful to expand dynamic param
    * - Arguments
      - * **template** - a template string
    * - Examples
-     - * eval_template('QGIS [% upper(\\'rocks\\') %]') → QGIS ROCKS
+     - * ``eval_template('QGIS [% upper(\\'rocks\\') %]')`` → QGIS ROCKS
 
 
 .. end_eval_template_section
@@ -92,7 +92,7 @@ Returns true if a specified layer is visible.
    * - Arguments
      - * **layer** - a string, representing either a layer name or layer ID
    * - Examples
-     - * is_layer_visible('baseraster') → True
+     - * ``is_layer_visible('baseraster')`` → True
 
 
 .. end_is_layer_visible_section
@@ -142,9 +142,9 @@ Returns a matching layer property or metadata value.
          
 
    * - Examples
-     - * layer_property('streets','title') → 'Basemap Streets'
-       * layer_property('airports','feature_count') → 120
-       * layer_property('landsat','crs') → 'EPSG:4326'
+     - * ``layer_property('streets','title')`` → 'Basemap Streets'
+       * ``layer_property('airports','feature_count')`` → 120
+       * ``layer_property('landsat','crs')`` → 'EPSG:4326'
 
 
 .. end_layer_property_section
@@ -166,7 +166,7 @@ Returns the value stored within a specified variable.
    * - Arguments
      - * **name** - a variable name
    * - Examples
-     - * var('qgis_version') → '2.12'
+     - * ``var('qgis_version')`` → '2.12'
 
 
 .. end_var_section
@@ -190,7 +190,7 @@ This function sets a variable for any expression code that will be provided as 3
        * **value** - the value to set
        * **expression** - the expression for which the variable will be available
    * - Examples
-     - * with_variable('my_sum', 1 + 2 + 3, @my_sum * 2 + @my_sum * 5) → 42
+     - * ``with_variable('my_sum', 1 + 2 + 3, @my_sum * 2 + @my_sum * 5)`` → 42
 
 
 .. end_with_variable_section

--- a/docs/user_manual/working_with_vector/expression_help/GeometryGroup.rst
+++ b/docs/user_manual/working_with_vector/expression_help/GeometryGroup.rst
@@ -24,7 +24,7 @@ Returns the bisector angle (average angle) to the geometry for a specified verte
      - * **geometry** - a linestring geometry
        * **vertex** - vertex index, starting from 0; if the value is negative, the selected vertex index will be its total count minus the absolute value
    * - Examples
-     - * angle_at_vertex(geometry:=geom_from_wkt('LineString(0 0, 10 0, 10 10)'),vertex:=1) → 45.0
+     - * ``angle_at_vertex(geometry:=geom_from_wkt('LineString(0 0, 10 0, 10 10)'),vertex:=1)`` → 45.0
 
 
 .. end_angle_at_vertex_section
@@ -44,7 +44,7 @@ Returns the area of the current feature. The area calculated by this function re
    * - Syntax
      - $area
    * - Examples
-     - * $area → 42
+     - * ``$area`` → 42
 
 
 .. end_$area_section
@@ -66,7 +66,7 @@ Returns the area of a geometry polygon object. Calculations are always planimetr
    * - Arguments
      - * **geometry** - polygon geometry object
    * - Examples
-     - * area(geom_from_wkt('POLYGON((0 0, 4 0, 4 2, 0 2, 0 0))')) → 8.0
+     - * ``area(geom_from_wkt('POLYGON((0 0, 4 0, 4 2, 0 2, 0 0))'))`` → 8.0
 
 
 .. end_area_section
@@ -89,8 +89,8 @@ Returns the north-based azimuth as the angle in radians measured clockwise from 
      - * **point_a** - point geometry
        * **point_b** - point geometry
    * - Examples
-     - * degrees( azimuth( make_point(25, 45), make_point(75, 100) ) ) → 42.273689
-       * degrees( azimuth( make_point(75, 100), make_point(25,45) ) ) → 222.273689
+     - * ``degrees( azimuth( make_point(25, 45), make_point(75, 100) ) )`` → 42.273689
+       * ``degrees( azimuth( make_point(75, 100), make_point(25,45) ) )`` → 222.273689
 
 
 .. end_azimuth_section
@@ -112,7 +112,7 @@ Returns the closure of the combinatorial boundary of the geometry (ie the topolo
    * - Arguments
      - * **geometry** - a geometry
    * - Examples
-     - * geom_to_wkt(boundary(geom_from_wkt('Polygon((1 1, 0 0, -1 1, 1 1))'))) → 'LineString(1 1,0 0,-1 1,1 1)'
+     - * ``geom_to_wkt(boundary(geom_from_wkt('Polygon((1 1, 0 0, -1 1, 1 1))')))`` → 'LineString(1 1,0 0,-1 1,1 1)'
 
 
 .. end_boundary_section
@@ -134,7 +134,7 @@ Returns a geometry which represents the bounding box of an input geometry. Calcu
    * - Arguments
      - * **geometry** - a geometry
    * - Examples
-     - * bounds($geometry) → bounding box of the current feature's geometry
+     - * ``bounds($geometry)`` → bounding box of the current feature's geometry
 
 
 .. end_bounds_section
@@ -156,7 +156,7 @@ Returns the height of the bounding box of a geometry. Calculations are in the Sp
    * - Arguments
      - * **geometry** - a geometry
    * - Examples
-     - * bounds_height($geometry) → height of bounding box of the current feature's geometry
+     - * ``bounds_height($geometry)`` → height of bounding box of the current feature's geometry
 
 
 .. end_bounds_height_section
@@ -178,7 +178,7 @@ Returns the width of the bounding box of a geometry. Calculations are in the Spa
    * - Arguments
      - * **geometry** - a geometry
    * - Examples
-     - * bounds_width($geometry) → width of bounding box of the current feature's geometry
+     - * ``bounds_width($geometry)`` → width of bounding box of the current feature's geometry
 
 
 .. end_bounds_width_section
@@ -204,7 +204,7 @@ Returns a geometry that represents all points whose distance from this geometry 
        * **distance** - buffer distance in layer units
        * **segments** - number of segments to use to represent a quarter circle when a round join style is used. A larger number results in a smoother buffer with more nodes.
    * - Examples
-     - * buffer($geometry, 10.5) → polygon of the current feature's geometry buffered by 10.5 units
+     - * ``buffer($geometry, 10.5)`` → polygon of the current feature's geometry buffered by 10.5 units
 
 
 .. end_buffer_section
@@ -229,7 +229,7 @@ Creates a buffer along a line geometry where the buffer diameter varies accordin
      - * **geometry** - input geometry. Must be a (multi)line geometry with m values.
        * **segments** - number of segments to approximate quarter-circle curves in the buffer.
    * - Examples
-     - * buffer_by_m(geometry:=geom_from_wkt('LINESTRINGM(1 2 0.5, 4 2 0.2)'),segments:=8) → A variable width buffer starting with a diameter of 0.5 and ending with a diameter of 0.2 along the linestring geometry.
+     - * ``buffer_by_m(geometry:=geom_from_wkt('LINESTRINGM(1 2 0.5, 4 2 0.2)'),segments:=8)`` → A variable width buffer starting with a diameter of 0.5 and ending with a diameter of 0.2 along the linestring geometry.
 
 
 .. end_buffer_by_m_section
@@ -251,7 +251,7 @@ Returns the geometric center of a geometry.
    * - Arguments
      - * **geometry** - a geometry
    * - Examples
-     - * centroid($geometry) → a point geometry
+     - * ``centroid($geometry)`` → a point geometry
 
 
 .. end_centroid_section
@@ -273,8 +273,8 @@ Returns a closed line string of the input line string by appending the first poi
    * - Arguments
      - * **geometry** - a line string geometry
    * - Examples
-     - * geom_to_wkt(close_line(geom_from_wkt('LINESTRING(0 0, 1 0, 1 1)'))) → LineString (0 0, 1 0, 1 1, 0 0)
-       * geom_to_wkt(close_line(geom_from_wkt('LINESTRING(0 0, 1 0, 1 1, 0 0)'))) → LineString (0 0, 1 0, 1 1, 0 0)
+     - * ``geom_to_wkt(close_line(geom_from_wkt('LINESTRING(0 0, 1 0, 1 1)')))`` → LineString (0 0, 1 0, 1 1, 0 0)
+       * ``geom_to_wkt(close_line(geom_from_wkt('LINESTRING(0 0, 1 0, 1 1, 0 0)')))`` → LineString (0 0, 1 0, 1 1, 0 0)
 
 
 .. end_close_line_section
@@ -297,7 +297,7 @@ Returns the point on geometry1 that is closest to geometry2.
      - * **geometry1** - geometry to find closest point on
        * **geometry2** - geometry to find closest point to
    * - Examples
-     - * geom_to_wkt(closest_point(geom_from_wkt('LINESTRING (20 80, 98 190, 110 180, 50 75 )'),geom_from_wkt('POINT(100 100)'))) → Point(73.0769 115.384)
+     - * ``geom_to_wkt(closest_point(geom_from_wkt('LINESTRING (20 80, 98 190, 110 180, 50 75 )'),geom_from_wkt('POINT(100 100)')))`` → Point(73.0769 115.384)
 
 
 .. end_closest_point_section
@@ -323,7 +323,7 @@ Geometry parts are specified as separate arguments to the function.
    * - Arguments
      - * **geometry** - a geometry
    * - Examples
-     - * geom_to_wkt(collect_geometries(make_point(1,2), make_point(3,4), make_point(5,6))) → 'MultiPoint ((1 2),(3 4),(5 6))'
+     - * ``geom_to_wkt(collect_geometries(make_point(1,2), make_point(3,4), make_point(5,6)))`` → 'MultiPoint ((1 2),(3 4),(5 6))'
 
 
 **Array variant**
@@ -338,7 +338,7 @@ Geometry parts are specified as an array of geometry parts.
    * - Arguments
      - * **array** - array of geometry objects
    * - Examples
-     - * geom_to_wkt(collect_geometries(array(make_point(1,2), make_point(3,4), make_point(5,6)))) → 'MultiPoint ((1 2),(3 4),(5 6))'
+     - * ``geom_to_wkt(collect_geometries(array(make_point(1,2), make_point(3,4), make_point(5,6))))`` → 'MultiPoint ((1 2),(3 4),(5 6))'
 
 
 .. end_collect_geometries_section
@@ -361,8 +361,8 @@ Returns the combination of two geometries.
      - * **geometry1** - a geometry
        * **geometry2** - a geometry
    * - Examples
-     - * geom_to_wkt( combine( geom_from_wkt( 'LINESTRING(3 3, 4 4, 5 5)' ), geom_from_wkt( 'LINESTRING(3 3, 4 4, 2 1)' ) ) ) → MULTILINESTRING((4 4, 2 1), (3 3, 4 4), (4 4, 5 5))
-       * geom_to_wkt( combine( geom_from_wkt( 'LINESTRING(3 3, 4 4)' ), geom_from_wkt( 'LINESTRING(3 3, 6 6, 2 1)' ) ) ) → LINESTRING(3 3, 4 4, 6 6, 2 1)
+     - * ``geom_to_wkt( combine( geom_from_wkt( 'LINESTRING(3 3, 4 4, 5 5)' ), geom_from_wkt( 'LINESTRING(3 3, 4 4, 2 1)' ) ) )`` → MULTILINESTRING((4 4, 2 1), (3 3, 4 4), (4 4, 5 5))
+       * ``geom_to_wkt( combine( geom_from_wkt( 'LINESTRING(3 3, 4 4)' ), geom_from_wkt( 'LINESTRING(3 3, 6 6, 2 1)' ) ) )`` → LINESTRING(3 3, 4 4, 6 6, 2 1)
 
 
 .. end_combine_section
@@ -385,8 +385,8 @@ Tests whether a geometry contains another. Returns true if and only if no points
      - * **geometry a** - a geometry
        * **geometry b** - a geometry
    * - Examples
-     - * contains( geom_from_wkt( 'POLYGON((0 0, 0 1, 1 1, 1 0, 0 0))' ), geom_from_wkt( 'POINT(0.5 0.5 )' ) ) → true
-       * contains( geom_from_wkt( 'POLYGON((0 0, 0 1, 1 1, 1 0, 0 0))' ), geom_from_wkt( 'LINESTRING(3 3, 4 4, 5 5)' ) ) → false
+     - * ``contains( geom_from_wkt( 'POLYGON((0 0, 0 1, 1 1, 1 0, 0 0))' ), geom_from_wkt( 'POINT(0.5 0.5 )' ) )`` → true
+       * ``contains( geom_from_wkt( 'POLYGON((0 0, 0 1, 1 1, 1 0, 0 0))' ), geom_from_wkt( 'LINESTRING(3 3, 4 4, 5 5)' ) )`` → false
 
 
 .. end_contains_section
@@ -408,7 +408,7 @@ Returns the convex hull of a geometry. It represents the minimum convex geometry
    * - Arguments
      - * **geometry** - a geometry
    * - Examples
-     - * geom_to_wkt( convex_hull( geom_from_wkt( 'LINESTRING(3 3, 4 4, 4 10)' ) ) ) → POLYGON((3 3,4 10,4 4,3 3))
+     - * ``geom_to_wkt( convex_hull( geom_from_wkt( 'LINESTRING(3 3, 4 4, 4 10)' ) ) )`` → POLYGON((3 3,4 10,4 4,3 3))
 
 
 .. end_convex_hull_section
@@ -431,8 +431,8 @@ Tests whether a geometry crosses another. Returns true if the supplied geometrie
      - * **geometry a** - a geometry
        * **geometry b** - a geometry
    * - Examples
-     - * crosses( geom_from_wkt( 'LINESTRING(3 5, 4 4, 5 3)' ), geom_from_wkt( 'LINESTRING(3 3, 4 4, 5 5)' ) ) → true
-       * crosses( geom_from_wkt( 'POINT(4 5)' ), geom_from_wkt( 'LINESTRING(3 3, 4 4, 5 5)' ) ) → false
+     - * ``crosses( geom_from_wkt( 'LINESTRING(3 5, 4 4, 5 3)' ), geom_from_wkt( 'LINESTRING(3 3, 4 4, 5 5)' ) )`` → true
+       * ``crosses( geom_from_wkt( 'POINT(4 5)' ), geom_from_wkt( 'LINESTRING(3 3, 4 4, 5 5)' ) )`` → false
 
 
 .. end_crosses_section
@@ -455,7 +455,7 @@ Returns a geometry that represents that part of geometry_a that does not interse
      - * **geometry_a** - a geometry
        * **geometry_b** - a geometry
    * - Examples
-     - * geom_to_wkt( difference( geom_from_wkt( 'LINESTRING(3 3, 4 4, 5 5)' ), geom_from_wkt( 'LINESTRING(3 3, 4 4)' ) ) ) → LINESTRING(4 4, 5 5)
+     - * ``geom_to_wkt( difference( geom_from_wkt( 'LINESTRING(3 3, 4 4, 5 5)' ), geom_from_wkt( 'LINESTRING(3 3, 4 4)' ) ) )`` → LINESTRING(4 4, 5 5)
 
 
 .. end_difference_section
@@ -478,8 +478,8 @@ Tests whether geometries do not spatially intersect. Returns true if the geometr
      - * **geometry a** - a geometry
        * **geometry b** - a geometry
    * - Examples
-     - * disjoint( geom_from_wkt( 'POLYGON((0 0, 0 1, 1 1, 1 0, 0 0 ))' ), geom_from_wkt( 'LINESTRING(3 3, 4 4, 5 5)' ) ) → true
-       * disjoint( geom_from_wkt( 'LINESTRING(3 3, 4 4, 5 5)' ), geom_from_wkt( 'POINT(4 4)' )) → false
+     - * ``disjoint( geom_from_wkt( 'POLYGON((0 0, 0 1, 1 1, 1 0, 0 0 ))' ), geom_from_wkt( 'LINESTRING(3 3, 4 4, 5 5)' ) )`` → true
+       * ``disjoint( geom_from_wkt( 'LINESTRING(3 3, 4 4, 5 5)' ), geom_from_wkt( 'POINT(4 4)' ))`` → false
 
 
 .. end_disjoint_section
@@ -502,7 +502,7 @@ Returns the minimum distance (based on spatial ref) between two geometries in pr
      - * **geometry a** - a geometry
        * **geometry b** - a geometry
    * - Examples
-     - * distance( geom_from_wkt( 'POINT(4 4)' ), geom_from_wkt( 'POINT(4 8)' ) ) → 4
+     - * ``distance( geom_from_wkt( 'POINT(4 4)' ), geom_from_wkt( 'POINT(4 8)' ) )`` → 4
 
 
 .. end_distance_section
@@ -525,7 +525,7 @@ Returns the distance along the geometry to a specified vertex.
      - * **geometry** - a linestring geometry
        * **vertex** - vertex index, starting from 0; if the value is negative, the selected vertex index will be its total count minus the absolute value
    * - Examples
-     - * distance_to_vertex(geometry:=geom_from_wkt('LineString(0 0, 10 0, 10 10)'),vertex:=1) → 10.0
+     - * ``distance_to_vertex(geometry:=geom_from_wkt('LineString(0 0, 10 0, 10 10)'),vertex:=1)`` → 10.0
 
 
 .. end_distance_to_vertex_section
@@ -547,7 +547,7 @@ Returns the last node from a geometry.
    * - Arguments
      - * **geometry** - geometry object
    * - Examples
-     - * geom_to_wkt(end_point(geom_from_wkt('LINESTRING(4 0, 4 2, 0 2)'))) → 'Point (0 2)'
+     - * ``geom_to_wkt(end_point(geom_from_wkt('LINESTRING(4 0, 4 2, 0 2)')))`` → 'Point (0 2)'
 
 
 .. end_end_point_section
@@ -571,7 +571,7 @@ Extends the start and end of a linestring geometry by a specified amount. Lines 
        * **start_distance** - distance to extend the start of the line
        * **end_distance** - distance to extend the end of the line.
    * - Examples
-     - * geom_to_wkt(extend(geom_from_wkt('LineString(0 0, 1 0, 1 1)'),1,2)) → LineString (-1 0, 1 0, 1 3)
+     - * ``geom_to_wkt(extend(geom_from_wkt('LineString(0 0, 1 0, 1 1)'),1,2))`` → LineString (-1 0, 1 0, 1 3)
 
 
 .. end_extend_section
@@ -593,7 +593,7 @@ Returns a line string representing the exterior ring of a polygon geometry. If t
    * - Arguments
      - * **geometry** - a polygon geometry
    * - Examples
-     - * geom_to_wkt(exterior_ring(geom_from_wkt('POLYGON((-1 -1, 4 0, 4 2, 0 2, -1 -1),( 0.1 0.1, 0.1 0.2, 0.2 0.2, 0.2, 0.1, 0.1 0.1))'))) → 'LineString (-1 -1, 4 0, 4 2, 0 2, -1 -1)'
+     - * ``geom_to_wkt(exterior_ring(geom_from_wkt('POLYGON((-1 -1, 4 0, 4 2, 0 2, -1 -1),( 0.1 0.1, 0.1 0.2, 0.2 0.2, 0.2, 0.1, 0.1 0.1))')))`` → 'LineString (-1 -1, 4 0, 4 2, 0 2, -1 -1)'
 
 
 .. end_exterior_ring_section
@@ -617,8 +617,8 @@ Returns an extruded version of the input (Multi-)Curve or (Multi-)Linestring geo
        * **x** - x extension, numeric value
        * **y** - y extension, numeric value
    * - Examples
-     - * extrude(geom_from_wkt('LineString(1 2, 3 2, 4 3)'), 1, 2) → Polygon ((1 2, 3 2, 4 3, 5 5, 4 4, 2 4, 1 2))
-       * extrude(geom_from_wkt('MultiLineString((1 2, 3 2), (4 3, 8 3)'), 1, 2) → MultiPolygon (((1 2, 3 2, 4 4, 2 4, 1 2)),((4 3, 8 3, 9 5, 5 5, 4 3)))
+     - * ``extrude(geom_from_wkt('LineString(1 2, 3 2, 4 3)'), 1, 2)`` → Polygon ((1 2, 3 2, 4 3, 5 5, 4 4, 2 4, 1 2))
+       * ``extrude(geom_from_wkt('MultiLineString((1 2, 3 2), (4 3, 8 3)'), 1, 2)`` → MultiPolygon (((1 2, 3 2, 4 4, 2 4, 1 2)),((4 3, 8 3, 9 5, 5 5, 4 3)))
 
 
 .. end_extrude_section
@@ -640,7 +640,7 @@ Returns a copy of the geometry with the x and y coordinates swapped. Useful for 
    * - Arguments
      - * **geometry** - a geometry
    * - Examples
-     - * geom_to_wkt(flip_coordinates(make_point(1, 2))) → Point (2 1)
+     - * ``geom_to_wkt(flip_coordinates(make_point(1, 2)))`` → Point (2 1)
 
 
 .. end_flip_coordinates_section
@@ -662,7 +662,7 @@ Forces a geometry to respect the Right-Hand-Rule, in which the area that is boun
    * - Arguments
      - * **geometry** - a geometry. Any non-polygon geometries are returned unchanged.
    * - Examples
-     - * geom_to_wkt(force_rhr(geometry:=geom_from_wkt('POLYGON((-1 -1, 4 0, 4 2, 0 2, -1 -1))'))) → Polygon ((-1 -1, 0 2, 4 2, 4 0, -1 -1))
+     - * ``geom_to_wkt(force_rhr(geometry:=geom_from_wkt('POLYGON((-1 -1, 4 0, 4 2, 0 2, -1 -1))')))`` → Polygon ((-1 -1, 0 2, 4 2, 4 0, -1 -1))
 
 
 .. end_force_rhr_section
@@ -684,7 +684,7 @@ Returns a geometry from a GML representation of geometry.
    * - Arguments
      - * **gml** - GML representation of a geometry as a string
    * - Examples
-     - * geom_from_gml('&lt;gml:LineString srsName="EPSG:4326"&gt;&lt;gml:coordinates&gt;4,4 5,5 6,6&lt;/gml:coordinates&gt;&lt;/gml:LineString&gt;') → a line geometry object
+     - * ``geom_from_gml('&lt;gml:LineString srsName="EPSG:4326"&gt;&lt;gml:coordinates&gt;4,4 5,5 6,6&lt;/gml:coordinates&gt;&lt;/gml:LineString&gt;')`` → a line geometry object
 
 
 .. end_geom_from_gml_section
@@ -706,7 +706,7 @@ Returns a geometry created from a Well-Known Binary (WKB) representation.
    * - Arguments
      - * **binary** - Well-Known Binary (WKB) representation of a geometry (as a binary blob)
    * - Examples
-     - * geom_from_wkb( geom_to_wkb( make_point(4,5) ) ) → a point geometry object
+     - * ``geom_from_wkb( geom_to_wkb( make_point(4,5) ) )`` → a point geometry object
 
 
 .. end_geom_from_wkb_section
@@ -728,7 +728,7 @@ Returns a geometry created from a Well-Known Text (WKT) representation.
    * - Arguments
      - * **text** - Well-Known Text (WKT) representation of a geometry
    * - Examples
-     - * geom_from_wkt( 'POINT(4 5)' ) → a geometry object
+     - * ``geom_from_wkt( 'POINT(4 5)' )`` → a geometry object
 
 
 .. end_geom_from_wkt_section
@@ -750,7 +750,7 @@ Returns the Well-Known Binary (WKB) representation of a geometry
    * - Arguments
      - * **geometry** - a geometry
    * - Examples
-     - * geom_to_wkb( $geometry ) → binary blob containing a geometry object
+     - * ``geom_to_wkb( $geometry )`` → binary blob containing a geometry object
 
 
 .. end_geom_to_wkb_section
@@ -775,7 +775,7 @@ Returns the Well-Known Text (WKT) representation of the geometry without SRID me
      - * **geometry** - a geometry
        * **precision** - numeric precision
    * - Examples
-     - * geom_to_wkt( $geometry ) → POINT(6 50)
+     - * ``geom_to_wkt( $geometry )`` → POINT(6 50)
 
 
 .. end_geom_to_wkt_section
@@ -795,7 +795,7 @@ Returns the geometry of the current feature. Can be used for processing with oth
    * - Syntax
      - $geometry
    * - Examples
-     - * geomToWKT( $geometry ) → POINT(6 50)
+     - * ``geomToWKT( $geometry )`` → POINT(6 50)
 
 
 .. end_$geometry_section
@@ -817,8 +817,8 @@ Returns a feature's geometry.
    * - Arguments
      - * **feature** - a feature object
    * - Examples
-     - * geom_to_wkt( geometry( get_feature( layer, attributeField, value ) ) ) → 'POINT(6 50)'
-       * intersects( $geometry, geometry( get_feature( layer, attributeField, value ) ) ) → true
+     - * ``geom_to_wkt( geometry( get_feature( layer, attributeField, value ) ) )`` → 'POINT(6 50)'
+       * ``intersects( $geometry, geometry( get_feature( layer, attributeField, value ) ) )`` → true
 
 
 .. end_geometry_section
@@ -841,7 +841,7 @@ Returns a specific geometry from a geometry collection, or NULL if the input geo
      - * **geometry** - geometry collection
        * **index** - index of geometry to return, where 1 is the first geometry in the collection
    * - Examples
-     - * geom_to_wkt(geometry_n(geom_from_wkt('GEOMETRYCOLLECTION(POINT(0 1), POINT(0 0), POINT(1 0), POINT(1 1))'),3)) → 'Point (1 0)'
+     - * ``geom_to_wkt(geometry_n(geom_from_wkt('GEOMETRYCOLLECTION(POINT(0 1), POINT(0 0), POINT(1 0), POINT(1 1))'),3))`` → 'Point (1 0)'
 
 
 .. end_geometry_n_section
@@ -879,9 +879,9 @@ If the default approximate provided by this method is insufficient, specify the 
        * **geometry b** - a geometry
        * **densify_fraction** - densify fraction amount
    * - Examples
-     - * hausdorff_distance( geometry1:= geom_from_wkt('LINESTRING (0 0, 2 1)'),geometry2:=geom_from_wkt('LINESTRING (0 0, 2 0)')) → 2
-       * hausdorff_distance( geom_from_wkt('LINESTRING (130 0, 0 0, 0 150)'),geom_from_wkt('LINESTRING (10 10, 10 150, 130 10)')) → 14.142135623
-       * hausdorff_distance( geom_from_wkt('LINESTRING (130 0, 0 0, 0 150)'),geom_from_wkt('LINESTRING (10 10, 10 150, 130 10)'),0.5) → 70.0
+     - * ``hausdorff_distance( geometry1:= geom_from_wkt('LINESTRING (0 0, 2 1)'),geometry2:=geom_from_wkt('LINESTRING (0 0, 2 0)'))`` → 2
+       * ``hausdorff_distance( geom_from_wkt('LINESTRING (130 0, 0 0, 0 150)'),geom_from_wkt('LINESTRING (10 10, 10 150, 130 10)'))`` → 14.142135623
+       * ``hausdorff_distance( geom_from_wkt('LINESTRING (130 0, 0 0, 0 150)'),geom_from_wkt('LINESTRING (10 10, 10 150, 130 10)'),0.5)`` → 70.0
 
 
 .. end_hausdorff_distance_section
@@ -904,10 +904,10 @@ Returns the inclination measured from the zenith (0) to the nadir (180) on point
      - * **point_a** - point geometry
        * **point_b** - point geometry
    * - Examples
-     - * inclination( make_point( 5, 10, 0 ), make_point( 5, 10, 5 ) ) → 0.0
-       * inclination( make_point( 5, 10, 0 ), make_point( 5, 10, 0 ) ) → 90.0
-       * inclination( make_point( 5, 10, 0 ), make_point( 50, 100, 0 ) ) → 90.0
-       * inclination( make_point( 5, 10, 0 ), make_point( 5, 10, -5 ) ) → 180.0
+     - * ``inclination( make_point( 5, 10, 0 ), make_point( 5, 10, 5 ) )`` → 0.0
+       * ``inclination( make_point( 5, 10, 0 ), make_point( 5, 10, 0 ) )`` → 90.0
+       * ``inclination( make_point( 5, 10, 0 ), make_point( 50, 100, 0 ) )`` → 90.0
+       * ``inclination( make_point( 5, 10, 0 ), make_point( 5, 10, -5 ) )`` → 180.0
 
 
 .. end_inclination_section
@@ -930,7 +930,7 @@ Returns a specific interior ring from a polygon geometry, or NULL if the geometr
      - * **geometry** - polygon geometry
        * **index** - index of interior to return, where 1 is the first interior ring
    * - Examples
-     - * geom_to_wkt(interior_ring_n(geom_from_wkt('POLYGON((-1 -1, 4 0, 4 2, 0 2, -1 -1),(-0.1 -0.1, 0.4 0, 0.4 0.2, 0 0.2, -0.1 -0.1),(-1 -1, 4 0, 4 2, 0 2, -1 -1))'),1)) → 'LineString (-0.1 -0.1, 0.4 0, 0.4 0.2, 0 0.2, -0.1 -0.1))'
+     - * ``geom_to_wkt(interior_ring_n(geom_from_wkt('POLYGON((-1 -1, 4 0, 4 2, 0 2, -1 -1),(-0.1 -0.1, 0.4 0, 0.4 0.2, 0 0.2, -0.1 -0.1),(-1 -1, 4 0, 4 2, 0 2, -1 -1))'),1))`` → 'LineString (-0.1 -0.1, 0.4 0, 0.4 0.2, 0 0.2, -0.1 -0.1))'
 
 
 .. end_interior_ring_n_section
@@ -953,7 +953,7 @@ Returns a geometry that represents the shared portion of two geometries.
      - * **geometry1** - a geometry
        * **geometry2** - a geometry
    * - Examples
-     - * geom_to_wkt( intersection( geom_from_wkt( 'LINESTRING(3 3, 4 4, 5 5)' ), geom_from_wkt( 'LINESTRING(3 3, 4 4)' ) ) ) → LINESTRING(3 3, 4 4)
+     - * ``geom_to_wkt( intersection( geom_from_wkt( 'LINESTRING(3 3, 4 4, 5 5)' ), geom_from_wkt( 'LINESTRING(3 3, 4 4)' ) ) )`` → LINESTRING(3 3, 4 4)
 
 
 .. end_intersection_section
@@ -976,8 +976,8 @@ Tests whether a geometry intersects another. Returns true if the geometries spat
      - * **geometry a** - a geometry
        * **geometry b** - a geometry
    * - Examples
-     - * intersects( geom_from_wkt( 'POINT(4 4)' ), geom_from_wkt( 'LINESTRING(3 3, 4 4, 5 5)' ) ) → true
-       * intersects( geom_from_wkt( 'POINT(4 5)' ), geom_from_wkt( 'POINT(5 5)' ) ) → false
+     - * ``intersects( geom_from_wkt( 'POINT(4 4)' ), geom_from_wkt( 'LINESTRING(3 3, 4 4, 5 5)' ) )`` → true
+       * ``intersects( geom_from_wkt( 'POINT(4 5)' ), geom_from_wkt( 'POINT(5 5)' ) )`` → false
 
 
 .. end_intersects_section
@@ -1000,8 +1000,8 @@ Tests whether a geometry's bounding box overlaps another geometry's bounding box
      - * **geometry** - a geometry
        * **geometry** - a geometry
    * - Examples
-     - * intersects_bbox( geom_from_wkt( 'POINT(4 5)' ), geom_from_wkt( 'LINESTRING(3 3, 4 4, 5 5)' ) ) → true
-       * intersects_bbox( geom_from_wkt( 'POINT(6 5)' ), geom_from_wkt( 'POLYGON((3 3, 4 4, 5 5, 3 3))' ) ) → false
+     - * ``intersects_bbox( geom_from_wkt( 'POINT(4 5)' ), geom_from_wkt( 'LINESTRING(3 3, 4 4, 5 5)' ) )`` → true
+       * ``intersects_bbox( geom_from_wkt( 'POINT(6 5)' ), geom_from_wkt( 'POLYGON((3 3, 4 4, 5 5, 3 3))' ) )`` → false
 
 
 .. end_intersects_bbox_section
@@ -1023,8 +1023,8 @@ Returns true if a line string is closed (start and end points are coincident), o
    * - Arguments
      - * **geometry** - a line string geometry
    * - Examples
-     - * is_closed(geom_from_wkt('LINESTRING(0 0, 1 1, 2 2)')) → false
-       * is_closed(geom_from_wkt('LINESTRING(0 0, 1 1, 2 2, 0 0)')) → true
+     - * ``is_closed(geom_from_wkt('LINESTRING(0 0, 1 1, 2 2)'))`` → false
+       * ``is_closed(geom_from_wkt('LINESTRING(0 0, 1 1, 2 2, 0 0)'))`` → true
 
 
 .. end_is_closed_section
@@ -1046,10 +1046,10 @@ Returns true if a geometry is empty (without coordinates), false if the geometry
    * - Arguments
      - * **geometry** - a geometry
    * - Examples
-     - * is_empty(geom_from_wkt('LINESTRING(0 0, 1 1, 2 2)')) → false
-       * is_empty(geom_from_wkt('LINESTRING EMPTY')) → true
-       * is_empty(geom_from_wkt('POINT(7 4)')) → false
-       * is_empty(geom_from_wkt('POINT EMPTY')) → true
+     - * ``is_empty(geom_from_wkt('LINESTRING(0 0, 1 1, 2 2)'))`` → false
+       * ``is_empty(geom_from_wkt('LINESTRING EMPTY'))`` → true
+       * ``is_empty(geom_from_wkt('POINT(7 4)'))`` → false
+       * ``is_empty(geom_from_wkt('POINT EMPTY'))`` → true
 
 
 .. end_is_empty_section
@@ -1071,11 +1071,11 @@ Returns true if a geometry is NULL or empty (without coordinates) or false other
    * - Arguments
      - * **geometry** - a geometry
    * - Examples
-     - * is_empty_or_null(NULL) → true
-       * is_empty_or_null(geom_from_wkt('LINESTRING(0 0, 1 1, 2 2)')) → false
-       * is_empty_or_null(geom_from_wkt('LINESTRING EMPTY')) → true
-       * is_empty_or_null(geom_from_wkt('POINT(7 4)')) → false
-       * is_empty_or_null(geom_from_wkt('POINT EMPTY')) → true
+     - * ``is_empty_or_null(NULL)`` → true
+       * ``is_empty_or_null(geom_from_wkt('LINESTRING(0 0, 1 1, 2 2)'))`` → false
+       * ``is_empty_or_null(geom_from_wkt('LINESTRING EMPTY'))`` → true
+       * ``is_empty_or_null(geom_from_wkt('POINT(7 4)'))`` → false
+       * ``is_empty_or_null(geom_from_wkt('POINT EMPTY'))`` → true
 
 
 .. end_is_empty_or_null_section
@@ -1097,8 +1097,8 @@ Returns true if the geometry is of Multi type.
    * - Arguments
      - * **geometry** - a geometry
    * - Examples
-     - * is_multipart(geom_from_wkt('MULTIPOINT ((0 0),(1 1),(2 2))')) → true
-       * is_multipart(geom_from_wkt('POINT (0 0)')) → false
+     - * ``is_multipart(geom_from_wkt('MULTIPOINT ((0 0),(1 1),(2 2))'))`` → true
+       * ``is_multipart(geom_from_wkt('POINT (0 0)'))`` → false
 
 
 .. end_is_multipart_section
@@ -1120,8 +1120,8 @@ Returns true if a geometry is valid; if it is well-formed in 2D according to the
    * - Arguments
      - * **geometry** - a geometry
    * - Examples
-     - * is_valid(geom_from_wkt('LINESTRING(0 0, 1 1, 2 2, 0 0)')) → true
-       * is_valid(geom_from_wkt('LINESTRING(0 0)')) → false
+     - * ``is_valid(geom_from_wkt('LINESTRING(0 0, 1 1, 2 2, 0 0)'))`` → true
+       * ``is_valid(geom_from_wkt('LINESTRING(0 0)'))`` → false
 
 
 .. end_is_valid_section
@@ -1141,7 +1141,7 @@ Returns the length of a linestring. If you need the length of a border of a poly
    * - Syntax
      - $length
    * - Examples
-     - * $length → 42.4711
+     - * ``$length`` → 42.4711
 
 
 .. end_$length_section
@@ -1167,7 +1167,7 @@ Returns the number of characters in a string.
    * - Arguments
      - * **string** - string to count length of
    * - Examples
-     - * length('hello') → 5
+     - * ``length('hello')`` → 5
 
 
 **Geometry variant**
@@ -1182,7 +1182,7 @@ Calculate the length of a geometry line object. Calculations are always planimet
    * - Arguments
      - * **geometry** - line geometry object
    * - Examples
-     - * length(geom_from_wkt('LINESTRING(0 0, 4 0)')) → 4.0
+     - * ``length(geom_from_wkt('LINESTRING(0 0, 4 0)'))`` → 4.0
 
 
 .. end_length_section
@@ -1205,7 +1205,7 @@ Returns the angle parallel to the geometry at a specified distance along a lines
      - * **geometry** - a linestring geometry
        * **distance** - distance along line to interpolate angle at
    * - Examples
-     - * line_interpolate_angle(geometry:=geom_from_wkt('LineString(0 0, 10 0)'),distance:=5) → 90.0
+     - * ``line_interpolate_angle(geometry:=geom_from_wkt('LineString(0 0, 10 0)'),distance:=5)`` → 90.0
 
 
 .. end_line_interpolate_angle_section
@@ -1228,7 +1228,7 @@ Returns the point interpolated by a specified distance along a linestring geomet
      - * **geometry** - a linestring geometry
        * **distance** - distance along line to interpolate
    * - Examples
-     - * geom_to_wkt(line_interpolate_point(geometry:=geom_from_wkt('LineString(0 0, 10 0)'),distance:=5)) → 'Point (5 0)'
+     - * ``geom_to_wkt(line_interpolate_point(geometry:=geom_from_wkt('LineString(0 0, 10 0)'),distance:=5))`` → 'Point (5 0)'
 
 
 .. end_line_interpolate_point_section
@@ -1251,7 +1251,7 @@ Returns the distance along a linestring corresponding to the closest position th
      - * **geometry** - a linestring geometry
        * **point** - point geometry to locate closest position on linestring to
    * - Examples
-     - * line_locate_point(geometry:=geom_from_wkt('LineString(0 0, 10 0)'),point:=geom_from_wkt('Point(5 0)')) → 5.0
+     - * ``line_locate_point(geometry:=geom_from_wkt('LineString(0 0, 10 0)'),point:=geom_from_wkt('Point(5 0)'))`` → 5.0
 
 
 .. end_line_locate_point_section
@@ -1273,8 +1273,8 @@ Returns a LineString or MultiLineString geometry, where any connected LineString
    * - Arguments
      - * **geometry** - a LineString/MultiLineString geometry
    * - Examples
-     - * geom_to_wkt(line_merge(geom_from_wkt('MULTILINESTRING((0 0, 1 1),(1 1, 2 2))'))) → 'LineString(0 0,1 1,2 2)'
-       * geom_to_wkt(line_merge(geom_from_wkt('MULTILINESTRING((0 0, 1 1),(11 1, 21 2))'))) → 'MultiLineString((0 0, 1 1),(11 1, 21 2)'
+     - * ``geom_to_wkt(line_merge(geom_from_wkt('MULTILINESTRING((0 0, 1 1),(1 1, 2 2))')))`` → 'LineString(0 0,1 1,2 2)'
+       * ``geom_to_wkt(line_merge(geom_from_wkt('MULTILINESTRING((0 0, 1 1),(11 1, 21 2))')))`` → 'MultiLineString((0 0, 1 1),(11 1, 21 2)'
 
 
 .. end_line_merge_section
@@ -1298,7 +1298,7 @@ Returns the portion of a line (or curve) geometry which falls between the specif
        * **start_distance** - distance to start of substring
        * **end_distance** - distance to end of substring
    * - Examples
-     - * geom_to_wkt(line_substring(geometry:=geom_from_wkt('LineString(0 0, 10 0)'),start_distance:=2,end_distance=6)) → 'LineString (2 0,6 0)'
+     - * ``geom_to_wkt(line_substring(geometry:=geom_from_wkt('LineString(0 0, 10 0)'),start_distance:=2,end_distance=6))`` → 'LineString (2 0,6 0)'
 
 
 .. end_line_substring_section
@@ -1320,7 +1320,7 @@ Returns the m value of a point geometry.
    * - Arguments
      - * **geometry** - a point geometry
    * - Examples
-     - * m( geom_from_wkt( 'POINTM(2 5 4)' ) ) → 4
+     - * ``m( geom_from_wkt( 'POINTM(2 5 4)' ) )`` → 4
 
 
 .. end_m_section
@@ -1342,8 +1342,8 @@ Returns the maximum m (measure) value of a geometry.
    * - Arguments
      - * **geometry** - a geometry containing m values
    * - Examples
-     - * m_max( make_point_m( 0,0,1 ) ) → 1
-       * m_max(make_line( make_point_m( 0,0,1 ), make_point_m( -1,-1,2 ), make_point_m( -2,-2,0 ) ) ) → 2
+     - * ``m_max( make_point_m( 0,0,1 ) )`` → 1
+       * ``m_max(make_line( make_point_m( 0,0,1 ), make_point_m( -1,-1,2 ), make_point_m( -2,-2,0 ) ) )`` → 2
 
 
 .. end_m_max_section
@@ -1365,8 +1365,8 @@ Returns the minimum m (measure) value of a geometry.
    * - Arguments
      - * **geometry** - a geometry containing m values
    * - Examples
-     - * m_min( make_point_m( 0,0,1 ) ) → 1
-       * m_min(make_line( make_point_m( 0,0,1 ), make_point_m( -1,-1,2 ), make_point_m( -2,-2,0 ) ) ) → 0
+     - * ``m_min( make_point_m( 0,0,1 ) )`` → 1
+       * ``m_min(make_line( make_point_m( 0,0,1 ), make_point_m( -1,-1,2 ), make_point_m( -2,-2,0 ) ) )`` → 0
 
 
 .. end_m_min_section
@@ -1388,7 +1388,7 @@ Returns the main angle of a geometry (clockwise, in degrees from North), which r
    * - Arguments
      - * **geometry** - a geometry
    * - Examples
-     - * main_angle(geom_from_wkt('Polygon ((321577 129614, 321581 129618, 321585 129615, 321581 129610, 321577 129614))')) → 38.66
+     - * ``main_angle(geom_from_wkt('Polygon ((321577 129614, 321581 129618, 321585 129615, 321581 129610, 321577 129614))'))`` → 38.66
 
 
 .. end_main_angle_section
@@ -1414,9 +1414,9 @@ Creates a circular polygon.
        * **radius** - radius of the circle
        * **segment** - optional argument for polygon segmentation. By default this value is 36
    * - Examples
-     - * geom_to_wkt(make_circle(make_point(10,10), 5, 4)) → 'Polygon ((10 15, 15 10, 10 5, 5 10, 10 15))'
-       * geom_to_wkt(make_circle(make_point(10,10,5), 5, 4)) → 'PolygonZ ((10 15 5, 15 10 5, 10 5 5, 5 10 5, 10 15 5))'
-       * geom_to_wkt(make_circle(make_point(10,10,5,30), 5, 4)) → 'PolygonZM ((10 15 5 30, 15 10 5 30, 10 5 5 30, 5 10 5 30, 10 15 5 30))'
+     - * ``geom_to_wkt(make_circle(make_point(10,10), 5, 4))`` → 'Polygon ((10 15, 15 10, 10 5, 5 10, 10 15))'
+       * ``geom_to_wkt(make_circle(make_point(10,10,5), 5, 4))`` → 'PolygonZ ((10 15 5, 15 10 5, 10 5 5, 5 10 5, 10 15 5))'
+       * ``geom_to_wkt(make_circle(make_point(10,10,5,30), 5, 4))`` → 'PolygonZM ((10 15 5 30, 15 10 5 30, 10 5 5 30, 5 10 5 30, 10 15 5 30))'
 
 
 .. end_make_circle_section
@@ -1444,9 +1444,9 @@ Creates an elliptical polygon.
        * **azimuth** - orientation of the ellipse
        * **segment** - optional argument for polygon segmentation. By default this value is 36
    * - Examples
-     - * geom_to_wkt(make_ellipse(make_point(10,10), 5, 2, 90, 4)) → 'Polygon ((15 10, 10 8, 5 10, 10 12, 15 10))'
-       * geom_to_wkt(make_ellipse(make_point(10,10,5), 5, 2, 90, 4)) → 'PolygonZ ((15 10 5, 10 8 5, 5 10 5, 10 12 5, 15 10 5))'
-       * geom_to_wkt(make_ellipse(make_point(10,10,5,30), 5, 2, 90, 4)) → 'PolygonZM ((15 10 5 30, 10 8 5 30, 5 10 5 30, 10 12 5 30, 15 10 5 30))'
+     - * ``geom_to_wkt(make_ellipse(make_point(10,10), 5, 2, 90, 4))`` → 'Polygon ((15 10, 10 8, 5 10, 10 12, 15 10))'
+       * ``geom_to_wkt(make_ellipse(make_point(10,10,5), 5, 2, 90, 4))`` → 'PolygonZ ((15 10 5, 10 8 5, 5 10 5, 10 12 5, 15 10 5))'
+       * ``geom_to_wkt(make_ellipse(make_point(10,10,5,30), 5, 2, 90, 4))`` → 'PolygonZM ((15 10 5 30, 10 8 5 30, 5 10 5 30, 10 12 5 30, 15 10 5 30))'
 
 
 .. end_make_ellipse_section
@@ -1472,8 +1472,8 @@ Line vertices are specified as separate arguments to the function.
    * - Arguments
      - * **point** - a point geometry (or array of points)
    * - Examples
-     - * geom_to_wkt(make_line(make_point(2,4),make_point(3,5))) → 'LineString (2 4, 3 5)'
-       * geom_to_wkt(make_line(make_point(2,4),make_point(3,5),make_point(9,7))) → 'LineString (2 4, 3 5, 9 7)'
+     - * ``geom_to_wkt(make_line(make_point(2,4),make_point(3,5)))`` → 'LineString (2 4, 3 5)'
+       * ``geom_to_wkt(make_line(make_point(2,4),make_point(3,5),make_point(9,7)))`` → 'LineString (2 4, 3 5, 9 7)'
 
 
 **Array variant**
@@ -1488,7 +1488,7 @@ Line vertices are specified as an array of points.
    * - Arguments
      - * **array** - array of points
    * - Examples
-     - * geom_to_wkt(make_line(array(make_point(2,4),make_point(3,5),make_point(9,7)))) → 'LineString (2 4, 3 5, 9 7)'
+     - * ``geom_to_wkt(make_line(array(make_point(2,4),make_point(3,5),make_point(9,7))))`` → 'LineString (2 4, 3 5, 9 7)'
 
 
 .. end_make_line_section
@@ -1515,9 +1515,9 @@ Creates a point geometry from an x and y (and optional z and m) value.
        * **z** - optional z coordinate of point
        * **m** - optional m value of point
    * - Examples
-     - * geom_to_wkt(make_point(2,4)) → 'Point (2 4)'
-       * geom_to_wkt(make_point(2,4,6)) → 'PointZ (2 4 6)'
-       * geom_to_wkt(make_point(2,4,6,8)) → 'PointZM (2 4 6 8)'
+     - * ``geom_to_wkt(make_point(2,4))`` → 'Point (2 4)'
+       * ``geom_to_wkt(make_point(2,4,6))`` → 'PointZ (2 4 6)'
+       * ``geom_to_wkt(make_point(2,4,6,8))`` → 'PointZM (2 4 6 8)'
 
 
 .. end_make_point_section
@@ -1541,7 +1541,7 @@ Creates a point geometry from an x, y coordinate and m value.
        * **y** - y coordinate of point
        * **m** - m value of point
    * - Examples
-     - * geom_to_wkt(make_point_m(2,4,6)) → 'PointM (2 4 6)'
+     - * ``geom_to_wkt(make_point_m(2,4,6))`` → 'PointM (2 4 6)'
 
 
 .. end_make_point_m_section
@@ -1566,8 +1566,8 @@ Creates a polygon geometry from an outer ring and optional series of inner ring 
      - * **outerRing** - closed line geometry for polygon's outer ring
        * **innerRing** - optional closed line geometry for inner ring
    * - Examples
-     - * geom_to_wkt(make_polygon(geom_from_wkt('LINESTRING( 0 0, 0 1, 1 1, 1 0, 0 0 )'))) → 'Polygon ((0 0, 0 1, 1 1, 1 0, 0 0))'
-       * geom_to_wkt(make_polygon(geom_from_wkt('LINESTRING( 0 0, 0 1, 1 1, 1 0, 0 0 )'),geom_from_wkt('LINESTRING( 0.1 0.1, 0.1 0.2, 0.2 0.2, 0.2 0.1, 0.1 0.1 )'),geom_from_wkt('LINESTRING( 0.8 0.8, 0.8 0.9, 0.9 0.9, 0.9 0.8, 0.8 0.8 )'))) → 'Polygon ((0 0, 0 1, 1 1, 1 0, 0 0),(0.1 0.1, 0.1 0.2, 0.2 0.2, 0.2 0.1, 0.1 0.1),(0.8 0.8, 0.8 0.9, 0.9 0.9, 0.9 0.8, 0.8 0.8))'
+     - * ``geom_to_wkt(make_polygon(geom_from_wkt('LINESTRING( 0 0, 0 1, 1 1, 1 0, 0 0 )')))`` → 'Polygon ((0 0, 0 1, 1 1, 1 0, 0 0))'
+       * ``geom_to_wkt(make_polygon(geom_from_wkt('LINESTRING( 0 0, 0 1, 1 1, 1 0, 0 0 )'),geom_from_wkt('LINESTRING( 0.1 0.1, 0.1 0.2, 0.2 0.2, 0.2 0.1, 0.1 0.1 )'),geom_from_wkt('LINESTRING( 0.8 0.8, 0.8 0.9, 0.9 0.9, 0.9 0.8, 0.8 0.8 )')))`` → 'Polygon ((0 0, 0 1, 1 1, 1 0, 0 0),(0.1 0.1, 0.1 0.2, 0.2 0.2, 0.2 0.1, 0.1 0.1),(0.8 0.8, 0.8 0.9, 0.9 0.9, 0.9 0.8, 0.8 0.8))'
 
 
 .. end_make_polygon_section
@@ -1594,8 +1594,8 @@ Creates a rectangle from 3 points.
        * **point3** - Third point.
        * **option** - An optional argument to construct the rectangle. By default this value is 0. Value can be 0 (distance) or 1 (projected). Option distance: Second distance is equal to the distance between 2nd and 3rd point. Option projected: Second distance is equal to the distance of the perpendicular projection of the 3rd point on the segment or its extension.
    * - Examples
-     - * geom_to_wkt(make_rectangle(make_point(0, 0), make_point(0,5), make_point(5, 5), 0))) → 'Polygon ((0 0, 0 5, 5 5, 5 0, 0 0))'
-       * geom_to_wkt(make_rectangle(make_point(0, 0), make_point(0,5), make_point(5, 3), 1))) → 'Polygon ((0 0, 0 5, 5 5, 5 0, 0 0))'
+     - * ``geom_to_wkt(make_rectangle(make_point(0, 0), make_point(0,5), make_point(5, 5), 0)))`` → 'Polygon ((0 0, 0 5, 5 5, 5 0, 0 0))'
+       * ``geom_to_wkt(make_rectangle(make_point(0, 0), make_point(0,5), make_point(5, 3), 1)))`` → 'Polygon ((0 0, 0 5, 5 5, 5 0, 0 0))'
 
 
 .. end_make_rectangle_3points_section
@@ -1622,8 +1622,8 @@ Creates a regular polygon.
        * **number_sides** - Number of sides/edges of the regular polygon
        * **circle** - Optional argument to construct the regular polygon. By default this value is 0. Value can be 0 (inscribed) or 1 (circumscribed)
    * - Examples
-     - * geom_to_wkt(make_regular_polygon(make_point(0,0), make_point(0,5), 5)) → 'Polygon ((0 5, 4.76 1.55, 2.94 -4.05, -2.94 -4.05, -4.76 1.55, 0 5))'
-       * geom_to_wkt(make_regular_polygon(make_point(0,0), project(make_point(0,0), 4.0451, radians(36)), 5)) → 'Polygon ((0 5, 4.76 1.55, 2.94 -4.05, -2.94 -4.05, -4.76 1.55, 0 5))'
+     - * ``geom_to_wkt(make_regular_polygon(make_point(0,0), make_point(0,5), 5))`` → 'Polygon ((0 5, 4.76 1.55, 2.94 -4.05, -2.94 -4.05, -4.76 1.55, 0 5))'
+       * ``geom_to_wkt(make_regular_polygon(make_point(0,0), project(make_point(0,0), 4.0451, radians(36)), 5))`` → 'Polygon ((0 5, 4.76 1.55, 2.94 -4.05, -2.94 -4.05, -4.76 1.55, 0 5))'
 
 
 .. end_make_regular_polygon_section
@@ -1646,8 +1646,8 @@ Creates a square from a diagonal.
      - * **point1** - First point of the regular polygon
        * **point2** - Second point
    * - Examples
-     - * geom_to_wkt(make_square( make_point(0,0), make_point(5,5))) → 'Polygon ((0 0, -0 5, 5 5, 5 0, 0 0))'
-       * geom_to_wkt(make_square( make_point(5,0), make_point(5,5))) → 'Polygon ((5 0, 2.5 2.5, 5 5, 7.5 2.5, 5 0))'
+     - * ``geom_to_wkt(make_square( make_point(0,0), make_point(5,5)))`` → 'Polygon ((0 0, -0 5, 5 5, 5 0, 0 0))'
+       * ``geom_to_wkt(make_square( make_point(5,0), make_point(5,5)))`` → 'Polygon ((5 0, 2.5 2.5, 5 5, 7.5 2.5, 5 0))'
 
 
 .. end_make_square_section
@@ -1671,8 +1671,8 @@ Creates a triangle polygon.
        * **point 2** - second point of the triangle
        * **point 3** - third point of the triangle
    * - Examples
-     - * geom_to_wkt(make_triangle(make_point(0,0), make_point(5,5), make_point(0,10))) → 'Triangle ((0 0, 5 5, 0 10, 0 0))'
-       * geom_to_wkt(boundary(make_triangle(make_point(0,0), make_point(5,5), make_point(0,10)))) → 'LineString (0 0, 5 5, 0 10, 0 0)'
+     - * ``geom_to_wkt(make_triangle(make_point(0,0), make_point(5,5), make_point(0,10)))`` → 'Triangle ((0 0, 5 5, 0 10, 0 0))'
+       * ``geom_to_wkt(boundary(make_triangle(make_point(0,0), make_point(5,5), make_point(0,10))))`` → 'LineString (0 0, 5 5, 0 10, 0 0)'
 
 
 .. end_make_triangle_section
@@ -1697,8 +1697,8 @@ Returns the minimal enclosing circle of a geometry. It represents the minimum ci
      - * **geometry** - a geometry
        * **segment** - optional argument for polygon segmentation. By default this value is 36
    * - Examples
-     - * geom_to_wkt( minimal_circle( geom_from_wkt( 'LINESTRING(0 5, 0 -5, 2 1)' ), 4 ) ) → Polygon ((0 5, 5 -0, -0 -5, -5 0, 0 5))
-       * geom_to_wkt( minimal_circle( geom_from_wkt( 'MULTIPOINT(1 2, 3 4, 3 2)' ), 4 ) ) → Polygon ((3 4, 3 2, 1 2, 1 4, 3 4))
+     - * ``geom_to_wkt( minimal_circle( geom_from_wkt( 'LINESTRING(0 5, 0 -5, 2 1)' ), 4 ) )`` → Polygon ((0 5, 5 -0, -0 -5, -5 0, 0 5))
+       * ``geom_to_wkt( minimal_circle( geom_from_wkt( 'MULTIPOINT(1 2, 3 4, 3 2)' ), 4 ) )`` → Polygon ((3 4, 3 2, 1 2, 1 4, 3 4))
 
 
 .. end_minimal_circle_section
@@ -1723,8 +1723,8 @@ Returns a multipoint geometry consisting of every node in the input geometry.
      - * **geometry** - geometry object
        * **ignore_closing_nodes** - optional argument specifying whether to include duplicate nodes which close lines or polygons rings. Defaults to false, set to true to avoid including these duplicate nodes in the output collection.
    * - Examples
-     - * geom_to_wkt(nodes_to_points(geom_from_wkt('LINESTRING(0 0, 1 1, 2 2)'))) → 'MultiPoint ((0 0),(1 1),(2 2))'
-       * geom_to_wkt(nodes_to_points(geom_from_wkt('POLYGON((-1 -1, 4 0, 4 2, 0 2, -1 -1))'),true)) → 'MultiPoint ((-1 -1),(4 0),(4 2),(0 2))'
+     - * ``geom_to_wkt(nodes_to_points(geom_from_wkt('LINESTRING(0 0, 1 1, 2 2)')))`` → 'MultiPoint ((0 0),(1 1),(2 2))'
+       * ``geom_to_wkt(nodes_to_points(geom_from_wkt('POLYGON((-1 -1, 4 0, 4 2, 0 2, -1 -1))'),true))`` → 'MultiPoint ((-1 -1),(4 0),(4 2),(0 2))'
 
 
 .. end_nodes_to_points_section
@@ -1746,7 +1746,7 @@ Returns the number of geometries in a geometry collection, or NULL if the input 
    * - Arguments
      - * **geometry** - geometry collection
    * - Examples
-     - * num_geometries(geom_from_wkt('GEOMETRYCOLLECTION(POINT(0 1), POINT(0 0), POINT(1 0), POINT(1 1))')) → 4
+     - * ``num_geometries(geom_from_wkt('GEOMETRYCOLLECTION(POINT(0 1), POINT(0 0), POINT(1 0), POINT(1 1))'))`` → 4
 
 
 .. end_num_geometries_section
@@ -1768,7 +1768,7 @@ Returns the number of interior rings in a polygon or geometry collection, or NUL
    * - Arguments
      - * **geometry** - input geometry
    * - Examples
-     - * num_interior_rings(geom_from_wkt('POLYGON((-1 -1, 4 0, 4 2, 0 2, -1 -1),(-0.1 -0.1, 0.4 0, 0.4 0.2, 0 0.2, -0.1 -0.1))')) → 1
+     - * ``num_interior_rings(geom_from_wkt('POLYGON((-1 -1, 4 0, 4 2, 0 2, -1 -1),(-0.1 -0.1, 0.4 0, 0.4 0.2, 0 0.2, -0.1 -0.1))'))`` → 1
 
 
 .. end_num_interior_rings_section
@@ -1790,7 +1790,7 @@ Returns the number of vertices in a geometry.
    * - Arguments
      - * **geometry** - a geometry
    * - Examples
-     - * num_points($geometry) → number of vertices in the current feature's geometry
+     - * ``num_points($geometry)`` → number of vertices in the current feature's geometry
 
 
 .. end_num_points_section
@@ -1812,7 +1812,7 @@ Returns the number of rings (including exterior rings) in a polygon or geometry 
    * - Arguments
      - * **geometry** - input geometry
    * - Examples
-     - * num_rings(geom_from_wkt('POLYGON((-1 -1, 4 0, 4 2, 0 2, -1 -1),(-0.1 -0.1, 0.4 0, 0.4 0.2, 0 0.2, -0.1 -0.1))')) → 2
+     - * ``num_rings(geom_from_wkt('POLYGON((-1 -1, 4 0, 4 2, 0 2, -1 -1),(-0.1 -0.1, 0.4 0, 0.4 0.2, 0 0.2, -0.1 -0.1))'))`` → 2
 
 
 .. end_num_rings_section
@@ -1840,10 +1840,10 @@ Returns a geometry formed by offsetting a linestring geometry to the side. Dista
        * **join** - join style for corners, where 1 = round, 2 = miter and 3 = bevel
        * **miter_limit** - limit on the miter ratio used for very sharp corners (when using miter joins only)
    * - Examples
-     - * offset_curve($geometry, 10.5) → line offset to the left by 10.5 units
-       * offset_curve($geometry, -10.5) → line offset to the right by 10.5 units
-       * offset_curve($geometry, 10.5, segments=16, join=1) → line offset to the left by 10.5 units, using more segments to result in a smoother curve
-       * offset_curve($geometry, 10.5, join=3) → line offset to the left by 10.5 units, using a beveled join
+     - * ``offset_curve($geometry, 10.5)`` → line offset to the left by 10.5 units
+       * ``offset_curve($geometry, -10.5)`` → line offset to the right by 10.5 units
+       * ``offset_curve($geometry, 10.5, segments=16, join=1)`` → line offset to the left by 10.5 units, using more segments to result in a smoother curve
+       * ``offset_curve($geometry, 10.5, join=3)`` → line offset to the left by 10.5 units, using a beveled join
 
 
 .. end_offset_curve_section
@@ -1867,8 +1867,8 @@ Orders the parts of a MultiGeometry by a given criteria
        * **orderby** - an expression string defining the order criteria
        * **ascending** - boolean, True for ascending, False for descending
    * - Examples
-     - * order_parts(geom_from_wkt('MultiPolygon (((1 1, 5 1, 5 5, 1 5, 1 1)),((1 1, 9 1, 9 9, 1 9, 1 1)))'), 'area($geometry)', False) → MultiPolygon (((1 1, 9 1, 9 9, 1 9, 1 1)),((1 1, 5 1, 5 5, 1 5, 1 1)))
-       * order_parts(geom_from_wkt('LineString(1 2, 3 2, 4 3)'), '1', True) → LineString(1 2, 3 2, 4 3)
+     - * ``order_parts(geom_from_wkt('MultiPolygon (((1 1, 5 1, 5 5, 1 5, 1 1)),((1 1, 9 1, 9 9, 1 9, 1 1)))'), 'area($geometry)', False)`` → MultiPolygon (((1 1, 9 1, 9 9, 1 9, 1 1)),((1 1, 5 1, 5 5, 1 5, 1 1)))
+       * ``order_parts(geom_from_wkt('LineString(1 2, 3 2, 4 3)'), '1', True)`` → LineString(1 2, 3 2, 4 3)
 
 
 .. end_order_parts_section
@@ -1890,7 +1890,7 @@ Returns a geometry which represents the minimal oriented bounding box of an inpu
    * - Arguments
      - * **geometry** - a geometry
    * - Examples
-     - * geom_to_wkt( oriented_bbox( geom_from_wkt( 'MULTIPOINT(1 2, 3 4, 3 2)' ) ) ) → Polygon ((1 4, 1 2, 3 2, 3 4, 1 4))
+     - * ``geom_to_wkt( oriented_bbox( geom_from_wkt( 'MULTIPOINT(1 2, 3 4, 3 2)' ) ) )`` → Polygon ((1 4, 1 2, 3 2, 3 4, 1 4))
 
 
 .. end_oriented_bbox_section
@@ -1913,8 +1913,8 @@ Tests whether a geometry overlaps another. Returns true if the geometries share 
      - * **geometry a** - a geometry
        * **geometry b** - a geometry
    * - Examples
-     - * overlaps( geom_from_wkt( 'LINESTRING(3 5, 4 4, 5 5, 5 3)' ), geom_from_wkt( 'LINESTRING(3 3, 4 4, 5 5)' ) ) → true
-       * overlaps( geom_from_wkt( 'LINESTRING(0 0, 1 1)' ), geom_from_wkt( 'LINESTRING(3 3, 4 4, 5 5)' ) ) → false
+     - * ``overlaps( geom_from_wkt( 'LINESTRING(3 5, 4 4, 5 5, 5 3)' ), geom_from_wkt( 'LINESTRING(3 3, 4 4, 5 5)' ) )`` → true
+       * ``overlaps( geom_from_wkt( 'LINESTRING(0 0, 1 1)' ), geom_from_wkt( 'LINESTRING(3 3, 4 4, 5 5)' ) )`` → false
 
 
 .. end_overlaps_section
@@ -1934,7 +1934,7 @@ Returns the perimeter length of the current feature. The perimeter calculated by
    * - Syntax
      - $perimeter
    * - Examples
-     - * $perimeter → 42
+     - * ``$perimeter`` → 42
 
 
 .. end_$perimeter_section
@@ -1956,7 +1956,7 @@ Returns the perimeter of a geometry polygon object. Calculations are always plan
    * - Arguments
      - * **geometry** - polygon geometry object
    * - Examples
-     - * perimeter(geom_from_wkt('POLYGON((0 0, 4 0, 4 2, 0 2, 0 0))')) → 12.0
+     - * ``perimeter(geom_from_wkt('POLYGON((0 0, 4 0, 4 2, 0 2, 0 0))'))`` → 12.0
 
 
 .. end_perimeter_section
@@ -1979,7 +1979,7 @@ Returns a specific node from a geometry.
      - * **geometry** - geometry object
        * **index** - index of node to return, where 1 is the first node; if the value is negative, the selected vertex index will be its total count minus the absolute value
    * - Examples
-     - * geom_to_wkt(point_n(geom_from_wkt('POLYGON((0 0, 4 0, 4 2, 0 2, 0 0))'),2)) → 'Point (4 0)'
+     - * ``geom_to_wkt(point_n(geom_from_wkt('POLYGON((0 0, 4 0, 4 2, 0 2, 0 0))'),2))`` → 'Point (4 0)'
 
 
 .. end_point_n_section
@@ -2001,7 +2001,7 @@ Returns a point guaranteed to lie on the surface of a geometry.
    * - Arguments
      - * **geometry** - a geometry
    * - Examples
-     - * point_on_surface($geometry) → a point geometry
+     - * ``point_on_surface($geometry)`` → a point geometry
 
 
 .. end_point_on_surface_section
@@ -2024,7 +2024,7 @@ Calculates the approximate pole of inaccessibility for a surface, which is the m
      - * **geometry** - a geometry
        * **tolerance** - maximum distance between the returned point and the true pole location
    * - Examples
-     - * geom_to_wkt(pole_of_inaccessibility( geom_from_wkt('POLYGON((0 1,0 9,3 10,3 3, 10 3, 10 1, 0 1))'), 0.1)) → Point(1.55, 1.55)
+     - * ``geom_to_wkt(pole_of_inaccessibility( geom_from_wkt('POLYGON((0 1,0 9,3 10,3 3, 10 3, 10 1, 0 1))'), 0.1))`` → Point(1.55, 1.55)
 
 
 .. end_pole_of_inaccessibility_section
@@ -2051,7 +2051,7 @@ Returns a point projected from a start point using a distance, a bearing (azimut
        * **azimuth** - azimuth in radians clockwise, where 0 corresponds to north
        * **elevation** - angle of inclination in radians
    * - Examples
-     - * geom_to_wkt(project(make_point(1, 2), 3, radians(270))) → Point(-2, 2)
+     - * ``geom_to_wkt(project(make_point(1, 2), 3, radians(270)))`` → Point(-2, 2)
 
 
 .. end_project_section
@@ -2078,7 +2078,7 @@ Returns the Dimensional Extended 9 Intersection Model (DE-9IM) representation of
      - * **geometry** - a geometry
        * **geometry** - a geometry
    * - Examples
-     - * relate( geom_from_wkt( 'LINESTRING(40 40,120 120)' ), geom_from_wkt( 'LINESTRING(40 40,60 120)' ) ) → 'FF1F00102'
+     - * ``relate( geom_from_wkt( 'LINESTRING(40 40,120 120)' ), geom_from_wkt( 'LINESTRING(40 40,60 120)' ) )`` → 'FF1F00102'
 
 
 **Pattern match variant**
@@ -2095,7 +2095,7 @@ Tests whether the DE-9IM relationship between two geometries matches a specified
        * **geometry** - a geometry
        * **pattern** - DE-9IM pattern to match
    * - Examples
-     - * relate( geom_from_wkt( 'LINESTRING(40 40,120 120)' ), geom_from_wkt( 'LINESTRING(40 40,60 120)' ), '**1F001**' ) → True
+     - * ``relate( geom_from_wkt( 'LINESTRING(40 40,120 120)' ), geom_from_wkt( 'LINESTRING(40 40,60 120)' ), '**1F001**' )`` → True
 
 
 .. end_relate_section
@@ -2117,7 +2117,7 @@ Reverses the direction of a line string by reversing the order of its vertices.
    * - Arguments
      - * **geometry** - a geometry
    * - Examples
-     - * geom_to_wkt(reverse(geom_from_wkt('LINESTRING(0 0, 1 1, 2 2)'))) → 'LINESTRING(2 2, 1 1, 0 0)'
+     - * ``geom_to_wkt(reverse(geom_from_wkt('LINESTRING(0 0, 1 1, 2 2)')))`` → 'LINESTRING(2 2, 1 1, 0 0)'
 
 
 .. end_reverse_section
@@ -2143,8 +2143,8 @@ Returns a rotated version of a geometry. Calculations are in the Spatial Referen
        * **rotation** - clockwise rotation in degrees
        * **point** - rotation center point. If not specified, the center of the geometry's bounding box is used.
    * - Examples
-     - * rotate($geometry, 45, make_point(4, 5)) → geometry rotated 45 degrees clockwise around the (4, 5) point
-       * rotate($geometry, 45) → geometry rotated 45 degrees clockwise around the center of its bounding box
+     - * ``rotate($geometry, 45, make_point(4, 5))`` → geometry rotated 45 degrees clockwise around the (4, 5) point
+       * ``rotate($geometry, 45)`` → geometry rotated 45 degrees clockwise around the center of its bounding box
 
 
 .. end_rotate_section
@@ -2166,7 +2166,7 @@ Returns a multi line geometry consisting of a line for every segment in the inpu
    * - Arguments
      - * **geometry** - geometry object
    * - Examples
-     - * geom_to_wkt(segments_to_lines(geom_from_wkt('LINESTRING(0 0, 1 1, 2 2)'))) → 'MultiLineString ((0 0, 1 1),(1 1, 2 2))'
+     - * ``geom_to_wkt(segments_to_lines(geom_from_wkt('LINESTRING(0 0, 1 1, 2 2)')))`` → 'MultiLineString ((0 0, 1 1),(1 1, 2 2))'
 
 
 .. end_segments_to_lines_section
@@ -2189,7 +2189,7 @@ Returns the shortest line joining geometry1 to geometry2. The resultant line wil
      - * **geometry1** - geometry to find shortest line from
        * **geometry2** - geometry to find shortest line to
    * - Examples
-     - * geom_to_wkt(shortest_line(geom_from_wkt('LINESTRING (20 80, 98 190, 110 180, 50 75 )'),geom_from_wkt('POINT(100 100)'))) → LineString(73.0769 115.384, 100 100)
+     - * ``geom_to_wkt(shortest_line(geom_from_wkt('LINESTRING (20 80, 98 190, 110 180, 50 75 )'),geom_from_wkt('POINT(100 100)')))`` → LineString(73.0769 115.384, 100 100)
 
 
 .. end_shortest_line_section
@@ -2212,7 +2212,7 @@ Simplifies a geometry by removing nodes using a distance based threshold (ie, th
      - * **geometry** - a geometry
        * **tolerance** - maximum deviation from straight segments for points to be removed
    * - Examples
-     - * geom_to_wkt(simplify(geometry:=geom_from_wkt('LineString(0 0, 5 0.1, 10 0)'),tolerance:=5)) → 'LineString(0 0, 10 0)'
+     - * ``geom_to_wkt(simplify(geometry:=geom_from_wkt('LineString(0 0, 5 0.1, 10 0)'),tolerance:=5))`` → 'LineString(0 0, 10 0)'
 
 
 .. end_simplify_section
@@ -2235,7 +2235,7 @@ Simplifies a geometry by removing nodes using an area based threshold (ie, the V
      - * **geometry** - a geometry
        * **tolerance** - a measure of the maximum area created by a node for the node to be removed
    * - Examples
-     - * geom_to_wkt(simplify_vw(geometry:=geom_from_wkt('LineString(0 0, 5 0, 5.01 10, 5.02 0, 10 0)'),tolerance:=5)) → 'LineString(0 0, 10 0)'
+     - * ``geom_to_wkt(simplify_vw(geometry:=geom_from_wkt('LineString(0 0, 5 0, 5.01 10, 5.02 0, 10 0)'),tolerance:=5))`` → 'LineString(0 0, 10 0)'
 
 
 .. end_simplify_vw_section
@@ -2263,10 +2263,10 @@ Returns a geometry formed by buffering out just one side of a linestring geometr
        * **join** - join style for corners, where 1 = round, 2 = miter and 3 = bevel
        * **miter_limit** - limit on the miter ratio used for very sharp corners (when using miter joins only)
    * - Examples
-     - * single_sided_buffer($geometry, 10.5) → line buffered to the left by 10.5 units
-       * single_sided_buffer($geometry, -10.5) → line buffered to the right by 10.5 units
-       * single_sided_buffer($geometry, 10.5, segments=16, join=1) → line buffered to the left by 10.5 units, using more segments to result in a smoother buffer
-       * single_sided_buffer($geometry, 10.5, join=3) → line buffered to the left by 10.5 units, using a beveled join
+     - * ``single_sided_buffer($geometry, 10.5)`` → line buffered to the left by 10.5 units
+       * ``single_sided_buffer($geometry, -10.5)`` → line buffered to the right by 10.5 units
+       * ``single_sided_buffer($geometry, 10.5, segments=16, join=1)`` → line buffered to the left by 10.5 units, using more segments to result in a smoother buffer
+       * ``single_sided_buffer($geometry, 10.5, join=3)`` → line buffered to the left by 10.5 units, using a beveled join
 
 
 .. end_single_sided_buffer_section
@@ -2294,7 +2294,7 @@ Smooths a geometry by adding extra nodes which round off corners in the geometry
        * **min_length** - minimum length of segments to apply smoothing to. This parameter can be used to avoid placing excessive additional nodes in shorter segments of the geometry.
        * **max_angle** - maximum angle at node for smoothing to be applied (0-180). By lowering the maximum angle intentionally sharp corners in the geometry can be preserved. For instance, a value of 80 degrees will retain right angles in the geometry.
    * - Examples
-     - * geom_to_wkt(smooth(geometry:=geom_from_wkt('LineString(0 0, 5 0, 5 5)'),iterations:=1,offset:=0.2,min_length:=-1,max_angle:=180)) → 'LineString (0 0, 4 0, 5 1, 5 5)'
+     - * ``geom_to_wkt(smooth(geometry:=geom_from_wkt('LineString(0 0, 5 0, 5 5)'),iterations:=1,offset:=0.2,min_length:=-1,max_angle:=180))`` → 'LineString (0 0, 4 0, 5 1, 5 5)'
 
 
 .. end_smooth_section
@@ -2316,7 +2316,7 @@ Returns the first node from a geometry.
    * - Arguments
      - * **geometry** - geometry object
    * - Examples
-     - * geom_to_wkt(start_point(geom_from_wkt('LINESTRING(4 0, 4 2, 0 2)'))) → 'Point (4 0)'
+     - * ``geom_to_wkt(start_point(geom_from_wkt('LINESTRING(4 0, 4 2, 0 2)')))`` → 'Point (4 0)'
 
 
 .. end_start_point_section
@@ -2339,7 +2339,7 @@ Returns a geometry that represents the portions of two geometries that do not in
      - * **geometry1** - a geometry
        * **geometry2** - a geometry
    * - Examples
-     - * geom_to_wkt( sym_difference( geom_from_wkt( 'LINESTRING(3 3, 4 4, 5 5)' ), geom_from_wkt( 'LINESTRING(3 3, 8 8)' ) ) ) → LINESTRING(5 5, 8 8)
+     - * ``geom_to_wkt( sym_difference( geom_from_wkt( 'LINESTRING(3 3, 4 4, 5 5)' ), geom_from_wkt( 'LINESTRING(3 3, 8 8)' ) ) )`` → LINESTRING(5 5, 8 8)
 
 
 .. end_sym_difference_section
@@ -2366,7 +2366,7 @@ Creates a buffer along a line geometry where the buffer diameter varies evenly o
        * **end_width** - width of buffer at end of line.
        * **segments** - number of segments to approximate quarter-circle curves in the buffer.
    * - Examples
-     - * tapered_buffer(geometry:=geom_from_wkt('LINESTRING(1 2, 4 2)'),start_width:=1,end_width:=2,segments:=8) → A tapered buffer starting with a diameter of 1 and ending with a diameter of 2 along the linestring geometry.
+     - * ``tapered_buffer(geometry:=geom_from_wkt('LINESTRING(1 2, 4 2)'),start_width:=1,end_width:=2,segments:=8)`` → A tapered buffer starting with a diameter of 1 and ending with a diameter of 2 along the linestring geometry.
 
 
 .. end_tapered_buffer_section
@@ -2389,8 +2389,8 @@ Tests whether a geometry touches another. Returns true if the geometries have at
      - * **geometry a** - a geometry
        * **geometry b** - a geometry
    * - Examples
-     - * touches( geom_from_wkt( 'LINESTRING(5 3, 4 4)' ), geom_from_wkt( 'LINESTRING(3 3, 4 4, 5 5)' ) ) → true
-       * touches( geom_from_wkt( 'POINT(4 4)' ), geom_from_wkt( 'POINT(5 5)' ) ) → false
+     - * ``touches( geom_from_wkt( 'LINESTRING(5 3, 4 4)' ), geom_from_wkt( 'LINESTRING(3 3, 4 4, 5 5)' ) )`` → true
+       * ``touches( geom_from_wkt( 'POINT(4 4)' ), geom_from_wkt( 'POINT(5 5)' ) )`` → false
 
 
 .. end_touches_section
@@ -2414,7 +2414,7 @@ Returns the geometry transformed from a source CRS to a destination CRS.
        * **source_auth_id** - the source auth CRS ID
        * **dest_auth_id** - the destination auth CRS ID
    * - Examples
-     - * geom_to_wkt( transform( $geometry, 'EPSG:2154', 'EPSG:4326' ) ) → POINT(0 51)
+     - * ``geom_to_wkt( transform( $geometry, 'EPSG:2154', 'EPSG:4326' ) )`` → POINT(0 51)
 
 
 .. end_transform_section
@@ -2438,7 +2438,7 @@ Returns a translated version of a geometry. Calculations are in the Spatial Refe
        * **dx** - delta x
        * **dy** - delta y
    * - Examples
-     - * translate($geometry, 5, 10) → a geometry of the same type like the original one
+     - * ``translate($geometry, 5, 10)`` → a geometry of the same type like the original one
 
 
 .. end_translate_section
@@ -2461,7 +2461,7 @@ Returns a geometry that represents the point set union of the geometries.
      - * **geometry1** - a geometry
        * **geometry2** - a geometry
    * - Examples
-     - * geom_to_wkt( union( geom_from_wkt( 'POINT(4 4)' ), geom_from_wkt( 'POINT(5 5)' ) ) ) → MULTIPOINT(4 4, 5 5)
+     - * ``geom_to_wkt( union( geom_from_wkt( 'POINT(4 4)' ), geom_from_wkt( 'POINT(5 5)' ) ) )`` → MULTIPOINT(4 4, 5 5)
 
 
 .. end_union_section
@@ -2489,7 +2489,7 @@ Returns a wedge shaped buffer originating from a point geometry.
        * **outer_radius** - outer radius for buffers
        * **inner_radius** - optional inner radius for buffers
    * - Examples
-     - * wedge_buffer(center:=geom_from_wkt('POINT(1 2)'),azimuth:=90,width:=180,outer_radius:=1) → A wedge shaped buffer centered on the point (1,2), facing to the East, with a width of 180 degrees and outer radius of 1.
+     - * ``wedge_buffer(center:=geom_from_wkt('POINT(1 2)'),azimuth:=90,width:=180,outer_radius:=1)`` → A wedge shaped buffer centered on the point (1,2), facing to the East, with a width of 180 degrees and outer radius of 1.
 
 
 .. end_wedge_buffer_section
@@ -2512,8 +2512,8 @@ Tests whether a geometry is within another. Returns true if the geometry a is co
      - * **geometry a** - a geometry
        * **geometry b** - a geometry
    * - Examples
-     - * within( geom_from_wkt( 'POINT( 0.5 0.5)' ), geom_from_wkt( 'POLYGON((0 0, 0 1, 1 1, 1 0, 0 0))' ) ) → true
-       * within( geom_from_wkt( 'POINT( 5 5 )' ), geom_from_wkt( 'POLYGON((0 0, 0 1, 1 1, 1 0, 0 0 ))' ) ) → false
+     - * ``within( geom_from_wkt( 'POINT( 0.5 0.5)' ), geom_from_wkt( 'POLYGON((0 0, 0 1, 1 1, 1 0, 0 0))' ) )`` → true
+       * ``within( geom_from_wkt( 'POINT( 5 5 )' ), geom_from_wkt( 'POLYGON((0 0, 0 1, 1 1, 1 0, 0 0 ))' ) )`` → false
 
 
 .. end_within_section
@@ -2533,7 +2533,7 @@ Returns the x coordinate of the current point feature. If the feature is a multi
    * - Syntax
      - $x
    * - Examples
-     - * $x → 42
+     - * ``$x`` → 42
 
 
 .. end_$x_section
@@ -2555,8 +2555,8 @@ Returns the x coordinate of a point geometry, or the x coordinate of the centroi
    * - Arguments
      - * **geometry** - a geometry
    * - Examples
-     - * x( geom_from_wkt( 'POINT(2 5)' ) ) → 2
-       * x( $geometry ) → x coordinate of the current feature's centroid
+     - * ``x( geom_from_wkt( 'POINT(2 5)' ) )`` → 2
+       * ``x( $geometry )`` → x coordinate of the current feature's centroid
 
 
 .. end_x_section
@@ -2578,7 +2578,7 @@ Retrieves a x coordinate of the current feature's geometry.
    * - Arguments
      - * **i** - index of point of a line (indices start at 0; negative values apply from the last index, starting at -1)
    * - Examples
-     - * $x_at(1) → 5
+     - * ``$x_at(1)`` → 5
 
 
 .. end_$x_at_section
@@ -2600,7 +2600,7 @@ Returns the maximum x coordinate of a geometry. Calculations are in the spatial 
    * - Arguments
      - * **geometry** - a geometry
    * - Examples
-     - * x_max( geom_from_wkt( 'LINESTRING(2 5, 3 6, 4 8)') ) → 4
+     - * ``x_max( geom_from_wkt( 'LINESTRING(2 5, 3 6, 4 8)') )`` → 4
 
 
 .. end_x_max_section
@@ -2622,7 +2622,7 @@ Returns the minimum x coordinate of a geometry. Calculations are in the spatial 
    * - Arguments
      - * **geometry** - a geometry
    * - Examples
-     - * x_min( geom_from_wkt( 'LINESTRING(2 5, 3 6, 4 8)') ) → 2
+     - * ``x_min( geom_from_wkt( 'LINESTRING(2 5, 3 6, 4 8)') )`` → 2
 
 
 .. end_x_min_section
@@ -2642,7 +2642,7 @@ Returns the y coordinate of the current point feature. If the feature is a multi
    * - Syntax
      - $y
    * - Examples
-     - * $y → 42
+     - * ``$y`` → 42
 
 
 .. end_$y_section
@@ -2664,8 +2664,8 @@ Returns the y coordinate of a point geometry, or the y coordinate of the centroi
    * - Arguments
      - * **geometry** - a geometry
    * - Examples
-     - * y( geom_from_wkt( 'POINT(2 5)' ) ) → 5
-       * y( $geometry ) → y coordinate of the current feature's centroid
+     - * ``y( geom_from_wkt( 'POINT(2 5)' ) )`` → 5
+       * ``y( $geometry )`` → y coordinate of the current feature's centroid
 
 
 .. end_y_section
@@ -2687,7 +2687,7 @@ Retrieves a y coordinate of the current feature's geometry.
    * - Arguments
      - * **i** - index of point of a line (indices start at 0; negative values apply from the last index, starting at -1)
    * - Examples
-     - * $y_at(1) → 2
+     - * ``$y_at(1)`` → 2
 
 
 .. end_$y_at_section
@@ -2709,7 +2709,7 @@ Returns the maximum y coordinate of a geometry. Calculations are in the spatial 
    * - Arguments
      - * **geometry** - a geometry
    * - Examples
-     - * y_max( geom_from_wkt( 'LINESTRING(2 5, 3 6, 4 8)') ) → 8
+     - * ``y_max( geom_from_wkt( 'LINESTRING(2 5, 3 6, 4 8)') )`` → 8
 
 
 .. end_y_max_section
@@ -2731,7 +2731,7 @@ Returns the minimum y coordinate of a geometry. Calculations are in the spatial 
    * - Arguments
      - * **geometry** - a geometry
    * - Examples
-     - * y_min( geom_from_wkt( 'LINESTRING(2 5, 3 6, 4 8)') ) → 5
+     - * ``y_min( geom_from_wkt( 'LINESTRING(2 5, 3 6, 4 8)') )`` → 5
 
 
 .. end_y_min_section
@@ -2753,7 +2753,7 @@ Returns the z coordinate of a point geometry, or NULL if the geometry has no z v
    * - Arguments
      - * **geometry** - a point geometry
    * - Examples
-     - * z( geom_from_wkt( 'POINTZ(2 5 7)' ) ) → 7
+     - * ``z( geom_from_wkt( 'POINTZ(2 5 7)' ) )`` → 7
 
 
 .. end_z_section
@@ -2775,11 +2775,11 @@ Returns the maximum z coordinate of a geometry, or NULL if the geometry has no z
    * - Arguments
      - * **geometry** - a geometry with z coordinate
    * - Examples
-     - * z_max( geom_from_wkt( 'POINT ( 0 0 1 )' ) ) → 1
-       * z_max( geom_from_wkt( 'MULTIPOINT ( 0 0 1 , 1 1 3 )' ) ) → 3
-       * z_max( make_line( make_point( 0,0,0 ), make_point( -1,-1,-2 ) ) ) → 0
-       * z_max( geom_from_wkt( 'LINESTRING( 0 0 0, 1 0 2, 1 1 -1 )' ) ) → 2
-       * z_max( geom_from_wkt( 'POINT ( 0 0 )' ) ) → NULL
+     - * ``z_max( geom_from_wkt( 'POINT ( 0 0 1 )' ) )`` → 1
+       * ``z_max( geom_from_wkt( 'MULTIPOINT ( 0 0 1 , 1 1 3 )' ) )`` → 3
+       * ``z_max( make_line( make_point( 0,0,0 ), make_point( -1,-1,-2 ) ) )`` → 0
+       * ``z_max( geom_from_wkt( 'LINESTRING( 0 0 0, 1 0 2, 1 1 -1 )' ) )`` → 2
+       * ``z_max( geom_from_wkt( 'POINT ( 0 0 )' ) )`` → NULL
 
 
 .. end_z_max_section
@@ -2801,11 +2801,11 @@ Returns the minimum z coordinate of a geometry, or NULL if the geometry has no z
    * - Arguments
      - * **geometry** - a geometry with z coordinate
    * - Examples
-     - * z_min( geom_from_wkt( 'POINT ( 0 0 1 )' ) ) → 1
-       * z_min( geom_from_wkt( 'MULTIPOINT ( 0 0 1 , 1 1 3 )' ) ) → 1
-       * z_min( make_line( make_point( 0,0,0 ), make_point( -1,-1,-2 ) ) ) → -2
-       * z_min( geom_from_wkt( 'LINESTRING( 0 0 0, 1 0 2, 1 1 -1 )' ) ) → -1
-       * z_min( geom_from_wkt( 'POINT ( 0 0 )' ) ) → NULL
+     - * ``z_min( geom_from_wkt( 'POINT ( 0 0 1 )' ) )`` → 1
+       * ``z_min( geom_from_wkt( 'MULTIPOINT ( 0 0 1 , 1 1 3 )' ) )`` → 1
+       * ``z_min( make_line( make_point( 0,0,0 ), make_point( -1,-1,-2 ) ) )`` → -2
+       * ``z_min( geom_from_wkt( 'LINESTRING( 0 0 0, 1 0 2, 1 1 -1 )' ) )`` → -1
+       * ``z_min( geom_from_wkt( 'POINT ( 0 0 )' ) )`` → NULL
 
 
 .. end_z_min_section

--- a/docs/user_manual/working_with_vector/expression_help/Layout.rst
+++ b/docs/user_manual/working_with_vector/expression_help/Layout.rst
@@ -23,7 +23,7 @@ Returns a map of variables from a composer item inside this composition.
    * - Arguments
      - * **id** - composer item ID
    * - Examples
-     - * map_get(item_variables('main_map'), 'map_scale') → 2000
+     - * ``map_get(item_variables('main_map'), 'map_scale')`` → 2000
 
 
 .. end_item_variables_section

--- a/docs/user_manual/working_with_vector/expression_help/Map_Layers.rst
+++ b/docs/user_manual/working_with_vector/expression_help/Map_Layers.rst
@@ -26,9 +26,9 @@ Takes a layer and decodes the uri of the underlying data provider. It depends on
      - * **layer** - The layer for which the uri should be decoded.
        * **part** - The part of the uri to return. If unspecified, a map with all uri parts will be returned.
    * - Examples
-     - * decode_uri(@layer) → {'layerId': '0', 'layerName': '', 'path': '/home/qgis/shapefile.shp'}
-       * decode_uri(@layer) → {'layerId': NULL, 'layerName': 'layer', 'path': '/home/qgis/geopackage.gpkg'}
-       * decode_uri(@layer, 'path') → 'C:\\my_data\\qgis\\shape.shp'
+     - * ``decode_uri(@layer)`` → {'layerId': '0', 'layerName': '', 'path': '/home/qgis/shapefile.shp'}
+       * ``decode_uri(@layer)`` → {'layerId': NULL, 'layerName': 'layer', 'path': '/home/qgis/geopackage.gpkg'}
+       * ``decode_uri(@layer, 'path')`` → 'C:\\my_data\\qgis\\shape.shp'
 
 
 .. end_decode_uri_section

--- a/docs/user_manual/working_with_vector/expression_help/Maps.rst
+++ b/docs/user_manual/working_with_vector/expression_help/Maps.rst
@@ -23,8 +23,8 @@ Loads a JSON formatted string.
    * - Arguments
      - * **string** - JSON string
    * - Examples
-     - * from_json('{"qgis":"rocks"}') → { "qgis" : "rocks" }
-       * from_json('[1,2,3]') → [1,2,3]
+     - * ``from_json('{"qgis":"rocks"}')`` → { "qgis" : "rocks" }
+       * ``from_json('[1,2,3]')`` → [1,2,3]
 
 
 .. end_from_json_section
@@ -46,7 +46,7 @@ Creates a map from a hstore-formatted string.
    * - Arguments
      - * **string** - the input string
    * - Examples
-     - * hstore_to_map('qgis=>rocks') → { "qgis" : "rocks" }
+     - * ``hstore_to_map('qgis=>rocks')`` → { "qgis" : "rocks" }
 
 
 .. end_hstore_to_map_section
@@ -68,7 +68,7 @@ Creates a map from a json-formatted string.
    * - Arguments
      - * **string** - the input string
    * - Examples
-     - * json_to_map('{"qgis":"rocks"}') → { "qgis" : "rocks" }
+     - * ``json_to_map('{"qgis":"rocks"}')`` → { "qgis" : "rocks" }
 
 
 .. end_json_to_map_section
@@ -91,7 +91,7 @@ Returns a map containing all the keys and values passed as pair of parameters.
      - * **key** - a key (string)
        * **value** - a value
    * - Examples
-     - * map('1','one','2', 'two') → { '1': 'one', '2': 'two' }
+     - * ``map('1','one','2', 'two')`` → { '1': 'one', '2': 'two' }
 
 
 .. end_map_section
@@ -113,7 +113,7 @@ Returns all the keys of a map as an array.
    * - Arguments
      - * **map** - a map
    * - Examples
-     - * map_akeys(map('1','one','2','two')) → [ '1', '2' ]
+     - * ``map_akeys(map('1','one','2','two'))`` → [ '1', '2' ]
 
 
 .. end_map_akeys_section
@@ -135,7 +135,7 @@ Returns all the values of a map as an array.
    * - Arguments
      - * **map** - a map
    * - Examples
-     - * map_avals(map('1','one','2','two')) → [ 'one', 'two' ]
+     - * ``map_avals(map('1','one','2','two'))`` → [ 'one', 'two' ]
 
 
 .. end_map_avals_section
@@ -157,7 +157,7 @@ Returns a map containing all the entries of the given maps. If two maps contain 
    * - Arguments
      - * **map** - a map
    * - Examples
-     - * map_concat(map('1','one', '2','overridden'),map('2','two', '3','three')) → { '1': 'one, '2': 'two', '3': 'three' }
+     - * ``map_concat(map('1','one', '2','overridden'),map('2','two', '3','three'))`` → { '1': 'one, '2': 'two', '3': 'three' }
 
 
 .. end_map_concat_section
@@ -180,7 +180,7 @@ Returns a map with the given key and its corresponding value deleted.
      - * **map** - a map
        * **key** - the key to delete
    * - Examples
-     - * map_delete(map('1','one','2','two'),'2') → { '1': 'one' }
+     - * ``map_delete(map('1','one','2','two'),'2')`` → { '1': 'one' }
 
 
 .. end_map_delete_section
@@ -203,7 +203,7 @@ Returns true if the given key exists in the map.
      - * **map** - a map
        * **key** - the key to lookup
    * - Examples
-     - * map_exist(map('1','one','2','two'),'3') → false
+     - * ``map_exist(map('1','one','2','two'),'3')`` → false
 
 
 .. end_map_exist_section
@@ -226,7 +226,7 @@ Returns the value of a map, given it's key.
      - * **map** - a map
        * **key** - the key to lookup
    * - Examples
-     - * map_get(map('1','one','2','two'),'2') → 'two'
+     - * ``map_get(map('1','one','2','two'),'2')`` → 'two'
 
 
 .. end_map_get_section
@@ -250,7 +250,7 @@ Returns a map with an added key/value.
        * **key** - the key to add
        * **value** - the value to add
    * - Examples
-     - * map_insert(map('1','one'),'3','three') → { '1': 'one', '3': 'three' }
+     - * ``map_insert(map('1','one'),'3','three')`` → { '1': 'one', '3': 'three' }
 
 
 .. end_map_insert_section
@@ -272,7 +272,7 @@ Merge map elements into a hstore-formatted string.
    * - Arguments
      - * **map** - the input map
    * - Examples
-     - * map_to_hstore(map('qgis','rocks')) → "qgis"=>"rocks"}
+     - * ``map_to_hstore(map('qgis','rocks'))`` → "qgis"=>"rocks"}
 
 
 .. end_map_to_hstore_section
@@ -294,7 +294,7 @@ Merge map elements into a json-formatted string.
    * - Arguments
      - * **map** - the input map
    * - Examples
-     - * map_to_json(map('qgis','rocks')) → {"qgis":"rocks"}
+     - * ``map_to_json(map('qgis','rocks'))`` → {"qgis":"rocks"}
 
 
 .. end_map_to_json_section
@@ -316,8 +316,8 @@ Create a JSON formatted string from a map, array or other value.
    * - Arguments
      - * **value** - The input value
    * - Examples
-     - * to_json(map('qgis','rocks')) → {"qgis":"rocks"}
-       * to_json(array(1,2,3)) → [1,2,3]
+     - * ``to_json(map('qgis','rocks'))`` → {"qgis":"rocks"}
+       * ``to_json(array(1,2,3))`` → [1,2,3]
 
 
 .. end_to_json_section

--- a/docs/user_manual/working_with_vector/expression_help/Math.rst
+++ b/docs/user_manual/working_with_vector/expression_help/Math.rst
@@ -23,7 +23,7 @@ Returns the absolute value of a number.
    * - Arguments
      - * **value** - a number
    * - Examples
-     - * abs(-2) → 2
+     - * ``abs(-2)`` → 2
 
 
 .. end_abs_section
@@ -45,7 +45,7 @@ Returns the inverse cosine of a value in radians.
    * - Arguments
      - * **value** - cosine of an angle in radians
    * - Examples
-     - * acos(0.5) → 1.0471975511966
+     - * ``acos(0.5)`` → 1.0471975511966
 
 
 .. end_acos_section
@@ -67,7 +67,7 @@ Returns the inverse sine of a value in radians.
    * - Arguments
      - * **value** - sine of an angle in radians
    * - Examples
-     - * asin(1.0) → 1.5707963267949
+     - * ``asin(1.0)`` → 1.5707963267949
 
 
 .. end_asin_section
@@ -89,7 +89,7 @@ Returns the inverse tangent of a value in radians.
    * - Arguments
      - * **value** - tan of an angle in radians
    * - Examples
-     - * atan(0.5) → 0.463647609000806
+     - * ``atan(0.5)`` → 0.463647609000806
 
 
 .. end_atan_section
@@ -112,7 +112,7 @@ Returns the inverse tangent of dy/dx by using the signs of the two arguments to 
      - * **dy** - y coordinate difference
        * **dx** - x coordinate difference
    * - Examples
-     - * atan2(1.0, 1.732) → 0.523611477769969
+     - * ``atan2(1.0, 1.732)`` → 0.523611477769969
 
 
 .. end_atan2_section
@@ -135,8 +135,8 @@ Returns the north-based azimuth as the angle in radians measured clockwise from 
      - * **point_a** - point geometry
        * **point_b** - point geometry
    * - Examples
-     - * degrees( azimuth( make_point(25, 45), make_point(75, 100) ) ) → 42.273689
-       * degrees( azimuth( make_point(75, 100), make_point(25,45) ) ) → 222.273689
+     - * ``degrees( azimuth( make_point(25, 45), make_point(75, 100) ) )`` → 42.273689
+       * ``degrees( azimuth( make_point(75, 100), make_point(25,45) ) )`` → 222.273689
 
 
 .. end_azimuth_section
@@ -158,8 +158,8 @@ Rounds a number upwards.
    * - Arguments
      - * **value** - a number
    * - Examples
-     - * ceil(4.9) → 5
-       * ceil(-4.9) → -4
+     - * ``ceil(4.9)`` → 5
+       * ``ceil(-4.9)`` → -4
 
 
 .. end_ceil_section
@@ -183,13 +183,13 @@ Restricts an input value to a specified range.
        * **input** - a value which will be restricted to the range specified by *minimum* and *maximum*
        * **maximum** - the largest value *input* is allowed to take
    * - Examples
-     - * clamp(1,5,10) → 5
+     - * ``clamp(1,5,10)`` → 5
 
          *input* is between 1 and 10 so is returned unchanged
-       * clamp(1,0,10) → 1
+       * ``clamp(1,0,10)`` → 1
 
          *input* is less than minimum value of 1, so function returns 1
-       * clamp(1,11,10) → 10
+       * ``clamp(1,11,10)`` → 10
 
          *input* is greater than maximum value of 10, so function returns 10
 
@@ -213,7 +213,7 @@ Returns cosine of an angle.
    * - Arguments
      - * **angle** - angle in radians
    * - Examples
-     - * cos(1.571) → 0.000796326710733263
+     - * ``cos(1.571)`` → 0.000796326710733263
 
 
 .. end_cos_section
@@ -235,8 +235,8 @@ Converts from radians to degrees.
    * - Arguments
      - * **radians** - numeric value
    * - Examples
-     - * degrees(3.14159) → 180
-       * degrees(1) → 57.2958
+     - * ``degrees(3.14159)`` → 180
+       * ``degrees(1)`` → 57.2958
 
 
 .. end_degrees_section
@@ -258,7 +258,7 @@ Returns exponential of an value.
    * - Arguments
      - * **value** - number to return exponent of
    * - Examples
-     - * exp(1.0) → 2.71828182845905
+     - * ``exp(1.0)`` → 2.71828182845905
 
 
 .. end_exp_section
@@ -280,8 +280,8 @@ Rounds a number downwards.
    * - Arguments
      - * **value** - a number
    * - Examples
-     - * floor(4.9) → 4
-       * floor(-4.9) → -5
+     - * ``floor(4.9)`` → 4
+       * ``floor(-4.9)`` → -5
 
 
 .. end_floor_section
@@ -304,10 +304,10 @@ Returns the inclination measured from the zenith (0) to the nadir (180) on point
      - * **point_a** - point geometry
        * **point_b** - point geometry
    * - Examples
-     - * inclination( make_point( 5, 10, 0 ), make_point( 5, 10, 5 ) ) → 0.0
-       * inclination( make_point( 5, 10, 0 ), make_point( 5, 10, 0 ) ) → 90.0
-       * inclination( make_point( 5, 10, 0 ), make_point( 50, 100, 0 ) ) → 90.0
-       * inclination( make_point( 5, 10, 0 ), make_point( 5, 10, -5 ) ) → 180.0
+     - * ``inclination( make_point( 5, 10, 0 ), make_point( 5, 10, 5 ) )`` → 0.0
+       * ``inclination( make_point( 5, 10, 0 ), make_point( 5, 10, 0 ) )`` → 90.0
+       * ``inclination( make_point( 5, 10, 0 ), make_point( 50, 100, 0 ) )`` → 90.0
+       * ``inclination( make_point( 5, 10, 0 ), make_point( 5, 10, -5 ) )`` → 180.0
 
 
 .. end_inclination_section
@@ -329,8 +329,8 @@ Returns the natural logarithm of a value.
    * - Arguments
      - * **value** - numeric value
    * - Examples
-     - * ln(1) → 0
-       * ln(2.7182818284590452354) → 1
+     - * ``ln(1)`` → 0
+       * ``ln(2.7182818284590452354)`` → 1
 
 
 .. end_ln_section
@@ -353,8 +353,8 @@ Returns the value of the logarithm of the passed value and base.
      - * **base** - any positive number
        * **value** - any positive number
    * - Examples
-     - * log(2, 32) → 5
-       * log(0.5, 32) → -5
+     - * ``log(2, 32)`` → 5
+       * ``log(0.5, 32)`` → -5
 
 
 .. end_log_section
@@ -376,8 +376,8 @@ Returns the value of the base 10 logarithm of the passed expression.
    * - Arguments
      - * **value** - any positive number
    * - Examples
-     - * log10(1) → 0
-       * log10(100) → 2
+     - * ``log10(1)`` → 0
+       * ``log10(100)`` → 2
 
 
 .. end_log10_section
@@ -399,8 +399,8 @@ Returns the largest value in a set of values.
    * - Arguments
      - * **value** - a number
    * - Examples
-     - * max(2,10.2,5.5) → 10.2
-       * max(20.5,NULL,6.2) → 20.5
+     - * ``max(2,10.2,5.5)`` → 10.2
+       * ``max(20.5,NULL,6.2)`` → 20.5
 
 
 .. end_max_section
@@ -422,8 +422,8 @@ Returns the smallest value in a set of values.
    * - Arguments
      - * **value** - a number
    * - Examples
-     - * min(20.5,10,6.2) → 6.2
-       * min(2,-10.3,NULL) → -10.3
+     - * ``min(20.5,10,6.2)`` → 6.2
+       * ``min(2,-10.3,NULL)`` → -10.3
 
 
 .. end_min_section
@@ -443,7 +443,7 @@ Returns value of pi for calculations.
    * - Syntax
      - pi()
    * - Examples
-     - * pi() → 3.14159265358979
+     - * ``pi()`` → 3.14159265358979
 
 
 .. end_pi_section
@@ -465,8 +465,8 @@ Converts from degrees to radians.
    * - Arguments
      - * **degrees** - numeric value
    * - Examples
-     - * radians(180) → 3.14159
-       * radians(57.2958) → 1
+     - * ``radians(180)`` → 3.14159
+       * ``radians(57.2958)`` → 1
 
 
 .. end_radians_section
@@ -492,7 +492,7 @@ Returns a random integer within the range specified by the minimum and maximum a
        * **max** - an integer representing the largest possible random number desired
        * **seed** - any value to use as seed
    * - Examples
-     - * rand(1, 10) → 8
+     - * ``rand(1, 10)`` → 8
 
 
 .. end_rand_section
@@ -518,7 +518,7 @@ Returns a random float within the range specified by the minimum and maximum arg
        * **max** - an float representing the largest possible random number desired
        * **seed** - any value to use as seed
    * - Examples
-     - * randf(1, 10) → 4.59258286403147
+     - * ``randf(1, 10)`` → 4.59258286403147
 
 
 .. end_randf_section
@@ -543,8 +543,8 @@ Rounds a number to number of decimal places.
      - * **value** - decimal number to be rounded
        * **places** - Optional integer representing number of places to round decimals to. Can be negative.
    * - Examples
-     - * round(1234.567, 2) → 1234.57
-       * round(1234.567) → 1235
+     - * ``round(1234.567, 2)`` → 1234.57
+       * ``round(1234.567)`` → 1235
 
 
 .. end_round_section
@@ -571,10 +571,10 @@ Transforms a given value from an input domain to an output range using an expone
        * **range_max** - Specifies the maximum value in the output range, the largest value which should be output by the function.
        * **exponent** - A positive value (greater than 0), which dictates the way input values are mapped to the output range. Large exponents will cause the output values to 'ease in', starting slowly before accelerating as the input values approach the domain maximum. Smaller exponents (less than 1) will cause output values to 'ease out', where the mapping starts quickly but slows as it approaches the domain maximum.
    * - Examples
-     - * scale_exp(5,0,10,0,100,2) → 25
+     - * ``scale_exp(5,0,10,0,100,2)`` → 25
 
          easing in, using an exponent of 2
-       * scale_exp(3,0,10,0,100,0.5) → 54.772
+       * ``scale_exp(3,0,10,0,100,0.5)`` → 54.772
 
          easing out, using an exponent of 0.5
 
@@ -602,11 +602,11 @@ Transforms a given value from an input domain to an output range using linear in
        * **range_min** - Specifies the minimum value in the output range, the smallest value which should be output by the function.
        * **range_max** - Specifies the maximum value in the output range, the largest value which should be output by the function.
    * - Examples
-     - * scale_linear(5,0,10,0,100) → 50
-       * scale_linear(0.2,0,1,0,360) → 72
+     - * ``scale_linear(5,0,10,0,100)`` → 50
+       * ``scale_linear(0.2,0,1,0,360)`` → 72
 
          scaling a value between 0 and 1 to an angle between 0 and 360
-       * scale_linear(1500,1000,10000,9,20) → 9.6111111
+       * ``scale_linear(1500,1000,10000,9,20)`` → 9.6111111
 
          scaling a population which varies between 1000 and 10000 to a font size between 9 and 20
 
@@ -630,7 +630,7 @@ Returns the sine of an angle.
    * - Arguments
      - * **angle** - angle in radians
    * - Examples
-     - * sin(1.571) → 0.999999682931835
+     - * ``sin(1.571)`` → 0.999999682931835
 
 
 .. end_sin_section
@@ -652,7 +652,7 @@ Returns square root of a value.
    * - Arguments
      - * **value** - a number
    * - Examples
-     - * sqrt(9) → 3
+     - * ``sqrt(9)`` → 3
 
 
 .. end_sqrt_section
@@ -674,7 +674,7 @@ Returns the tangent of an angle.
    * - Arguments
      - * **angle** - angle in radians
    * - Examples
-     - * tan(1.0) → 1.5574077246549
+     - * ``tan(1.0)`` → 1.5574077246549
 
 
 .. end_tan_section

--- a/docs/user_manual/working_with_vector/expression_help/Processing.rst
+++ b/docs/user_manual/working_with_vector/expression_help/Processing.rst
@@ -23,7 +23,7 @@ Returns the value of a processing algorithm input parameter.
    * - Arguments
      - * **name** - name of the corresponding input parameter
    * - Examples
-     - * parameter('BUFFER_SIZE') → 5.6
+     - * ``parameter('BUFFER_SIZE')`` → 5.6
 
 
 .. end_parameter_section

--- a/docs/user_manual/working_with_vector/expression_help/Rasters.rst
+++ b/docs/user_manual/working_with_vector/expression_help/Rasters.rst
@@ -36,8 +36,8 @@ Returns statistics from a raster layer.
          
 
    * - Examples
-     - * raster_statistic('lc',1,'avg') → Average value from band 1 from 'lc' raster layer
-       * raster_statistic('ac2010',3,'min') → Minimum value from band 3 from 'ac2010' raster layer
+     - * ``raster_statistic('lc',1,'avg')`` → Average value from band 1 from 'lc' raster layer
+       * ``raster_statistic('ac2010',3,'min')`` → Minimum value from band 3 from 'ac2010' raster layer
 
 
 .. end_raster_statistic_section
@@ -61,7 +61,7 @@ Returns the raster value found at the provided point.
        * **band** - the band number to sample the value from.
        * **point** - point geometry (for multipart geometries having more than one part, a NULL value will be returned)
    * - Examples
-     - * raster_value('dem', 1, make_point(1,1)) → 25
+     - * ``raster_value('dem', 1, make_point(1,1))`` → 25
 
 
 .. end_raster_value_section

--- a/docs/user_manual/working_with_vector/expression_help/Record_and_Attributes.rst
+++ b/docs/user_manual/working_with_vector/expression_help/Record_and_Attributes.rst
@@ -27,7 +27,7 @@ Returns the value of an attribute from the current feature.
    * - Arguments
      - * **attribute_name** - name of attribute to be returned
    * - Examples
-     - * attribute( 'name' ) → value stored in 'name' attribute for the current feature
+     - * ``attribute( 'name' )`` → value stored in 'name' attribute for the current feature
 
 
 **Variant 2**
@@ -43,7 +43,7 @@ Allows the target feature and attribute name to be specified.
      - * **feature** - a feature
        * **attribute_name** - name of attribute to be returned
    * - Examples
-     - * attribute( @atlas_feature, 'name' ) → value stored in 'name' attribute for the current atlas feature
+     - * ``attribute( @atlas_feature, 'name' )`` → value stored in 'name' attribute for the current atlas feature
 
 
 .. end_attribute_section
@@ -67,7 +67,7 @@ Returns a map of all attributes from the current feature.
    * - Syntax
      - attributes()
    * - Examples
-     - * attributes()['name'] → value stored in 'name' attribute for the current feature
+     - * ``attributes()['name']`` → value stored in 'name' attribute for the current feature
 
 
 **Variant 2**
@@ -82,7 +82,7 @@ Allows the target feature to be specified.
    * - Arguments
      - * **feature** - a feature
    * - Examples
-     - * attributes( @atlas_feature )['name'] → value stored in 'name' attribute for the current atlas feature
+     - * ``attributes( @atlas_feature )['name']`` → value stored in 'name' attribute for the current atlas feature
 
 
 .. end_attributes_section
@@ -102,7 +102,7 @@ Returns the current feature being evaluated. This can be used with the 'attribut
    * - Syntax
      - $currentfeature
    * - Examples
-     - * attribute( $currentfeature, 'name' ) → value stored in 'name' attribute for the current feature
+     - * ``attribute( $currentfeature, 'name' )`` → value stored in 'name' attribute for the current feature
 
 
 .. end_$currentfeature_section
@@ -126,7 +126,7 @@ If called with no parameters, the function will evaluate the display expression 
    * - Syntax
      - display_expression()
    * - Examples
-     - * display_expression() → The display expression of the current feature in the current layer.
+     - * ``display_expression()`` → The display expression of the current feature in the current layer.
 
 
 **One 'feature' parameter**
@@ -141,7 +141,7 @@ If called with a 'feature' parameter only, the function will evaluate the specif
    * - Arguments
      - * **feature** - The feature which should be evaluated.
    * - Examples
-     - * display_expression(@atlas_feature) → The display expression of the current atlas feature.
+     - * ``display_expression(@atlas_feature)`` → The display expression of the current atlas feature.
 
 
 **Layer and feature parameters**
@@ -160,8 +160,8 @@ If the function is called with both a layer and a feature, it will evaluate the 
        * **feature** - The feature which should be evaluated.
        * **evaluate** - If the expression must be evaluated. If false, the expression will be returned as a string literal only (which could potentially be later evaluated using the 'eval' function).
    * - Examples
-     - * display_expression( 'streets', get_feature_by_id('streets', 1)) → The display expression of the feature with the ID 1 on the layer 'streets'.
-       * display_expression('a_layer_id', $currentfeature, 'False') → The display expression of the given feature not evaluated.
+     - * ``display_expression( 'streets', get_feature_by_id('streets', 1))`` → The display expression of the feature with the ID 1 on the layer 'streets'.
+       * ``display_expression('a_layer_id', $currentfeature, 'False')`` → The display expression of the given feature not evaluated.
 
 
 .. end_display_expression_section
@@ -185,7 +185,7 @@ Returns the first feature of a layer matching a given attribute value.
        * **attribute** - attribute name
        * **value** - attribute value to match
    * - Examples
-     - * get_feature('streets','name','main st') → first feature found in "streets" layer with "main st" value in the "name" field
+     - * ``get_feature('streets','name','main st')`` → first feature found in "streets" layer with "main st" value in the "name" field
 
 
 .. end_get_feature_section
@@ -208,7 +208,7 @@ Returns the feature with an id on a layer.
      - * **layer** - layer, layer name or layer id
        * **feature_id** - the id of the feature which should be returned
    * - Examples
-     - * get_feature('streets', 1) → the feature with the id 1 on the layer "streets"
+     - * ``get_feature('streets', 1)`` → the feature with the id 1 on the layer "streets"
 
 
 .. end_get_feature_by_id_section
@@ -228,7 +228,7 @@ Returns the feature id of the current row.
    * - Syntax
      - $id
    * - Examples
-     - * $id → 42
+     - * ``$id`` → 42
 
 
 .. end_$id_section
@@ -252,7 +252,7 @@ If called with no parameters, the function will return true if the current featu
    * - Syntax
      - is_selected()
    * - Examples
-     - * is_selected() → True if the current feature in the current layer is selected.
+     - * ``is_selected()`` → True if the current feature in the current layer is selected.
 
 
 **One 'feature' parameter**
@@ -267,7 +267,7 @@ If called with a 'feature' parameter only, the function returns true if the spec
    * - Arguments
      - * **feature** - The feature which should be checked for selection.
    * - Examples
-     - * is_selected(@atlas_feature) → True if the current atlas feature is selected.
+     - * ``is_selected(@atlas_feature)`` → True if the current atlas feature is selected.
 
 
 **Two parameters**
@@ -283,7 +283,7 @@ If the function is called with both a layer and a feature, it will return true i
      - * **layer** - The layer (or its ID or name) on which the selection will be checked.
        * **feature** - The feature which should be checked for selection.
    * - Examples
-     - * is_selected( 'streets', get_feature('streets', 'name', "street_name")) → True if the current building's street is selected (assuming the building layer has a field named 'street_name' and the 'streets' layer has a field called 'name').
+     - * ``is_selected( 'streets', get_feature('streets', 'name', "street_name"))`` → True if the current building's street is selected (assuming the building layer has a field named 'street_name' and the 'streets' layer has a field called 'name').
 
 
 .. end_is_selected_section
@@ -307,7 +307,7 @@ If called with no parameters, the function will evaluate the maptip of the curre
    * - Syntax
      - maptip()
    * - Examples
-     - * maptip() → The maptip of the current feature in the current layer.
+     - * ``maptip()`` → The maptip of the current feature in the current layer.
 
 
 **One 'feature' parameter**
@@ -322,7 +322,7 @@ If called with a 'feature' parameter only, the function will evaluate the specif
    * - Arguments
      - * **feature** - The feature which should be evaluated.
    * - Examples
-     - * maptip(@atlas_feature) → The maptip of the current atlas feature.
+     - * ``maptip(@atlas_feature)`` → The maptip of the current atlas feature.
 
 
 **Layer and feature parameters**
@@ -341,8 +341,8 @@ If the function is called with both a layer and a feature, it will evaluate the 
        * **feature** - The feature which should be evaluated.
        * **evaluate** - If the expression must be evaluated. If false, the expression will be returned as a string literal only (which could potentially be later evaluated using the 'eval_template' function).
    * - Examples
-     - * maptip('streets', get_feature_by_id('streets', 1)) → The maptip of the feature with the ID 1 on the layer 'streets'.
-       * maptip('a_layer_id', $currentfeature, 'False') → The maptip of the given feature not evaluated.
+     - * ``maptip('streets', get_feature_by_id('streets', 1))`` → The maptip of the feature with the ID 1 on the layer 'streets'.
+       * ``maptip('a_layer_id', $currentfeature, 'False')`` → The maptip of the given feature not evaluated.
 
 
 .. end_maptip_section
@@ -366,8 +366,8 @@ Returns the number of selected features on a given layer. By default works on th
    * - Arguments
      - * **layer** - The layer (or its id or name) on which the selection will be checked.
    * - Examples
-     - * num_selected() → The number of selected features on the current layer.
-       * num_selected('streets') → The number of selected features on the layer streets
+     - * ``num_selected()`` → The number of selected features on the current layer.
+       * ``num_selected('streets')`` → The number of selected features on the layer streets
 
 
 .. end_num_selected_section
@@ -390,8 +390,8 @@ Returns the configured representation value for a field value. It depends on the
      - * **value** - The value which should be resolved. Most likely a field.
        * **fieldName** - The field name for which the widget configuration should be loaded. (Optional)
    * - Examples
-     - * represent_value("field_with_value_map") → Description for value
-       * represent_value('static value', 'field_name') → Description for static value
+     - * ``represent_value("field_with_value_map")`` → Description for value
+       * ``represent_value('static value', 'field_name')`` → Description for static value
 
 
 .. end_represent_value_section
@@ -446,8 +446,8 @@ When the database parameter is a layer and the layer is in transaction mode, the
        * **filter_value** - Name of the sequence to use.
        * **default_values** - Map with default values for additional columns on the table. The values need to be fully quoted. Functions are allowed.
    * - Examples
-     - * sqlite_fetch_and_increment(@layer, 'sequence_table', 'last_unique_id', 'sequence_id', 'global', map('last_change','date(''now'')','user','''' || @user_account_name || '''')) → 0
-       * sqlite_fetch_and_increment(layer_property(@layer, 'path'), 'sequence_table', 'last_unique_id', 'sequence_id', 'global', map('last_change','date(''now'')','user','''' || @user_account_name || '''')) → 0
+     - * ``sqlite_fetch_and_increment(@layer, 'sequence_table', 'last_unique_id', 'sequence_id', 'global', map('last_change','date(''now'')','user','''' || @user_account_name || ''''))`` → 0
+       * ``sqlite_fetch_and_increment(layer_property(@layer, 'path'), 'sequence_table', 'last_unique_id', 'sequence_id', 'global', map('last_change','date(''now'')','user','''' || @user_account_name || ''''))`` → 0
 
 
 .. end_sqlite_fetch_and_increment_section
@@ -467,7 +467,7 @@ Generates a Universally Unique Identifier (UUID) for each row using the Qt `QUui
    * - Syntax
      - uuid()
    * - Examples
-     - * uuid() → '{0bd2f60f-f157-4a6d-96af-d4ba4cb366a1}'
+     - * ``uuid()`` → '{0bd2f60f-f157-4a6d-96af-d4ba4cb366a1}'
 
 
 .. end_uuid_section

--- a/docs/user_manual/working_with_vector/expression_help/String.rst
+++ b/docs/user_manual/working_with_vector/expression_help/String.rst
@@ -23,7 +23,7 @@ Returns the unicode code associated with the first character of a string.
    * - Arguments
      - * **string** - the string to convert to unicode code
    * - Examples
-     - * ascii('Q') → 81
+     - * ``ascii('Q')`` → 81
 
 
 .. end_ascii_section
@@ -45,7 +45,7 @@ Returns the character associated with a unicode code.
    * - Arguments
      - * **code** - a unicode code number
    * - Examples
-     - * char(81) → 'Q'
+     - * ``char(81)`` → 'Q'
 
 
 .. end_char_section
@@ -67,10 +67,10 @@ Concatenates several strings to one. NULL values are converted to empty strings.
    * - Arguments
      - * **string** - a string value
    * - Examples
-     - * concat('sun', 'set') → 'sunset'
-       * concat('a','b','c','d','e') → 'abcde'
-       * concat('Anno ', 1984) → 'Anno 1984'
-       * concat('The Wall', NULL) → 'The Wall'
+     - * ``concat('sun', 'set')`` → 'sunset'
+       * ``concat('a','b','c','d','e')`` → 'abcde'
+       * ``concat('Anno ', 1984)`` → 'Anno 1984'
+       * ``concat('The Wall', NULL)`` → 'The Wall'
 
 
 .. end_concat_section
@@ -93,7 +93,7 @@ Format a string using supplied arguments.
      - * **string** - A string with place holders for the arguments. Use %1, %2, etc for placeholders. Placeholders can be repeated.
        * **arg** - any type. Any number of arguments.
    * - Examples
-     - * format('This %1 a %2','is', 'test') → 'This is a test''
+     - * ``format('This %1 a %2','is', 'test')`` → 'This is a test''
 
 
 .. end_format_section
@@ -158,8 +158,8 @@ Formats a date type or string into a custom string format. Uses Qt date/time for
 
        * **language** - language (lowercase, two- or three-letter, ISO 639 language code) used to format the date into a custom string
    * - Examples
-     - * format_date('2012-05-15','dd.MM.yyyy') → '15.05.2012'
-       * format_date('2012-05-15','d MMMM yyyy','fr') → '15 juin 2012'
+     - * ``format_date('2012-05-15','dd.MM.yyyy')`` → '15.05.2012'
+       * ``format_date('2012-05-15','d MMMM yyyy','fr')`` → '15 juin 2012'
 
 
 .. end_format_date_section
@@ -185,7 +185,7 @@ Returns a number formatted with the locale separator for thousands. Also truncat
        * **places** - integer representing the number of decimal places to truncate the string to.
        * **language** - language (lowercase, two- or three-letter, ISO 639 language code) used to format the number into a string
    * - Examples
-     - * format_number(10000000.332,2) → '10,000,000.33'
+     - * ``format_number(10000000.332,2)`` → '10,000,000.33'
 
 
 .. end_format_number_section
@@ -208,7 +208,7 @@ Returns a substring that contains the *n* leftmost characters of the string.
      - * **string** - a string
        * **length** - integer. The number of characters from the left of the string to return.
    * - Examples
-     - * left('Hello World',5) → 'Hello'
+     - * ``left('Hello World',5)`` → 'Hello'
 
 
 .. end_left_section
@@ -234,7 +234,7 @@ Returns the number of characters in a string.
    * - Arguments
      - * **string** - string to count length of
    * - Examples
-     - * length('hello') → 5
+     - * ``length('hello')`` → 5
 
 
 **Geometry variant**
@@ -249,7 +249,7 @@ Calculate the length of a geometry line object. Calculations are always planimet
    * - Arguments
      - * **geometry** - line geometry object
    * - Examples
-     - * length(geom_from_wkt('LINESTRING(0 0, 4 0)')) → 4.0
+     - * ``length(geom_from_wkt('LINESTRING(0 0, 4 0)'))`` → 4.0
 
 
 .. end_length_section
@@ -271,7 +271,7 @@ Converts a string to lower case letters.
    * - Arguments
      - * **string** - the string to convert to lower case
    * - Examples
-     - * lower('HELLO World') → 'hello world'
+     - * ``lower('HELLO World')`` → 'hello world'
 
 
 .. end_lower_section
@@ -295,8 +295,8 @@ Returns a string padded on the left to the specified width, using a fill charact
        * **width** - length of new string
        * **fill** - character to pad the remaining space with
    * - Examples
-     - * lpad('Hello', 10, 'x') → 'xxxxxHello'
-       * lpad('Hello', 3, 'x') → 'Hel'
+     - * ``lpad('Hello', 10, 'x')`` → 'xxxxxHello'
+       * ``lpad('Hello', 3, 'x')`` → 'Hel'
 
 
 .. end_lpad_section
@@ -319,7 +319,7 @@ Return the first matching position matching a regular expression within a string
      - * **input_string** - the string to test against the regular expression
        * **regex** - The regular expression to test against. Backslash characters must be double escaped (e.g., "\\\\s" to match a white space character).
    * - Examples
-     - * regexp_match('QGIS ROCKS','\\\\sROCKS') → 4
+     - * ``regexp_match('QGIS ROCKS','\\\\sROCKS')`` → 4
 
 
 .. end_regexp_match_section
@@ -343,7 +343,7 @@ Returns a string with the supplied regular expression replaced.
        * **regex** - The regular expression to replace. Backslash characters must be double escaped (e.g., "\\\\s" to match a white space character).
        * **replacement** - The string that will replace any matching occurrences of the supplied regular expression. Captured groups can be inserted into the replacement string using \\\\1, \\\\2, etc.
    * - Examples
-     - * regexp_replace('QGIS SHOULD ROCK','\\\\sSHOULD\\\\s',' DOES ') → 'QGIS DOES ROCK'
+     - * ``regexp_replace('QGIS SHOULD ROCK','\\\\sSHOULD\\\\s',' DOES ')`` → 'QGIS DOES ROCK'
 
 
 .. end_regexp_replace_section
@@ -366,7 +366,7 @@ Returns the portion of a string which matches a supplied regular expression.
      - * **input_string** - the string to find matches in
        * **regex** - The regular expression to match against. Backslash characters must be double escaped (e.g., "\\\\s" to match a white space character).
    * - Examples
-     - * regexp_substr('abc123','(\\\\d+)') → '123'
+     - * ``regexp_substr('abc123','(\\\\d+)')`` → '123'
 
 
 .. end_regexp_substr_section
@@ -394,9 +394,9 @@ Returns a string with the supplied string or array of strings replaced by a stri
        * **before** - the string or array of strings to replace
        * **after** - the string or array of strings to use as a replacement
    * - Examples
-     - * replace('QGIS SHOULD ROCK','SHOULD','DOES') → 'QGIS DOES ROCK'
-       * replace('QGIS ABC',array('A','B','C'),array('X','Y','Z')) → 'QGIS XYZ'
-       * replace('QGIS',array('Q','S'),'') → 'GI'
+     - * ``replace('QGIS SHOULD ROCK','SHOULD','DOES')`` → 'QGIS DOES ROCK'
+       * ``replace('QGIS ABC',array('A','B','C'),array('X','Y','Z'))`` → 'QGIS XYZ'
+       * ``replace('QGIS',array('Q','S'),'')`` → 'GI'
 
 
 **Map variant**
@@ -412,7 +412,7 @@ Returns a string with the supplied map keys replaced by paired values.
      - * **string** - the input string
        * **map** - the map containing keys and values
    * - Examples
-     - * replace('APP SHOULD ROCK',map('APP','QGIS','SHOULD','DOES')) → 'QGIS DOES ROCK'
+     - * ``replace('APP SHOULD ROCK',map('APP','QGIS','SHOULD','DOES'))`` → 'QGIS DOES ROCK'
 
 
 .. end_replace_section
@@ -435,7 +435,7 @@ Returns a substring that contains the *n* rightmost characters of the string.
      - * **string** - a string
        * **length** - integer. The number of characters from the right of the string to return.
    * - Examples
-     - * right('Hello World',5) → 'World'
+     - * ``right('Hello World',5)`` → 'World'
 
 
 .. end_right_section
@@ -459,8 +459,8 @@ Returns a string padded on the right to the specified width, using a fill charac
        * **width** - length of new string
        * **fill** - character to pad the remaining space with
    * - Examples
-     - * rpad('Hello', 10, 'x') → 'Helloxxxxx'
-       * rpad('Hello', 3, 'x') → 'Hel'
+     - * ``rpad('Hello', 10, 'x')`` → 'Helloxxxxx'
+       * ``rpad('Hello', 3, 'x')`` → 'Hel'
 
 
 .. end_rpad_section
@@ -483,8 +483,8 @@ Return the first matching position of a substring within another string, or 0 if
      - * **haystack** - string that is to be searched
        * **needle** - string to search for
    * - Examples
-     - * strpos('HELLO WORLD','WORLD') → 7
-       * strpos('HELLO WORLD','GOODBYE') → 0
+     - * ``strpos('HELLO WORLD','WORLD')`` → 7
+       * ``strpos('HELLO WORLD','GOODBYE')`` → 0
 
 
 .. end_strpos_section
@@ -510,12 +510,12 @@ Returns a part of a string.
        * **start** - integer representing start position to extract beginning with 1; if start is negative, the return string will begin at the end of the string minus the start value
        * **length** - integer representing length of string to extract; if length is negative, the return string will omit the given length of characters from the end of the string
    * - Examples
-     - * substr('HELLO WORLD',3,5) → 'LLO W'
-       * substr('HELLO WORLD',6) → ' WORLD'
-       * substr('HELLO WORLD',-5) → 'WORLD'
-       * substr('HELLO',3,-1) → 'LL'
-       * substr('HELLO WORLD',-5,2) → 'WO'
-       * substr('HELLO WORLD',-5,-1) → 'WORL'
+     - * ``substr('HELLO WORLD',3,5)`` → 'LLO W'
+       * ``substr('HELLO WORLD',6)`` → ' WORLD'
+       * ``substr('HELLO WORLD',-5)`` → 'WORLD'
+       * ``substr('HELLO',3,-1)`` → 'LL'
+       * ``substr('HELLO WORLD',-5,2)`` → 'WO'
+       * ``substr('HELLO WORLD',-5,-1)`` → 'WORL'
 
 
 .. end_substr_section
@@ -537,7 +537,7 @@ Converts all words of a string to title case (all words lower case with leading 
    * - Arguments
      - * **string** - the string to convert to title case
    * - Examples
-     - * title('hello WOrld') → 'Hello World'
+     - * ``title('hello WOrld')`` → 'Hello World'
 
 
 .. end_title_section
@@ -559,7 +559,7 @@ Converts a number to string.
    * - Arguments
      - * **number** - Integer or real value. The number to convert to string.
    * - Examples
-     - * to_string(123) → '123'
+     - * ``to_string(123)`` → '123'
 
 
 .. end_to_string_section
@@ -581,7 +581,7 @@ Removes all leading and trailing whitespace (spaces, tabs, etc) from a string.
    * - Arguments
      - * **string** - string to trim
    * - Examples
-     - * trim('   hello world    ') → 'hello world'
+     - * ``trim('   hello world    ')`` → 'hello world'
 
 
 .. end_trim_section
@@ -603,7 +603,7 @@ Converts a string to upper case letters.
    * - Arguments
      - * **string** - the string to convert to upper case
    * - Examples
-     - * upper('hello WOrld') → 'HELLO WORLD'
+     - * ``upper('hello WOrld')`` → 'HELLO WORLD'
 
 
 .. end_upper_section
@@ -629,8 +629,8 @@ Returns a string wrapped to a maximum/minimum number of characters.
        * **wrap_length** - an integer. If wrap_length is positive the number represents the ideal maximum number of characters to wrap; if negative, the number represents the minimum number of characters to wrap.
        * **delimiter_string** - Optional delimiter string to wrap to a new line.
    * - Examples
-     - * wordwrap('UNIVERSITY OF QGIS',13) → 'UNIVERSITY OF<br>QGIS'
-       * wordwrap('UNIVERSITY OF QGIS',-3) → 'UNIVERSITY<br>OF QGIS'
+     - * ``wordwrap('UNIVERSITY OF QGIS',13)`` → 'UNIVERSITY OF<br>QGIS'
+       * ``wordwrap('UNIVERSITY OF QGIS',-3)`` → 'UNIVERSITY<br>OF QGIS'
 
 
 .. end_wordwrap_section

--- a/scripts/populate_expressions_list.py
+++ b/scripts/populate_expressions_list.py
@@ -126,7 +126,7 @@ def format_variant(function_dict, f_name):
     if 'examples' in function_dict:
         ex_list = []
         for ex in function_dict['examples']:
-            example = f"{ex['expression']} → {ex['returns']}"
+            example = f"``{ex['expression']}`` → {ex['returns']}"
             if 'note' in ex:
                 example += f"\n\n         {sphynxify_html(ex['note'])}"
 


### PR DESCRIPTION
by putting them between backticks (fix #5953) and moving from 
![image](https://user-images.githubusercontent.com/7983394/89445656-beb4d180-d753-11ea-9cba-2c17cb6d377a.png)
 to 
![image](https://user-images.githubusercontent.com/7983394/89445721-d3916500-d753-11ea-8d14-fee0c7d18b23.png)

Happens that quotes are kept as is within backticks or a code block. When in plain-text, another character code is used, and that one does not work in QGIS.
The only drawback I see is that the sqlite_fetch_increment examples go beyond the "paper" limits but it was already the case with the [hash](https://docs.qgis.org/testing/en/docs/user_manual/working_with_vector/expression.html#hash) examples. So not really a new issue.