### PR TITLE
Superfluous whitespace and removed unwanted string

### DIFF
--- a/docs/server_manual/getting_started.rst
+++ b/docs/server_manual/getting_started.rst
@@ -235,7 +235,6 @@ as it adds the parameters from :file:`/etc/nginx/fastcgi_params`:
  fastcgi_param  REDIRECT_STATUS    200;
 
 Moreover, you can use some :ref:`qgis-server-envvar` to configure QGIS Server.
-
 In the NGINX configuration file, :file:`/etc/nginx/nginx.conf`, you have to use
 ``fastcgi_param`` instruction to define these variables as shown below:
 

--- a/docs/server_manual/getting_started.rst
+++ b/docs/server_manual/getting_started.rst
@@ -193,7 +193,7 @@ Install NGINX:
   QGIS Server processes.
   Official Debian packages exist for both.
   When you have no X server running and you need, for example,
-  printing,	you can use :ref:`xvfb <xvfb>`.
+  printing, you can use :ref:`xvfb <xvfb>`.
 
 * Another option is to rely on **Systemd**, the init system for GNU/Linux that most
   Linux distributions use today.
@@ -235,7 +235,7 @@ as it adds the parameters from :file:`/etc/nginx/fastcgi_params`:
  fastcgi_param  REDIRECT_STATUS    200;
 
 Moreover, you can use some :ref:`qgis-server-envvar` to configure QGIS Server.
-0123456789012345678901234567890123456789012345678901234567890123456789
+
 In the NGINX configuration file, :file:`/etc/nginx/nginx.conf`, you have to use
 ``fastcgi_param`` instruction to define these variables as shown below:
 


### PR DESCRIPTION
Line 196 : "printing,    you can use :ref:`xvfb <xvfb>`." should be "printing, you can use :ref:`xvfb <xvfb>`."
Line 238 : "0123456789012345678901234567890123456789012345678901234567890123456789" should be removed

Goal:  Display correct documentation

- [ ] Backport to LTR documentation is required


