### PR TITLE
Small mod to start service or socket after enable

### DIFF
--- a/docs/server_manual/getting_started.rst
+++ b/docs/server_manual/getting_started.rst
@@ -337,8 +337,7 @@ Then enable and start the service:
 
 .. code-block:: bash
 
- systemctl enable qgis-server
- systemctl start qgis-server
+ systemctl enable --now qgis-server
 
 .. warning::
 
@@ -416,7 +415,7 @@ Now enable and start sockets:
 
 .. code-block:: bash
 
- for i in 1 2 3 4; do systemctl enable qgis-server@$i.socket && systemctl start qgis-server@$i.socket; done
+ for i in 1 2 3 4; do systemctl enable --now qgis-server@$i.socket; done
 
 The **QGIS Server Service unit** defines and starts the QGIS Server process.
 The important part is that the Service process’ standard input is connected to
@@ -456,7 +455,7 @@ Now start socket service:
 
 .. code-block:: bash
 
- for i in 1 2 3 4; do systemctl enable qgis-server@$i.service && systemctl start qgis-server@$i.service; done
+ for i in 1 2 3 4; do systemctl enable --now qgis-server@$i.service; done
 
 Finally, for the NGINX HTTP server, lets introduce the configuration for this setup:
 
@@ -519,8 +518,7 @@ Enable, start and check the status of the ``xvfb.service``:
 
 .. code-block:: bash
 
-   systemctl enable xvfb.service
-   systemctl start xvfb.service
+   systemctl enable --now xvfb.service
    systemctl status xvfb.service
 
 Then, according to your HTTP server, you should configure the **DISPLAY**


### PR DESCRIPTION
```
systemctl enable service_name && systemctl start service_name
```

has same effect as 

```
systemctl enable --now service_name
```

Source : https://github.com/systemd/systemd/blob/dd95b381b26369c02a3ca03585184cb2ea17295b/NEWS#L3043-L3046

> "systemctl enable", "systemctl disable" and "systemctl mask"
> now support a **new "--now" switch**. If specified the units
> that are **enabled will also be started**, and the ones
>  disabled/masked also stopped.

Require systemd 220 released in 2015-05-22 which is now present in all distributions

<!---
Include a few sentences describing the overall goals for this Pull Request.
 
A list of issues is at https://github.com/qgis/QGIS-Documentation/issues.
Add "fix #issuenumber" for each issue the PR fixes. The ticket(s) will be closed automatically.
If your PR doesn't fix entirely the ticket, only add the ticket(s) reference preceded by # character.
-->
Goal:

Ticket(s): #
<!---
Indicate whether the fix should be backported to previous release.
Replace the space between square brackets by a `x` to make it checked.
-->
- [ ] Backport to LTR documentation is required

<!---
Reviewing is a process done by community members, mostly on a volunteer basis.
We try to keep the overhead as small as possible and appreciate if you help us.
Please read carefully and ensure you comply with our writing guidelines at
https://docs.qgis.org/testing/en/docs/documentation_guidelines/index.html.
Feel free to ask in a comment or the (qgis-community-team mailing list)
[https://lists.osgeo.org/mailman/listinfo/qgis-community-team] if you have troubles with any item.
--->
