### PR TITLE
add query history DB Manager

### DIFF
--- a/docs/user_manual/plugins/core_plugins/plugins_db_manager.rst
+++ b/docs/user_manual/plugins/core_plugins/plugins_db_manager.rst
@@ -90,6 +90,10 @@ button.
    See :ref:`vector_virtual_layers` for instructions on the SQL syntax
    to use.
 
+The :guilabel:`Query History` button stores the last 20 queries of each database
+and provider.  
+
+Double clicking on a query will fill add the string to the SQL window.
 
 .. Substitutions definitions - AVOID EDITING PAST THIS LINE
    This will be automatically updated by the find_set_subst.py script.

--- a/docs/user_manual/plugins/core_plugins/plugins_db_manager.rst
+++ b/docs/user_manual/plugins/core_plugins/plugins_db_manager.rst
@@ -75,6 +75,11 @@ It is possible to highlight a portion of the SQL to only execute that
 portion when pressing :kbd:`Ctrl+R` or clicking the :guilabel:`Execute`
 button.
 
+The :guilabel:`Query History` button stores the last 20 queries of each database
+and provider.  
+
+Double clicking on an entry will add the string to the SQL window.
+
 .. _figure_db_manager_queries:
 
 .. figure:: img/db_manager_sql.png
@@ -90,10 +95,6 @@ button.
    See :ref:`vector_virtual_layers` for instructions on the SQL syntax
    to use.
 
-The :guilabel:`Query History` button stores the last 20 queries of each database
-and provider.  
-
-Double clicking on a query will fill add the string to the SQL window.
 
 .. Substitutions definitions - AVOID EDITING PAST THIS LINE
    This will be automatically updated by the find_set_subst.py script.


### PR DESCRIPTION
Goal: add the description of the `Query History` button of DB Manager. I didn't add any screenshot (not worth it IMHO)

Ticket(s): fixes #2607

- [x] Backport to LTR documentation is required
