### PR TITLE
Make a bullet character of menu selection more visible

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -118,6 +118,10 @@ html_favicon = 'static/common/qgis_logo.ico'
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ['static']
 
+## Set a bullet character for :menuselection: role
+from sphinx.roles import MenuSelection
+MenuSelection.BULLET_CHARACTER = '\N{BLACK RIGHT-POINTING TRIANGLE}'
+
 ## for rtd themes, creating a html_context for the version/language part
 
 import os


### PR DESCRIPTION
[ Goal ]
* Improve visibility of menu selection
* The more similar appearance of menu selection to the GUI

Before:
![before](https://user-images.githubusercontent.com/1511441/95688495-99f24400-0c45-11eb-97c9-efdb758d750f.png)

After:
![after](https://user-images.githubusercontent.com/1511441/95688502-a8d8f680-0c45-11eb-8127-7d20b53ea855.png)


[ Problem ]
The default bullet character of menu selection is 'TRIANGULAR BULLET'. This symbol is too small for high visibility.
For example, in Japanese text, a symbol of 'KATAKANA MIDDLE DOT' is often used for a separator of two words, especially foreign words or foreign names. 'Donald John Trump' is written as 'ドナルド・ジョン・トランプ' in Japanese. 'Triangular Bullet' and 'KATAKANA MIDDLE DOT' are so alike that it is almost impossible to tell them apart.

TRIANGULAR BULLET:
![tri_bullet](https://user-images.githubusercontent.com/1511441/95688535-0c632400-0c46-11eb-8ec8-daa72dba604e.png)

KATAKANA MIDDLE DOT:
![katakana_middle_dot](https://user-images.githubusercontent.com/1511441/95688543-1c7b0380-0c46-11eb-9f5a-d4c91b78972a.png)


[ Solution ]
In conf.py, set the BULLET_CHARACTER constant of MenuSelection class into 'BLACK RIGHT-POINTING TRIANGLE'.
ref. https://github.com/sphinx-doc/sphinx/issues/7006
This symbol has high visibility and is more similar to the actual GUI. Also, differences in shapes among diverse fonts are relatively small in comparison with 'BLACK RIGHT-POINTING POINTER'.
