### PR TITLE
correct the expression for picture item's X

### DIFF
--- a/docs/training_manual/map_composer/dynamic_layout.rst
+++ b/docs/training_manual/map_composer/dynamic_layout.rst
@@ -234,7 +234,7 @@ Also, the date of creation will adapt dynamically.
 
    #. For :guilabel:`X`, use the expression::
 
-        @layout_pagewidth - @sw_layout_margin * 2 - 78
+        @layout_pagewidth - @sw_layout_margin - 49.5
 
    #. For :guilabel:`Y`, use the expression::
 


### PR DESCRIPTION
The original expression is `@layout_pagewidth - @sw_layout_margin * 2 - 78`, which makes the picrure item not x-aligned with the label just created in previous section, and is conflict with the north arrow created in following context.
