### PR TITLE
change XML to qmd extension metadata

### DIFF
--- a/docs/user_manual/working_with_vector/vector_properties.rst
+++ b/docs/user_manual/working_with_vector/vector_properties.rst
@@ -3109,7 +3109,7 @@ A summary of the filled information is provided in the :guilabel:`Validation`
 tab and helps you identify potential issues related to the form. You can then
 either fix them or ignore them.
 
-Metadata are currently saved in the project file. It can also be saved as an
+Metadata are currently saved in the project file. It can also be saved as a
 :file:`.qmd` file alongside file based layers or in a local :file:`.sqlite`
 database for remote layers (e.g. PostGIS).
 

--- a/docs/user_manual/working_with_vector/vector_properties.rst
+++ b/docs/user_manual/working_with_vector/vector_properties.rst
@@ -3109,7 +3109,7 @@ A summary of the filled information is provided in the :guilabel:`Validation`
 tab and helps you identify potential issues related to the form. You can then
 either fix them or ignore them.
 
-Metadata are currently saved in the project file. It can also be saved as a
+Metadata are currently saved in the project file. They can also be saved in a
 :file:`.qmd` file alongside file based layers or in a local :file:`.sqlite`
 database for remote layers (e.g. PostGIS).
 

--- a/docs/user_manual/working_with_vector/vector_properties.rst
+++ b/docs/user_manual/working_with_vector/vector_properties.rst
@@ -3110,7 +3110,7 @@ tab and helps you identify potential issues related to the form. You can then
 either fix them or ignore them.
 
 Metadata are currently saved in the project file. It can also be saved as an
-:file:`.XML` file alongside file based layers or in a local :file:`.sqlite`
+:file:`.qmd` file alongside file based layers or in a local :file:`.sqlite`
 database for remote layers (e.g. PostGIS).
 
 .. index:: Dependencies


### PR DESCRIPTION
Goal: we have `qmd` file extension for metadata so let's use it ;)

Ticket(s): fix #6034 

- [x] Backport to LTR documentation is required
