### PR TITLE
Apply :numref: to all figures references

### DIFF
--- a/docs/documentation_guidelines/do_translations.rst
+++ b/docs/documentation_guidelines/do_translations.rst
@@ -171,7 +171,7 @@ The Target language should be filled correctly. The Source language can be left
 as is with language POSIX and Country/Region on Any Country.
 
 When you press the :guilabel:`OK` button Qt Linguist is filled with sentences and
-you can start translating, see Figure_translation_menu_.
+you can start translating, see :numref:`Figure_translation_menu`.
 
 
 .. _figure_translation_menu:
@@ -278,7 +278,7 @@ A bit further we meet the following tricky translation item:
 .. code-block:: rst
 
    The |heatmap| :sup:`Heatmap` tool button starts the Dialog of the Heatmap
-   plugin (see figure_heatmap_settings_).
+   plugin (see :numref:`figure_heatmap_settings`).
 
 It holds a reference to a figure ``figure_heatmap_settings_``, and like a reference
 to a section this reference should not be changed!! The reference definition

--- a/docs/documentation_guidelines/writing.rst
+++ b/docs/documentation_guidelines/writing.rst
@@ -295,19 +295,6 @@ renders like this:
 
 see :ref:`figure_logo`
 
-It is also possible (but not recommended) to use the following mechanism:
-
-.. code-block:: rst
-
-   (see Figure_logo_).
-
-It will render like this:
-
-(see Figure_logo_).
-
-You can use uppercase if you want.
-This mechanism can only be used in the same :file:`.rst` file.
-
 
 Tables
 ......

--- a/docs/gentle_gis_introduction/coordinate_reference_systems.rst
+++ b/docs/gentle_gis_introduction/coordinate_reference_systems.rst
@@ -63,7 +63,7 @@ Different ways of projecting can be produced by surrounding the globe in a
 these methods produces what is called a **map projection family**. Therefore,
 there is a family of **planar projections**, a family of **cylindrical
 projections**, and another called **conical projections** (see
-figure_projection_families_)
+:numref:`figure_projection_families`)
 
 .. _figure_projection_families:
 
@@ -87,7 +87,7 @@ of angular conformity, distance and area**. A map projection may combine several
 of these characteristics, or may be a compromise that distorts all the properties
 of area, distance and angular conformity, within some acceptable limit. Examples
 of compromise projections are the **Winkel Tripel projection** and the **Robinson
-projection** (see figure_robinson_projection_), which are often used for producing
+projection** (see :numref:`figure_robinson_projection`), which are often used for producing
 and visualizing world maps.
 
 .. _figure_robinson_projection:
@@ -123,7 +123,7 @@ large areas and should be attempted only for small portions of the earth. The
 conformal type of projection results in distortions of areas, meaning that if
 area measurements are made on the map, they will be incorrect. The larger the
 area the less accurate the area measurements will be. Examples are the **Mercator
-projection** (as shown in figure_mercator_projection_) and the **Lambert Conformal
+projection** (as shown in :numref:`figure_mercator_projection`) and the **Lambert Conformal
 Conic projection**. The U.S. Geological Survey uses a conformal projection for
 many of its topographic maps.
 
@@ -147,10 +147,10 @@ from the centre of the projection to any other place on the map. **Equidistant
 projections** maintain accurate distances from the centre of the projection or
 along given lines. These projections are used for radio and seismic mapping, and
 for navigation. The **Plate Carree Equidistant Cylindrical** (see
-figure_plate_caree_projection_) and the **Equirectangular projection** are two
+:numref:`figure_plate_caree_projection`) and the **Equirectangular projection** are two
 good examples of equidistant projections. The **Azimuthal Equidistant projection**
 is the projection used for the emblem of the United Nations (see
-figure_azimuthal_equidistant_projection_).
+:numref:`figure_azimuthal_equidistant_projection`).
 
 .. _figure_plate_caree_projection:
 
@@ -186,7 +186,7 @@ projection results in **distortions of angular conformity** when dealing with
 large areas. Small areas will be far less prone to having their angles distorted
 when you use an equal area projection. **Alber's equal area**, **Lambert's equal
 area** and **Mollweide Equal Area Cylindrical projections** (shown in
-figure_mollweide_equal_area_projection_) are types of equal area projections that
+:numref:`figure_mollweide_equal_area_projection`) are types of equal area projections that
 are often encountered in GIS work.
 
 .. _figure_mollweide_equal_area_projection:
@@ -230,7 +230,7 @@ pole. In the southern hemisphere, degrees of latitude are measured from zero at
 the equator to ninety degrees at the south pole. To simplify the digitisation of
 maps, degrees of latitude in the southern hemisphere are often assigned negative
 values (0 to -90°). Wherever you are on the earth’s surface, the distance between
-the lines of latitude is the same (60 nautical miles). See figure_geographic_crs_
+the lines of latitude is the same (60 nautical miles). See :numref:`figure_geographic_crs`
 for a pictorial view.
 
 .. _figure_geographic_crs:
@@ -248,7 +248,7 @@ converge at the poles. The reference line for longitude (the prime meridian) run
 from the North pole to the South pole through Greenwich, England. Subsequent
 lines of longitude are measured from zero to 180 degrees East or West of the prime
 meridian. Note that values West of the prime meridian are assigned negative values
-for use in digital mapping applications. See figure_geographic_crs_ for a pictorial
+for use in digital mapping applications. See :numref:`figure_geographic_crs` for a pictorial
 \view.
 
 At the equator, and only at the equator, the distance represented by one line of
@@ -273,11 +273,11 @@ Projected coordinate reference systems
 
 A two-dimensional coordinate reference system is commonly defined by two axes.
 At right angles to each other, they form a so called **XY-plane** (see
-figure_projected_crs_ on the left side). The horizontal axis is normally labelled
+:numref:`figure_projected_crs` on the left side). The horizontal axis is normally labelled
 **X**, and the vertical axis is normally labelled **Y**. In a three-dimensional
 coordinate reference system, another axis, normally labelled **Z**, is added. It
 is also at right angles to the **X** and **Y** axes. The **Z** axis provides the
-third dimension of space (see figure_projected_crs_ on the right side). Every
+third dimension of space (see :numref:`figure_projected_crs` on the right side). Every
 point that is expressed in spherical coordinates can be expressed as an **X Y Z**
 coordinate.
 
@@ -312,7 +312,7 @@ zones** that are all **6 degrees** wide in longitude from East to West. The **UT
 zones** are numbered **1 to 60**, starting at the **antimeridian**
 (**zone 1** at 180 degrees West longitude) and progressing East back to the
 **antemeridian** (**zone 60** at 180 degrees East longitude) as shown
-in figure_utm_zones_.
+in :numref:`figure_utm_zones`.
 
 .. _figure_utm_zones:
 
@@ -323,7 +323,7 @@ in figure_utm_zones_.
    The Universal Transverse Mercator zones. For South Africa UTM zones 33S, 34S,
    35S, and 36S are used.
 
-As you can see in figure_utm_zones_ and figure_utm_for_sa_, South Africa is
+As you can see in :numref:`figure_utm_zones` and :numref:`figure_utm_for_sa`, South Africa is
 covered by four **UTM zones** to minimize distortion. The **zones** are called
 **UTM 33S**, **UTM 34S**, **UTM 35S** and **UTM 36S**. The **S** after the zone
 means that the UTM zones are located **south of the equator**.
@@ -339,7 +339,7 @@ means that the UTM zones are located **south of the equator**.
    of Interest (AOI).
 
 Say, for example, that we want to define a two-dimensional coordinate within the
-**Area of Interest (AOI)** marked with a red cross in figure_utm_for_sa_. You can
+**Area of Interest (AOI)** marked with a red cross in :numref:`figure_utm_for_sa`. You can
 see, that the area is located within the **UTM zone 35S**. This means, to minimize
 distortion and to get accurate analysis results, we should use **UTM zone 35S**
 as the coordinate reference system.
@@ -349,7 +349,7 @@ the **zone number** (35) and with its **northing (Y) value** and **easting (X)
 value** in meters. The **northing value** is the distance of the position from
 the **equator** in meters. The **easting value** is the distance from the
 **central meridian** (longitude) of the used UTM zone. For UTM zone 35S it is
-**27 degrees** **East** as shown in figure_utm_for_sa_. Furthermore, because we
+**27 degrees** **East** as shown in :numref:`figure_utm_for_sa`. Furthermore, because we
 are south of the equator and negative values are not allowed in the UTM coordinate
 reference system, we have to add a so called **false northing value** of
 10,000,000 m to the northing (Y) value and a false easting value of 500,000 m to
@@ -370,7 +370,7 @@ The easting (X) value
 ---------------------
 
 First we have to find the **central meridian** (longitude) for the **UTM zone
-35S**. As we can see in figure_utm_for_sa_ it is **27 degrees East**. The place
+35S**. As we can see in :numref:`figure_utm_for_sa` it is **27 degrees East**. The place
 we are looking for is **85,000 meters West** from the central meridian. Just like
 the northing value, the easting (X) value gets a negative sign, giving a result
 of **-85,000 m**. According to the UTM definitions we have to add a **false

--- a/docs/gentle_gis_introduction/data_capture.rst
+++ b/docs/gentle_gis_introduction/data_capture.rst
@@ -52,9 +52,9 @@ data, as shown in table_shapefile_.
 Table Shapefile 1: The basic files that together make up a 'shapefile'.
 
 When you look at the files that make up a shapefile on the computer hard disk,
-you will see something like figure_shapefile_. If you want to share vector data
+you will see something like :numref:`figure_shapefile`. If you want to share vector data
 stored in shapefiles with another person, it is important to give them all of
-the files for that layer. So in the case of the trees layer shown in figure_shapefile_,
+the files for that layer. So in the case of the trees layer shown in :numref:`figure_shapefile`,
 you would need to give the person :file:`trees.shp`, :file:`trees.shx`,
 :file:`trees.dbf`, :file:`trees.prj` and :file:`trees.qml`.
 
@@ -103,7 +103,7 @@ you need. So, for example, if you look at digital data provided by the Chief
 Directorate: Surveys and Mapping, South Africa, they provide a river areas
 (polygons) layer and a rivers polyline layer. They use the river areas (polygons)
 to represent river stretches that are wide, and they use river polylines to
-represent narrow stretches of river. In figure_tourism_ we can see how our tourism
+represent narrow stretches of river. In :numref:`figure_tourism` we can see how our tourism
 layers might look on a map if we used all three geometry types.
 
 .. _figure_tourism:
@@ -160,7 +160,7 @@ geometry type and attributes that each feature should have, you can move on to
 the next step of creating an empty shapefile.
 
 The process usually starts with choosing the 'new vector layer' option in your
-GIS Application and then selecting a geometry type (see figure_new_shapefile_).
+GIS Application and then selecting a geometry type (see :numref:`figure_new_shapefile`).
 As we covered in an earlier topic, this means choosing either point, polyline or
 polygon for the geometry.
 
