### PR TITLE
Add map0: in GetPrint request with redlining

### DIFF
--- a/docs/server_manual/services.rst
+++ b/docs/server_manual/services.rst
@@ -2133,7 +2133,7 @@ image (map).
 This permits the user to put emphasis or maybe add some comments (labels)
 to some areas, locations etc. that are not in the standard map.
 
-The request is in the format::
+The ``GetMap`` request is in the format::
 
  http://qgisplatform.demo/cgi-bin/qgis_mapserv.fcgi?map=/world.qgs&SERVICE=WMS&VERSION=1.3.0&
  REQUEST=GetMap
@@ -2145,6 +2145,19 @@ The request is in the format::
  &HIGHLIGHT_LABELCOLOR=%23000000
  &HIGHLIGHT_LABELBUFFERCOLOR=%23FFFFFF
  &HIGHLIGHT_LABELBUFFERSIZE=1.5
+ 
+The ``GetPrint`` equivalent is in the format (note that ``mapX:`` parameter is added to tell which map has redlining)::
+ 
+ http://qgisplatform.demo/cgi-bin/qgis_mapserv.fcgi?map=/world.qgs&SERVICE=WMS&VERSION=1.3.0&
+ REQUEST=GetMap
+ ...
+ &map0:HIGHLIGHT_GEOM=POLYGON((590000 5647000, 590000 6110620, 2500000 6110620, 2500000 5647000, 590000 5647000))
+ &map0:HIGHLIGHT_SYMBOL=<StyledLayerDescriptor><UserStyle><Name>Highlight</Name><FeatureTypeStyle><Rule><Name>Symbol</Name><LineSymbolizer><Stroke><SvgParameter name="stroke">%23ea1173</SvgParameter><SvgParameter name="stroke-opacity">1</SvgParameter><SvgParameter name="stroke-width">1.6</SvgParameter></Stroke></LineSymbolizer></Rule></FeatureTypeStyle></UserStyle></StyledLayerDescriptor>
+ &map0:HIGHLIGHT_LABELSTRING=Write label here
+ &map0:HIGHLIGHT_LABELSIZE=16
+ &map0:HIGHLIGHT_LABELCOLOR=%23000000
+ &map0:HIGHLIGHT_LABELBUFFERCOLOR=%23FFFFFF
+ &map0:HIGHLIGHT_LABELBUFFERSIZE=1.5
 
 Here is the image outputed by the above request in which a polygon and
 a label are drawn on top of the normal map:

--- a/docs/server_manual/services.rst
+++ b/docs/server_manual/services.rst
@@ -2149,7 +2149,7 @@ The ``GetMap`` request is in the format::
 The ``GetPrint`` equivalent is in the format (note that ``mapX:`` parameter is added to tell which map has redlining)::
  
  http://qgisplatform.demo/cgi-bin/qgis_mapserv.fcgi?map=/world.qgs&SERVICE=WMS&VERSION=1.3.0&
- REQUEST=GetMap
+ REQUEST=GetPrint
  ...
  &map0:HIGHLIGHT_GEOM=POLYGON((590000 5647000, 590000 6110620, 2500000 6110620, 2500000 5647000, 590000 5647000))
  &map0:HIGHLIGHT_SYMBOL=<StyledLayerDescriptor><UserStyle><Name>Highlight</Name><FeatureTypeStyle><Rule><Name>Symbol</Name><LineSymbolizer><Stroke><SvgParameter name="stroke">%23ea1173</SvgParameter><SvgParameter name="stroke-opacity">1</SvgParameter><SvgParameter name="stroke-width">1.6</SvgParameter></Stroke></LineSymbolizer></Rule></FeatureTypeStyle></UserStyle></StyledLayerDescriptor>


### PR DESCRIPTION
Goal:
map0:, map1: ... has to be specified in GetPrint request to tell which map will get redlining drawn.

Previous PR : https://github.com/qgis/QGIS-Documentation/pull/5897
<!---
Indicate whether the fix should be backported to previous release.
Replace the space between square brackets by a `x` to make it checked.
-->
- [x] Backport to LTR documentation is required

<!---
Reviewing is a process done by community members, mostly on a volunteer basis.
We try to keep the overhead as small as possible and appreciate if you help us.
Please read carefully and ensure you comply with our writing guidelines at
https://docs.qgis.org/testing/en/docs/documentation_guidelines/index.html.
Feel free to ask in a comment or the (qgis-community-team mailing list)
[https://lists.osgeo.org/mailman/listinfo/qgis-community-team] if you have troubles with any item.
--->
