### PR TITLE
Update documentation on OGC conformance testing

### DIFF
--- a/docs/developers_guide/ogcconformancetesting.rst
+++ b/docs/developers_guide/ogcconformancetesting.rst
@@ -15,77 +15,55 @@ charge to make sure a server is compliant with a certain specification.
 This chapter provides a quick tutorial to setup the WMS tests on an Ubuntu system.
 A detailed documentation can be found at the `OGC website <https://www.opengeospatial.org/compliance>`_.
 
-Setup of WMS 1.3 and WMS 1.1.1 conformance tests
-=================================================
+
+pyogctest
+=========
+
+`pyogctest <https://github.com/pblottiere/pyogctest>`_ is a Python tool
+dedicated to run OGC tests easily. The installation may be done in a
+virtual environment:
 
 .. code-block:: bash
 
-  sudo apt install openjdk-8-jdk maven
-  cd ~/src
-  git clone https://github.com/opengeospatial/teamengine.git
-  cd teamengine
-  mvn install
-  mkdir ~/TE_BASE
-  export TE_BASE=~/TE_BASE
-  unzip -o ./teamengine-console/target/teamengine-console-4.11-SNAPSHOT-base.zip -d $TE_BASE
-  mkdir ~/te-install
-  unzip -o ./teamengine-console/target/teamengine-console-4.11-SNAPSHOT-bin.zip -d ~/te-install
+   git clone https://github.com/pblottiere/pyogctest
+   virtualenv venv
+   source venv/bin/activate
+   pip install -e pyogctest/
 
-Download and install WMS 1.3.0 test
 
-.. code-block:: bash
+WMS 1.3.0 test suite
+====================
 
-  cd ~/src
-  git clone https://github.com/opengeospatial/ets-wms13.git
-  cd ets-wms13
-  mvn install
-
-Download and install WMS 1.1.1 test
+To run the WMS 1.3.0 test suite with success, a test data is necessary and may
+be downloaded thanks to **pyogctest**:
 
 .. code-block:: bash
 
-  cd ~/src
-  git clone https://github.com/opengeospatial/ets-wms11.git
-  cd ets-wms11
-  mvn install
+  ./pyogctest.py -s wms130 --download
 
+After the download, a ``teamengine_wms_130.qgs`` project is available in the
+new ``data`` directory. This project has to be registered as the default
+project for QGIS Server thanks to the **QGIS_SERVER_PROJECT_FILE** environment
+variable. This way, we don't need to explicitely set the ``MAP``
+vendor-parameter of QGIS Server.
 
-Test project
-=============
-
-For the WMS tests, data can be downloaded and loaded into a QGIS project:
-
-.. code-block:: bash
-
-  wget https://cite.opengeospatial.org/teamengine/about/wms/1.3.0/site/data-wms-1.3.0.zip
-  unzip data-wms-1.3.0.zip
-
-Then create a :source:`QGIS project <tests/testdata/qgis_server/ets-wms13/project.qgs>`
-according to the description in
-https://cite.opengeospatial.org/teamengine/about/wms/1.3.0/site/.
-To run the tests, we need to provide the GetCapabilities URL of the service later.
-
-
-Running the WMS 1.3.0 test
-===========================
+A specific configuration is also necessary to comply with metadata tests.
+Indeed, some metadata are available in the ``data/metadata`` directory and have
+to be available for the OGC testing framework thanks to an URL. The easiest
+option is to configure your web server to have an access through something like
+``http://XXX.XXX.XXX.XXX/metadata/Autos.xml``. These metadata URLs are defined
+in the project and inserted in the WMS ``GetCapabilities`` document. So the
+project needs to be updated according to your testing environment to let QGIS
+Server generate a valid XML document:
 
 .. code-block:: bash
 
-  export PATH=/usr/lib/jvm/java-8-openjdk-amd64/bin:$PATH
-  export TE_BASE=$HOME/TE_BASE
-  export JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
-  cd ~/te-install
-  ./bin/unix/test.sh -source=$HOME/src/ets-wms13/src/main/scripts/ctl/main.xml
+  ./pyogctest.py -s wms130 -m http://XXX.XXX.XXX.XXX/metadata
 
 
-Running the WMS 1.1.1 test
-===========================
+Now that everything is properly configured, we can run the WMS 1.3.0 test
+suite:
 
 .. code-block:: bash
 
-  export PATH=/usr/lib/jvm/java-8-openjdk-amd64/bin:$PATH
-  export TE_BASE=$HOME/TE_BASE
-  export ETS_SRC=$HOME/ets-resources
-  export JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
-  cd ~/te-install
-  ./bin/unix/test.sh -source=$HOME/src/ets-wms11/src/main/scripts/ctl/wms.xml
+  ./pyogctest.py -s wms130 -u http://XXX.XXX.XXX.XXX/qgisserver


### PR DESCRIPTION
[pyogctest](https://github.com/pblottiere/pyogctest) is now used in QGIS continuous integration (cf the next [PR](https://github.com/qgis/QGIS/pull/38644)) to run OGC tests. Indeed, it allows to run these tests easily and in command line without bothering about the testing environment (Java, Teamengine, OGC test suites, ...).

This PR updates the documentation accordingly. This way, QGIS Server developers will have an entry point to run these tests locally during the development phase.

Opinions are welcome of course :).