### PR TITLE
Disable translations for 3.10 documentation

### DIFF
--- a/themes/rtd_qgis/versions.html
+++ b/themes/rtd_qgis/versions.html
@@ -37,12 +37,12 @@
           <dd>
             <a href="{{ github_url }}/{{ pagename }}.rst" target="_blank" rel="noopener noreferrer">{{ _('Edit on GitHub') }}</a>
           </dd>
-          {# Display the call for translation only for the latest document. #}
+          <!--{# Display the call for translation only for the latest document. #}
           {% if not isTesting %} 
           <dd>
             <a href="{{ transifex_url }}/#{{ language }}/{{ pagename | replace("/","--") }}" target="_blank" rel="noopener noreferrer">{{ _('Translate Page') }}</a>
           </dd>
-          {% endif %}
+          {% endif %}-->
           <dd>
             <a href="https://github.com/qgis/QGIS-Documentation/issues" target="_blank" rel="noopener noreferrer">{{ _('Report Issue') }}</a>
           </dd>


### PR DESCRIPTION
Ideally we should set the outdated status to True but I fee the top banner would be confusing to people since 3.10 is still active code-wise. We should do that in February.