### PR TITLE
Updated HTTP to HTTPS

### DIFF
--- a/docs/user_manual/processing/3rdParty.rst
+++ b/docs/user_manual/processing/3rdParty.rst
@@ -230,7 +230,7 @@ some example scripts in the :guilabel:`Processing Toolbox`:
   the packages it depends on) for you, using the
   :guilabel:`Package repository` specified in
   :menuselection:`Provider --> R` in the Processing options.
-  The default is `http://cran.at.r-project.org/`.
+  The default is `https://cran.at.r-project.org/`.
   Installing may take some time...
 * :guilabel:`test_sp` can be used to check if the R package ``sp`` is
   installed.

--- a/docs/user_manual/processing/3rdParty.rst
+++ b/docs/user_manual/processing/3rdParty.rst
@@ -230,7 +230,7 @@ some example scripts in the :guilabel:`Processing Toolbox`:
   the packages it depends on) for you, using the
   :guilabel:`Package repository` specified in
   :menuselection:`Provider --> R` in the Processing options.
-  The default is `https://cran.at.r-project.org/`.
+  The default is https://cran.at.r-project.org/.
   Installing may take some time...
 * :guilabel:`test_sp` can be used to check if the R package ``sp`` is
   installed.


### PR DESCRIPTION
line 233  :  `http://cran.at.r-project.org/`  changed to HTTPS : `https://cran.at.r-project.org/`.  Checked and works

Goal: Display correct documentation

- [x] Backport to LTR documentation is required
