### PR TITLE
QGIS_SERVER_TRUST_LAYER_METADATA setting environnement

### DIFF
--- a/docs/server_manual/config.rst
+++ b/docs/server_manual/config.rst
@@ -193,8 +193,10 @@ This is an option at the project level to improve project read time by using the
 layer extents defined in the project metadata and disabling the check for
 PostgreSQL/PostGIS layer primary key uniqueness.
 
-The trust layer metadata can be forced by setting this variable to ``1`` or ``true``.
-In this case, the vector layer's extent will be the one defined in the project and Postgres/Postgis layers' primary key defined in the datasource are considered as unique without check.
+Trusting layer metadata can be forced by setting this variable to ``1`` or ``true``.
+The vector layer's extent will then be the one defined in the project, and the
+PostgreSQL/PostGIS layer's primary key defined in the data source is
+considered as unique without a check.
 
 Do not use it if layers' extent is not fixed during the project's use.
 

--- a/docs/server_manual/config.rst
+++ b/docs/server_manual/config.rst
@@ -186,6 +186,16 @@ The default behavior can be overridden by setting this variable to ``1`` or ``tr
 In this case, "bad" layers will just be ignored, and the project will be considered
 valid and available.
 
+QGIS_SERVER_TRUST_LAYER_METADATA
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Trust layer metadata is an option at the project level to improve project read time by using vector layer's extent defined in the project and disabling the check primary key unicity for Postgres/Postgis layers.
+
+The trust layer metadata can be forced by setting this variable to ``1`` or ``true``.
+In this case, the vector layer's extent will be the one defined in the project and Postgres/Postgis layers' primary key defined in the datasource are considered as unique without check.
+
+Do not use it if layers' extent is not fixed during the project's use.
+
 
 Settings summary
 ================

--- a/docs/server_manual/config.rst
+++ b/docs/server_manual/config.rst
@@ -189,7 +189,9 @@ valid and available.
 QGIS_SERVER_TRUST_LAYER_METADATA
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Trust layer metadata is an option at the project level to improve project read time by using vector layer's extent defined in the project and disabling the check primary key unicity for Postgres/Postgis layers.
+This is an option at the project level to improve project read time by using the vector
+layer extents defined in the project metadata and disabling the check for
+PostgreSQL/PostGIS layer primary key uniqueness.
 
 The trust layer metadata can be forced by setting this variable to ``1`` or ``true``.
 In this case, the vector layer's extent will be the one defined in the project and Postgres/Postgis layers' primary key defined in the datasource are considered as unique without check.


### PR DESCRIPTION
Goal: Enhance QGIS Server documentation by adding QGIS_SERVER_TRUST_LAYER_METADATA setting environnement description.

Ticket(s): #6013