### PR TITLE
Fixes broken URLs in the documentation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -143,3 +143,8 @@ doctest:
 	LD_PRELOAD=/lib/x86_64-linux-gnu/libSegFault.so $(SPHINXBUILD) -b doctest . $(BUILDDIR)/doctest
 	@echo "Testing of doctests in the sources finished, look at the " \
 	      "results in $(BUILDDIR)/doctest/output.txt."
+
+linkcheck:
+	$(SPHINXBUILD) -b linkcheck $(SOURCEDIR) $(BUILDDIR)/linkcheck
+	@echo "Check finished. Report is in $(BUILDDIR)/linkcheck/output.txt."
+

--- a/conf.py
+++ b/conf.py
@@ -442,6 +442,18 @@ class BetterOutputChecker(doctest.OutputChecker):
 
 ext_doctest.SphinxDocTestRunner = BetterDocTestRunner
 
+# -- External Link check settings --------------------------------
+
+# A list of regular expressions that match URIs that should not be checked
+# when doing a linkcheck build.
+linkcheck_ignore = [r'http://localhost(:|/)?',
+                    r'http://qgis(platform)?\.demo',
+                    r'http://myhost/'
+                   ]
+
+# The number of times the linkcheck builder will attempt to check a URL
+# before declaring it broken. Defaults to 1 attempt.
+linkcheck_retries = 2
 
 # -- Redirection settings --------------------------------
 

--- a/docs/gentle_gis_introduction/coordinate_reference_systems.rst
+++ b/docs/gentle_gis_introduction/coordinate_reference_systems.rst
@@ -1,3 +1,4 @@
+.. _gis_coord_ref_system:
 
 ****************************
 Coordinate Reference Systems
@@ -479,8 +480,8 @@ Further reading
 
 **Websites**:
 
-* https://www.colorado.edu/geography/gcraft/notes/mapproj/mapproj_f.html
-* https://geology.isu.edu/wapi/geostac/Field_Exercise/topomaps/index.htm
+* https://foote.geography.uconn.edu/gcraft/notes/mapproj/mapproj_f.html
+* http://geology.isu.edu/wapi/geostac/Field_Exercise/topomaps/index.htm
 
 The QGIS User Guide also has more detailed information on working with map
 projections in QGIS.

--- a/docs/gentle_gis_introduction/data_capture.rst
+++ b/docs/gentle_gis_introduction/data_capture.rst
@@ -419,11 +419,8 @@ then fill in all the additional information you want to record.
 Further reading
 ===============
 
-**Website** http://www.k12science.org/curriculum/waterproj/S00project/miami2000/miamiriverfinal/
---- A school project to assess water quality in their local river.
-
-The QGIS User Guide also has more detailed information on digitising vector data
-in QGIS.
+The QGIS User Guide has more detailed information on :ref:`digitising vector data
+<editingvector>` in QGIS.
 
 What's next?
 ============

--- a/docs/gentle_gis_introduction/map_production.rst
+++ b/docs/gentle_gis_introduction/map_production.rst
@@ -291,7 +291,7 @@ Further reading
 * DeMers, Michael N. (2005). Fundamentals of Geographic Information Systems. 3rd
   Edition. Wiley. ISBN: 9814126195
 
-**Website**: https://en.wikipedia.org/wiki/Scale_(map)
+**Website**: `Scale (map) <https://en.wikipedia.org/wiki/Scale_(map)>`_
 
 The QGIS User Guide also has more detailed information on map production provided
 in QGIS.

--- a/docs/gentle_gis_introduction/vector_attribute_data.rst
+++ b/docs/gentle_gis_introduction/vector_attribute_data.rst
@@ -493,7 +493,7 @@ the same technique?
 Further reading
 ===============
 
-**Website:** https://en.wikipedia.org/wiki/Cartography#Map_symbology
+**Website:** https://en.wikipedia.org/wiki/Cartography
 
 The QGIS User Guide also has more detailed information on working with attribute
 data and symbology in QGIS.

--- a/docs/pyqgis_developer_cookbook/network_analysis.rst
+++ b/docs/pyqgis_developer_cookbook/network_analysis.rst
@@ -71,7 +71,8 @@ In the latter case the edge will be split and a new vertex added.
 Vector layer attributes and length of an edge can be used as the properties
 of an edge.
 
