### PR TITLE
Display :menuselection: arrow in PDF output using unicode format

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -119,9 +119,10 @@ html_favicon = 'static/common/qgis_logo.ico'
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ['static']
 
-## Set a bullet character for :menuselection: role
+# Set a bullet character for :menuselection: role
+# easier to identify in non latin languages, e.g. japanese
 from sphinx.roles import MenuSelection
-MenuSelection.BULLET_CHARACTER = '\N{BLACK RIGHT-POINTING POINTER}'
+MenuSelection.BULLET_CHARACTER = '\u25BA' #'\N{BLACK RIGHT-POINTING POINTER}'
 
 ## for rtd themes, creating a html_context for the version/language part
 
@@ -238,8 +239,9 @@ latex_use_parts = False
 # If false, no module index is generated.
 #latex_use_modindex = True
 
+
 latex_elements = {
-  # The paper size ('letterpaper' or 'a4paper').
+    # The paper size ('letterpaper' or 'a4paper').
     'papersize': 'a4paper',
 
     # The font size ('10pt', '11pt' or '12pt').
@@ -259,6 +261,7 @@ latex_elements = {
     \\newunicodechar{≤}{$\leq$}
     \\newunicodechar{π}{$\pi$}
     \\newunicodechar{㎡}{$m^2$}
+    \\newunicodechar{\u25BA}{$\u25BA$}
     \\newunicodechar{′}{\ensuremath{^{\prime}}}
     \\newunicodechar{″}{\ensuremath{^{\prime\prime}}}
     \\newunicodechar{​}{ }'''


### PR DESCRIPTION
Download a pdf doc and you get this kind of paragraph (note the arrow replacement in the menu path)
> ![image](https://user-images.githubusercontent.com/7983394/109927782-00473400-7cc5-11eb-8bc5-b091fec588a2.png)

This is like this since #6212 (4 months ago). Wonder how nobody reports this if there are any PDF user .
I don't know what is the proper/elegant fix but the changes here display the arrow now instead of interrogation mark (in English build)
> ![image](https://user-images.githubusercontent.com/7983394/109931634-60d87000-7cc9-11eb-8791-5177aa7afc05.png)