@@ -189,7 +189,7 @@ a whole number (**integer**) or a decimal number (**floating point**) –-- so y
 need to think before hand whether the numeric data you are going to capture will
 have decimal places or not.
 
-The final step (as shown in figure_save_shapefile_) for creating a shapefile is
+The final step (as shown in :numref:`figure_save_shapefile`) for creating a shapefile is
 to give it a name and a place on the computer hard disk where it should be
 created. Once again it is a good idea to give the shapefile a short and meaningful
 name. Good examples are 'rivers', 'watersamples' and so on.
@@ -228,7 +228,7 @@ correct geographical area that you are going to be recording data for. Next you
 will need to enable the point capture tool. Having done that, the next place you
 click with the **left mouse button** in the map view, is where you want your new
 point **geometry** to appear. After you click on the map, a window will appear
-and you can enter all of the **attribute data** for that point (see figure_attribute_dialog_).
+and you can enter all of the **attribute data** for that point (see :numref:`figure_attribute_dialog`).
 If you are unsure of the data for a given field you can usually leave it blank,
 but be aware that if you leave a lot of fields blank it will be hard to make a
 useful map from your data!
@@ -252,7 +252,7 @@ capture icon in the tool bar and then start drawing your line by clicking on the
 map. After you make your first click, you will notice that the line stretches
 like an elastic band to follow the mouse cursor around as you move it. Each time
 you click with the **left mouse button**, a new vertex will be added to the map.
-This process is shown in figure_capture_polyline_.
+This process is shown in :numref:`figure_capture_polyline`.
 
 .. _figure_capture_polyline:
 
@@ -293,7 +293,7 @@ solution to this problem is to use a raster layer (such as an aerial photograph
 or a satellite image) as a backdrop layer. You can then use this layer as a
 reference map, or even trace the features off the raster layer into your vector
 layer if they are visible. This process is known as 'heads-up digitising' and is
-shown in figure_headsup_digitizing_.
+shown in :numref:`figure_headsup_digitizing`.
 
 .. _figure_headsup_digitizing:
 
@@ -315,7 +315,7 @@ special device called a 'puck' is used to trace features from the map. Tiny
 cross-hairs in the puck are used to ensure that lines and points are drawn
 accurately. The puck is connected to a computer and each feature that is captured
 using the puck gets stored in the computer's memory. You can see what a digitising
-puck looks like in figure_digitizing_table_.
+puck looks like in :numref:`figure_digitizing_table`.
 
 .. _figure_digitizing_table:
 
@@ -342,7 +342,7 @@ or satellite image, it is very important that the raster layer is properly
 georeferenced. A layer that is georeferenced properly displays in the correct
 position in the map view based on the GIS Application's internal model of the
 Earth. We can see the effect of a poorly georeferenced image in
-figure_georeference_issue_.
+:numref:`figure_georeference_issue`.
 
 .. _figure_georeference_issue:
 

--- a/docs/gentle_gis_introduction/introducing_gis.rst
+++ b/docs/gentle_gis_introduction/introducing_gis.rst
@@ -87,7 +87,7 @@ will be focusing on GIS Software.
 What is GIS Software / a GIS Application?
 =========================================
 
-You can see an example of what a **GIS Application** looks like figure_gis_application_.
+You can see an example of what a **GIS Application** looks like :numref:`figure_gis_application`.
 GIS Applications are normally programs with a graphical user interface that can
 be manipulated using the mouse and keyboard. The application provides **menus**
 near to the top of the window (File, Edit etc.) which, when clicked using the
@@ -121,8 +121,8 @@ will have data about the street network.
 When you open a layer in the GIS Application it will appear in the **map view**.
 The map view shows a graphic representing your layer. When you add more than one
 layer to a map view, the layers are overlaid on top of each other. Look at
-figures figure_map_view_towns_, figure_map_view_schools_, figure_map_view_railways_ and
-figure_map_view_rivers_ to see a map view that has several layers being added to it.
+figures :numref:`figure_map_view_towns`, :numref:`figure_map_view_schools`, :numref:`figure_map_view_railways` and
+:numref:`figure_map_view_rivers` to see a map view that has several layers being added to it.
 An important function of the map view is to allow you to zoom in to magnify,
 zoom out to see a greater area and move around (panning) in the map.
 
@@ -168,8 +168,8 @@ provides a list of layers that have been loaded in the GIS Application. Unlike a
 paper map legend, the map legend or 'layers list' in the GIS Application provides
 a way to re-order, hide, show and group layers. Changing the layer order is done
 by clicking on a layer in the legend, holding the mouse button down and then
-dragging the layer to a new position. In figures figure_map_legend_before_ and
-figure_map_legend_after_ the map legend is shown as the area to the left of the GIS
+dragging the layer to a new position. In figures :numref:`figure_map_legend_before` and
+:numref:`figure_map_legend_after` the map legend is shown as the area to the left of the GIS
 Application window. By changing the layer order, the way that layers are drawn
 can be adjusted –-- in this case so that rivers are drawn over the roads instead
 of below them.
@@ -245,7 +245,7 @@ data associated with places.
 
 GIS Systems work with many different types of data. **Vector data** is stored as
 a series of ``X, Y`` coordinate pairs inside the computer's memory. Vector data
-is used to represent points, lines and areas. Illustration figure_vector_data_
+is used to represent points, lines and areas. Illustration :numref:`figure_vector_data`
 shows different types of vector data being viewed in a GIS application. In the
 tutorials that follow we will be exploring vector data in more detail.
 
@@ -262,7 +262,7 @@ tutorials that follow we will be exploring vector data in more detail.
 the earth and the photographs they take are a kind of raster data that can be
 viewed in a GIS. One important difference between raster and vector data is that
 if you zoom in too much on a raster image, it will start to appear 'blocky' (see
-illustrations figure_raster_data_ and figure_raster_data_zoom_). In fact these
+illustrations :numref:`figure_raster_data` and :numref:`figure_raster_data_zoom`). In fact these
 blocks are the individual cells of the data grid that makes up the raster image.
 We will be looking at raster data in greater detail in later tutorials.
 

--- a/docs/gentle_gis_introduction/map_production.rst
+++ b/docs/gentle_gis_introduction/map_production.rst
@@ -17,7 +17,7 @@ all about. Maps are usually produced for presentations and reports where the
 audience or reader is a politician, citizen or a learner with no professional
 background in GIS. Because of this, a map has to be effective in communicating
 spatial information. Common elements of a map are the title, map body, legend,
-north arrow, scale bar, acknowledgement, and map border (see figure_map_elements_).
+north arrow, scale bar, acknowledgement, and map border (see :numref:`figure_map_elements`).
 
 .. _figure_map_elements:
 
@@ -49,7 +49,7 @@ Map Border in detail
 The map border is a line that defines exactly the edges of the area shown on the
 map. When printing a map with a graticule (which we describe further down), you
 often find the coordinate information of the graticule lines along the border
-lines, as you can see in figure_map_legend_.
+lines, as you can see in :numref:`figure_map_legend`.
 
 Map Legend in detail
 ====================
@@ -61,7 +61,7 @@ a key to all the symbols used on the map. It is like a dictionary that allows yo
 to understand the meaning of what the map shows. A map legend is usually shown a
 a little box in a corner of the map. It contains icons, each of which will
 represent a type of feature. For example, a *house* icon will show you how to
-identify houses on the map (see figure_map_legend_).
+identify houses on the map (see :numref:`figure_map_legend`).
 
 .. _figure_map_legend:
 
@@ -73,7 +73,7 @@ identify houses on the map (see figure_map_legend_).
    different themes, map symbols and colours in the legend.
 
 You can also use different symbols and icons in your legend to show different
-themes. In figure_map_legend_ you can see a map with a lake in light blue overlaid
+themes. In :numref:`figure_map_legend` you can see a map with a lake in light blue overlaid
 with contour lines and spot heights to show information about the terrain in that
 area. On the right side you see the same area with the lake in the background but
 this map is designed to show tourists the location of houses they can rent for
@@ -99,15 +99,15 @@ Scale in detail
 The scale of a map, is the value of a single unit of distance on the map,
 representing distance in the real world. The values are shown in map units
 (meters, feet or degrees). The scale can be expressed in several ways, for
-example, in words, as a ratio or as a graphical scale bar (see figure_map_scale_).
+example, in words, as a ratio or as a graphical scale bar (see :numref:`figure_map_scale`).
 
 **Expressing a scale in words** is a commonly used method and has the advantage
 of being easily understood by most map users. You can see an example of a word
-based scale in a figure_map_scale_ (a). Another option is the **representative
+based scale in a :numref:`figure_map_scale` (a). Another option is the **representative
 fraction (RF)** method, where both the map distance and the ground distance in
 the real world are given in the same map units, as a ratio. For example, a RF
 value 1:25,000 means that any distance on the map is 1/25,000 *th* of the real
-distance on the ground (see figure_map_scale_ (b)). The value 25,000 in the ratio
+distance on the ground (see :numref:`figure_map_scale` (b)). The value 25,000 in the ratio
 is called the **scale denominator**. More experienced users often prefer the
 representative fraction method, because it reduces confusion.
 
@@ -119,7 +119,7 @@ scale map covers a **small area**!
 
 A **scale expression as a graphic or bar scale** is another basic method of
 expressing a scale. A bar scale shows measured distances on the map. The equivalent
-distance in the real world is placed above as you can see in figure_map_scale_ (c).
+distance in the real world is placed above as you can see in :numref:`figure_map_scale` (c).
 
 .. _figure_map_scale:
 
@@ -147,7 +147,7 @@ real word.
 
 Another interesting aspect of a map scale, is that the lower the map scale, the
 more detailed the feature information in the map will be. In
-figure_map_scale_compare_, you can see an example of this. Both maps are the same
+:numref:`figure_map_scale_compare`, you can see an example of this. Both maps are the same
 size but have a different scale. The image on the left side shows more details,
 for example the houses south-west of the water body can be clearly identified as
 separate squares. In the image on the right you can only see a black clump of
@@ -184,7 +184,7 @@ lines of a graticule can represent the earth's parallels of latitude and meridia
 of longitude. When you want to refer to a special area on a map during your
 presentation or in a report you could say: 'the houses close to latitude 26.04 /
 longitude -32.11 are often exposed to flooding during January and February' (see
-figure_map_graticule_).
+:numref:`figure_map_graticule`).
 
 .. _figure_map_graticule:
 
@@ -208,7 +208,7 @@ projection has advantages and disadvantages.
 To be able to create maps as precisely as possible, people have studied, modified,
 and produced many different kinds of projections. In the end almost every country
 has developed its own map projection with the goal of improving the map accuracy
-for their territorial area (see figure_map_projection_).
+for their territorial area (see :numref:`figure_map_projection`).
 
 .. _figure_map_projection:
 
