### PR TITLE
Use string comparison operator

### DIFF
--- a/scripts/find_set_subst.py
+++ b/scripts/find_set_subst.py
@@ -28,7 +28,7 @@ def get_subst_from_file(file):
     with open(file, 'r+') as f:
         pos = f.tell()
         line = f.readline()
-        while line is not "":
+        while line != "":
             if s_title.match(line) is not None:
                 f.seek(pos-2)
                 f.truncate()


### PR DESCRIPTION
and fix warning 
```
$ python3 scripts/find_set_subst.py 
scripts/find_set_subst.py:31: SyntaxWarning: "is not" with a literal. Did you mean "!="?
  while line is not "":
```