### PR TITLE
Keep older zonal statistics anchor for 3.12 and 3.14

### DIFF
--- a/docs/user_manual/processing_algs/qgis/rasteranalysis.rst
+++ b/docs/user_manual/processing_algs/qgis/rasteranalysis.rst
@@ -2172,6 +2172,7 @@ Python code
   :end-before: **end_algorithm_code_section**
 
 
+.. _qgiszonalstatistics:
 .. _qgiszonalstatisticsfb:
 
 Zonal statistics

--- a/docs/user_manual/processing_algs/qgis/rasteranalysis.rst
+++ b/docs/user_manual/processing_algs/qgis/rasteranalysis.rst
@@ -2180,6 +2180,9 @@ Zonal statistics
 Calculates statistics of a raster layer for each feature of an
 overlapping polygon vector layer.
 
+Prior to QGIS 3.16, the algorithm edited the layer in-place, adding the new
+statistics fields to it. Now, it outputs a new layer with these statistics.
+
 Parameters
 ..........
 
@@ -2232,7 +2235,7 @@ Parameters
        * 9 --- Majority
        * 10 --- Variety
        * 11 --- Variance
-   * - **Zonal Statistics**
+   * - **Zonal Statistics** |316|
      - ``OUTPUT``
      - [vector: polygon]
 
@@ -2259,7 +2262,7 @@ Outputs
      - Name
      - Type
      - Description
-   * - **Zonal Statistics**
+   * - **Zonal Statistics** |316|
      - ``OUTPUT``
      - [vector: polygon]
      - The zone vector layer with added statistics.
@@ -2274,6 +2277,7 @@ Python code
   :end-before: **end_algorithm_code_section**
 
 
+.. |316| replace:: ``NEW in 3.16``
 .. |gaussian_formula| image:: img/fuzzy_gaussian_formula.png
    :height: 1.5em
 .. |fuzzy_large_formula| image:: img/fuzzy_large_formula.png


### PR DESCRIPTION
and update the docs to mention the difference of behavior
If you are using 3.12 or 3.14 and you hit help button of the zonal statistics alg, it won't bring you to the alg section but to the top of the page, because the anchor has changed. Moreover the description does not match the behavior which may look confusing. This fixes these issues.