### PR TITLE
mention visible rules only

### DIFF
--- a/docs/user_manual/introduction/general_tools.rst
+++ b/docs/user_manual/introduction/general_tools.rst
@@ -392,6 +392,10 @@ From a drop-down list of current layers in the layer panel, select an item and:
   layer style in the current project: you can therefore cancel or restore to any
   state by selecting it in the list and clicking :guilabel:`Apply`.
 
+For Vector Tile layers there is an option to show |checkbox| :guilabel:`Visible rules only`.
+This is very useful if you just want to work with rules that fall inside the
+current map cancas zoom level.
+ 
 Another powerful feature of this panel is the |checkbox| :guilabel:`Live update` checkbox.
 Tick it to render your changes immediately on the map canvas:
 you no longer need to click the :guilabel:`Apply` button.


### PR DESCRIPTION
This is a proposal for explaining the visible rules only option for symbolizing vector tiles. I didn't insert a screenshot. Do we need to mention this information in the vector layer properties, too?

<!---
Give information about the additional option for showing visible rules only.
 
A list of issues is at https://github.com/qgis/QGIS-Documentation/issues.
Add "fix #issuenumber" for each issue the PR fixes. The ticket(s) will be closed automatically.
If your PR doesn't fix entirely the ticket, only add the ticket(s) reference preceded by # character.
-->
Goal: Users shall be informed that for vector tiles they can work only with the rules that fall inside the current map canvas zoom level

Ticket(s): fix #6085 
<!---
Indicate whether the fix should be backported to previous release.
Replace the space between square brackets by a `x` to make it checked.
-->
- [ ] Backport to LTR documentation is required

<!---
Reviewing is a process done by community members, mostly on a volunteer basis.
We try to keep the overhead as small as possible and appreciate if you help us.
Please read carefully and ensure you comply with our writing guidelines at
https://docs.qgis.org/testing/en/docs/documentation_guidelines/index.html.
Feel free to ask in a comment or the (qgis-community-team mailing list)
[https://lists.osgeo.org/mailman/listinfo/qgis-community-team] if you have troubles with any item.
--->