@@ -223,7 +223,7 @@ With this in mind, we can now understand why it makes sense to add the name of
 the projection on a map. It allows the reader to see quickly, if one map can be
 compared with another. For example, features on a map in a so-called Equal Area
 projection appear very different to features projected in a Cylindrical
-Equidistant projection (see figure_map_projection_).
+Equidistant projection (see :numref:`figure_map_projection`).
 
 Map projection is a very complex topic and we cannot cover it completely here.
 You may want to take a look at our previous topic: Coordinate Reference Systems

--- a/docs/gentle_gis_introduction/raster_data.rst
+++ b/docs/gentle_gis_introduction/raster_data.rst
@@ -16,7 +16,7 @@ In the previous topics we have taken a closer look at vector data. While vector
 features use geometry (points, polylines and polygons) to represent the real
 world, raster data takes a different approach. Rasters are made up of a matrix
 of pixels (also called cells), each containing a value that represents the
-conditions for the area covered by that cell (see figure_raster_). In this topic
+conditions for the area covered by that cell (see :numref:`figure_raster`). In this topic
 we are going to take a closer look at raster data, when it is useful and when it
 makes more sense to use vector data.
 
@@ -36,7 +36,7 @@ Raster data in detail
 
 Raster data is used in a GIS application when we want to display information that
 is continuous across an area and cannot easily be divided into vector features.
-When we introduced you to vector data we showed you the image in figure_landscape_.
+When we introduced you to vector data we showed you the image in :numref:`figure_landscape`.
 Point, polyline and polygon features work well for representing some features on
 this landscape, such as trees, roads and building footprints. Other features on
 a landscape can be more difficult to represent using vector features. For example
@@ -76,7 +76,7 @@ each cell in the raster represents a different value e.g. risk of fire on a scal
 of one to ten.
 
 An example that shows the difference between an image obtained from a satellite
-and one that shows calculated values can be seen in figure_raster_types_.
+and one that shows calculated values can be seen in :numref:`figure_raster_types`.
 
 .. _figure_raster_types:
 
@@ -115,7 +115,7 @@ imported into a computer and georeferenced. Satellite imagery is created when
 satellites orbiting the earth point special digital cameras towards the earth
 and then take an image of the area on earth they are passing over. Once the image
 has been taken it is sent back to earth using radio signals to special receiving
-stations such as the one shown in figure_csir_station_. The process of capturing raster data from
+stations such as the one shown in :numref:`figure_csir_station`. The process of capturing raster data from
 an aeroplane or satellite is called **remote sensing**.
 
 .. _figure_csir_station:
@@ -133,7 +133,7 @@ take police crime incident reports and create a country wide raster map showing
 how high the incidence of crime is likely to be in each area. Meteorologists
 (people who study weather patterns) might generate a province level raster showing
 average temperature, rainfall and wind direction using data collected from weather
-stations (see figure_csir_station_). In these cases, they will often use raster
+stations (see :numref:`figure_csir_station`). In these cases, they will often use raster
 analysis techniques such as interpolation (which we describe in Topic
 :ref:`spatial_analysys`).
 
@@ -152,8 +152,8 @@ Spatial Resolution
 
 Every raster layer in a GIS has pixels (cells) of a fixed size that determine its
 spatial resolution. This becomes apparent when you look at an image at a small
-scale (see figure_raster_small_scale_) and then zoom in to a large scale (see
-figure_raster_large_scale_).
+scale (see :numref:`figure_raster_small_scale`) and then zoom in to a large scale (see
+:numref:`figure_raster_large_scale`).
 
 .. _figure_raster_small_scale:
 

--- a/docs/gentle_gis_introduction/spatial_analysis_interpolation.rst
+++ b/docs/gentle_gis_introduction/spatial_analysis_interpolation.rst
@@ -33,7 +33,7 @@ values at other unknown points. For example, to make a precipitation (rainfall)
 map for your country, you will not find enough evenly spread weather stations to
 cover the entire region. Spatial interpolation can estimate the temperatures at
 locations without recorded data by using known temperature readings at nearby
-weather stations (see figure_temperature_map_). This type of interpolated surface
+weather stations (see :numref:`figure_temperature_map`). This type of interpolated surface
 is often called a **statistical surface**. Elevation data, precipitation, snow
 accumulation, water table and population density are other types of data that can
 be computed using interpolation.
@@ -69,7 +69,7 @@ Inverse Distance Weighted (IDW)
 In the IDW interpolation method, the sample points are weighted during
 interpolation such that the influence of one point relative to another declines
 with distance from the unknown point you want to create (see
-figure_idw_interpolation_).
+:numref:`figure_idw_interpolation`).
 
 .. _figure_idw_interpolation:
 
@@ -93,10 +93,10 @@ disadvantages: the quality of the interpolation result can decrease, if the
 distribution of sample data points is uneven. Furthermore, maximum and minimum
 values in the interpolated surface can only occur at sample data points. This
 often results in small peaks and pits around the sample data points as shown in
-figure_idw_interpolation_.
+:numref:`figure_idw_interpolation`.
 
 In GIS, interpolation results are usually shown as a 2 dimensional raster layer.
-In figure_idw_result_, you can see a typical IDW interpolation result, based on
+In :numref:`figure_idw_result`, you can see a typical IDW interpolation result, based on
 elevation sample points collected in the field with a GPS device.
 
 .. _figure_idw_result:
@@ -115,7 +115,7 @@ TIN interpolation is another popular tool in GIS. A common TIN algorithm is call
 **Delaunay triangulation**. It tries to create a surface formed by triangles of
 nearest neighbour points. To do this, circumcircles around selected sample points
 are created and their intersections are connected to a network of non overlapping
-and as compact as possible triangles (see figure_tin_interpolation_).
+and as compact as possible triangles (see :numref:`figure_tin_interpolation`).
 
 .. _figure_tin_interpolation:
 
@@ -131,7 +131,7 @@ The main disadvantage of the TIN interpolation is that the surfaces are not smoo
 and may give a jagged appearance. This is caused by discontinuous slopes at the
 triangle edges and sample data points. In addition, triangulation is generally
 not suitable for extrapolation beyond the area with collected sample data points
-(see figure_tin_result_ ).
+(see :numref:`figure_tin_result` ).
 
 .. _figure_tin_result:
 

--- a/docs/gentle_gis_introduction/topology.rst
+++ b/docs/gentle_gis_introduction/topology.rst
@@ -22,7 +22,7 @@ analysis, such as network analysis.
 
 Imagine you travel to London. On a sightseeing tour you plan to visit St. Paul's
 Cathedral first and in the afternoon Covent Garden Market for some souvenirs.
-Looking at the Underground map of London (see figure_topology_london_) you have
+Looking at the Underground map of London (see :numref:`figure_topology_london`) you have
 to find connecting trains to get from Covent Garden to St. Paul's. This requires
 topological information (data) about where it is possible to change trains.
 Looking at a map of the underground, the topological relationships are illustrated
@@ -46,7 +46,7 @@ borders or overlapping polygon borders. A common topological error with
 **polyline** features is that they do not meet perfectly at a point (node). This
 type of error is called an **undershoot** if a gap exists between the lines, and
 an **overshoot** if a line ends beyond the line it should connect to (see
-figure_topology_errors_).
+:numref:`figure_topology_errors`).
 
 .. _figure_topology_errors:
 
@@ -106,10 +106,10 @@ you can **enable topological editing** to improve editing and maintaining common
 boundaries in polygon layers. A GIS such as QGIS 'detects' a shared boundary in
 a polygon map so you only have to move the edge vertex of one polygon boundary
 and QGIS will ensure the updating of the other polygon boundaries as shown in
-figure_topological_tools_ (1).
+:numref:`figure_topological_tools` (1).
 
 Another topological option allows you to prevent** polygon overlaps** during
-digitising (see figure_topological_tools_ (2)). If you already have one polygon,
+digitising (see :numref:`figure_topological_tools` (2)). If you already have one polygon,
 it is possible with this option to digitise a second adjacent polygon so that
 both polygons overlap and QGIS then clips the second polygon to the common
 boundary.
@@ -133,7 +133,7 @@ and / or segment you are trying to connect when you digitise. A **segment** is a
 straight line formed between two vertices in a polygon or polyline geometry. If
 you aren't within the snapping distance, a GIS such as QGIS will leave the vertex
 where you release the mouse button, instead of snapping it to an existing vertex
-and / or segment (see figure_snapping_distance_).
+and / or segment (see :numref:`figure_snapping_distance`).
 
 .. _figure_snapping_distance:
 

--- a/docs/gentle_gis_introduction/vector_attribute_data.rst
+++ b/docs/gentle_gis_introduction/vector_attribute_data.rst
@@ -15,7 +15,7 @@ Overview
 
 If every line on a map was the same colour, width, thickness, and had the same
 label, it would be very hard to make out what was going on. The map would also
-give us very little information. Take a look at figure_map_attributes_ for example.
+give us very little information. Take a look at :numref:`figure_map_attributes` for example.
 
 .. _figure_map_attributes:
 
@@ -31,7 +31,7 @@ give us very little information. Take a look at figure_map_attributes_ for examp
 In this topic we will look at how attribute data can help us to make interesting
 and informative maps. In the previous topic on vector data, we briefly explained
 that **attribute data** are used to **describe vector features**. Take a look at
-the house pictures in figure_house_.
+the house pictures in :numref:`figure_house`.
 
 .. _figure_house:
 
@@ -47,7 +47,7 @@ house), the attributes we have recorded are roof colour, whether there is a
 balcony, and the year the house was built. Note that attributes don't have to be
 visible things --– they can describe things we know about the feature such as the
 year it was built. In a GIS Application, we can represent this feature type in a
-houses polygon layer, and the attributes in an attribute table (see figure_house_gis_).
+houses polygon layer, and the attributes in an attribute table (see :numref:`figure_house_gis`).
 
 .. _figure_house_gis:
 
@@ -62,7 +62,7 @@ houses polygon layer, and the attributes in an attribute table (see figure_house
 
 The fact that features have attributes as well geometry in a GIS Application opens
 up many possibilities. For example we can use the attribute values to tell the
-GIS what colours and style to use when drawing features (see figure_style_by_attribute_).
+GIS what colours and style to use when drawing features (see :numref:`figure_style_by_attribute`).
 The process of setting colours and drawing styles is often referred to as setting
 feature **symbology**.
 
@@ -83,7 +83,7 @@ label each feature.
 
 If you have ever **searched a map** for a place name or a specific feature, you
 will know how time consuming it can be. Having attribute data can make searching
-for a specific feature quick and easy. In figure_search_by_attribute_ you can see
+for a specific feature quick and easy. In :numref:`figure_search_by_attribute` you can see
 an example of an attribute search in a GIS.
 
 .. _figure_search_by_attribute:
@@ -112,7 +112,7 @@ Before we move on to attribute data in more detail, let's take a quick recap.
 Features are real world things such as roads, property boundaries, electrical
 substation sites and so on. A **feature** has a **geometry** (which determines
 if it is a **point**, **polyline** or **polygon**) and **attributes** (which
-describe the feature). This is shown in figure_features_at_glance_.
+describe the feature). This is shown in :numref:`figure_features_at_glance`.
 
 .. _figure_features_at_glance:
 
