### PR TITLE
tracing on curved geometries

### DIFF
--- a/docs/user_manual/introduction/qgis_configuration.rst
+++ b/docs/user_manual/introduction/qgis_configuration.rst
@@ -701,6 +701,12 @@ from GEOS 3.3.
 * :guilabel:`Quadrant segments`
 * :guilabel:`Miter limit`
 
+**Tracing**
+
+By activating the |checkbox| :guilabel:`Convert tracing to curve` you can
+create curve segments while digitizing. Keep in mind that your data provider
+must support this feature.
+
 
 .. _layout_options:
 

--- a/docs/user_manual/working_with_vector/editing_geometry_attributes.rst
+++ b/docs/user_manual/working_with_vector/editing_geometry_attributes.rst
@@ -283,7 +283,7 @@ digitization:
 #. Move the mouse over another vertex or segment you'd like to snap and,
    instead of the usual straight line, the digitizing rubber band
    represents a path from the last point you snapped to the current
-   position.
+   position. The tool also works with curved geometries.
 
    QGIS actually uses the underlying features topology to build the
    shortest path between the two points.

--- a/docs/user_manual/working_with_vector/editing_geometry_attributes.rst
+++ b/docs/user_manual/working_with_vector/editing_geometry_attributes.rst
@@ -323,6 +323,12 @@ direction and a negative value does the opposite.
    digitize parts of the feature with tracing enabled and other
    parts with tracing disabled.
    Tools behave as usual when tracing is disabled.
+   
+.. tip:: **Convert tracing to curved geometries**
+   
+   By using :menuselection:`Settings --> Options --> Digitizing --> Tracing` 
+   you can create curved geometries while digitizing.
+   See :ref:`digitizing options <digitizing_options>`.
 
 
 .. index:: Digitizing, Digitizing tools


### PR DESCRIPTION
The tracing tool was extended. The user can now trance on curved geometries.

<!---
We should mention in short that curved geometries can be traced while digitizing.
 
A list of issues is at https://github.com/qgis/QGIS-Documentation/issues.
Add "fix #issuenumber" for each issue the PR fixes. The ticket(s) will be closed automatically.
If your PR doesn't fix entirely the ticket, only add the ticket(s) reference preceded by # character.
-->
Goal: The user shall be able to use the tracing of curved geometries while digitizing.

Ticket(s): fix #6287 
<!---
Indicate whether the fix should be backported to previous release.
Replace the space between square brackets by a `x` to make it checked.
-->
- [ ] Backport to LTR documentation is required

<!---
Reviewing is a process done by community members, mostly on a volunteer basis.
We try to keep the overhead as small as possible and appreciate if you help us.
Please read carefully and ensure you comply with our writing guidelines at
https://docs.qgis.org/testing/en/docs/documentation_guidelines/index.html.
Feel free to ask in a comment or the (qgis-community-team mailing list)
[https://lists.osgeo.org/mailman/listinfo/qgis-community-team] if you have troubles with any item.
--->
