### PR TITLE
[pyqgis] add methods to QgsVectorLayer

### DIFF
--- a/docs/pyqgis_developer_cookbook/vector.rst
+++ b/docs/pyqgis_developer_cookbook/vector.rst
@@ -95,8 +95,8 @@ methods you can easily get both:
 .. testcode:: vectors
 
     vlayer = iface.addVectorLayer("testdata/airports.shp", "airports", "ogr")
-    vlayer.displayField()
-    vlayer.mapTipTemplate()
+    print(vlayer.displayField())
+    print(vlayer.mapTipTemplate())
 
 
 .. testoutput:: vectors

--- a/docs/pyqgis_developer_cookbook/vector.rst
+++ b/docs/pyqgis_developer_cookbook/vector.rst
@@ -83,6 +83,28 @@ by calling :meth:`fields() <qgis.core.QgsVectorLayer.fields>` on a :class:`QgsVe
     NAME String
     USE String
 
+The :meth:`displayField() <qgis.core.QgsVectorLayer.displayField>` and 
+:meth:`mapTipTemplate() <qgis.core.QgsVectorLayer.mapTipTemplate>` methods of
+the :class:`QgsVectorLayer <qgis.core.QgsVectorLayer>` class allows you to get
+information of the field and template used in the :ref:`maptips` tab.
+
+When you load a vector alyer, a field is always chosen by QGIS as the 
+``Display Name`` while the ``HTML Map Tip`` is empty by default. With these 
+methods you can easily get both information:
+
+.. testcode:: vectors
+
+    vlayer = QgsVectorLayer("testdata/airports.shp", "airports", "ogr")
+    vlayer.displayField()
+    vlayer.mapTipTemplate()
+
+
+.. testoutput:: vectors
+
+    NAME
+    ''
+
+
 .. index:: Iterating features
 
 Iterating over Vector Layer

--- a/docs/pyqgis_developer_cookbook/vector.rst
+++ b/docs/pyqgis_developer_cookbook/vector.rst
@@ -104,8 +104,8 @@ methods you can easily get both:
     NAME
     ''
 
-.. note:: If you change the ``Display Name`` from a field to an expression, 
-   you have to use :meth:`displayExpression() <qgis.core.QgsVectorLayer.displayExpression>`
+.. note:: If you change the ``Display Name`` from a field to an expression, you have to
+   use :meth:`displayExpression() <qgis.core.QgsVectorLayer.displayExpression>`
    instead of :meth:`displayField() <qgis.core.QgsVectorLayer.displayField>`.
 
 .. index:: Iterating features

--- a/docs/pyqgis_developer_cookbook/vector.rst
+++ b/docs/pyqgis_developer_cookbook/vector.rst
@@ -105,8 +105,8 @@ methods you can easily get both:
     ''
 
 .. note:: If you change the ``Display Name`` from a field to an expression, 
-  you have to use :meth:`displayExpression() <qgis.core.QgsVectorLayer.displayExpression>`
-  instead of :meth:`displayField() <qgis.core.QgsVectorLayer.displayField>`.
+   you have to use :meth:`displayExpression() <qgis.core.QgsVectorLayer.displayExpression>`
+   instead of :meth:`displayField() <qgis.core.QgsVectorLayer.displayField>`.
 
 .. index:: Iterating features
 

--- a/docs/pyqgis_developer_cookbook/vector.rst
+++ b/docs/pyqgis_developer_cookbook/vector.rst
@@ -94,15 +94,13 @@ methods you can easily get both:
 
 .. testcode:: vectors
 
-    vlayer = iface.addVectorLayer("testdata/airports.shp", "airports", "ogr")
+    vlayer = QgsVectorLayer("testdata/airports.shp", "airports", "ogr")
     print(vlayer.displayField())
-    print(vlayer.mapTipTemplate())
 
 
 .. testoutput:: vectors
 
     NAME
-    ''
 
 .. note:: If you change the ``Display Name`` from a field to an expression, you have to
    use :meth:`displayExpression() <qgis.core.QgsVectorLayer.displayExpression>`

--- a/docs/pyqgis_developer_cookbook/vector.rst
+++ b/docs/pyqgis_developer_cookbook/vector.rst
@@ -85,8 +85,8 @@ by calling :meth:`fields() <qgis.core.QgsVectorLayer.fields>` on a :class:`QgsVe
 
 The :meth:`displayField() <qgis.core.QgsVectorLayer.displayField>` and 
 :meth:`mapTipTemplate() <qgis.core.QgsVectorLayer.mapTipTemplate>` methods of
