### PR TITLE
Added colon to let expression show as expression in build docs

### DIFF
--- a/docs/training_manual/complete_analysis/analysis_exercise.rst
+++ b/docs/training_manual/complete_analysis/analysis_exercise.rst
@@ -446,7 +446,7 @@ in the resulting raster (it's almost as if they are being lit by the
 morning sunlight).
 
 Find the correct rainfall (greater than ``1000`` mm) the same way.
-Use the following expression:
+Use the following expression::
 
   rainfall30@1 > 1000
 


### PR DESCRIPTION
Line 449 : "Use the following expression:"  should be "Use the following expression::" to let the expression show as an expression in the built documentation.
At the moment it shows as regular text.

Goal:  Display correct documentation

- [x ] Backport to LTR documentation is required
