### PR TITLE
Typo corrected

### DIFF
--- a/docs/user_manual/working_with_ogc/ogc_client_support.rst
+++ b/docs/user_manual/working_with_ogc/ogc_client_support.rst
@@ -270,7 +270,7 @@ Each item can be identified by:
 * an :guilabel:`ID`
 * a :guilabel:`Name`
 * a :guilabel:`Title`
-* and an :guilabel:`Astract`.
+* and an :guilabel:`Abstract`.
 
 The list can be filtered using the |search| widget in the top right corner.
 


### PR DESCRIPTION
Line 273: " :guilabel:`Astract`. " should probably be " :guilabel:`Abstract`. "


Goal: Display correct documentation

- [ ] Backport to LTR documentation is required
