### PR TITLE
Issues #6177

### DIFF
--- a/docs/training_manual/create_vector_data/forms.rst
+++ b/docs/training_manual/create_vector_data/forms.rst
@@ -162,9 +162,9 @@ the person who creates the forms).
    .. figure:: img/qt_line_edit.png
       :align: center
 
-#. Set its name to ``Name``.
+#. Set its name to ``name``.
 #. Using the same approach, create a new spinbox and set its name to
-   ``Age``.
+   ``age``.
 #. Add a :guilabel:`Label` with the text ``Add a New Person`` in a
    bold font (look in the object *properties* to find out how to set
    this).


### PR DESCRIPTION
Training Manual - Lesson 5.3: Forms - integer overflow and widget boxes in custom forms #6177
- adapted the names for the QObjects, so that they are consistent with the geopackage field names

<!---
Include a few sentences describing the overall goals for this Pull Request.
 
A list of issues is at https://github.com/qgis/QGIS-Documentation/issues.
Add "fix #issuenumber" for each issue the PR fixes. The ticket(s) will be closed automatically.
If your PR doesn't fix entirely the ticket, only add the ticket(s) reference preceded by # character.
-->
Goal:

Ticket(s): #
<!---
Indicate whether the fix should be backported to previous release.
Replace the space between square brackets by a `x` to make it checked.
-->
- [ ] Backport to LTR documentation is required

<!---
Reviewing is a process done by community members, mostly on a volunteer basis.
We try to keep the overhead as small as possible and appreciate if you help us.
Please read carefully and ensure you comply with our writing guidelines at
https://docs.qgis.org/testing/en/docs/documentation_guidelines/index.html.
Feel free to ask in a comment or the (qgis-community-team mailing list)
[https://lists.osgeo.org/mailman/listinfo/qgis-community-team] if you have troubles with any item.
--->
