### PR TITLE
Move "Handling broken file paths" section to Project files chapter

### DIFF
--- a/docs/user_manual/introduction/general_tools.rst
+++ b/docs/user_manual/introduction/general_tools.rst
@@ -195,6 +195,7 @@ Option                                                             Vector Layer 
 |allEdits| :menuselection:`Current Edits -->`                      |checkbox|          \                  \
 :guilabel:`Filter...`                                              |checkbox|          \                  \
 :guilabel:`Change Data Source...`                                  |checkbox|          \                  \
+:guilabel:`Repair Data Source...`                                  |checkbox|          \                  \
 :menuselection:`Actions on selections -->` (in edit mode)          |checkbox|          \                  \
 :menuselection:`--> Duplicate Feature`                             |checkbox|          \                  \
 :menuselection:`--> Duplicate Feature and Digitize`                |checkbox|          \                  \
@@ -297,7 +298,9 @@ symbols are:
 * |indicatorEmbedded| to identify an :ref:`embedded group or layer
   <nesting_projects>` and the path to their original project file
 * |indicatorBadLayer| to identify a layer whose data source was not available
-  at the project file opening. Click the icon to update the source path.
+  at the project file opening (see :ref:`handle_broken_paths`).
+  Click the icon to update the source path or select :guilabel:`Repair Data Source...`
+  entry from the layer contextual menu.
 * |indicatorMemory| to remind you that the layer is a :ref:`temporary scratch
   layer <vector_new_scratch_layer>` and its content will be discarded when you
   close this project. To avoid data loss and make the layer permanent, click

--- a/docs/user_manual/introduction/project_files.rst
+++ b/docs/user_manual/introduction/project_files.rst
@@ -134,6 +134,36 @@ through the QGIS browser panel, either by double-clicking them or by
 dragging them to the map canvas.
 
 
+.. _handle_broken_paths:
+
+Handling broken file paths
+==========================
+
+When opening a project, QGIS may fail to reach some data sources due to
+unavailable service/database, or to a renamed or moved file.
+QGIS then opens the :guilabel:`Handle Unavailable Layers` dialog, referencing
+the unfound layers.
+You can:
+
+* Double-click in the :guilabel:`Datasource` field, adjust the path of
+  each layer and click :guilabel:`Apply changes`;
+* Select a row, press :guilabel:`Browse` to indicate the correct location
+  and click :guilabel:`Apply changes`;
+* Press :guilabel:`Auto-Find` to browse the folders and try to automatically fix
+  all or selected broken path(s). Be aware that the browsing may take some time.
+* Ignore the message and open your project with the broken path(s) by clicking
+  :guilabel:`Keep Unavailable Layers`. Your layer is then displayed in the
+  :guilabel:`Layers` panel, but without any data until you fix the path using
+  the |indicatorBadLayer| :sup:`Unavailable layer!` icon next to it in the
+  :guilabel:`Layers` panel, or :guilabel:`Repair Data Source...` in the
+  layer contextual menu.
+
+  With the :guilabel:`Repair Data Source...` tool, once a layer path has been
+  fixed, QGIS scans through all other broken paths and tries
+  to auto-fix those that have the same broken file path.
+* |deleteSelected| :guilabel:`Remove Unavailable Layers` from the project.
+
+
 .. _`sec_output`:
 
 Generating output
@@ -182,6 +212,8 @@ Other ways to produce output files are:
 
 .. |checkbox| image:: /static/common/checkbox.png
    :width: 1.3em
+.. |deleteSelected| image:: /static/common/mActionDeleteSelected.png
+   :width: 1.5em
 .. |fileNew| image:: /static/common/mActionFileNew.png
    :width: 1.5em
 .. |fileOpen| image:: /static/common/mActionFileOpen.png
@@ -189,6 +221,8 @@ Other ways to produce output files are:
 .. |fileSave| image:: /static/common/mActionFileSave.png
    :width: 1.5em
 .. |fileSaveAs| image:: /static/common/mActionFileSaveAs.png
+   :width: 1.5em
+.. |indicatorBadLayer| image:: /static/common/mIndicatorBadLayer.png
    :width: 1.5em
 .. |newLayout| image:: /static/common/mActionNewLayout.png
    :width: 1.5em

--- a/docs/user_manual/managing_data_source/opening_data.rst
+++ b/docs/user_manual/managing_data_source/opening_data.rst
@@ -1200,35 +1200,6 @@ Examples of XYZ Tile services:
 * Open Weather Map Temperature:
   :guilabel:`URL`: ``http://tile.openweathermap.org/map/temp_new/{z}/{x}/{y}.png?appid={api_key}``
   :guilabel:`Min. Zoom Level`: 0, :guilabel:`Max. Zoom Level`: 19.
