### PR TITLE
Typo corrected

### DIFF
--- a/locale/en/LC_MESSAGES/docs/user_manual/print_composer/composer_items/composer_tables.po
+++ b/locale/en/LC_MESSAGES/docs/user_manual/print_composer/composer_items/composer_tables.po
@@ -660,7 +660,7 @@ msgid ""
 msgstr ""
 
 #~ msgid ""
-#~ "by defining the :guilabel:`Horizonatl "
+#~ "by defining the :guilabel:`Horizontal "
 #~ "alignment` and the :guilabel:`Vertical "
 #~ "alignment`"
 #~ msgstr ""


### PR DESCRIPTION
line 663  : 'Horzinatl'  should be 'Horizontal'


Goal: Display correct documentation