-Converting from a vector layer to the graph is done using the `Builder <https://en.wikipedia.org/wiki/Builder_pattern>`_
+Converting from a vector layer to the graph is done using the
+`Builder <https://en.wikipedia.org/wiki/Builder_pattern>`_
 programming pattern. A graph is constructed using a so-called Director.
 There is only one Director for now: :api:`QgsVectorLayerDirector
 <classQgsVectorLayerDirector.html>`.
@@ -79,9 +80,9 @@ The director sets the basic settings that will be used to construct a graph
 from a line vector layer, used by the builder to create the graph. Currently, as
 in the case with the director, only one builder exists: :class:`QgsGraphBuilder <qgis.analysis.QgsGraphBuilder>`,
 that creates :class:`QgsGraph <qgis.analysis.QgsGraph>` objects.
-You may want to implement your own builders that will build a graphs compatible
+You may want to implement your own builders that will build a graph compatible
 with such libraries as `BGL <https://www.boost.org/doc/libs/1_48_0/libs/graph/doc/index.html>`_
-or `NetworkX <https://networkx.lanl.gov/>`_.
+or `NetworkX <https://networkx.org/>`_.
 
 To calculate edge properties the programming pattern `strategy <https://en.wikipedia.org/wiki/Strategy_pattern>`_
 is used. For now only :api:`QgsNetworkDistanceStrategy <classQgsNetworkDistanceStrategy.html>`

--- a/docs/server_manual/containerized_deployment.rst
+++ b/docs/server_manual/containerized_deployment.rst
@@ -295,17 +295,17 @@ Installation
 
 If you have a **Docker Desktop** installation, using Kubernetes (aka
 k8s) is pretty straight forward:
-`enable k8s <https://docs.docker.com/get-started/orchestration/#enable-Kubernetes>`_. 
+`enable k8s <https://docs.docker.com/get-started/orchestration/#enable-kubernetes>`_.
 
 If not, follow the
-`minikube tutorial <https://Kubernetes.io/docs/tutorials/hello-minikube/>`_
+`minikube tutorial <https://kubernetes.io/docs/tutorials/hello-minikube/>`_
 or
-`microk8s for Ubuntu <https://ubuntu.com/tutorials/install-a-local-Kubernetes-with-microk8s>`_.
+`microk8s for Ubuntu <https://ubuntu.com/tutorials/install-a-local-kubernetes-with-microk8s>`_.
 
 As Kubernetes installation can be really complex, we will only focus
 on aspects used by this demo.
 For further / deeper information, check the
-`official documentation <https://Kubernetes.io/docs/home/>`_. 
+`official documentation <https://kubernetes.io/docs/home/>`_.
 
 microk8s
 """"""""

--- a/docs/server_manual/services.rst
+++ b/docs/server_manual/services.rst
@@ -2020,7 +2020,7 @@ The HTML template language
 The HTML representation uses a set of HTML templates to generate the
 response.
 The template is parsed by a template engine called
-`inja <https://github.com/pantor/inja#tutorial>`_.
+`inja <https://github.com/pantor/inja/>`_.
 The templates can be customized by overriding them (see:
 :ref:`server_wfs3_template_override`).
 The template has access to the same data that are available to the

--- a/docs/training_manual/appendix/preparing_data.rst
+++ b/docs/training_manual/appendix/preparing_data.rst
@@ -182,8 +182,8 @@ For modules :ref:`tm_create_vector_data` and :ref:`tm_rasters`, you'll also need
 raster images (SRTM DEM) which cover the region you have selected for your
 course.
 
-The `CGIAR-CGI <http://srtm.csi.cgiar.org/>`_ provides some SRTM DEM you can download
-from http://srtm.csi.cgiar.org/srtmdata/.
+The `CGIAR-CGI <https://srtm.csi.cgiar.org/>`_ provides some SRTM DEM you can download
+from https://srtm.csi.cgiar.org/srtmdata/.
 
 You'll need images which cover the entire region you have chosen to use.
 To find the extent coordinates, in QGIS , |zoomToLayer| zoom to the extent of

