### PR TITLE
clipping settings for map items

### DIFF
--- a/docs/user_manual/print_composer/composer_items/composer_map.rst
+++ b/docs/user_manual/print_composer/composer_items/composer_map.rst
@@ -68,35 +68,36 @@ functionalities:
     are missing from the layout map (e.g. due to conflicts with other
     map labels or due to insufficient space to place the label) by
     highlighting them in a :ref:`predefined color <automated_placement>`.
-*  |clip| :sup:`Clipping settings`: allows to clip the map item to the atlas
-   feature and to shape and polygon items:
+* |clip| :sup:`Clipping settings`: allows to clip the map item to the atlas
+  feature and to shape and polygon items:
 
-   * |checkbox| :guilabel:`Clip to atlas feature`: you can determine that
-     the layout map item will be clipped automatically to the current atlas feature.
+  * |checkbox| :guilabel:`Clip to atlas feature`: you can determine that
+    the layout map item will be clipped automatically to the current :ref:`atlas
+    feature <atlas_generation>`.
 
-     There are different clipping modes available:
+    There are different clipping modes available:
 
-     * :guilabel:`Clip During Render Only`: applies a painter based clip,
-       so that portions of vector features which sit outside the atlas feature
-       become invisible
-     * :guilabel:`Clip Feature Before Render`: applies the clip before rendering
-       features, so borders of features which fall partially outside the atlas
-       feature will still be visible on the boundary of the atlas feature
-     * :guilabel:`Render Intersecting Features Unchanged`: renders all
-       features which intersect the current atlas feature, but without clipping their
-       their geometry.
+    * :guilabel:`Clip During Render Only`: applies a painter based clip,
+      so that portions of vector features which sit outside the atlas feature
+      become invisible
+    * :guilabel:`Clip Feature Before Render`: applies the clip before rendering
+      features, so borders of features which fall partially outside the atlas
+      feature will still be visible on the boundary of the atlas feature
+    * :guilabel:`Render Intersecting Features Unchanged`: renders all
+      features which intersect the current atlas feature, but without clipping their
+      their geometry.
 
-     You can |checkbox| :guilabel:`Force labels inside atlas feature`.
-     If you don't want to |radiobuttonoff| :guilabel:`Clip all layers` to the
-     atlas feature you can use the |radiobuttonon| :guilabel:`Clip selected layers`
-     option.
-   * |checkbox| :guilabel:`Clip to item`: it is possible to change the shape of the
-     map item by using a :ref:`shape <layout_basic_shape_item>` or :ref:`polygon
-     <layout_node_based_shape_item>` item from the print layout. When you
-     enable this option the map will be automatically clipped to the selected shape
-     in the combobox. Again, the above mentioned clipping modes are available.
-   When creating an atlas, the clipping settings are relevant.
-   See :ref:`atlas creation <atlas_generation>`.
+    You can |checkbox| :guilabel:`Force labels inside atlas feature`.
+    If you don't want to |radiobuttonoff| :guilabel:`Clip all layers` to the
+    atlas feature you can use the |radiobuttonon| :guilabel:`Clip selected layers`
+    option.
+  * |checkbox| :guilabel:`Clip to item`: it is possible to change the shape of the
+    map item by using a :ref:`shape <layout_basic_shape_item>` or :ref:`polygon
+    <layout_node_based_shape_item>` item from the print layout. When you
+    enable this option the map will be automatically clipped to the selected shape
+    in the combobox. Again, the above mentioned clipping modes are available and
+    labels can be forced to display only inside the clipping shape.
+
 
 .. _`layout_main_properties`:
 

--- a/docs/user_manual/print_composer/composer_items/composer_map.rst
+++ b/docs/user_manual/print_composer/composer_items/composer_map.rst
@@ -70,7 +70,7 @@ functionalities:
     highlighting them in a :ref:`predefined color <automated_placement>`.
 *  |clip| :sup:`Clipping settings`: allows to clip the map item to the atlas
    feature and to shape and polygon items:
-   * in |checkbox|`:guilabel:`Clip to atlas feature` you can determine that
+   * in |checkbox| `:guilabel:`Clip to atlas feature` you can determine that
      the map layers will be clipped automatically to the current atlas feature.
      There are different clipping nodes available: :guilabel:`Clip During Render Only`,
      :guilabel:`Clip Feature Before Render` and

