### PR TITLE
adds no-recommend and no-suggest option to aptprevents pulling giant …

### DIFF
--- a/docs/server_manual/getting_started.rst
+++ b/docs/server_manual/getting_started.rst
@@ -31,7 +31,7 @@ Once the chosen repository is configured, installation is simply done with:
 .. code-block:: bash
 
  apt install qgis-server --no-install-recommends --no-install-suggests
- # if you want to install server plugins, also:
+ # if you want to install server Python plugins, also:
  apt install python-qgis
 
 To test the installation, run:

--- a/docs/server_manual/getting_started.rst
+++ b/docs/server_manual/getting_started.rst
@@ -30,7 +30,7 @@ Once the chosen repository is configured, installation is simply done with:
 
 .. code-block:: bash
 
- apt install qgis-server
+ apt install qgis-server --no-install-recommends --no-install-suggests
  # if you want to install server plugins, also:
  apt install python-qgis
 

--- a/docs/training_manual/qgis_server/install.rst
+++ b/docs/training_manual/qgis_server/install.rst
@@ -23,7 +23,8 @@ Install QGIS Server with:
 
 .. code-block:: bash
 
- apt install qgis-server
+ apt install qgis-server --no-install-recommends --no-install-suggests
+
  # if you want to install server plugins, also:
  apt install python-qgis
 


### PR DESCRIPTION
As suggested on the [dev list](http://osgeo-org.1560.x6.nabble.com/QGIS-Developer-Problem-with-installation-of-qgis-server-LTR-on-Ubuntu-20-04-td5448348.html) I propose to add the `--no-recommend` and `--no-install-suggest` in the manual to avoid having users ending in installing GNOME with QGIS server 

 
