### PR TITLE
[Processing] describe the use of expression/variable in Execute SQL algorithm

### DIFF
--- a/docs/user_manual/processing_algs/qgis/vectorgeneral.rst
+++ b/docs/user_manual/processing_algs/qgis/vectorgeneral.rst
@@ -821,6 +821,15 @@ Execute SQL
 Runs a simple or complex query with ``SQL`` syntax on the source
 layer.
 
+Input datasources are identified with ``input1``, ``input2``... ``inputN`` and
+a simple query will look like ``SELECT * FROM input1``.
+
+Beside a simple query, you can add expressions or variables within the 
+``SQL query`` parameter itself. This is particulary useful if this algorithm is
+executed within a Processing model and you want to use a model input as a
+parameter of the query. An example of a query will then be ``SELECT * FROM 
+[% @table %]`` where ``@table`` is the variable that identifies the model input.
+
 The result of the query will be added as a new layer.
 
 .. seealso:: :ref:`qgisspatialiteexecutesql`,


### PR DESCRIPTION
Goal: add a description to ``Execute SQL`` Processing algorithm to describe the potential usage of expression and/or variable. I didn't added the description to the parameters itself because it is defined as an unique parameter (`ParameterExecuteSql` basically a String + Expression) used only in this algorithm. 

IMHO it is better to describe what is the general aim of this parameter in the algorithm description


Ticket(s): fixes #2579

- [x] Backport to LTR documentation is required