-  
-.. _handle_broken_paths:
-
-Handling broken file paths
-==========================
-
-When opening a project, QGIS may fail to reach some data sources due to
-unavailable service/database, or to a renamed or moved file.
-QGIS then opens the :guilabel:`Handle Unavailable Layers` dialog, referencing
-the unfound layers.
-You can:
-
-* Double-click in the :guilabel:`Datasource` field, adjust the path of
-  each layer and click :guilabel:`Apply changes`;
-* Select a row, press :guilabel:`Browse` to indicate the correct location
-  and click :guilabel:`Apply changes`;
-* Press :guilabel:`Auto-Find` to browse the folders and try to automatically fix
-  all or selected broken path(s). Be aware that the browsing may take some time.
-* Ignore the message and open your project with the broken path(s) by clicking
-  :guilabel:`Keep Unavailable Layers`. Your layer is then displayed in the
-  :guilabel:`Layers` panel, but without any data until you fix the path using
-  the |indicatorBadLayer| :sup:`Unavailable layer!` icon next to it in the
-  :guilabel:`Layers` panel, or :guilabel:`Repair Data Source...` in the
-  layer contextual menu.
-
-  With the :guilabel:`Repair Data Source...` tool, once a layer path has been
-  fixed, QGIS scans through all other broken paths and tries
-  to auto-fix those that have the same broken file path.
-* |deleteSelected| :guilabel:`Remove Unavailable Layers` from the project.
 
 
 .. Substitutions definitions - AVOID EDITING PAST THIS LINE
@@ -1271,15 +1242,11 @@ You can:
    :width: 1.5em
 .. |dbManager| image:: /static/common/dbmanager.png
    :width: 1.5em
-.. |deleteSelected| image:: /static/common/mActionDeleteSelected.png
-   :width: 1.5em
 .. |filterMap| image:: /static/common/mActionFilterMap.png
    :width: 1.5em
 .. |geoPackage| image:: /static/common/mGeoPackage.png
    :width: 1.5em
 .. |geonode| image:: /static/common/mIconGeonode.png
-   :width: 1.5em
-.. |indicatorBadLayer| image:: /static/common/mIndicatorBadLayer.png
    :width: 1.5em
 .. |kde| image:: /static/common/kde.png
    :width: 1.5em

--- a/docs/user_manual/managing_data_source/opening_data.rst
+++ b/docs/user_manual/managing_data_source/opening_data.rst
@@ -1206,24 +1206,29 @@ Examples of XYZ Tile services:
 Handling broken file paths
 ==========================
 
-When the path to a data source is wrong, QGIS opens the
-:guilabel:`Handle Unavailable Layers` dialog.
-You can double-click in the :guilabel:`Datasource` field or click :guilabel:`Browse` to fix
-the path.
-It is possible to continue working with your project with the broken path by clicking
-:guilabel:`Keep Unavailable Layers`. Your layer is then displayed in the
-:guilabel:`Layers` panel, but without any data until you fix the path using
-the |indicatorBadLayer| :sup:`Unavailable layer!` icon next to it in the
-:guilabel:`Layers` panel, or :guilabel:`Change Data Source...` in the
-layer contextual menu. To fix the broken path automatically click
-:guilabel:`Auto-Find`. Be aware that in this version of QGIS the browsing 
-takes some time.
-Another possibility is to |deleteSelected| :guilabel:`Remove Unavailable Layers`.
-As the last step, click :guilabel:`Apply changes`.
+When opening a project, QGIS may fail to reach some data sources due to
+unavailable service/database, or to a renamed or moved file.
+QGIS then opens the :guilabel:`Handle Unavailable Layers` dialog, referencing
+the unfound layers.
+You can:
 
-When a layer path has been fixed, QGIS scans through all other broken paths and tries
-to auto-fix those that have the same broken file path.
+* Double-click in the :guilabel:`Datasource` field, adjust the path of
+  each layer and click :guilabel:`Apply changes`;
+* Select a row, press :guilabel:`Browse` to indicate the correct location
+  and click :guilabel:`Apply changes`;
+* Press :guilabel:`Auto-Find` to browse the folders and try to automatically fix
+  all or selected broken path(s). Be aware that the browsing may take some time.
+* Ignore the message and open your project with the broken path(s) by clicking
+  :guilabel:`Keep Unavailable Layers`. Your layer is then displayed in the
+  :guilabel:`Layers` panel, but without any data until you fix the path using
+  the |indicatorBadLayer| :sup:`Unavailable layer!` icon next to it in the
+  :guilabel:`Layers` panel, or :guilabel:`Repair Data Source...` in the
+  layer contextual menu.
 
+  With the :guilabel:`Repair Data Source...` tool, once a layer path has been
+  fixed, QGIS scans through all other broken paths and tries
+  to auto-fix those that have the same broken file path.
+* |deleteSelected| :guilabel:`Remove Unavailable Layers` from the project.
 
 
 .. Substitutions definitions - AVOID EDITING PAST THIS LINE


### PR DESCRIPTION
because the "Handle Unavailable layers" dialog is only shown when opening a project. It's not really the way to open/fix an existing data but a way to fix an existing project. 
Also tweaks some description and fixes #6054