### PR TITLE
Check doctest build with GitHub action

### DIFF
--- a/.github/workflows/doctest.yml
+++ b/.github/workflows/doctest.yml
@@ -1,0 +1,31 @@
+name: Doctest build
+
+on: [push, pull_request]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    services:
+      image: docker
+
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 1
+    - name: Set up Python 3.7
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.7
+    - name: Pip upgrade
+      run: |
+          python -m pip install --upgrade pip
+    - name: Build test code
+      run: |
+          make -f docker.mk doctest
+    - name: Upload build artifact
+      uses: actions/upload-artifact@v2
+      with:
+        name: Doctest build
+        path: ./build/doctest/output.txt


### PR DESCRIPTION
I don't know whether it's better than travis but,  it's faster, and it outputs an artifact of summary for the build a noob like me can find
If approved, the idea would be to remove travis in the next step.

It seems to run fine but I'd very much appreciate some review. Thanks
@elpaso @3nids .... ?