@@ -187,13 +187,13 @@ In order to do that, you need to use either a **graduated**, **continuous** or
 follow.
 
 A GIS application will normally allow you to set the symbology of a layer using
-a **dialog box** such as the one shown in in figure_single_symbol_. In this
+a **dialog box** such as the one shown in in :numref:`figure_single_symbol`. In this
 dialog box you can choose colours and symbol styles. Depending on the geometry
 type of a layer, different options may be shown. For example with point layers
 you can choose a **marker style**. With line and polygon layers there is no marker
 style option, but instead you can select a **line style** and **colour** such as
 dashed orange for gravel roads, solid orange for minor roads, and so on (as shown
-in figure_single_symbol_poly_). With polygon layers you also have the option of
+in :numref:`figure_single_symbol_poly`). With polygon layers you also have the option of
 setting a **fill style** and color.
 
 .. _figure_single_symbol:
@@ -245,8 +245,8 @@ areas with another and high-altitude areas with a third.
    Our map after setting graduated colours for our contours.
 
 Setting colours based on discrete groups of attribute values is called Graduated
-Symbology in QGIS. The process is shown in Illustrations figure_graduated_symbol_
-and figure_graduated_symbol_map_. **Graduated symbols** are most useful when you
+Symbology in QGIS. The process is shown in Illustrations :numref:`figure_graduated_symbol`
+and :numref:`figure_graduated_symbol_map`. **Graduated symbols** are most useful when you
 want to show clear differences between features with attribute values in different
 value ranges. The GIS Application will analyse the attribute data (e.g. height)
 and, based on the number of classes you request, create groupings for you. This
@@ -320,7 +320,7 @@ series of shades between those colours.
 Using the same contours example we used in the previous section, let's see how a
 map with continuous colour symbology is defined and looks. The process starts by
 setting the layers properties to continuous colour using a dialog like the one
-shown in figure_continuous_symbol_.
+shown in :numref:`figure_continuous_symbol`.
 
 .. _figure_continuous_symbol:
 
@@ -340,7 +340,7 @@ at 1000 m and ending at 1400 m, the value range is 1000 to 1400. If the colour
 set for the minimum value is set to orange and the colour for the maximum value
 is black, contours with a value of close to 1400 m will be drawn close to black.
 On the other hand contours with a value near to 1000 m will be drawn close to
-orange (see figure_continuous_symbol_map_).
+orange (see :numref:`figure_continuous_symbol_map`).
 
 .. _figure_continuous_symbol_map:
 
@@ -381,7 +381,7 @@ have their own symbol.
 Within the GIS Application we can open/choose to use Unique Value symbology for
 a layer. The GIS will scan through all the different string values in the
 attribute field and build a list of unique strings or numbers. Each unique value
-can then be assigned a colour and style. This is shown in figure_unique_symbol_.
+can then be assigned a colour and style. This is shown in :numref:`figure_unique_symbol`.
 
 .. _figure_unique_symbol:
 
@@ -394,7 +394,7 @@ can then be assigned a colour and style. This is shown in figure_unique_symbol_.
 When the GIS draws the layer, it will look at the attributes of each feature
 before drawing it to the screen. Based on the value in the chosen field in the
 attribute table, the road line will be drawn with suitable colour and line style
-(and fill style if its a polygon feature). This is shown in figure_unique_symbol_map_.
+(and fill style if its a polygon feature). This is shown in :numref:`figure_unique_symbol_map`.
 
 .. _figure_unique_symbol_map:
 

--- a/docs/gentle_gis_introduction/vector_data.rst
+++ b/docs/gentle_gis_introduction/vector_data.rst
@@ -16,7 +16,7 @@ Overview
 **Vector** data provide a way to represent real world **features** within the GIS
 environment. A feature is anything you can see on the landscape. Imagine you are
 standing on the top of a hill. Looking down you can see houses, roads, trees,
-rivers, and so on (see figure_vector_landscape_). Each one of these things would be a
+rivers, and so on (see :numref:`figure_vector_landscape`). Each one of these things would be a
 **feature** when we represent them in a GIS Application. Vector features have
 **attributes**, which consist of text or numerical information that **describe**
 the features.
@@ -37,11 +37,11 @@ vertices with a ``Z`` axis are often referred to as **2.5D** since they describe
 height or depth at each vertex, but not both.
 
 When a feature's geometry consists of only a single vertex, it is referred to as
-a **point** feature (see illustration figure_geometry_point_). Where the geometry
+a **point** feature (see illustration :numref:`figure_geometry_point`). Where the geometry
 consists of two or more vertices and the first and last vertex are not equal, a
-**polyline** feature is formed (see illustration figure_geometry_polyline_). Where
+**polyline** feature is formed (see illustration :numref:`figure_geometry_polyline`). Where
 three or more vertices are present, and the last vertex is equal to the first, an
-enclosed **polygon** feature is formed (see illustration figure_geometry_polygon_).
+enclosed **polygon** feature is formed (see illustration :numref:`figure_geometry_polygon`).
 
 .. _figure_geometry_point:
 
@@ -72,7 +72,7 @@ enclosed **polygon** feature is formed (see illustration figure_geometry_polygon
 
 Looking back at the picture of a landscape we showed you further up, you should
 be able to see the different types of features in the way that a GIS represents
-them now (see illustration figure_geometry_landscape_).
+them now (see illustration :numref:`figure_geometry_landscape`).
 
 .. _figure_geometry_landscape:
 
@@ -99,7 +99,7 @@ When you choose to use points to represent a feature is mostly a matter of scale
 effort to create point features than polygon features), and the type of feature
 (some things like telephone poles just don't make sense to be stored as polygons).
 
-As we show in illustration figure_geometry_point_, a point feature has an X, Y
+As we show in illustration :numref:`figure_geometry_point`, a point feature has an X, Y
 and optionally, Z value. The X and Y values will depend on the **Coordinate
 Reference System** (CRS) being used. We are going to go into more detail about
 Coordinate Reference Systems in a later tutorial. For now let's simply say that
@@ -119,7 +119,7 @@ Polyline features in detail
 
 Where a point feature is a single vertex, **a polyline has two or more vertices**.
 The polyline is a continuous path drawn through each vertex, as shown in
-figure_geometry_polyline_. When two vertices are joined, a line is created. When
+:numref:`figure_geometry_polyline`. When two vertices are joined, a line is created. When
 more than two are joined, they form a 'line of lines', or **polyline**.
 
 A polyline is used to show the geometry of **linear features** such as roads,
@@ -133,7 +133,7 @@ comply to these rules.
 
 If a curved polyline has very large distances between vertices, it may appear
 **angular** or jagged, depending on the scale at which it is viewed (see
-figure_polyline_jagged_). Because of this it is important that polylines are
+:numref:`figure_polyline_jagged`). Because of this it is important that polylines are
 digitised (captured into the computer) with distances between vertices that are
 small enough for the scale at which you want to use the data.
 
@@ -215,9 +215,9 @@ taking information from surveyor records and global positioning system devices.
 Maps have different scales, so if you import vector data from a map into a GIS
 environment (for example by digitising paper maps), the digital vector data will
 have the same scale issues as the original map. This effect can be seen in
-illustrations figure_vector_small_scale_ and figure_vector_large_scale_. Many
+illustrations :numref:`figure_vector_small_scale` and :numref:`figure_vector_large_scale`. Many
 issues can arise from making a poor choice of map scale. For example using the
-vector data in illustration figure_vector_small_scale_ to plan a wetland
+vector data in illustration :numref:`figure_vector_small_scale` to plan a wetland
 conservation area could result in important parts of the wetland being left out
 of the reserve! On the other hand if you are trying to create a regional map,
 using data captured at 1:1000 000 might be just fine and will save you a lot of
@@ -249,8 +249,8 @@ let you choose colours to suite the feature type (e.g. you can tell it to draw a
 water bodies vector layer in blue). The GIS will also let you adjust the symbol
 used. So if you have a trees point layer, you can show each tree position with a
 small picture of a tree, rather than the basic circle marker that the GIS uses
-when you first load the layer (see illustrations figure_vector_symbology_,
-figure_generic_symbology_ and figure_custom_symbology_).
+when you first load the layer (see illustrations :numref:`figure_vector_symbology`,
+:numref:`figure_generic_symbology` and :numref:`figure_custom_symbology`).
 
 .. _figure_vector_symbology:
 
@@ -310,7 +310,7 @@ so on.
 
 If you have poor quality vector data, you can often detect this when viewing the
 data in a GIS. For example **slivers** can occur when the edges of two polygon
-areas don't meet properly (see figure_vector_slivers_).
+areas don't meet properly (see :numref:`figure_vector_slivers`).
 
 .. _figure_vector_slivers:
 
@@ -326,7 +326,7 @@ areas don't meet properly (see figure_vector_slivers_).
 **Overshoots** can occur when a line feature such as a road does not meet another
 road exactly at an intersection. **Undershoots** can occur when a line feature
 (e.g. a river) does not exactly meet another feature to which it should be
-connected. Figure figure_vector_shoots_ demonstrates what undershoots and
+connected. Figure :numref:`figure_vector_shoots` demonstrates what undershoots and
 overshoots look like.
 
 .. _figure_vector_shoots:
@@ -369,7 +369,7 @@ Let's wrap up what we covered in this worksheet:
 * Vector data can be used for **spatial analysis** in a GIS application, for
   example to find the nearest hospital to a school.
 
-We have summarised the GIS Vector Data concept in Figure figure_vector_summary_.
+We have summarised the GIS Vector Data concept in Figure :numref:`figure_vector_summary`.
 
 .. _figure_vector_summary:
 
@@ -385,7 +385,7 @@ Now you try!
 Here are some ideas for you to try with your learners:
 
 * Using a copy of a toposheet map for your local area (like the one shown in
-  figure_sample_map_), see if your learners can identify examples of the different
+  :numref:`figure_sample_map`), see if your learners can identify examples of the different
   types of vector data by highlighting them on the map.
 * Think of how you would create vector features in a GIS to represent real world
   features on your school grounds. Create a table of different features in and

--- a/docs/gentle_gis_introduction/vector_spatial_analysis_buffers.rst
+++ b/docs/gentle_gis_introduction/vector_spatial_analysis_buffers.rst
@@ -36,7 +36,7 @@ features distant from one another. Buffer zones are often set up to protect the
 environment, protect residential and commercial zones from industrial accidents
 or natural disasters, or to prevent violence. Common types of buffer zones may
 be greenbelts between residential and commercial areas, border zones between
-countries (see figure_buffer_zone_), noise protection zones around airports, or
+countries (see :numref:`figure_buffer_zone`), noise protection zones around airports, or
 pollution protection zones along rivers.
 
 .. _figure_buffer_zone:
