### PR TITLE
Add an action to update English PO files when rst files change

### DIFF
--- a/.github/workflows/pofiles.yml
+++ b/.github/workflows/pofiles.yml
@@ -1,0 +1,53 @@
+name: Update English PO files for translation
+
+on:
+  push:
+    branches:
+      - release_3.16
+    paths:
+      - 'docs/**'
+
+  schedule: #run at 02:00 UTC every day
+    - cron:  '00 02 * * *'
+
+jobs:
+  prepare_translation:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: checkout
+      uses: actions/checkout@v2
+      with:
+        ref: release_3.16
+
+    - name: Set up Python 3.7
+      uses: actions/setup-python@v1
+      with:
+        python-version: 3.7
+
+    - name: Install dependencies
+      run: |
+          python -m pip install --upgrade pip
+          pip install sphinx sphinx-intl pyYAML
+
+    - name: Generate English PO files
+      id: "generate-po-files"
+      run: |
+          make gettext
+          sphinx-intl update -p build/gettext -l en
+
+    - name: Commit the PO files
+      description: Update the PO files if there are changes
+      id: "auto-commit-action"
+      uses: stefanzweifel/git-auto-commit-action@v4
+      with:
+        commit_message: Update English PO files
+
+    - name: "Inform that changes have been made"
+      if: steps.auto-commit-action.outputs.changes_detected == 'true'
+      run: echo "Changes committed!"
+
+    - name: "Inform that no changes were performed"
+      if: steps.auto-commit-action.outputs.changes_detected == 'false'
+      run: echo "No Changes detected!"


### PR DESCRIPTION
This PR adds an action that automatically generates and commits the translation .po files. It aims to help us automate the push/pull of files from/to Transifex. This should happen at every night whenever the 3.16 branch has got a change on an rst file.
In its current shape, it (seems to) work(s).

Review and feedback welcome...