### PR TITLE
Use ubuntu-latest for backport github action

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   backport:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     name: Backport
     steps:
       - name: Backport Bot


### PR DESCRIPTION
Merged pull-requests do not backport changes to 3.16 anymore (https://github.com/qgis/QGIS-Documentation/actions?query=workflow%3ABackport). And the report is `Unexpected input(s) 'bot_token_key', valid inputs are ['bot_username', 'bot_token', 'github_token'] `. So let's try to follow...?