### PR TITLE
Only pull translated parts of files from Transifex and not the whole files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -132,12 +132,12 @@ all: springclean
 # transifex, we need to replace the underscores by dashes,
 # the english language is removed to avoid pulling the po source files.
 # finally, the spaces are replaced by commas. In the end we have something like this
-# tx pull -f --parallel -l lang1,lang2,lang2,lang4
+# tx pull -f --parallel --mode onlytranslated -l lang1,lang2,lang3,lang4
 tx_force_pull_translations:
 	$(eval space := )
 	$(eval space += )
 	$(eval comma += ,)
-	tx pull -f --parallel -l $(subst $(space),$(comma),$(subst en$(space),,$(subst zh_,zh-,$(LANGUAGES)))) ;
+	tx pull -f --parallel --mode onlytranslated -l $(subst $(space),$(comma),$(subst en$(space),,$(subst zh_,zh-,$(LANGUAGES)))) ;
 
 doctest:
 	LD_PRELOAD=/lib/x86_64-linux-gnu/libSegFault.so $(SPHINXBUILD) -b doctest . $(BUILDDIR)/doctest

--- a/scripts/minimize_translation.sh
+++ b/scripts/minimize_translation.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+# This script is used to clean QGIS-Documentation translated resources pulled
+# from Transifex and keep only the translated strings/files
+# https://www.transifex.com
+#
+# Harrissou Sant-anna, December 2020
+
+# list of target folders
+SOURCEPOFILES='locale'
+#ENGLISHPOFILES='locale/pofiles_count_string.txt'
+#UNTRANSLATEDPOFILES='locale/about_to_delete.txt'
+#rm -rf $ENGLISHPOFILES  $UNTRANSLATEDPOFILES
+
+# Pull translations of all languages from Transifex,
+# fetching only the strings that are really translated and not the whole file
+tx pull --mode onlytranslated -a
+
+# The onlytranslated mode actually pulls all the existing files
+# (with only the file header when no string has been translated yet)
+# so let's remove those files that have no translated string (except for English)
+for POFILE in `find $SOURCEPOFILES -type f -not -path "*/en/*" -name '*.po'`
+do
+  # if only 'msgstr ""' appears in the file (with no text between quotes),
+  # then there's not a single translated string in it
+  # so let's find those files and delete them
+  COUNT=`grep -oce 'msgstr ".\+"' $POFILE`
+  #echo "$POFILE: $COUNT" >>  $ENGLISHPOFILES
+  if [ $COUNT -eq 0 ]; then \
+    #echo "$POFILE" >> $UNTRANSLATEDPOFILES;\
+    rm "$POFILE"
+  fi;
+done
+
+#remove the resulting empty folders
+find $SOURCEPOFILES -type d -empty -delete
+


### PR DESCRIPTION
using the --mode onlytranslated option
Also add a script that cleans the folder from unnecessary downloaded files (transifex still pulls files with untranslated strings, only their header)
Sphinx is smart enough to build the translated docs so we don't need to pull in target PO files, the English strings if untranslated. [Using this method](https://github.com/qgis/QGIS-Documentation/commit/0c20b7ddd8ab4b93cc9436f19d6059b3a80d5d6e), we fall down from 22k files (450MB) to 8k files (77MB). The 57 languages are downloaded in almost 1h from scratch here.