### PR TITLE
Zooming and panning for 3.18 (fixes #6406)

### DIFF
--- a/docs/training_manual/answers/answers.rst
+++ b/docs/training_manual/answers/answers.rst
@@ -21,7 +21,7 @@ remember the names and functions of the screen elements.
 ...............................................................................
 
 #. :guilabel:`Save as`
-#. :guilabel:`Zoom to layer`
+#. :guilabel:`Zoom to layer(s)`
 #. :guilabel:`Invert selection`
 #. :guilabel:`Rendering on/off`
 #. :guilabel:`Measure line`

--- a/docs/training_manual/online_resources/wms.rst
+++ b/docs/training_manual/online_resources/wms.rst
@@ -123,7 +123,7 @@ symbology:
 
    #. Click :guilabel:`OK`.
 #. Now right-click on one of your own layers in the :guilabel:`Layers` panel and
-   click :guilabel:`Zoom to layer extent`. You should see the |majorUrbanName|
+   click :guilabel:`Zoom to layer(s)`. You should see the |majorUrbanName|
    area:
 
    .. figure:: img/wms_result.png

--- a/docs/user_manual/introduction/general_tools.rst
+++ b/docs/user_manual/introduction/general_tools.rst
@@ -173,7 +173,7 @@ right-click shows a dedicated set of options presented below.
 =================================================================  ==================  =================  =============
 Option                                                             Vector Layer        Raster Layer       Group
 =================================================================  ==================  =================  =============
-|zoomToLayer| :guilabel:`Zoom to Layer/Group`                      |checkbox|          |checkbox|         |checkbox|
+|zoomToLayer| :guilabel:`Zoom to Layer(s)/Group`                   |checkbox|          |checkbox|         |checkbox|
 |zoomToLayer| :guilabel:`Zoom to Selection`                        |checkbox|          \                  \
 |inOverview| :guilabel:`Show in Overview`                          |checkbox|          |checkbox|         \
 :guilabel:`Show Feature Count`                                     |checkbox|          \                  \
@@ -762,8 +762,7 @@ Zooming and Panning
 There are multiple ways to zoom and pan to an area of interest.
 You can use the :guilabel:`Map Navigation` toolbar, the mouse and keyboard on
 the map canvas and also the menu actions from the :menuselection:`View`
-menu and the layers' contextual menu in the :menuselection:`Layers` panel.
-
+menu and the layers' contextual menu in the :guilabel:`Layers` panel.
 
 .. list-table::
    :header-rows: 1
@@ -804,19 +803,22 @@ menu and the layers' contextual menu in the :menuselection:`Layers` panel.
      -
    * - |panToSelected|
      - Pan Map to Selection
-     - Pan the map to the active layer's selected features.
+     - Pan the map to the selected features of all the selected layers in the
+       :guilabel:`Layers` panel.
      - |checkbox|
      - |checkbox|
      -
    * - |zoomToSelected|
      - Zoom To Selection
-     - Zoom to the active layer's selected features.
+     - Zoom to the selected features of all the selected layers in the
+       :guilabel:`Layers` panel.
      - |checkbox|
      - |checkbox|
      - |checkbox|
    * - |zoomToLayer|
-     - Zoom To Layer
-     - Zoom to the active layer's extent.
+     - Zoom To Layer(s)
+     - Zoom to the extent of all the selected layers in the
+       :guilabel:`Layers` panel.
      - |checkbox|
      - |checkbox|
      - |checkbox|

--- a/docs/user_manual/introduction/qgis_gui.rst
+++ b/docs/user_manual/introduction/qgis_gui.rst
@@ -685,7 +685,7 @@ actions like:
      - :kbd:`Ctrl+J`
      - :guilabel:`Map Navigation`
      -
-   * - |zoomToLayer| :guilabel:`Zoom To Layer`
+   * - |zoomToLayer| :guilabel:`Zoom To Layer(s)`
      -
      - :guilabel:`Map Navigation`
      -
@@ -2051,13 +2051,15 @@ Click on the map view and you should be able to interact with it:
   and |zoomIn| :sup:`Zoom Out` tools. Hold the :kbd:`Alt` key to switch from
   one tool to the other. Zooming is also performed by rolling
   the wheel forward to zoom in and backwards to zoom out.
-  The zoom is centered on the mouse cursor position.
-
-  You can customize the :guilabel:`Zoom factor` under the
+  The zoom is centered on the mouse cursor position. You can customize the
+  :guilabel:`Zoom factor` under the
   :menuselection:`Settings --> Options --> Map tools` menu.
 * it can be zoomed to the full extent of all loaded layers (|zoomFullExtent|
-  :sup:`Zoom Full`), to a layer extent (|zoomToLayer| :sup:`Zoom to Layer`)
-  or to the extent of selected features (|zoomToSelected| :sup:`Zoom to Selection`)
+  :sup:`Zoom Full`), to the extent of all the selected layers in the
+  :menuselection:`Layers` panel (|zoomToLayer| :sup:`Zoom to Layer(s)`)
+  or to the extent of the selected features of all the selected layers in the
+  :menuselection:`Layers` panel (|zoomToSelected| :sup:`Zoom to
+  Selection`)
 * you can navigate back/forward through the canvas view history with
   the |zoomLast|:sup:`Zoom Last` and |zoomNext|:sup:`Zoom Next` buttons
   or using the back/forward mouse buttons.
@@ -2094,7 +2096,7 @@ At the top of an additional map canvas, there's a toolbar with the following
 capabilities:
 
 * |zoomFullExtent| :sup:`Zoom Full`, |zoomToSelected| :sup:`Zoom to Selection`
-  and |zoomToLayer| :sup:`Zoom to Layer` to navigate within the view
+  and |zoomToLayer| :sup:`Zoom to Layer(s)` to navigate within the view
 * |showMapTheme| :sup:`Set View Theme` to select the :ref:`map theme <map_themes>`
   to display in the map view. If set to ``(none)``, the view will follow
   the :guilabel:`Layers` panel changes.


### PR DESCRIPTION
Edited the documentation for the new behavior of Zoom to Layer, Zoom to Selection and Pan Map to Selection (QGIS/QGIS#40460 and QGIS/QGIS#40857) that will be in release 3.18

Fixes #6406 