### PR TITLE
Add HTML scaling control documentation

### DIFF
--- a/docs/user_manual/print_composer/composer_items/composer_html_frame.rst
+++ b/docs/user_manual/print_composer/composer_items/composer_html_frame.rst
@@ -13,9 +13,8 @@ It is possible to add a frame that displays the contents of a website or even
 create and style your own HTML page and display it!
 You can add a picture with the |addHtml| :guilabel:`Add HTML` following
 :ref:`items creation instructions <create_layout_item>` and manipulate it the
-same way as exposed in :ref:`interact_layout_item`. The HTML scale is controlled
-by the layout export resolution at the time the HTML frame is created. HTML is 
-displayed at approximately 100% when the layout export resolution is around 272dpi.
+same way as exposed in :ref:`interact_layout_item`. Note tha the HTML scale is
+controlled by the layout export resolution at the time the HTML frame is created.
 
 The HTML item can be customized using its :guilabel:`Item Properties` panel.
 Other than the :ref:`items common properties <item_common_properties>`, this

--- a/docs/user_manual/print_composer/composer_items/composer_html_frame.rst
+++ b/docs/user_manual/print_composer/composer_items/composer_html_frame.rst
@@ -13,7 +13,9 @@ It is possible to add a frame that displays the contents of a website or even
 create and style your own HTML page and display it!
 You can add a picture with the |addHtml| :guilabel:`Add HTML` following
 :ref:`items creation instructions <create_layout_item>` and manipulate it the
-same way as exposed in :ref:`interact_layout_item`.
+same way as exposed in :ref:`interact_layout_item`. The HTML scale is controlled
+by the layout export resolution at the time the HTML frame is created. HTML is 
+displayed at approximately 100% when the layout export resolution is around 272dpi.
 
 The HTML item can be customized using its :guilabel:`Item Properties` panel.
 Other than the :ref:`items common properties <item_common_properties>`, this


### PR DESCRIPTION
<!---
Include a few sentences describing the overall goals for this Pull Request.
 
A list of issues is at https://github.com/qgis/QGIS-Documentation/issues.
Add "fix #issuenumber" for each issue the PR fixes. The ticket(s) will be closed automatically.
If your PR doesn't fix entirely the ticket, only add the ticket(s) reference preceded by # character.
-->
Goal: Documents unexpected behavior of scaling when adding HTML frames. 

Ticket(s): #
Fixes #6387

<!---
Indicate whether the fix should be backported to previous release.
Replace the space between square brackets by a `x` to make it checked.
-->
- [ ] Backport to LTR documentation is required

<!---
Reviewing is a process done by community members, mostly on a volunteer basis.
We try to keep the overhead as small as possible and appreciate if you help us.
Please read carefully and ensure you comply with our writing guidelines at
https://docs.qgis.org/testing/en/docs/documentation_guidelines/index.html.
Feel free to ask in a comment or the (qgis-community-team mailing list)
[https://lists.osgeo.org/mailman/listinfo/qgis-community-team] if you have troubles with any item.
--->
