### PR TITLE
Fix format item in list

### DIFF
--- a/docs/user_manual/processing/standalone.rst
+++ b/docs/user_manual/processing/standalone.rst
@@ -28,7 +28,7 @@ Specify the name of the algorithm or a path to a model as first parameter.
 
 The ``run`` command also supports further parameters.
 
- - `--json` will format stdout output in a JSON structured way.
+ - ``--json`` will format stdout output in a JSON structured way.
  - ``--ellipsoid`` will set the ellipsoid to the specified one.
  - ``--distance_units`` will use the specified distance units.
  - ``--area_units`` will use the specified area units.


### PR DESCRIPTION
line 31 :    - `--json`  should be  - ``--json`` to have the same format as the rest of the list. Without it is showed as italic text

Goal:  Display correct documentation

- [x] Backport to LTR documentation is required
