### PR TITLE
Removed superfluous whitespace

### DIFF
--- a/docs/server_manual/getting_started.rst
+++ b/docs/server_manual/getting_started.rst
@@ -193,7 +193,7 @@ Install NGINX:
   QGIS Server processes.
   Official Debian packages exist for both.
   When you have no X server running and you need, for example,
-  printing,	you can use :ref:`xvfb <xvfb>`.
+  printing, you can use :ref:`xvfb <xvfb>`.
 
 * Another option is to rely on **Systemd**, the init system for GNU/Linux that most
   Linux distributions use today.


### PR DESCRIPTION
Line 196 : "printing, [here was some excessive whitespace]   you can use :ref:`xvfb <xvfb>`." should be "printing, you can use :ref:`xvfb <xvfb>`."


Goal:  Display correct documentation  (the superfluous whitespace was not displayed in the PR so I added [here was some excessive whitespace] )
Superfluous whitespace showed in the used tool for translation Transifex

- [ ] Backport to LTR documentation is required