@@ -50,7 +50,7 @@ pollution protection zones along rivers.
 
 In a GIS Application, **buffer zones are** always represented as **vector
 polygons** enclosing other polygon, line or point features (see
-figure_point_buffer_, figure_line_buffer_, ).
+:numref:`figure_point_buffer`, :numref:`figure_line_buffer`, ).
 
 .. _figure_point_buffer:
 
@@ -85,7 +85,7 @@ table for each feature. The numerical values have to be defined in map units
 according to the Coordinate Reference System (CRS) used with the data. For example,
 the width of a buffer zone along the banks of a river can vary depending on the
 intensity of the adjacent land use. For intensive cultivation the buffer distance
-may be bigger than for organic farming (see Figure figure_variable_buffer_ and
+may be bigger than for organic farming (see Figure :numref:`figure_variable_buffer` and
 Table table_buffer_attributes_).
 
 .. _figure_variable_buffer:
@@ -123,7 +123,7 @@ Multiple buffer zones
 
 A feature can also have more than one buffer zone. A nuclear power plant may be
 buffered with distances of 10, 15, 25 and 30 km, thus forming multiple rings
-around the plant as part of an evacuation plan (see figure_multiple_buffers_).
+around the plant as part of an evacuation plan (see :numref:`figure_multiple_buffers`).
 
 .. _figure_multiple_buffers:
 
@@ -140,7 +140,7 @@ Buffer zones often have dissolved boundaries so that there are no overlapping
 areas between the buffer zones. In some cases though, it may also be useful for
 boundaries of buffer zones to remain intact, so that each buffer zone is a
 separate polygon and you can identify the overlapping areas (see
-Figure figure_buffer_dissolve_).
+Figure :numref:`figure_buffer_dissolve`).
 
 .. _figure_buffer_dissolve:
 
@@ -183,7 +183,7 @@ many others that can be used in a GIS and explored by the user.
 **Spatial overlay** is a process that allows you to identify the relationships
 between two polygon features that share all or part of the same area. The output
 vector layer is a combination of the input features information (see
-figure_overlay_operations_).
+:numref:`figure_overlay_operations`).
 
 .. _figure_overlay_operations:
 
@@ -227,7 +227,7 @@ Here are some ideas for you to try with your learners:
 
 * Because of dramatic traffic increase, the town planners want to widen the main
   road and add a second lane. Create a buffer around the road to find properties
-  that fall within the buffer zone (see figure_buffer_road_).
+  that fall within the buffer zone (see :numref:`figure_buffer_road`).
 * For controlling protesting groups, the police want to establish a neutral zone
   to keep protesters at least 100 meters from a building. Create a buffer around
   a building and colour it so that event planners can see where the buffer area

--- a/docs/training_manual/basic_map/mapviewnavigation.rst
+++ b/docs/training_manual/basic_map/mapviewnavigation.rst
@@ -39,7 +39,7 @@ Next, let's zoom in and take a closer look at the layers we imported.
    density of buildings and roads.
 #. Left click and hold. 
 #. Then drag the mouse, which will create a rectangle, and cover the dense area of 
-   buildings and roads (:ref:`figure_zoom_in_mapview`).
+   buildings and roads (:numref:`figure_zoom_in_mapview`).
 
    .. _figure_zoom_in_mapview:
 

--- a/docs/user_manual/grass_integration/grass_integration.rst
+++ b/docs/user_manual/grass_integration/grass_integration.rst
@@ -222,7 +222,7 @@ install the dataset on your computer (see :ref:`label_sampledata`).
 #. We can use this wizard to create a new :file:`MAPSET` within an existing
    :file:`LOCATION` (see section :ref:`sec_add_mapset`) or to create a new
    :file:`LOCATION` altogether. Select |radioButtonOn| :guilabel:`Create new
-   location` (see figure_grass_new_location_).
+   location` (see :numref:`figure_grass_new_location`).
 #. Enter a name for the :file:`LOCATION` -- we used 'alaska' -- and click :guilabel:`Next`.
 #. Define the projection by clicking on the radio button |radioButtonOn|
    :guilabel:`Projection` to enable the projection list.
@@ -290,7 +290,7 @@ coordinate values and the currently selected raster resolution (see Neteler & Mi
 #. We can use this wizard to create a new :file:`MAPSET` within an existing
    :file:`LOCATION` or to create a new :file:`LOCATION` altogether. Click on the
    radio button |radioButtonOn| :guilabel:`Select location`
-   (see figure_grass_new_location_) and click :guilabel:`Next`.
+   (see :numref:`figure_grass_new_location`) and click :guilabel:`Next`.
 #. Enter the name :file:`test` for the new :file:`MAPSET`. Below in the wizard, you
    see a list of existing :file:`MAPSETs` and corresponding owners.
 #. Click :guilabel:`Next`, check out the summary to make sure it's all correct and
@@ -601,7 +601,7 @@ https://grasswiki.osgeo.org/wiki/GRASS-QGIS_relevant_module_list.
 It is also possible to customize the GRASS Toolbox content. This procedure is
 described in section :ref:`sec_toolbox-customizing`.
 
-As shown in figure_grass_toolbox_, you can look for the appropriate GRASS
+As shown in :numref:`figure_grass_toolbox`, you can look for the appropriate GRASS
 module using the thematically grouped :guilabel:`Modules Tree` or the searchable
 :guilabel:`Modules List` tab.
 

--- a/docs/user_manual/introduction/general_tools.rst
+++ b/docs/user_manual/introduction/general_tools.rst
@@ -432,7 +432,7 @@ in :menuselection:`View --> Panels -->` menu or with :kbd:`Ctrl+9`.
 Check |checkbox| :guilabel:`Control rendering order` underneath
 the list of layers and reorganize the layers in the panel as you want. This
 order becomes the one applied to the map canvas.
-For example, in figure_layer_order_, you can see that the ``airports``
+For example, in :numref:`figure_layer_order`, you can see that the ``airports``
 features are displayed over the ``alaska`` polygon despite those layers'
 respective placement in the Layers panel.
 
@@ -581,7 +581,7 @@ If you want to embed content from other project files into your project, select
 :menuselection:`Layer --> Embed Layers and Groups`:
 
 #. Click the :guilabel:`...` button to look for a project: you can see the content of the
-   project (see figure_embed_dialog_)
+   project (see :numref:`figure_embed_dialog`)
 #. Hold down :kbd:`Ctrl` ( or |osx| :kbd:`Cmd`) and click on the layers and
    groups you wish to retrieve
 #. Click :guilabel:`OK`
@@ -1224,7 +1224,7 @@ added using the corresponding tools in the :guilabel:`Attributes Toolbar`:
   file
 * |svgAnnotation| :sup:`SVG Annotation` to add an :file:`SVG` symbol
 * |formAnnotation| :sup:`Form Annotation`: useful to display attributes
-  of a vector layer in a customized :file:`ui` file (see figure_custom_annotation_).
+  of a vector layer in a customized :file:`ui` file (see :numref:`figure_custom_annotation`).
   This is similar to the :ref:`custom attribute forms <provide_ui_file>`,
   but displayed in an annotation item. Also see this video
   https://www.youtube.com/watch?v=0pDBuSbQ02o&feature=youtu.be&t=2m25s
@@ -2082,7 +2082,7 @@ options to:
 * copy, paste, import or export colors
 * create, import or remove color palettes
 * add the custom palette to the color selector widget with the :guilabel:`Show
-  in Color Buttons` item (see figure_color_selector_)
+  in Color Buttons` item (see :numref:`figure_color_selector`)
 
 .. _figure_color_selector_swatches:
 

--- a/docs/user_manual/introduction/qgis_configuration.rst
+++ b/docs/user_manual/introduction/qgis_configuration.rst
@@ -921,7 +921,7 @@ cache on SSL errors (recommended)`.
 Credentials of proxy are set using the :ref:`authentication widget <authentication>`.
 
 Excluding some URLs can be added to the text box below the proxy settings (see
-Figure_Network_Tab_). No proxy will be used if the target url starts with one of
+:numref:`Figure_Network_Tab`). No proxy will be used if the target url starts with one of
 the string listed in this text box.
 
 If you need more detailed information about the different proxy settings,

--- a/docs/user_manual/managing_data_source/create_layers.rst
+++ b/docs/user_manual/managing_data_source/create_layers.rst
@@ -46,7 +46,7 @@ To create a new GeoPackage layer, press the |newGeoPackageLayer|
 :menuselection:`Layer --> Create Layer -->` menu or from the
 :guilabel:`Data Source Manager` toolbar.
 The :guilabel:`New GeoPackage Layer` dialog will be displayed as shown in
-figure_create_geopackage_.
+:numref:`figure_create_geopackage`.
 
 .. _figure_create_geopackage:
 
@@ -104,7 +104,7 @@ To create a new ESRI Shapefile format layer, press the |newVectorLayer|
 :menuselection:`Layer --> Create Layer -->` menu or from the
 :guilabel:`Data Source Manager` toolbar.
 The :guilabel:`New Shapefile Layer` dialog will be displayed as shown in
-figure_create_shapefile_.
+:numref:`figure_create_shapefile`.
 
 #. Provide a path and file name using the
    :guilabel:`...` button next to :guilabel:`File name`. QGIS will
@@ -150,7 +150,7 @@ To create a new SpatiaLite layer, press the |newSpatiaLiteLayer|
 :menuselection:`New SpatiaLite Layer...` button in the :menuselection:`Layer
 --> Create Layer -->` menu or from the :guilabel:`Data Source Manager` toolbar.
 The :guilabel:`New SpatiaLite Layer` dialog will be displayed as shown in
-Figure_create_spatialite_.
+:numref:`Figure_create_spatialite`.
 
 .. _figure_create_spatialite:
 
@@ -224,7 +224,7 @@ To create a new Temporary Scratch layer, choose the |createMemory|
 :menuselection:`Layer --> Create Layer -->` menu or in the :guilabel:`Data
 Source Manager` toolbar.
 The :guilabel:`New Temporary Scratch Layer` dialog will be displayed as shown in
-figure_create_temporary_. Then:
+:numref:`figure_create_temporary`. Then:
 
 #. Provide the :guilabel:`Layer name`
 #. Select the :guilabel:`Geometry type`. Here you can create a:

--- a/docs/user_manual/managing_data_source/opening_data.rst
+++ b/docs/user_manual/managing_data_source/opening_data.rst
@@ -377,7 +377,7 @@ To load a layer from a file:
    Source Manager` dialog
 #. You can specify the encoding for vector file if desired
 #. Press :guilabel:`Add` to load the file in QGIS and display them in the map view.
-   figure_vector_loaded_ shows QGIS after loading the :file:`alaska.shp` file.
+   :numref:`figure_vector_loaded` shows QGIS after loading the :file:`alaska.shp` file.
 
    .. _figure_vector_loaded:
 
@@ -743,7 +743,7 @@ corresponding descriptions at:
 The first time you use a PostGIS data source, you must create a connection to a
 database that contains the data. Begin by clicking the appropriate button as
 exposed above, opening an :guilabel:`Add PostGIS Table(s)` dialog
