### PR TITLE
Remove QGIS_SERVER_LOG_FILE and QGIS_DEBUG from code snippets

### DIFF
--- a/docs/server_manual/config.rst
+++ b/docs/server_manual/config.rst
@@ -255,7 +255,7 @@ For example with spawn-fcgi:
 .. code-block:: bash
 
  export QGIS_OPTIONS_PATH=/home/user/.local/share/QGIS/QGIS3/profiles/default/
- export QGIS_SERVER_LOG_FILE=/home/user/qserv.log
+ export QGIS_SERVER_LOG_STDERR=1
  export QGIS_SERVER_LOG_LEVEL=2
  spawn-fcgi -f /usr/lib/cgi-bin/qgis_mapserv.fcgi -s /tmp/qgisserver.sock -U www-data -G www-data -n
 
@@ -269,7 +269,7 @@ For example with spawn-fcgi:
 
     - QGIS_SERVER_LOG_LEVEL / '' (Log level): '2' (read from ENVIRONMENT_VARIABLE)
 
-    - QGIS_SERVER_LOG_FILE / '' (Log file): '/tmp/qserv.log' (read from ENVIRONMENT_VARIABLE)
+    - QGIS_SERVER_LOG_STDERR / '' (Activate/Deactivate logging to stderr): '1' (read from ENVIRONMENT_VARIABLE)
 
     - QGIS_PROJECT_FILE / '' (QGIS project file): '' (read from DEFAULT_VALUE)
 

--- a/docs/server_manual/getting_started.rst
+++ b/docs/server_manual/getting_started.rst
@@ -115,11 +115,9 @@ called :file:`qgis.demo.conf`, with this content:
    FcgidInitialEnv PYTHONIOENCODING UTF-8
    FcgidInitialEnv LANG "en_US.UTF-8"
 
-   # QGIS log (different from apache logs)
-   FcgidInitialEnv QGIS_SERVER_LOG_FILE /var/log/qgis/qgisserver.log
+   # QGIS log
+   FcgidInitialEnv QGIS_SERVER_LOG_STDERR 1
    FcgidInitialEnv QGIS_SERVER_LOG_LEVEL 0
-
-   FcgidInitialEnv QGIS_DEBUG 1
 
    # default QGIS project
    SetEnv QGIS_PROJECT_FILE /home/qgis/projects/world.qgs
@@ -295,8 +293,7 @@ In the NGINX configuration file, :file:`/etc/nginx/nginx.conf`, you have to use
     location /qgisserver {
          gzip           off;
          include        fastcgi_params;
-         fastcgi_param  QGIS_DEBUG              1;
-         fastcgi_param  QGIS_SERVER_LOG_FILE    /var/log/qgis/qgisserver.log;
+         fastcgi_param  QGIS_SERVER_LOG_STDERR  1;
          fastcgi_param  QGIS_SERVER_LOG_LEVEL   0;
          fastcgi_pass   unix:/var/run/qgisserver.socket;
      }
@@ -357,7 +354,7 @@ QGIS Server is now available at http://localhost/qgisserver.
 
     When using spawn-fcgi, you may directly define environment variables
     before running the server. For example:
-    ``export QGIS_SERVER_LOG_FILE=/var/log/qgis/qgisserver.log``
+    ``export QGIS_SERVER_LOG_STDERR=1``
 
 Of course, you can add an init script to start QGIS Server at boot time or whenever you want.
 For example with **systemd**, edit the file
@@ -375,8 +372,7 @@ For example with **systemd**, edit the file
     ;Environment="QGIS_SERVER_PARALLEL_RENDERING=1"
     ;Environment="QGIS_SERVER_MAX_THREADS=12"
     ;Environment="QGIS_SERVER_LOG_LEVEL=0"
-    ;Environment="DEBUG=1"
-    ;Environment="QGIS_SERVER_LOG_FILE=/var/log/qgis-server.log"
+    ;Environment="QGIS_SERVER_LOG_STDERR=1"
     ;; or use a file:
     ;EnvironmentFile=/etc/qgis-server/env
 


### PR DESCRIPTION
Remove QGIS_SERVER_LOG_FILE and QGIS_DEBUG from code snippets

@elpaso What do you think ?

If I'm not wrong, people running a debug build are just a few (geeks compiling QGIS ?). So these people should just read the table of available environment variable #6492 
So if QGIS_DEBUG doesn't have an effect for the majority of people, we shouldn't provide it in code snippets, as usually people do a copy/paste from here.

Backport to 3.16