### PR TITLE
Several typo's corrected

### DIFF
--- a/docs/user_manual/introduction/browser.rst
+++ b/docs/user_manual/introduction/browser.rst
@@ -73,11 +73,11 @@ When enabled, it opens at the bottom of the browser panel, as shown in
 
    The properties widget
 
-A second browser panels can be opened by activating the
+A second browser panel can be opened by activating the
 :guilabel:`Browser (2)` panel in :menuselection:`View --> Panels`.
 Having two browser panels can be useful when copying layers between
 resources that are locationed deep down in different branches of the
-browser hierarcy.
+browser hierarchy.
 
 
 Resources that can be opened / run from the Browser
@@ -112,7 +112,7 @@ The ones you have tagged will appear here.
 
 In addition to the operations described under *Home*, the
 context menu allows you to :guilabel:`Rename Favorite...` and
-:guilabel:`Remove Favourite`.
+:guilabel:`Remove Favorite`.
 
 
 Spatial Bookmarks
@@ -124,7 +124,7 @@ From the top level context menu, you can create a bookmark
 (:guilabel:`New Spatial Bookmark...`),
 :guilabel:`Show the Spatial Bookmark Manager`,
 :guilabel:`Import Spatial Bookmarks...` and
-:guilabel:`Export Spatial Bookmarks...`,
+:guilabel:`Export Spatial Bookmarks...`.
 
 For bookmark entries you can :guilabel:`Zoom to Bookmark`,
 :guilabel:`Edit Spatial Bookmark...` and
@@ -386,33 +386,33 @@ Resources
   The context menu for QGIS project files allows you to:
 
   * open it (:guilabel:`Open Project`)
-  * extract symbols (:guilabel:`Extract Symbols...`) - open the style
+  * extract symbols (:guilabel:`Extract Symbols...`) - opens the style
     manager that allows you to export symbols to an XML file, add
     symbols to the default style or export as PNG or SVG.
   * inspect properties (:guilabel:`File Properties...`)
 
   You can expand the project file to see its layers.
-  The context menu of a layers offers the same actions as elsewhere
+  The context menu of a layer offers the same actions as elsewhere
   in the browser.
-* QGIS Layer Definition files (QLR)
+* QGIS Layer Definition files (QLR).
   The following actions are available from the context menu:
 
   * export it (:menuselection:`Export Layer --> To file`)
   * add it to the project (:guilabel:`Add Layer to Project`)
   * inspect properties (:guilabel:`Layer Properties...`)
 
-* QGIS Models (.model3)
+* QGIS Models (.model3).
   The following actions are available from the context menu:
 
   * :guilabel:`Run Model...`)
   * :guilabel:`Edit Model...`)
 
-* QGIS print composer templates (QPT)
+* QGIS print composer templates (QPT).
   The following action is available from the context menu:
 
   * (:guilabel:`New Layout from Template`)
 
-* Python scripts (.py)
+* Python scripts (.py).
   The following actions are available from the context menu:
 
   * (:guilabel:`Run script...`)


### PR DESCRIPTION
Line 76   :  "browser panels can"  should probably be  "browser panel can"  Singular, not plural
Line 80   :   "hierarcy"  should be "hierarchy" - missing letter h at the end
Line 115 :  "Favourite"  should be "Favorite" to be consistent with other instances of the word
Line 127 :  ending comma (,) should be a dot (.), since it is at the end of the sentence and the end of the paragraph
Line 389 :  "- open the style manager"  should probably be "- opens the style manager", since pressing "Extract symbols" automagicly opens Style Manager
Line 395 : "menu of a layers offers" should probably be "menu of a layer offers".  Singular, not plural
Line 397 : Should probably have a dot (.) at the end since next sentence starts with capital letter and other items for this list do have a dot at the end
Line 404 : Should probably have a dot (.) at the end since next sentence starts with capital letter and other items for this list do have a dot at the end
Line 410 : Should probably have a dot (.) at the end since next sentence starts with capital letter and other items for this list do have a dot at the end
Line 415 : Should probably have a dot (.) at the end since next sentence starts with capital letter and other items for this list do have a dot at the end


Goal:  Display correct documentation

- [x] Backport to LTR documentation is required