-(see figure_add_postgis_tables_).
+(see :numref:`figure_add_postgis_tables`).
 To access the connection manager, click on the :guilabel:`New`
 button to display the
 :guilabel:`Create a New PostGIS Connection` dialog.
@@ -846,7 +846,7 @@ clicking the :guilabel:`Test Connection` button or apply it by clicking
 the :guilabel:`OK` button.
 From :guilabel:`Add PostGIS Table(s)`, click now on :guilabel:`Connect`,
 and the dialog is filled with tables from the selected database
-(as shown in figure_add_postgis_tables_).
+(as shown in :numref:`figure_add_postgis_tables`).
 
 
 .. _db_requirements:
@@ -1161,7 +1161,7 @@ will then be used to render the Vector Tile in QGIS.
 For Mercator projection (used by OpenStreetMap Vector Tiles) Zoom Level 0
 represents the whole world at a scale of 1:500.000.000. Zoom Level 14
 represents the scale 1:35.000. 
-figure_vector_tiles_maptilerplanet_ shows the dialog with the
+:numref:`figure_vector_tiles_maptilerplanet` shows the dialog with the
 MapTiler planet Vector Tiles service configuration.
 
 .. _figure_vector_tiles_maptilerplanet:
@@ -1186,7 +1186,7 @@ By default, the OpenStreetMap XYZ Tile service is configured. You can
 add other services that use the XYZ Tile protocol by choosing
 :guilabel:`New Connection` in the XYZ Tiles context menu (right-click
 to open).
-figure_xyz_tiles_openstreetmap_ shows the dialog with the OpenStreetMap
+:numref:`figure_xyz_tiles_openstreetmap` shows the dialog with the OpenStreetMap
 XYZ Tile service configuration.
 
 .. _figure_xyz_tiles_openstreetmap:

