### PR TITLE
Changed name of used dialog

### DIFF
--- a/docs/training_manual/complete_analysis/analysis_exercise.rst
+++ b/docs/training_manual/complete_analysis/analysis_exercise.rst
@@ -232,7 +232,7 @@ this area.
 #. Click :guilabel:`Run`
 
    After the clipping operation has completed, leave the
-   :guilabel:`Clip Raster by Extent` dialog open, to be able to reuse
+   :guilabel:`Clip Raster by Mask Layer` dialog open, to be able to reuse
    the clipping area
 #. Select the ``Rainfall`` raster layer in the :guilabel:`Input layer`
    dropdown list and save your output as :file:`Rainfall_clipped.tif`


### PR DESCRIPTION
line 235 :  "'Clip Raster by Extent' dialog" should be " 'Clip Raster by Mask Layer' dialog" since that is the algorithm that is used here.
Clip Raster by Mask Layer is also used the first time and should again be used the second time.


Goal: Display correct documentation

- [x] Backport to LTR documentation is required

