### PR TITLE
Doctest build is turning QgsMapLayer into QgsVectorLayer

### DIFF
--- a/docs/pyqgis_developer_cookbook/legend.rst
+++ b/docs/pyqgis_developer_cookbook/legend.rst
@@ -64,7 +64,7 @@ return a dictionary of the loaded layers:
 
 .. testoutput:: legend
 
-  {'countries_89ae1b0f_f41b_4f42_bca4_caf55ddbe4b6': <QgsMapLayer: 'countries' (ogr)>}
+  {'countries_89ae1b0f_f41b_4f42_bca4_caf55ddbe4b6': <QgsVectorLayer: 'countries' (ogr)>}
 
 The dictionary ``keys`` are the unique layer ids while the ``values`` are the
 related objects.
@@ -84,7 +84,7 @@ It is now straightforward to obtain any other information about the layers:
 
 .. testoutput:: legend
 
-  {'countries': <QgsMapLayer: 'countries' (ogr)>}
+  {'countries': <QgsVectorLayer: 'countries' (ogr)>}
 
 
 You can also query the TOC using the name of the layer:
@@ -162,7 +162,7 @@ methods that can be used to obtain more information about the TOC:
 
 .. testoutput:: legend
 
-    [<QgsMapLayer: 'countries' (ogr)>]
+    [<QgsVectorLayer: 'countries' (ogr)>]
 
 Now let’s add some layers to the project’s layer tree. There are two ways of doing
 that:
@@ -200,8 +200,8 @@ You can switch between :class:`QgsVectorLayer <qgis.core.QgsVectorLayer>` and
 
 .. testoutput:: legend
 
-    Layer node: <qgis._core.QgsLayerTreeLayer object at 0x7fecceb46ca8>
-    Map layer: <QgsMapLayer: 'countries' (ogr)>
+    Layer node: <qgis._core.QgsLayerTreeLayer object at 0x7f24423175e0>
+    Map layer: <QgsVectorLayer: 'countries' (ogr)>
 
 
 Groups can be added with the :meth:`addGroup() <qgis.core.QgsLayerTreeGroup.addGroup>`


### PR DESCRIPTION
I don't know what has changed in QGIS code or our data but doctest build is failing and outputs that were expected to be of QgsMapLayer type are returned as QgsVectorLayer (eg https://github.com/qgis/QGIS-Documentation/runs/1394492880?check_suite_focus=true#step:6:514). 
Note that the layer ID also changes at each run, something I don't know how to fix it.

Any help is more than appreciated. Thanks