### PR TITLE
Enable pages redirection using the sphinxext-rediraffe extension

### DIFF
--- a/REQUIREMENTS.txt
+++ b/REQUIREMENTS.txt
@@ -2,6 +2,7 @@ Sphinx==3.2.1
 sphinx-intl==2.0.1
 sphinx_rtd_theme
 sphinx-intl[transifex]
+sphinxext-rediraffe
 transifex-client
 PyYAML
 pdflatex

--- a/conf.py
+++ b/conf.py
@@ -48,6 +48,7 @@ extensions = [
     'sphinx.ext.intersphinx',
     'sphinx.ext.doctest',
     'sphinx.ext.extlinks',
+    'sphinxext.rediraffe',
 ]
 
 # Add any paths that contain templates here, relative to this directory.
@@ -440,3 +441,9 @@ class BetterOutputChecker(doctest.OutputChecker):
         return doctest.OutputChecker.check_output(self, want, got, optionflags)
 
 ext_doctest.SphinxDocTestRunner = BetterDocTestRunner
+
+
+# -- Redirection settings --------------------------------
+
+rediraffe_redirects = "redirects.txt"
+#rediraffe_branch = "release_3.4"

--- a/redirects.txt
+++ b/redirects.txt
@@ -1,0 +1,21 @@
+# Use this file to redirect pages when coming from older releases
+# Processing algorithm
+docs/user_manual/processing_algs/qgis/graphics.rst: docs/user_manual/processing_algs/qgis/plots.rst,
+
+# Server manual
+docs/user_manual/working_with_ogc/server/containerized_deployment.rst: docs/server_manual/containerized_deployment.rst,
+docs/user_manual/working_with_ogc/server/development_server.rst: docs/server_manual/development_server.rst,
+docs/user_manual/working_with_ogc/server/plugins.rst: docs/server_manual/plugins.rst,
+docs/user_manual/working_with_ogc/server/services.rst: docs/server_manual/services.rst,
+docs/user_manual/working_with_ogc/server/getting_started.rst: docs/server_manual/getting_started.rst
+
+# Training manual
+docs/training_manual/foreword/preparing_data.rst: docs/training_manual/appendix/preparing_data.rst,
+docs/training_manual/introduction/index.rst: docs/training_manual/foreword/index.rst,
+docs/training_manual/introduction/intro.rst: docs/training_manual/foreword/intro.rst,
+docs/training_manual/introduction/preparation.rst: docs/training_manual/basic_map/preparation.rst,
+docs/training_manual/introduction/overview.rst: docs/training_manual/basic_map/overview.rst,
+docs/training_manual/basic_map/vector_data.rst: docs/training_manual/basic_map/preparation.rst,
+
+# Print Layout
+docs/user_manual/print_composer/composer_items/composer_attribute_table.rst: docs/user_manual/print_composer/composer_items/composer_table_items.rst


### PR DESCRIPTION
* Add [sphinxext-rediraffe](https://github.com/wpilibsuite/sphinxext-rediraffe) extension to redirect HTML pages
* Add the extension to REQUIREMENTS.txt file to consolidate the build
* Add a set of pages redirection

It wouldn't solve issues with moving section from a page to another (to keep tracking the help button from QGIS application - #1926) but when a whole file is renamed or moved to another directory (eg the server manual reshuffle) we can still catch the right page. Gives also more sense to the top banner of outdated pages that sends to the latest version (and sometimes a 404).
Bonus: the redirection is tested by the HTML build which fails if a target page is missing.

@rduivenvoorde @mbernasocchi we were looking for something like this in https://github.com/qgis/QGIS-Website/issues/762