--- a/docs/user_manual/print_composer/composer_items/composer_map.rst
+++ b/docs/user_manual/print_composer/composer_items/composer_map.rst
@@ -72,7 +72,7 @@ functionalities:
    feature and to shape and polygon items:
 
    * |checkbox| :guilabel:`Clip to atlas feature`: you can determine that
-     the map layers will be clipped automatically to the current atlas feature.
+     the layout map item will be clipped automatically to the current atlas feature.
      There are different clipping nodes available: :guilabel:`Clip During Render Only`,
      :guilabel:`Clip Feature Before Render` and
      :guilabel:`Render Intersecting Features Unchanged`. They define how features 

--- a/docs/user_manual/print_composer/composer_items/composer_map.rst
+++ b/docs/user_manual/print_composer/composer_items/composer_map.rst
@@ -88,7 +88,7 @@ functionalities:
 
      You can |checkbox| :guilabel:`Force labels inside atlas feature`.
      If you don't want to |radiobuttonoff| :guilabel:`Clip all layers` to the
-     atlas feature you can use the |radiobuttonon| :guilabel:`Clip selected layers:`
+     atlas feature you can use the |radiobuttonon| :guilabel:`Clip selected layers`
      option.
    * |checkbox| :guilabel:`Clip to item`: it is possible to change the shape of the
      map item by using a :ref:`shape <layout_basic_shape_item>` or :ref:`polygon

--- a/docs/user_manual/print_composer/composer_items/composer_map.rst
+++ b/docs/user_manual/print_composer/composer_items/composer_map.rst
@@ -90,7 +90,7 @@ functionalities:
      If you don't want to |radiobuttonoff| :guilabel:`Clip all layers` to the
      atlas feature you can use the |radiobuttonon| :guilabel:`Clip selected layers:`
      option.
-   * in |checkbox| :guilabel:`Clip to item` it is possible to change the shape of the
+   * |checkbox| :guilabel:`Clip to item`: it is possible to change the shape of the
      map item by using a :ref:`shape <layout_basic_shape_item>` or :ref:`polygon
      <layout_node_based_shape_item>` item from the print layout. When you
      enable this option the map will be automatically clipped to the selected shape

--- a/docs/user_manual/print_composer/composer_items/composer_map.rst
+++ b/docs/user_manual/print_composer/composer_items/composer_map.rst
@@ -424,6 +424,8 @@ of the overview on the selected map frame. You can customize it with:
    :width: 1.5em
 .. |checkbox| image:: /static/common/checkbox.png
    :width: 1.3em
+.. |clip| image:: /static/common/clip.png
+   :width: 1.5em
 .. |dataDefined| image:: /static/common/mIconDataDefine.png
    :width: 1.5em
 .. |labeling| image:: /static/common/labelingSingle.png

--- a/docs/user_manual/print_composer/composer_items/composer_map.rst
+++ b/docs/user_manual/print_composer/composer_items/composer_map.rst
@@ -70,7 +70,8 @@ functionalities:
     highlighting them in a :ref:`predefined color <automated_placement>`.
 *  |clip| :sup:`Clipping settings`: allows to clip the map item to the atlas
    feature and to shape and polygon items:
-   * in |checkbox| `:guilabel:`Clip to atlas feature` you can determine that
+
+   * |checkbox| :guilabel:`Clip to atlas feature`: you can determine that
      the map layers will be clipped automatically to the current atlas feature.
      There are different clipping nodes available: :guilabel:`Clip During Render Only`,
      :guilabel:`Clip Feature Before Render` and

--- a/docs/user_manual/print_composer/composer_items/composer_map.rst
+++ b/docs/user_manual/print_composer/composer_items/composer_map.rst
@@ -68,7 +68,21 @@ functionalities:
     are missing from the layout map (e.g. due to conflicts with other
     map labels or due to insufficient space to place the label) by
     highlighting them in a :ref:`predefined color <automated_placement>`.