--- a/docs/user_manual/managing_data_source/supported_data.rst
+++ b/docs/user_manual/managing_data_source/supported_data.rst
@@ -510,7 +510,7 @@ Many GIS packages don't wrap vector maps with a geographic reference system
 (http://postgis.refractions.net/documentation/manual-2.0/ST_Shift_Longitude.html).
 As result, if we open such a map in QGIS, we could see two widely
 separated locations, that should appear near each other.
-In Figure_vector_crossing_, the tiny point on the far left of the map
+In :numref:`Figure_vector_crossing`, the tiny point on the far left of the map
 canvas (Chatham Islands) should be within the grid, to the right of
 the New Zealand main islands.
 

--- a/docs/user_manual/plugins/core_plugins/plugins_coordinate_capture.rst
+++ b/docs/user_manual/plugins/core_plugins/plugins_coordinate_capture.rst
@@ -23,7 +23,7 @@ coordinates on the map canvas for two selected coordinate reference systems (CRS
    :ref:`managing_plugins`) and ensure that the dialog is visible by going to
    :menuselection:`View --> Panels` and ensuring that |checkbox|
    :guilabel:`Coordinate Capture` is enabled. The coordinate capture dialog
-   appears as shown in Figure figure_coordinate_capture_. Alternatively,
+   appears as shown in Figure :numref:`figure_coordinate_capture`. Alternatively,
    you can also look for :menuselection:`Vector --> Coordinate Capture`.
 #. Click on the |geographic| :sup:`Click to the select the CRS to use for
    coordinate display` icon and select a different CRS from the one you selected

--- a/docs/user_manual/print_composer/composer_items/composer_html_frame.rst
+++ b/docs/user_manual/print_composer/composer_items/composer_html_frame.rst
@@ -17,7 +17,7 @@ same way as exposed in :ref:`interact_layout_item`.
 
 The HTML item can be customized using its :guilabel:`Item Properties` panel.
 Other than the :ref:`items common properties <item_common_properties>`, this
-feature has the following functionalities (see figure_layout_html_):
+feature has the following functionalities (see :numref:`figure_layout_html`):
 
 
 .. _figure_layout_html:
@@ -32,7 +32,7 @@ HTML Source
 ------------
 
 The :guilabel:`HTML Source` group of the HTML frame :guilabel:`Item Properties`
-panel provides the following functionalities (see figure_layout_html_ppt_):
+panel provides the following functionalities (see :numref:`figure_layout_html_ppt`):
 
 .. _figure_layout_html_ppt:
 
@@ -64,7 +64,7 @@ Frames
 -------
 
 The :guilabel:`Frames` group of the HTML frame :guilabel:`Item Properties`
-panel provides the following functionalities (see figure_layout_html_frames_):
+panel provides the following functionalities (see :numref:`figure_layout_html_frames`):
 
 .. _figure_layout_html_frames:
 
@@ -103,7 +103,7 @@ Use smart page breaks and User style sheet
 
 The :guilabel:`Use smart page breaks` dialog and :guilabel:`User style sheet`
 dialog of the HTML frame :guilabel:`Item Properties` panel provides the
-following functionalities (see figure_layout_html_breaks_):
+following functionalities (see :numref:`figure_layout_html_breaks`):
 
 .. _figure_layout_html_breaks:
 

--- a/docs/user_manual/print_composer/composer_items/composer_image.rst
+++ b/docs/user_manual/print_composer/composer_items/composer_image.rst
@@ -25,7 +25,7 @@ blank frame that you can customize using its
 :guilabel:`Item Properties` panel.
 Other than the :ref:`items common properties <item_common_properties>`,
 this feature has the following functionalities (see
-:ref:`figure_layout_image`):
+:numref:`figure_layout_image`):
 
 .. _figure_layout_image:
 

--- a/docs/user_manual/print_composer/composer_items/composer_items_options.rst
+++ b/docs/user_manual/print_composer/composer_items/composer_items_options.rst
@@ -175,7 +175,7 @@ in this list.
    Alignment helper lines in the print layout
 
 There are several alignment options available within the |alignLeft|
-:sup:`Align selected items` pull-down menu (see figure_layout_common_align_).
+:sup:`Align selected items` pull-down menu (see :numref:`figure_layout_common_align`).
 To use an alignment function, you first select the elements and then click on
 one of the alignment icons:
 
@@ -195,7 +195,7 @@ Items Common Properties
 
 Layout items have a set of common properties you will find at the bottom of
 the :guilabel:`Item Properties` panel: Position and size, Rotation, Frame,
-Background, Item ID, Variables and Rendering (See figure_layout_common_).
+Background, Item ID, Variables and Rendering (See :numref:`figure_layout_common`).
 
 .. _figure_layout_common:
 

--- a/docs/user_manual/print_composer/composer_items/composer_label.rst
+++ b/docs/user_manual/print_composer/composer_items/composer_label.rst
@@ -19,7 +19,7 @@ same way as exposed in :ref:`interact_layout_item`.
 By default, the label item provides a default text that you can customize using
 its :guilabel:`Item Properties` panel. Other than the :ref:`items common
 properties <item_common_properties>`, this feature has the following
-functionalities (see figure_layout_label_):
+functionalities (see :numref:`figure_layout_label`):
 
 .. _figure_layout_label:
 

--- a/docs/user_manual/print_composer/composer_items/composer_legend.rst
+++ b/docs/user_manual/print_composer/composer_items/composer_legend.rst
@@ -19,7 +19,7 @@ same way as exposed in :ref:`interact_layout_item`.
 By default, the legend item displays all available layers and can be refined
 using its :guilabel:`Item Properties` panel. Other than the :ref:`items common
 properties <item_common_properties>`, this feature has the following
-functionalities (see figure_layout_legend_):
+functionalities (see :numref:`figure_layout_legend`):
 
 .. showing all layers is a bug (https://issues.qgis.org/issues/13575) but given
    that it's the behavior for a long moment now, let's document it...
@@ -35,7 +35,7 @@ Main properties
 ---------------
 
 The :guilabel:`Main properties` group of the legend :guilabel:`Item Properties`
-panel provides the following functionalities (see figure_layout_legend_ppt_):
+panel provides the following functionalities (see :numref:`figure_layout_legend_ppt`):
 
 .. _figure_layout_legend_ppt:
 
@@ -72,7 +72,7 @@ Legend items
 ------------
 
 The :guilabel:`Legend items` group of the legend :guilabel:`Item Properties`
-panel provides the following functionalities (see figure_layout_legend_items_):
+panel provides the following functionalities (see :numref:`figure_layout_legend_items`):
 
 .. _figure_layout_legend_items:
 
@@ -224,7 +224,7 @@ WMS LegendGraphic and Spacing
 
 The :guilabel:`WMS LegendGraphic` and :guilabel:`Spacing` groups of the legend
 :guilabel:`Item Properties` panel provide the following functionalities (see
-figure_layout_legend_wms_):
+:numref:`figure_layout_legend_wms`):
 
 .. _figure_layout_legend_wms:
 

--- a/docs/user_manual/print_composer/composer_items/composer_map.rst
+++ b/docs/user_manual/print_composer/composer_items/composer_map.rst
@@ -104,7 +104,7 @@ functionalities:
 Main properties
 ---------------
 
-In the :guilabel:`Main properties` group (see figure_layout_map_) of the map
+In the :guilabel:`Main properties` group (see :numref:`figure_layout_map`) of the map
 :guilabel:`Item Properties` panel, available options are:
 
 * The :guilabel:`Update Preview` button to refresh the map item rendering if the view
@@ -130,7 +130,7 @@ that toggling visibility of the layers or modifying their style in the
 like any other item, you may want to add multiple map items to a print layout,
 there's a need to break this synchronization in order to allow showing
 different areas, layer combinations, at different scales...
-The :guilabel:`Layers` properties group (see figure_layout_map_layers_) helps
+The :guilabel:`Layers` properties group (see :numref:`figure_layout_map_layers`) helps
 you do that.
 
 .. _figure_layout_map_layers:
@@ -185,7 +185,7 @@ Extents
 -------
 
 The :guilabel:`Extents` group of the map item properties panel provides the
-following functionalities (see figure_layout_map_extents_):
+following functionalities (see :numref:`figure_layout_map_extents`):
 
 .. _figure_layout_map_extents:
 
@@ -380,7 +380,7 @@ map item's extent and expand the :guilabel:`Overviews` option in the
 :guilabel:`Item Properties` panel. Then press the |signPlus| button to add
 an overview.
 
-Initially this overview is named 'Overview 1' (see Figure_layout_map_overview_).
+Initially this overview is named 'Overview 1' (see :numref:`Figure_layout_map_overview`).
 You can:
 
 * Rename it with a double-click

--- a/docs/user_manual/print_composer/composer_items/composer_scale_bar.rst
+++ b/docs/user_manual/print_composer/composer_items/composer_scale_bar.rst
@@ -19,7 +19,7 @@ By default, a new scale bar item shows the scale of the map item over which
 it is drawn. If there is no map item below, the :ref:`reference map <reference_map>` is
 used. You can customize it in the :guilabel:`Item Properties` panel.
 Other than the :ref:`items common properties <item_common_properties>`, this
-feature has the following functionalities (see figure_layout_scalebar_):
+feature has the following functionalities (see :numref:`figure_layout_scalebar`):
 
 .. _figure_layout_scalebar:
 
@@ -33,7 +33,7 @@ Main properties
 
 The :guilabel:`Main properties` group of the scale bar
 :guilabel:`Item Properties` panel provides the following functionalities
-(see figure_layout_scalebar_ppt_):
+(see :numref:`figure_layout_scalebar_ppt`):
 
 .. _figure_layout_scalebar_ppt:
 
@@ -59,7 +59,7 @@ Units
 
 The :guilabel:`Units` group of the scale bar :guilabel:`Item Properties` panel
 provides the functionalities to set the units of display and some text formatting
-(see figure_layout_scalebar_units_):
+(see :numref:`figure_layout_scalebar_units`):
 
 .. _figure_layout_scalebar_units:
 
@@ -92,7 +92,7 @@ Segments
 
 The :guilabel:`Segments` group of the scale bar :guilabel:`Item Properties` panel
 provides the functionalities to configure the number and size of segments and
-subdivisions (see figure_layout_scalebar_segments_):
+subdivisions (see :numref:`figure_layout_scalebar_segments`):
 
 .. _figure_layout_scalebar_segments:
 

--- a/docs/user_manual/print_composer/composer_items/composer_shapes.rst
+++ b/docs/user_manual/print_composer/composer_items/composer_shapes.rst
@@ -36,7 +36,7 @@ items, a regular shape can be manipulated the same way as exposed in
 
 The default shape item can be customized using its :guilabel:`Item Properties`
 panel. Other than the :ref:`items common properties <item_common_properties>`,
-this feature has the following functionalities (see figure_layout_label):
+this feature has the following functionalities (see :numref:`figure_layout_basic_shape`):
 
 .. _figure_layout_basic_shape:
 

--- a/docs/user_manual/print_composer/composer_items/composer_tables.rst
+++ b/docs/user_manual/print_composer/composer_items/composer_tables.rst
@@ -30,7 +30,7 @@ By default, a new attribute table item loads first rows of the first
 (alphabetically sorted) layer, with all the fields. You can however customize
 the table thanks to its :guilabel:`Item Properties` panel. Other than the
 :ref:`items common properties <item_common_properties>`, this feature has the
-following functionalities (see figure_layout_table_):
+following functionalities (see :numref:`figure_layout_table`):
 
 .. _figure_layout_table:
 
@@ -44,7 +44,7 @@ Main properties
 ...............
 
 The :guilabel:`Main properties` group of the attribute table provides the
-following functionalities (see figure_layout_table_ppt_):
+following functionalities (see :numref:`figure_layout_table_ppt`):
 
 .. _figure_layout_table_ppt:
 
@@ -70,10 +70,10 @@ following functionalities (see figure_layout_table_ppt_):
   the :guilabel:`Atlas` panel (see :ref:`atlas_generation`), there are
   two additional :guilabel:`Source` possible:
 
-  * **Current atlas feature** (see figure_layout_table_atlas_): you won't see
+  * **Current atlas feature** (see :numref:`figure_layout_table_atlas`): you won't see
     any option to choose the layer, and the table item will only show a row with
     the attributes from the current feature of the atlas coverage layer.
-  * and **Relation children** (see figure_layout_table_relation_): an option
+  * and **Relation children** (see :numref:`figure_layout_table_relation`): an option
     with the relation names will show up. This feature can only be used if you
     have defined a :ref:`relation <vector_relations>` using your atlas coverage
     layer as parent, and the table will show the children rows of the atlas
@@ -100,7 +100,7 @@ following functionalities (see figure_layout_table_ppt_):
 
 
 * The button :guilabel:`Attributes...` starts the :guilabel:`Select Attributes` dialog,
-  (see figure_layout_table_select_) that can be used to change the visible
+  (see :numref:`figure_layout_table_select`) that can be used to change the visible
   contents of the table. The upper part of the window shows the list of the
   attributes to display and the lower part helps you sort the data.
 
@@ -147,7 +147,7 @@ Feature filtering
 .................
 
 The :guilabel:`Feature filtering` group of the attribute table provides
-the following functionalities (see figure_layout_table_filter_):
+the following functionalities (see :numref:`figure_layout_table_filter`):
 
 .. _figure_layout_table_filter:
 
@@ -182,7 +182,7 @@ Appearance
 ..........
 
 The :guilabel:`Appearance` group of the attribute table provides
-the following functionalities  (see figure_layout_table_appearance_):
+the following functionalities (see :numref:`figure_layout_table_appearance`):
 
 .. _figure_layout_table_appearance:
 
@@ -212,7 +212,7 @@ the following functionalities  (see figure_layout_table_appearance_):
 * With :guilabel:`Background color` you can set the background color of the table using
   the :ref:`color selector <color-selector>` widget.
   The :guilabel:`Advanced customization` option helps you define different background colors
-  for each cell (see figure_layout_table_background_)
+  for each cell (see :numref:`figure_layout_table_background`)
 
 .. _figure_layout_table_background:
 
@@ -311,7 +311,7 @@ Show grid
 .........
 
 The :guilabel:`Show grid` group of the table items provides
-the following functionalities (see figure_layout_table_grid_):
+the following functionalities (see :numref:`figure_layout_table_grid`):
 
 .. _figure_layout_table_grid:
 
@@ -331,7 +331,7 @@ Fonts and text styling
 ......................
 
 The :guilabel:`Fonts and text styling` group of the table items
-provides the following functionalities (see figure_layout_table_fonts_):
+provides the following functionalities (see :numref:`figure_layout_table_fonts`):
 
 .. _figure_layout_table_fonts:
 
@@ -345,14 +345,14 @@ provides the following functionalities (see figure_layout_table_fonts_):
 * For :guilabel:`Table heading` you can additionally set the :guilabel:`Alignment`
   to ``Follow column alignment`` or override this setting by choosing ``Left``,
   ``Center`` or ``Right``. The column alignment is set using the :guilabel:`Select
-  Attributes` dialog (see figure_layout_table_select_ ).
+  Attributes` dialog (see :numref:`figure_layout_table_select` ).
 
 
 Frames
 ......
 
 The :guilabel:`Frames` group of the table item properties provides
-the following functionalities (see figure_layout_table_frames_):
+the following functionalities (see :numref:`figure_layout_table_frames`):
 
 .. _figure_layout_table_frames:
 

--- a/docs/user_manual/print_composer/create_output.rst
+++ b/docs/user_manual/print_composer/create_output.rst
@@ -295,7 +295,7 @@ to their exports settings.
 
 To enable the generation of an atlas and access atlas parameters, refer to
 the :guilabel:`Atlas` panel. This panel contains the following
-(see figure_layout_atlas_):
+(see :numref:`figure_layout_atlas`):
 
 .. _figure_layout_atlas:
 

--- a/docs/user_manual/print_composer/overview_composer.rst
+++ b/docs/user_manual/print_composer/overview_composer.rst
@@ -149,7 +149,7 @@ zoom in on an area and pan the view on the layout a well as buttons to
 select any layout item and to move the contents of the map item.
 
 
-figure_layout_overview_ shows the initial view of the print layout before
+:numref:`figure_layout_overview` shows the initial view of the print layout before
 any elements are added.
 
 .. _figure_layout_overview:
@@ -771,7 +771,7 @@ any time you right-click in the print layout area:
 * |redo| :sup:`Restore last change`
 
 This can also be done by mouse click within the :guilabel:`Undo history`
-panel (see figure_layout_). The History panel lists the last actions done
+panel (see :numref:`figure_layout`). The History panel lists the last actions done
 within the print layout.
 Just select the point you want to revert to and once you do new action all
 the actions done after the selected one will be removed.

--- a/docs/user_manual/processing_algs/qgis/interpolation.rst
+++ b/docs/user_manual/processing_algs/qgis/interpolation.rst
@@ -175,7 +175,7 @@ Another excellent QGIS tutorial on making heatmaps can be found at
 `http://qgistutorials.com
 <http://www.qgistutorials.com/en/docs/creating_heatmaps.html>`_.
 
-In Figure_Heatmap_data_processing_, the airports of Alaska are shown.
+In :numref:`Figure_Heatmap_data_processing`, the airports of Alaska are shown.
 
 .. _figure_heatmap_data_processing:
 
@@ -195,7 +195,7 @@ In Figure_Heatmap_data_processing_, the airports of Alaska are shown.
    The :guilabel:`Pixel size Y`, :guilabel:`Rows` and
    :guilabel:`Columns` will be automatically updated.
 #. Click on :guilabel:`Run` to create and load the airports heatmap
-   (see Figure_Heatmap_created_processing_).
+   (see :numref:`Figure_Heatmap_created_processing`).
 
 .. _figure_heatmap_settings_processing:
 
@@ -228,7 +228,7 @@ The heatmap can now be styled in QGIS to improve its appearance.
 #. Click the :guilabel:`Classify` button.
 #. Press :guilabel:`OK` to update the layer.
 
-The final result is shown in Figure_Heatmap_styled_processing_.
+The final result is shown in :numref:`Figure_Heatmap_styled_processing`.
 
 .. _figure_heatmap_styled_processing:
 

--- a/docs/user_manual/style_library/style_manager.rst
+++ b/docs/user_manual/style_library/style_manager.rst
@@ -82,7 +82,7 @@ listed in the panel on the left:
   :guilabel:`Add Tag...` button or select the |signPlus| :guilabel:`Add Tag...`
   from any tag contextual menu;
 * **Smart Group**: a smart group dynamically fetches its symbols according to
-  conditions set (see eg, figure_smart_group_). Click the :guilabel:`Add Smart Group...`
+  conditions set (see eg, :numref:`figure_smart_group`). Click the :guilabel:`Add Smart Group...`
   button to create smart groups. The dialog box allows you to enter an expression
   to filter the items to select (has a particular tag, have a string in its name,
   etc.). Any symbol, color ramp, text format or label setting that satisfies

--- a/docs/user_manual/working_with_gps/live_GPS_tracking.rst
+++ b/docs/user_manual/working_with_gps/live_GPS_tracking.rst
@@ -18,7 +18,7 @@ There are four possible screens in this GPS tracking window:
 * |metadata| GPS position coordinates and an interface for manually entering
   vertices and features
 * |gpsTrackBarChart| GPS signal strength of satellite connections
-* |options| GPS options screen (see figure_gps_options_)
+* |options| GPS options screen (see :numref:`figure_gps_options`)
 
 With a plugged-in GPS receiver (has to be supported by your operating system),
 a simple click on :guilabel:`Connect` connects the GPS to QGIS. A second click (now

--- a/docs/user_manual/working_with_gps/plugins_gps.rst
+++ b/docs/user_manual/working_with_gps/plugins_gps.rst
@@ -53,7 +53,7 @@ sample dataset: :file:`qgis_sample_data/gps/national_monuments.gpx`. See section
 
 #. Select :menuselection:`Vector --> GPS Tools` or click the
    |importGPX| :sup:`GPS Tools` icon in the toolbar and open the
-   :guilabel:`Load GPX file` tab (see figure_GPS_).
+   :guilabel:`Load GPX file` tab (see :numref:`figure_GPS`).
 #. Browse to the folder :file:`qgis_sample_data/gps/`, select the GPX file
    :file:`national_monuments.gpx` and click :guilabel:`Open`.
 
@@ -104,7 +104,7 @@ Downloading GPS data from a device
 
 QGIS can use GPSBabel to download data from a GPS device directly as new vector
 layers. For this we use the :guilabel:`Download from GPS` tab of the GPS
-Tools dialog (see Figure_GPS_download_). Here, we select the type of GPS device, the
+Tools dialog (see :numref:`Figure_GPS_download`). Here, we select the type of GPS device, the
 port that it is connected to (or USB if your GPS supports this), the feature type
 that you want to download, the GPX file where the data should be stored, and the
 name of the new layer.

--- a/docs/user_manual/working_with_projections/working_with_projections.rst
+++ b/docs/user_manual/working_with_projections/working_with_projections.rst
@@ -142,7 +142,7 @@ This default CRS is ``EPSG:4326`` (also known as "WGS 84"), and it is a global
 latitude/longitude based reference system.
 This default CRS can be changed via the :guilabel:`CRS for New Projects`
 setting in the :guilabel:`CRS` tab under :menuselection:`Settings -->` |options|
-:menuselection:`Options...` (see figure_projection_options_).
+:menuselection:`Options...` (see :numref:`figure_projection_options`).
 There is an option to automatically set the project's CRS
 to match the CRS of the first layer loaded into a new project, or alternatively
 you can select a different default CRS to use for all newly created projects.

--- a/docs/user_manual/working_with_raster/georeferencer.rst
+++ b/docs/user_manual/working_with_raster/georeferencer.rst
@@ -72,7 +72,7 @@ the result will be.
 
 The first step is to start QGIS and click on :menuselection:`Raster -->` |georefRun|
 :menuselection:`Georeferencer`, which appears in the QGIS menu bar. The Georeferencer
-dialog appears as shown in figure_georeferencer_dialog_.
+dialog appears as shown in :numref:`figure_georeferencer_dialog`.
 
 For this example, we are using a topo sheet of South Dakota from SDGS. It can
 later be visualized together with the data from the GRASS :file:`spearfish60`
@@ -97,7 +97,7 @@ Entering ground control points (GCPs)
    area of the dialog. Once the raster is loaded, we can start to enter reference
    points.
 #. Using the |addGCPPoint| :sup:`Add Point` button, add points to the
-   main working area and enter their coordinates (see Figure figure_georeferencer_add_points_).
+   main working area and enter their coordinates (see Figure :numref:`figure_georeferencer_add_points`).
    For this procedure you have three options:
 
    - Click on a point in the raster image and enter the X and Y coordinates

--- a/docs/user_manual/working_with_vector/attribute_table.rst
+++ b/docs/user_manual/working_with_vector/attribute_table.rst
@@ -466,7 +466,7 @@ to a new field (that can be a :ref:`virtual <virtual_field>` one).
 
 The field calculator is available on any layer that supports edit.
 When you click on the field calculator icon the dialog opens (see
-figure_field_calculator_). If the layer is not in edit mode, a warning is
+:numref:`figure_field_calculator`). If the layer is not in edit mode, a warning is
 displayed and using the field calculator will cause the layer to be put in
 edit mode before the calculation is made.
 

--- a/docs/user_manual/working_with_vector/editing_geometry_attributes.rst
+++ b/docs/user_manual/working_with_vector/editing_geometry_attributes.rst
@@ -69,7 +69,7 @@ There are three options to select the layer(s) to snap to:
 * :guilabel:`Current layer`: only the active layer is used, a convenient
   way to ensure topological consistency within the layer being edited.
 * :guilabel:`Advanced Configuration`: allows you to enable and adjust
-  snapping mode and tolerance on a layer basis (see figure_edit_snapping_).
+  snapping mode and tolerance on a layer basis (see :numref:`figure_edit_snapping`).
   If you need to edit a layer and snap its vertices to another, make
   sure that the target layer is checked and increase the snapping
   tolerance to a higher value.
@@ -465,7 +465,7 @@ geometry then enter its attributes. To digitize the geometry:
     update rubber band during node editing`.
 
 #. The attribute window will appear, allowing you to enter the information for
-   the new feature. Figure_edit_values_ shows setting attributes for a fictitious
+   the new feature. :numref:`Figure_edit_values` shows setting attributes for a fictitious
    new river in Alaska. However, in the :guilabel:`Digitizing` menu under the
    :menuselection:`Settings --> Options` menu, you can also activate:
 
@@ -752,7 +752,7 @@ Undo and Redo
 
 The |undo| :sup:`Undo` and |redo| :sup:`Redo` tools allows you to undo or redo
 vector editing operations. There is also a dockable widget, which shows all
-operations in the undo/redo history (see Figure_edit_undo_). This widget is not
+operations in the undo/redo history (see :numref:`Figure_edit_undo`). This widget is not
 displayed by default; it can be displayed by right-clicking on the toolbar and
 activating the :guilabel:`Undo/Redo Panel` checkbox. The Undo/Redo capability
 is however active, even if the widget is not displayed.
@@ -1313,7 +1313,7 @@ change the rotation of point symbols in the map canvas.
    |rotatePointSymbols| :sup:`Rotate Point Symbols` tool
 #. Move the mouse around.
    A red arrow with the rotation value will be visualized (see
-   Figure_rotate_point_).
+   :numref:`Figure_rotate_point`).
    If you hold the :kbd:`Ctrl` key while moving, the rotation will be done
    in 15 degree steps.
 #. When you get the expected angle value, click again. The symbol is rendered

--- a/docs/user_manual/working_with_vector/vector_properties.rst
+++ b/docs/user_manual/working_with_vector/vector_properties.rst
@@ -137,7 +137,7 @@ project.
 
 You can use one or more layer attributes to define the filter in the ``Query
 Builder``.
-The use of more than one attribute is shown in Figure_vector_querybuilder_.
+The use of more than one attribute is shown in :numref:`Figure_vector_querybuilder`.
 In the example, the filter combines the attributes
 
 * ``toa`` (``DateTime`` field: ``cast("toa" as character) > '2017-05-17'`` and
@@ -535,7 +535,7 @@ Right-clicking over selected item(s) shows a contextual menu to:
 * :guilabel:`Change Size...` of the selected point symbol(s)
 * :guilabel:`Change Angle...` of the selected point symbol(s)
 
-The example in figure_graduated_symbology_ shows the graduated rendering dialog for
+The example in :numref:`figure_graduated_symbology` shows the graduated rendering dialog for
 the major_rivers layer of the QGIS sample dataset.
 
 .. _figure_graduated_symbology:
@@ -708,7 +708,7 @@ Double-click the rules in the map legend and the Symbology tab of the layer
 properties appears showing the rule that is the background for the symbol in
 the tree.
 
-The example in figure_rule_based_symbology_ shows the rule-based rendering
+The example in :numref:`figure_rule_based_symbology` shows the rule-based rendering
 dialog for the rivers layer of the QGIS sample dataset.
 
 .. _figure_rule_based_symbology:
@@ -1052,7 +1052,7 @@ to corresponding features). You can combine both usage.
 
 Paint effects can be activated by checking the |checkbox| :guilabel:`Draw effects` option
 and clicking the |paintEffects| :sup:`Customize effects` button. That will open
-the :guilabel:`Effect Properties` Dialog (see figure_effects_source_). The following
+the :guilabel:`Effect Properties` Dialog (see :numref:`figure_effects_source`). The following
 effect types, with custom options are available:
 
 * **Source**: Draws the feature's original style according to the configuration
@@ -1336,7 +1336,7 @@ seen beforehand.
 
    Rule settings
 
-A summary of existing rules is shown in the main dialog (see figure_labels_rule_based_).
+A summary of existing rules is shown in the main dialog (see :numref:`figure_labels_rule_based`).
 You can add multiple rules, reorder or imbricate them with a drag-and-drop.
 You can as well remove them with the |signMinus| button or edit them with
 |projectProperties| button or a double-click.
@@ -1363,7 +1363,7 @@ Assuming you are using the :guilabel:`Single labels` method, click the
 |expression| button near the :guilabel:`Value` drop-down list in the
 |labeling| :guilabel:`Labels` tab of the properties dialog.
 
-In figure_labels_expression_, you see a sample expression to label the alaska
+In :numref:`figure_labels_expression`, you see a sample expression to label the alaska
 trees layer with tree type and area, based on the field 'VEGDESC', some
 descriptive text, and the function ``$area`` in combination with
 ``format_number()`` to make it look nicer.
@@ -1598,7 +1598,7 @@ Customize the labels from the map canvas
 Combined with the :guilabel:`Label Toolbar`, the data defined override setting
 helps you manipulate labels in the map canvas (move, edit, rotate).
 We now describe an example using the data-defined override function for the
-|moveLabel|:sup:`Move label` function (see figure_labels_coordinate_data_defined_).
+|moveLabel|:sup:`Move label` function (see :numref:`figure_labels_coordinate_data_defined`).
 
 #. Import :file:`lakes.shp` from the QGIS sample dataset.
 #. Double-click the layer to open the Layer Properties. Click on :guilabel:`Labels`
@@ -1617,7 +1617,7 @@ We now describe an example using the data-defined override function for the
 #. Zoom into a lake.
 #. Set editable the layer using the |toggleEditing| :sup:`Toggle Editing` button.
 #. Go to the Label toolbar and click the |moveLabel| icon.
-   Now you can shift the label manually to another position (see figure_labels_move_).
+   Now you can shift the label manually to another position (see :numref:`figure_labels_move`).
    The new position of the label is saved in the ``xlabel`` and ``ylabel`` columns
    of the attribute table.
 #. It's also possible to add a line connecting each lake to its moved label using:
@@ -1650,7 +1650,7 @@ Diagrams Properties
 ===================
 
 |diagram| The :guilabel:`Diagrams` tab allows you to add a graphic overlay to
-a vector layer (see figure_diagrams_attributes_).
+a vector layer (see :numref:`figure_diagrams_attributes`).
 
 The current core implementation of diagrams provides support for:
 
@@ -2044,7 +2044,7 @@ The drag and drop designer
 
 The drag and drop designer allows you to create a form with several containers
 (tabs or groups) to present the attribute fields, as shown for example
-in figure_fields_form_.
+in :numref:`figure_fields_form`.
 
 .. _figure_fields_form:
 


### PR DESCRIPTION
Many figures are still referenced with their anchor while some have been turned into the most easy-to-find (especially for PDF users) numbering
Let's be coherent everywhere