### PR TITLE
Categorize documents in the sidebar of the QGIS documentation website 

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -18,7 +18,7 @@ Please have a look into one of the documents below.
 
 .. toctree::
    :maxdepth: 2
-   :caption: For Documentation Writers
+   :caption: For Writers
 
    Documentation Guidelines <documentation_guidelines/index>
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -9,13 +9,24 @@ Please have a look into one of the documents below.
 
 .. toctree::
    :maxdepth: 2
+   :caption: For Users
 
    QGIS Desktop User Guide/Manual (QGIS Testing) <user_manual/index>
    QGIS Server Guide/Manual (QGIS Testing) <server_manual/index>
-   Documentation Guidelines <documentation_guidelines/index>
-   PyQGIS Cookbook (QGIS Testing) <pyqgis_developer_cookbook/index>
-   Developers Guide <developers_guide/index>
    Training Manual <training_manual/index>
    A Gentle Introduction to GIS <gentle_gis_introduction/index>
-   
+
+.. toctree::
+   :maxdepth: 2
+   :caption: For Documentation Writers
+
+   Documentation Guidelines <documentation_guidelines/index>
+
+.. toctree::
+   :maxdepth: 2
+   :caption: For Developers
+
+   PyQGIS Cookbook (QGIS Testing) <pyqgis_developer_cookbook/index>
+   Developers Guide <developers_guide/index>
+
 * :ref:`genindex`


### PR DESCRIPTION
Categorize documents into three groups of "For users", "For documentation writers" and "For developers" in the sidebar of the QGIS documentation website in accordance with the description of the documentation area in the [QGIS website](https://qgis.org/en/docs/).
https://docs.qgis.org/testing/en/docs/index.html

![screenshot2](https://user-images.githubusercontent.com/1511441/95220195-2ad5b380-0831-11eb-9cc6-535982ab64ce.jpg)

![screenshot](https://user-images.githubusercontent.com/1511441/95220236-35904880-0831-11eb-9eb0-7dac97c2fd26.png)
