### PR TITLE
Delay the PO files generation

### DIFF
--- a/.github/workflows/pofiles.yml
+++ b/.github/workflows/pofiles.yml
@@ -7,8 +7,8 @@ on:
     paths:
       - 'docs/**'
 
-  schedule: #run at 02:00 UTC every day
-    - cron:  '30 09 * * *'
+  schedule: #run at 02:00 UTC on Wednesday
+    - cron:  '00 02 * * 03'
 
 jobs:
   prepare_translation:


### PR DESCRIPTION
Create the files to pull by Transifex once a week instead of every day. Reduces files traffic and the frequency of files modification for translators (and I'm personally not convinced that it's necessary to load changes every day). Once per week is already far better than the previous once in a while.