### PR TITLE
Avoid table content overflow

### DIFF
--- a/themes/rtd_qgis/static/css/qgis_docs.css
+++ b/themes/rtd_qgis/static/css/qgis_docs.css
@@ -65,7 +65,7 @@ from https://rackerlabs.github.io/docs-rackspace/tools/rtd-tables.html */
    }
 
    .wy-table-responsive {
-      overflow: visible !important;
+      overflow: auto !important;
    }
 }
 


### PR DESCRIPTION
Prevents situation where text is out of the table (like https://docs.qgis.org/testing/en/docs/user_manual/working_with_vector/functions_list.html#sqlite-fetch-and-increment) by adding a scroll bar within the table.
Fix suggested in a [french forum](https://georezo.net/forum/viewtopic.php?pid=340191#p340191)