### PR TITLE
Add direct access to issue reports page

### DIFF
--- a/themes/rtd_qgis/versions.html
+++ b/themes/rtd_qgis/versions.html
@@ -43,6 +43,9 @@
             <a href="{{ transifex_url }}/#{{ language }}/{{ pagename | replace("/","--") }}" target="_blank" rel="noopener noreferrer">{{ _('Translate Page') }}</a>
           </dd>
           {% endif %}
+          <dd>
+            <a href="https://github.com/qgis/QGIS-Documentation/issues" target="_blank" rel="noopener noreferrer">{{ _('Report Issue') }}</a>
+          </dd>
       </dl>
       {% endif %}
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/7983394/91775141-a1f0aa00-ebea-11ea-84b7-f80f7fd05b35.png)

but not a direct link to the "new issue" page to give people a chance to check whether the issue is not already reported