### PR TITLE
Fix Merge algorithm name

### DIFF
--- a/docs/training_manual/processing/cutting_merging.rst
+++ b/docs/training_manual/processing/cutting_merging.rst
@@ -62,7 +62,7 @@ polygon* algorithm.
 
 .. figure:: img/cutting_merging/clip.png 
 
-Once the layers have been cropped, they can be merged using the GDAL *Merge* algorithm.
+Once the layers have been cropped, they can be merged using the SAGA *Mosaic raster layers* algorithm.
 
 .. figure:: img/cutting_merging/merge.png
 


### PR DESCRIPTION
<!---
Include a few sentences describing the overall goals for this Pull Request.
 
A list of issues is at https://github.com/qgis/QGIS-Documentation/issues.
Add "fix #issuenumber" for each issue the PR fixes. The ticket(s) will be closed automatically.
If your PR doesn't fix entirely the ticket, only add the ticket(s) reference preceded by # character.
-->
Goal:

In the **_17.15. Clipping and merging raster layers_** chapter is currently mentioned the "GDAL Merge" algorithm.

Previously, the mentioned algorithm was "Merge raster layers", but it was incorrectly replaced in the documentation by "GDAL Merge" https://github.com/qgis/QGIS-Documentation/commit/265ae574567d15a979c640d1901b37f93e54523d.

Anyway the correct replacement for the "Merge raster layers" algorithm is the SAGA "Mosaic raster layers" algorithm (https://github.com/qgis/QGIS/pull/1636 - https://github.com/qgis/QGIS/commit/62302377db1990485f7821f1ccef4ff6ef4d07d9#diff-aad3ad85caa27c517e2934f3aa74fc25021fe41164fdd74e808b0920d3243cf8).

See also http://osgeo-org.1560.x6.nabble.com/gdal-merge-td5456099.html
