### PR TITLE
Update list of pages redirection

### DIFF
--- a/redirects.txt
+++ b/redirects.txt
@@ -1,22 +1,27 @@
 # Use this file to redirect pages when coming from older releases
-# Processing algorithm
-docs/user_manual/processing_algs/qgis/graphics.rst: docs/user_manual/processing_algs/qgis/plots.rst,
 
 # Server manual
-docs/user_manual/working_with_ogc/server/containerized_deployment.rst: docs/server_manual/containerized_deployment.rst,
-docs/user_manual/working_with_ogc/server/development_server.rst: docs/server_manual/development_server.rst,
-docs/user_manual/working_with_ogc/server/plugins.rst: docs/server_manual/plugins.rst,
-docs/user_manual/working_with_ogc/server/services.rst: docs/server_manual/services.rst,
+docs/user_manual/working_with_ogc/ogc_server_support.rst: docs/server_manual/index.rst
+docs/user_manual/working_with_ogc/server/containerized_deployment.rst: docs/server_manual/containerized_deployment.rst
+docs/user_manual/working_with_ogc/server/development_server.rst: docs/server_manual/development_server.rst
+docs/user_manual/working_with_ogc/server/plugins.rst: docs/server_manual/plugins.rst
+docs/user_manual/working_with_ogc/server/services.rst: docs/server_manual/services.rst
 docs/user_manual/working_with_ogc/server/getting_started.rst: docs/server_manual/getting_started.rst
 
 # Training manual
-docs/training_manual/foreword/preparing_data.rst: docs/training_manual/appendix/preparing_data.rst,
-docs/training_manual/introduction/index.rst: docs/training_manual/foreword/index.rst,
-docs/training_manual/introduction/intro.rst: docs/training_manual/foreword/intro.rst,
-docs/training_manual/introduction/preparation.rst: docs/training_manual/basic_map/preparation.rst,
-docs/training_manual/introduction/overview.rst: docs/training_manual/basic_map/overview.rst,
-docs/training_manual/basic_map/vector_data.rst: docs/training_manual/basic_map/preparation.rst,
+docs/training_manual/foreword/preparing_data.rst: docs/training_manual/appendix/preparing_data.rst
+docs/training_manual/introduction/index.rst: docs/training_manual/foreword/index.rst
+docs/training_manual/introduction/intro.rst: docs/training_manual/foreword/intro.rst
+docs/training_manual/introduction/preparation.rst: docs/training_manual/basic_map/preparation.rst
+docs/training_manual/introduction/overview.rst: docs/training_manual/basic_map/overview.rst
+docs/training_manual/basic_map/vector_data.rst: docs/training_manual/basic_map/preparation.rst
+
+# User manual
+docs/user_manual/working_with_vector/virtual_layers.rst: docs/user_manual/managing_data_source/create_layers.rst
 
 # Print Layout
-docs/user_manual/print_composer/composer_items/composer_attribute_table.rst: docs/user_manual/print_composer/composer_items/composer_tables.rst,
+docs/user_manual/print_composer/composer_items/composer_attribute_table.rst: docs/user_manual/print_composer/composer_items/composer_tables.rst
 docs/user_manual/print_composer/composer_items/composer_items_shape.rst: docs/user_manual/print_composer/composer_items/composer_shapes.rst
+
+# Processing algorithm
+docs/user_manual/processing_algs/qgis/graphics.rst: docs/user_manual/processing_algs/qgis/plots.rst


### PR DESCRIPTION
- Redirect old single "server manual" page
- Remove unnecessary comma
- Group pages by manual

Fixes #4325 (3.4 is no longer maintained but manually changing version in the mentioned URL will now lead to an existing page in recent versions)