### PR TITLE
Upgrade sphinx and sphinx-intl dependencies version

### DIFF
--- a/REQUIREMENTS.txt
+++ b/REQUIREMENTS.txt
@@ -1,5 +1,5 @@
-Sphinx==2.4.4
-sphinx-intl==0.9.11
+Sphinx==3.2.1
+sphinx-intl==2.0.1
 sphinx_rtd_theme
 sphinx-intl[transifex]
 PyYAML


### PR DESCRIPTION
I've been using 3.x versions of sphinx locally for a moment to build , create pot file and pull translation. Issues I encountered were fixed long time ago so it does neither fix anything new, nor afaics brings new issues. But I think it's good we stay close to the new versions to avoid the big gap we had to deal with recently while restructuring docs. 