--- a/docs/training_manual/database_concepts/data_model.rst
+++ b/docs/training_manual/database_concepts/data_model.rst
@@ -11,11 +11,8 @@ implement our example database.
 Install PostgreSQL
 -------------------------------------------------------------------------------
 
-.. note:: Although outside the scope of this document, Mac users can install
-  PostgreSQL using
-  `Homebrew <www.russbrooks.com/2010/11/25/install-postgresql-9-on-os-x>`_.
-  Windows users can use the
-  `graphical installer <https://www.postgresql.org/download/windows/>`_.
+.. note:: You can find PostGreSQL packages and installation instructions for
+  your operating system at https://www.postgresql.org/download/.
   Please note that the documentation will assume users are running QGIS under
   Ubuntu.
 

--- a/docs/training_manual/forestry/basic_lidar.rst
+++ b/docs/training_manual/forestry/basic_lidar.rst
@@ -176,7 +176,7 @@ soil drains that have been dug in the forests.
 
 Using LiDAR data to get a DEM, specially in forested areas, gives good results
 with not much effort. You could also use ready LiDAR derived DEMs or other
-sources like the `SRTM 9m resolution DEMs <http://srtm.csi.cgiar.org/srtmdata/>`_.
+sources like the `SRTM 9m resolution DEMs <https://srtm.csi.cgiar.org/srtmdata/>`_.
 Either way, you can use them to create a hillshade raster to use in your map
 presentations.
 

--- a/docs/training_manual/forestry/forestry_intro.rst
+++ b/docs/training_manual/forestry/forestry_intro.rst
@@ -17,12 +17,10 @@ Forestry Sample Data
 -------------------------------------------------------------------------------
 
 .. note:: The sample data used in this module is part of the training manual
- data set and can be `downloaded here  <https://qgis.org/downloads/data/training_manual_exercise_data.zip>`_.
- Download the zip file and extract the :file:`forestry\\` folder into your
- :file:`exercise_data\\` folder.
+ data set and is available in the :file:`exercise_data\\forestry\\` folder.
 
 The forestry related sample data (forestry map, forest data), has been provided
-by the `EVO-HAMK forestry school <https://www.hamk.fi/tietoa-hamkista/kartat-ja-toimipaikat/Sivut/evo.aspx>`_.
+by the `EVO-HAMK forestry school <https://www.hamk.fi/campuses-and-maps/evo/?lang=en>`_.
 The datasets have been modified to adapt to the lessons needs.
 
 The general sample data (aerial images, LiDAR data, basic maps) has been

--- a/docs/training_manual/spatial_databases/geometry.rst
+++ b/docs/training_manual/spatial_databases/geometry.rst
@@ -224,7 +224,7 @@ Geometry Cleaning
 -------------------------------------------------------------------------------
 
 You can get more information for this topic in `this blog entry
-<https://linfiniti.com/?s=cleangeometry>`_.
+<https://gisforthought.com/projects/postgis_tutorial/validity.html>`_.
 
 Differences between tables
 -------------------------------------------------------------------------------

--- a/docs/training_manual/spatial_databases/index.rst
+++ b/docs/training_manual/spatial_databases/index.rst
@@ -21,7 +21,7 @@ available from Boundless Geo:
 * `Spatial Database Tips and Tricks
   <http://workshops.boundlessgeo.com/postgis-spatialdbtips/>`_
 
-See also `PostGIS In Action <www.postgis.us/>`_.
+See also `PostGIS In Action <https://www.postgis.us>`_.
 
 .. toctree::
    :maxdepth: 2

--- a/docs/training_manual/spatial_databases/spatial_functions.rst
+++ b/docs/training_manual/spatial_databases/spatial_functions.rst
@@ -73,11 +73,9 @@ previous exercise.
 
   $ psql -d address -c "CREATE EXTENSION postgis;"
 