-the :class:`QgsVectorLayer <qgis.core.QgsVectorLayer>` class allows you to get
-information of the field and template used in the :ref:`maptips` tab.
+the :class:`QgsVectorLayer <qgis.core.QgsVectorLayer>` class provide
+information on the field and template used in the :ref:`maptips` tab.
 
 When you load a vector layer, a field is always chosen by QGIS as the 
 ``Display Name`` while the ``HTML Map Tip`` is empty by default. With these 

--- a/docs/pyqgis_developer_cookbook/vector.rst
+++ b/docs/pyqgis_developer_cookbook/vector.rst
@@ -90,7 +90,7 @@ information on the field and template used in the :ref:`maptips` tab.
 
 When you load a vector layer, a field is always chosen by QGIS as the 
 ``Display Name`` while the ``HTML Map Tip`` is empty by default. With these 
-methods you can easily get both information:
+methods you can easily get both:
 
 .. testcode:: vectors
 

--- a/docs/pyqgis_developer_cookbook/vector.rst
+++ b/docs/pyqgis_developer_cookbook/vector.rst
@@ -89,7 +89,7 @@ the :class:`QgsVectorLayer <qgis.core.QgsVectorLayer>` class provide
 information on the field and template used in the :ref:`maptips` tab.
 
 When you load a vector layer, a field is always chosen by QGIS as the 
-``Display Name`,` while the ``HTML Map Tip`` is empty by default. With these 
+``Display Name``, while the ``HTML Map Tip`` is empty by default. With these 
 methods you can easily get both:
 
 .. testcode:: vectors

--- a/docs/pyqgis_developer_cookbook/vector.rst
+++ b/docs/pyqgis_developer_cookbook/vector.rst
@@ -104,7 +104,7 @@ methods you can easily get both:
     NAME
     ''
 
-.. note:: If you change the ``Display Name`` from a field to an expression than 
+.. note:: If you change the ``Display Name`` from a field to an expression, 
   you have to use :meth:`displayExpression() <qgis.core.QgsVectorLayer.displayExpression>`
   instead of :meth:`displayField() <qgis.core.QgsVectorLayer.displayField>`.
 

--- a/docs/pyqgis_developer_cookbook/vector.rst
+++ b/docs/pyqgis_developer_cookbook/vector.rst
@@ -94,7 +94,7 @@ methods you can easily get both information:
 
 .. testcode:: vectors
 
-    vlayer = QgsVectorLayer("testdata/airports.shp", "airports", "ogr")
+    vlayer = iface.addVectorLayer("testdata/airports.shp", "airports", "ogr")
     vlayer.displayField()
     vlayer.mapTipTemplate()
 

--- a/docs/pyqgis_developer_cookbook/vector.rst
+++ b/docs/pyqgis_developer_cookbook/vector.rst
@@ -88,7 +88,7 @@ The :meth:`displayField() <qgis.core.QgsVectorLayer.displayField>` and
 the :class:`QgsVectorLayer <qgis.core.QgsVectorLayer>` class allows you to get
 information of the field and template used in the :ref:`maptips` tab.
 
-When you load a vector alyer, a field is always chosen by QGIS as the 
+When you load a vector layer, a field is always chosen by QGIS as the 
 ``Display Name`` while the ``HTML Map Tip`` is empty by default. With these 
 methods you can easily get both information:
 

--- a/docs/pyqgis_developer_cookbook/vector.rst
+++ b/docs/pyqgis_developer_cookbook/vector.rst
@@ -89,7 +89,7 @@ the :class:`QgsVectorLayer <qgis.core.QgsVectorLayer>` class provide
 information on the field and template used in the :ref:`maptips` tab.
 
 When you load a vector layer, a field is always chosen by QGIS as the 
-``Display Name`` while the ``HTML Map Tip`` is empty by default. With these 
+``Display Name`,` while the ``HTML Map Tip`` is empty by default. With these 
 methods you can easily get both:
 
 .. testcode:: vectors

--- a/docs/pyqgis_developer_cookbook/vector.rst
+++ b/docs/pyqgis_developer_cookbook/vector.rst
@@ -104,6 +104,9 @@ methods you can easily get both:
     NAME
     ''
 
+.. note:: If you change the ``Display Name`` from a field to an expression than 
+  you have to use :meth:`displayExpression() <qgis.core.QgsVectorLayer.displayExpression>`
+  instead of :meth:`displayField() <qgis.core.QgsVectorLayer.displayField>`.
 
 .. index:: Iterating features
 


### PR DESCRIPTION
Goal: add some missing methods to `QgsVectorLayer`

Ticket(s): fixes #1542

- [x] Backport to LTR documentation is required
