### PR TITLE
Open qgis with grass

### DIFF
--- a/docs/training_manual/grass/grass_setup.rst
+++ b/docs/training_manual/grass/grass_setup.rst
@@ -6,13 +6,13 @@ different way. Remember that you're not working in QGIS directly, but working
 in GRASS *via* QGIS. Hence, make sure you have installed QGIS Desktop with
 Grass support.
 
+|win| To open a QGIS session with GRASS available on Windows you have to click
+on the ``QGIS Desktop with GRASS`` icon.
+
 **The goal for this lesson:** To begin a GRASS project in QGIS.
 
 |basic| |FA| Start a New GRASS Session
 -------------------------------------------------------------------------------
-
-When you install QGIS, depending on your OS you have to click on the
-``QGIS Desktop with GRASS`` icon to open a QGIS session with GRASS available.
 
 To launch GRASS from within QGIS, you need to activate it as with any other
 plugin:
@@ -338,3 +338,5 @@ operations that GRASS offers.
    :width: 1.5em
 .. |hard| image:: /static/common/hard.png
 .. |srtmFileName| replace:: :file:`srtm_41_19_4326.tif`
+.. |win| image:: /static/common/win.png
+   :width: 1em

--- a/docs/training_manual/grass/grass_setup.rst
+++ b/docs/training_manual/grass/grass_setup.rst
@@ -12,7 +12,7 @@ Grass support.
 -------------------------------------------------------------------------------
 
 When you install QGIS, depending on your OS you have to click on the
-``QGIS Desktop with GRASS`` to open a QGIS session with GRASS available.
+``QGIS Desktop with GRASS`` icon to open a QGIS session with GRASS available.
 
 To launch GRASS from within QGIS, you need to activate it as with any other
 plugin:

--- a/docs/training_manual/grass/grass_setup.rst
+++ b/docs/training_manual/grass/grass_setup.rst
@@ -11,8 +11,12 @@ Grass support.
 |basic| |FA| Start a New GRASS Session
 -------------------------------------------------------------------------------
 
+When you install QGIS, depending on your OS you have to click on the
+``QGIS Desktop with GRASS`` to open a QGIS session with GRASS available.
+
 To launch GRASS from within QGIS, you need to activate it as with any other
-plugin
+plugin:
+
 
 #. First, open a new QGIS project.
 #. In the :guilabel:`Plugin Manager`, enable :guilabel:`GRASS` in the list:

--- a/docs/training_manual/grass/grass_setup.rst
+++ b/docs/training_manual/grass/grass_setup.rst
@@ -17,7 +17,6 @@ on the ``QGIS Desktop with GRASS`` icon.
 To launch GRASS from within QGIS, you need to activate it as with any other
 plugin:
 
-
 #. First, open a new QGIS project.
 #. In the :guilabel:`Plugin Manager`, enable :guilabel:`GRASS` in the list:
 


### PR DESCRIPTION
Goal: add a small note on how to open a QGIS session with GRASS available **before** activating it as a plugin

Ticket(s): fix #3331

- [x] Backport to LTR documentation is required