-.. note:: If you are using PostGIS 1.5 and a version of PostgreSQL lower than
-   9.1, you will need to follow a different set of steps in order to install
-   the postgis extensions for your database. Please consult the
-   `PostGIS Documentation <https://postgis.net/docs/postgis_installation.html#create_new_db>`_
-   for instructions on how to do this.
+.. note:: Depending on your version, you could find more instructions on how
+   to spatially enable a database at
+   https://postgis.net/docs/postgis_administration.html#create_spatial_db.
 
 Looking at the installed PostGIS functions
 -------------------------------------------------------------------------------

--- a/docs/training_manual/vector_analysis/reproject_transform.rst
+++ b/docs/training_manual/vector_analysis/reproject_transform.rst
@@ -227,8 +227,7 @@ represented accurately.
 Materials for the *Advanced* section of this lesson were taken from `this
 article <https://anitagraser.com/2012/03/18/beautiful-global-projections-adding-custom-projections-to-qgis/>`_.
 
-Further information on Coordinate Reference Systems is available `here
-<https://linfiniti.com/dla/worksheets/7_CRS.pdf>`_.
+Read further information on :ref:`Coordinate Reference Systems <gis_coord_ref_system>`.
 
 |WN|
 ----------------------------------------------------------------------

--- a/docs/user_manual/appendices/qgis_r_syntax.rst
+++ b/docs/user_manual/appendices/qgis_r_syntax.rst
@@ -6,7 +6,8 @@
 Appendix D: QGIS R script syntax
 ********************************
 
-Contributed by Matteo Ghetta - funded by `Scuola Superiore Sant'Anna <http://www.santannapisa.it/it/istituto/scienze-della-vita/agricultural-water-management>`_
+Contributed by Matteo Ghetta - funded by `Scuola Superiore Sant'Anna
+<https://www.santannapisa.it/en/istituto/scienze-della-vita/istituto-di-scienze-della-vita>`_
 
 Writing R scripts in Processing is a bit tricky because of the
 special syntax.

--- a/docs/user_manual/introduction/qgis_gui.rst
+++ b/docs/user_manual/introduction/qgis_gui.rst
@@ -2414,7 +2414,7 @@ Terrain
     * a :guilabel:`Flat terrain`
     * a loaded :guilabel:`DEM (Raster Layer)`
     * an :guilabel:`Online` service, loading `elevation tiles
-      <http://s3.amazonaws.com/elevation-tiles-prod/terrarium/{z}/{x}/{y}.png>`_
+      <http://s3.amazonaws.com/elevation-tiles-prod/>`_
       produced by Mapzen tools -- more details at https://registry.opendata.aws/terrain-tiles/
     * a loaded :guilabel:`Mesh` dataset
   * :guilabel:`Elevation`: Raster or mesh layer to be used for generation of

--- a/docs/user_manual/preamble/help_and_support.rst
+++ b/docs/user_manual/preamble/help_and_support.rst
@@ -83,7 +83,7 @@ channel on irc.freenode.net. Please wait for a response to your
 question, as many folks on the channel are doing other things and it
 may take a while for them to notice your question. If you missed a
 discussion on IRC, not a problem! We log all discussion, so you can
-easily catch up. Just go to https://qgis.org/irclogs and read the
+easily catch up. Just go to http://irclogs.geoapt.com/qgis/ and read the
 IRC-logs.
 
 Commercial support
@@ -120,7 +120,7 @@ Blog
 ====
 
 The QGIS community also runs a weblog at
-https://planet.qgis.org/planet/, which has some interesting articles
+https://plugins.qgis.org/planet/, which has some interesting articles
 for users and developers.
 Many other QGIS blogs exist, and you are invited to contribute
 with your own QGIS blog!


### PR DESCRIPTION
Running `make linkcheck` to find them and browsing the web for a replacement. The idea is to close #4182
Missing fixes for:
1. Qt [qdatetime::fromstring]( https://docs.qgis.org/3.16/en/docs/user_manual/working_with_vector/functions_list.html#expression-function-date-and-time-to-datetime): underway at https://github.com/qgis/QGIS/pull/40908
1. the http://apps1.gdr.nrcan.gc.ca/cgi-bin/worldmin_en-ca_ows link used in [training manual answers](https://docs.qgis.org/3.16/en/docs/training_manual/answers/answers.html#moderate-finding-a-wms-server). Any suggestion for a good replacement would be more than welcome.