### PR TITLE
Update composer_map.rst

### DIFF
--- a/docs/user_manual/print_composer/composer_items/composer_map.rst
+++ b/docs/user_manual/print_composer/composer_items/composer_map.rst
@@ -250,7 +250,12 @@ As grid type, you can specify to use a:
 
 Other than the grid type, you can define: 
 
-* the :guilabel:`CRS`of the grid.  If not changed it will follow the Map CRS. The change button allows it to be set to a different CRS.  Once set it can be changed back to default by selecting any heading (not a CRS) in the CRS selection dialogue.
+* the :guilabel:`CRS` of the grid. If not changed, it will follow the Map CRS.
+The :guilabel:`Change` button lets you set it to a different CRS.
+Once set, it can be changed back to default by selecting any group heading
+(e.g **Geographic Coordinate System**) under
+:guilabel:`Predefined Coordinate Reference Systems` in the CRS
+selection dialog.
 * the :guilabel:`Interval` type to use for the grid references. Available
   options are ``Map Unit``, ``Fit Segment Width``, ``Millimeter`` or ``Centimeter``:
 

--- a/docs/user_manual/print_composer/composer_items/composer_map.rst
+++ b/docs/user_manual/print_composer/composer_items/composer_map.rst
@@ -251,11 +251,11 @@ As grid type, you can specify to use a:
 Other than the grid type, you can define: 
 
 * the :guilabel:`CRS` of the grid. If not changed, it will follow the Map CRS.
-The :guilabel:`Change` button lets you set it to a different CRS.
-Once set, it can be changed back to default by selecting any group heading
-(e.g **Geographic Coordinate System**) under
-:guilabel:`Predefined Coordinate Reference Systems` in the CRS
-selection dialog.
+  The :guilabel:`Change` button lets you set it to a different CRS.
+  Once set, it can be changed back to default by selecting any group heading
+  (e.g **Geographic Coordinate System**) under
+  :guilabel:`Predefined Coordinate Reference Systems` in the CRS
+  selection dialog.
 * the :guilabel:`Interval` type to use for the grid references. Available
   options are ``Map Unit``, ``Fit Segment Width``, ``Millimeter`` or ``Centimeter``:
 

--- a/docs/user_manual/print_composer/composer_items/composer_map.rst
+++ b/docs/user_manual/print_composer/composer_items/composer_map.rst
@@ -250,7 +250,7 @@ As grid type, you can specify to use a:
 
 Other than the grid type, you can define: 
 
-* the :guilabel:`CRS`, which could be different from the project CRS
+* the :guilabel:`CRS`of the grid.  If not changed it will follow the Map CRS. The change button allows it to be set to a different CRS.  Once set it can be changed back to default by selecting any heading (not a CRS) in the CRS selection dialogue.
 * the :guilabel:`Interval` type to use for the grid references. Available
   options are ``Map Unit``, ``Fit Segment Width``, ``Millimeter`` or ``Centimeter``:
 


### PR DESCRIPTION
Added detail to the CRS setting for map grids, explaining that it is automatically linked to the map CRS (not the project CRS as previously suggested).  Also explained the method to set back to following the map CRS as this is not obvious.  You need to set it to blank again, but clicking the button opens a CRS dialogue, fortunately selecting a heading rather than a CRS provides the blank output required.

<!---
Include a few sentences describing the overall goals for this Pull Request.
 
A list of issues is at https://github.com/qgis/QGIS-Documentation/issues.
Add "fix #issuenumber" for each issue the PR fixes. The ticket(s) will be closed automatically.
If your PR doesn't fix entirely the ticket, only add the ticket(s) reference preceded by # character.
-->
Goal:

Ticket(s): #
<!---
Indicate whether the fix should be backported to previous release.
Replace the space between square brackets by a `x` to make it checked.
-->
- [x ] Backport to LTR documentation is required

<!---
Reviewing is a process done by community members, mostly on a volunteer basis.
We try to keep the overhead as small as possible and appreciate if you help us.
Please read carefully and ensure you comply with our writing guidelines at
https://docs.qgis.org/testing/en/docs/documentation_guidelines/index.html.
Feel free to ask in a comment or the (qgis-community-team mailing list)
[https://lists.osgeo.org/mailman/listinfo/qgis-community-team] if you have troubles with any item.
--->
