### PR TITLE
Undocumented WMS parameters

### DIFF
--- a/docs/server_manual/getting_started.rst
+++ b/docs/server_manual/getting_started.rst
@@ -784,6 +784,8 @@ to faster loading times on the client side.
 You can receive requested GetFeatureInfo as plain text, XML and GML. Default is XML,
 text or GML format depends the output format chosen for the GetFeatureInfo request.
 
+.. _`addGeometryToFeatureResponse` : 
+
 If you wish, you can check |checkbox| :guilabel:`Add geometry to feature response`.
 This will include the bounding box for each feature in the GetFeatureInfo response.
 See also the :ref:`WITH_GEOMETRY <server_wms_getfeatureinfo>` parameter.

--- a/docs/server_manual/services.rst
+++ b/docs/server_manual/services.rst
@@ -120,7 +120,11 @@ extra parameters:
    * FORCE_2D: Force 2D output. This is required for polyline width.
    "
    "TILED", "No", "Working in *tiled mode*"
-
+   "SLD", "No", "SLD file URL to be used for styling"
+   "SLD_BODY", "No", "SLD XML content to be used for styling"
+   "WMS_PRECISION", "No", "The precision (number of digits) to deal with when
+   passing float in request (e.g. BBOX parameters). The default value is ``-1``
+   meaning that precision defined in the project is used.
 
 URL example:
 
@@ -949,6 +953,8 @@ implementation:
   .. figure:: img/getfeaturecount_legend.png
     :align: center
 
+* **RULE** set it to a given rule name to get only the named rule symbol
+	    
 GetProjectSettings
 ------------------
 
@@ -2090,6 +2096,9 @@ You can see there are several parameters in this request:
 
 * **HIGHLIGHT_LABELSIZE**: This parameter controls the size of the
   label.
+
+* **HIGHLIGHT_LABELFONT**: This parameter controls the font of the
+  label (e.g. Arial)
 
 * **HIGHLIGHT_LABELCOLOR**: This parameter controls the label color.
 

--- a/docs/server_manual/services.rst
+++ b/docs/server_manual/services.rst
@@ -563,7 +563,7 @@ the OGC WMS 1.1.0 and 1.3.0 specifications:
    "Y", "No", "Same as `J` parameter, but in WMS 1.1.0"
    "WMS_PRECISION", "No", "The precision (number of digits) to be used
    when returning geometry (see :ref:`how to add geometry to feature response<addGeometryToFeatureResponse>`).
-   The default value is ``-1`` meaning that precision defined in the project is used."
+   The default value is ``-1`` meaning that the precision defined in the project is used."
 
 
 In addition to the standard ones, QGIS Server supports the following

--- a/docs/server_manual/services.rst
+++ b/docs/server_manual/services.rst
@@ -122,9 +122,6 @@ extra parameters:
    "TILED", "No", "Working in *tiled mode*"
    "SLD", "No", "SLD file URL to be used for styling"
    "SLD_BODY", "No", "SLD XML content to be used for styling"
-   "WMS_PRECISION", "No", "The precision (number of digits) to deal with when
-   passing float in request (e.g. BBOX parameters). The default value is ``-1``
-   meaning that precision defined in the project is used.
 
 URL example:
 
@@ -564,6 +561,9 @@ the OGC WMS 1.1.0 and 1.3.0 specifications:
    "X", "No", "Same as `I` parameter, but in WMS 1.1.0"
    "J", "No", "Pixel row of the point to query"
    "Y", "No", "Same as `J` parameter, but in WMS 1.1.0"
+   "WMS_PRECISION", "No", "The precision (number of digits) to be used
+   when returning geometry (see :ref:`how to add geometry to feature response<addGeometryToFeatureResponse>`).
+   The default value is ``-1`` meaning that precision defined in the project is used."
 
 
 In addition to the standard ones, QGIS Server supports the following


### PR DESCRIPTION
I went through the code to identify possible undocumented QGIS Server parameters. 

I found some in WMS, none in other services. This PR proposed to document the missing one. 

For the record, I didn't document those one
- **STYLE** : works the same way as STYLES, and it's not in the standard, only here for backward compatilibity I presume
- **WMTVER** : same as VERSION, only here for backwards capability

@signedav SRCWIDTH and SRCHEIGHT are not documented. From what I understand from your [PR](https://github.com/qgis/QGIS/pull/9545) and from the code, they serve the same purpose than HEIGHT/WIDTH on a GetMap but could be used when you want both HEIGHT/WIDTH and SRCHEIGHT/SRCWIDTH on a GetLegendGraphics.

From your PR, you said
> But on a GetLegendGraphics request these parameters (HEIGHT and WIDTH) are used for the size of the generated legend image.

I failed to make this work, HEIGHT and WIDTH are always the map width/height for content based legend. It looks like the legend size is always automatically computed. Am I wrong? Is this really possible to set the output legend size.


No backport planned
- [ ] Backport to LTR documentation is required

