### PR TITLE
Modify the confusing word

### DIFF
--- a/docs/documentation_guidelines/first_contribution.rst
+++ b/docs/documentation_guidelines/first_contribution.rst
@@ -87,7 +87,7 @@ without any harm.
 Alternative 1: Use the ``Edit on GitHub`` shortcut
 ..................................................
 
-Pages on the QGIS website can be edited quickly and easily by clicking on the
+Pages on the QGIS documentation website can be edited quickly and easily by clicking on the
 ``Edit on GitHub`` link at the top right of each page.
 
 #. This will open the file in the ``qgis:master`` branch with a message at the


### PR DESCRIPTION
It is QGIS documentation website (https://docs.qgis.org) which has "Edit on GitHub" link at the top right of each page. It isn't QGIS website (https://qgis.org/xx/site/). It is more confusing because the note says "Though QGIS-Documentation is used to demonstrate the process, all commands and steps shown below also apply to QGIS-Website" above.
https://docs.qgis.org/testing/en/docs/documentation_guidelines/first_contribution.html