### PR TITLE
Place the images in PDF where they are expected in the rst

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -261,7 +261,11 @@ latex_elements = {
     \\newunicodechar{㎡}{$m^2$}
     \\newunicodechar{′}{\ensuremath{^{\prime}}}
     \\newunicodechar{″}{\ensuremath{^{\prime\prime}}}
-    \\newunicodechar{​}{ }'''
+    \\newunicodechar{​}{ }''',
+
+    # Latex figure float alignment
+    # use ‘H’ to disable floating, and position the figures strictly in the order they appear in the source
+    'figure_align': 'H'
 }
 
 # Special case of korean that need different latex settings to work


### PR DESCRIPTION
avoiding accumulation of screenshots at the end of exercises, making them almost useless (iow download the training manual in pdf and try to understand any logic in the screenshot - I really wonder if there are people using the PDF...)