### PR TITLE
Use  'BLACK RIGHT-POINTING POINTER' as MenuSelection.BULLET_CHARACTER

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -120,7 +120,7 @@ html_static_path = ['static']
 
 ## Set a bullet character for :menuselection: role
 from sphinx.roles import MenuSelection
-MenuSelection.BULLET_CHARACTER = '\N{BLACK RIGHT-POINTING TRIANGLE}'
+MenuSelection.BULLET_CHARACTER = '\N{BLACK RIGHT-POINTING POINTER}'
 
 ## for rtd themes, creating a html_context for the version/language part
 


### PR DESCRIPTION
I found a matter with  my already merged pull request “Make a bullet character of menu selection more visible” (#6187). On the iOS operating system, 'BLACK RIGHT-POINTING TRIANGLE' is displayed as a button instead of the right pointing triangle. This is an undesirable result of a lack of similarity to real GUI.

![triangle_ios](https://user-images.githubusercontent.com/1511441/96794466-392eec80-1439-11eb-9a63-0bbfd2c13ab7.png)

I didn’t realized this because I always worked on the issue using macOS.
According to this website, the problem is only on iOS.
https://www.utf8icons.com/character/9654/black-right-pointing-triangle

Using  'BLACK RIGHT-POINTING POINTER' instead of 'BLACK RIGHT-POINTING TRIANGLE' solves the problem.

On iOS:
![pointer_ios](https://user-images.githubusercontent.com/1511441/96798273-7e541e00-143b-11eb-9383-2b96bfd6de43.png)

On macOS:
![pointer_macos](https://user-images.githubusercontent.com/1511441/96798312-94fa7500-143b-11eb-9ea6-62795e8e7c11.png)

On Windows:
![pointer_windows](https://user-images.githubusercontent.com/1511441/96798338-a80d4500-143b-11eb-80c5-5ff31d578f12.png)

I couldn’t test it on Linux and Android because I don’t have them.
Above website doesn’t have images for BLACK RIGHT-POINTING POINTER.
https://www.utf8icons.com/character/9658/black-right-pointing-pointer