### PR TITLE
Use latest release for dependencies

### DIFF
--- a/REQUIREMENTS.txt
+++ b/REQUIREMENTS.txt
@@ -1,5 +1,5 @@
-Sphinx==3.2.1
-sphinx-intl==2.0.1
+Sphinx
+sphinx-intl
 sphinx_rtd_theme
 sphinx-intl[transifex]
 sphinxext-rediraffe


### PR DESCRIPTION
I think we should follow dependencies upgrade and stick to a version only if there are issues with the newer releases.
We already use no version for the GitHub workflow and Transifex also seems to rely on a more recent version (eg, babel 2.9 vs 2.8) so this PR aligns them all...