### PR TITLE
PyQGIS - Use the API to get the sublayer separator

### DIFF
--- a/docs/pyqgis_developer_cookbook/cheat_sheet.rst
+++ b/docs/pyqgis_developer_cookbook/cheat_sheet.rst
@@ -400,12 +400,14 @@ Otherwise
 
 .. testcode:: cheat_sheet
 
+    from qgis.core import QgsDataProvider
+
     fileName = "testdata/sublayers.gpkg"
     layer = QgsVectorLayer(fileName, "test", "ogr")
     subLayers = layer.dataProvider().subLayers()
 
     for subLayer in subLayers:
-        name = subLayer.split('!!::!!')[1]
+        name = subLayer.split(QgsDataProvider.SUBLAYER_SEPARATOR)[1]
         uri = "%s|layername=%s" % (fileName, name,)
         # Create layer
         sub_vlayer = QgsVectorLayer(uri, name, 'ogr')


### PR DESCRIPTION
PyQGIS - Use the API to get the sublayer separator, instead of hardcoded string

- [x] Backport to LTR documentation is required
