### PR TITLE
Do not keep old strings in generated po files

### DIFF
--- a/.github/workflows/pofiles.yml
+++ b/.github/workflows/pofiles.yml
@@ -36,6 +36,8 @@ jobs:
       run: |
           make gettext
           sphinx-intl update -p build/gettext -l en
+          # Remove obsolete strings from the generated *.po files
+          find locale/en/LC_MESSAGES/docs/ -type f -name '*.po' -exec sed -i '/^#~ /,/^$/d' {} \;
 
     - name: Commit the changes in the PO files      
       id: "auto-commit-action"

--- a/scripts/create_transifex_resources.sh
+++ b/scripts/create_transifex_resources.sh
@@ -20,8 +20,12 @@ make springclean
 
 # Regenerate the English PO files
 make gettext
-rm -r $SOURCEPOFILES
+# Only rm if really starting from scratch (might "break" metadata in transifex)
+# rm -r $SOURCEPOFILES
 sphinx-intl update -p build/gettext -l en
+
+# Clean generated translation *.po files from obsolete strings, if any
+find $SOURCEPOFILES -type f -name '*.po' -exec sed -i '/^#~ /,/^$/d' {} \;
 
 # Clean the .tx/config files from existing references, out of the main section
 # each reference is made of 5 lines and a blank line


### PR DESCRIPTION
Avoids pushing to transifex strings that were replaced and no longer exist in the rst file (translators already have enough to do)