-
+*  |clip| :sup:`Clipping settings`: allows to clip the map item to the atlas
+   feature and to shape and polygon items:
+   * in |checkbox|`:guilabel:`Clip to atlas feature` you can determine that
+     the map layers will be clipped automatically to the current atlas feature.
+     There are different clipping nodes available: :guilabel:`Clip During Render Only`,
+     :guilabel:`Clip Feature Before Render` and
+     :guilabel:`Render Intersecting Features Unchanged`. They define how features 
+     will be clipped. You can |checkbox| :guilabel:`Force labels inside atlas feature`.
+     If you don't want to |radiobuttonoff| :guilabel:`Clip all layers` to the
+     atlas feature you can use the |radiobuttonon| :guilabel:`Clip selected layers:`
+     option.
+   * in |checkbox| :guilabel:`Clip to item` it is possible to change the shape of the
+     map item by using a shape or polygon feature from the print layout. When you
+     enable this option the map will be automatically clipped to the selected shape
+     in the combobox. Again, the above mentioned clipping modes are available.
 
 .. _`layout_main_properties`:
 

--- a/docs/user_manual/print_composer/composer_items/composer_map.rst
+++ b/docs/user_manual/print_composer/composer_items/composer_map.rst
@@ -73,10 +73,20 @@ functionalities:
 
    * |checkbox| :guilabel:`Clip to atlas feature`: you can determine that
      the layout map item will be clipped automatically to the current atlas feature.
-     There are different clipping nodes available: :guilabel:`Clip During Render Only`,
-     :guilabel:`Clip Feature Before Render` and
-     :guilabel:`Render Intersecting Features Unchanged`. They define how features 
-     will be clipped. You can |checkbox| :guilabel:`Force labels inside atlas feature`.
+
+     There are different clipping modes available:
+
+     * :guilabel:`Clip During Render Only`: applies a painter based clip,
+       so that portions of vector features which sit outside the atlas feature
+       become invisible
+     * :guilabel:`Clip Feature Before Render`: applies the clip before rendering
+       features, so borders of features which fall partially outside the atlas
+       feature will still be visible on the boundary of the atlas feature
+     * :guilabel:`Render Intersecting Features Unchanged`: renders all
+       features which intersect the current atlas feature, but without clipping their
+       their geometry.
+
+     You can |checkbox| :guilabel:`Force labels inside atlas feature`.
      If you don't want to |radiobuttonoff| :guilabel:`Clip all layers` to the
      atlas feature you can use the |radiobuttonon| :guilabel:`Clip selected layers:`
      option.

--- a/docs/user_manual/print_composer/composer_items/composer_map.rst
+++ b/docs/user_manual/print_composer/composer_items/composer_map.rst
@@ -91,7 +91,8 @@ functionalities:
      atlas feature you can use the |radiobuttonon| :guilabel:`Clip selected layers:`
      option.
    * in |checkbox| :guilabel:`Clip to item` it is possible to change the shape of the
-     map item by using a shape or polygon feature from the print layout. When you
+     map item by using a :ref:`shape <layout_basic_shape_item>` or :ref:`polygon
+     <layout_node_based_shape_item>` item from the print layout. When you
      enable this option the map will be automatically clipped to the selected shape
      in the combobox. Again, the above mentioned clipping modes are available.
    When creating an atlas, the clipping settings are relevant.

--- a/docs/user_manual/print_composer/composer_items/composer_map.rst
+++ b/docs/user_manual/print_composer/composer_items/composer_map.rst
@@ -83,6 +83,8 @@ functionalities:
      map item by using a shape or polygon feature from the print layout. When you
      enable this option the map will be automatically clipped to the selected shape
      in the combobox. Again, the above mentioned clipping modes are available.
+   When creating an atlas, the clipping settings are relevant.
+   See :ref:`atlas creation <atlas_generation>`.
 
 .. _`layout_main_properties`:
 


### PR DESCRIPTION
The map item properties panels were extended by a clipping settings panel

<!---
Users shall be able to use the map item clipping settings.
 
A list of issues is at https://github.com/qgis/QGIS-Documentation/issues.
Add "fix #issuenumber" for each issue the PR fixes. The ticket(s) will be closed automatically.
If your PR doesn't fix entirely the ticket, only add the ticket(s) reference preceded by # character.
-->
Goal: Precise steps to enable the clipping settings.

Ticket(s): fix #5820 fix #5937
<!---
Indicate whether the fix should be backported to previous release.
Replace the space between square brackets by a `x` to make it checked.
-->
- [ ] Backport to LTR documentation is required

<!---
Reviewing is a process done by community members, mostly on a volunteer basis.
We try to keep the overhead as small as possible and appreciate if you help us.
Please read carefully and ensure you comply with our writing guidelines at
https://docs.qgis.org/testing/en/docs/documentation_guidelines/index.html.
Feel free to ask in a comment or the (qgis-community-team mailing list)
[https://lists.osgeo.org/mailman/listinfo/qgis-community-team] if you have troubles with any item.
--->
