### PR TITLE
Use format function for an example

### DIFF
--- a/docs/user_manual/print_composer/composer_items/composer_legend.rst
+++ b/docs/user_manual/print_composer/composer_items/composer_legend.rst
@@ -144,10 +144,10 @@ e.g. ``Borough (3) - 850ha``:
    dialog
 #. Enter the following expression (*assuming symbol labels have not been edited*)::
 
-    concat( @symbol_label,
-            ' (', @symbol_count, ') - ',
-            round( aggregate(@layer, 'sum', $area, filter:= "type"=@symbol_label)/10000 ),
-            'ha'
+    format( '%1 (%2) - %3ha',
+            @symbol_label,
+            @symbol_count,
+            round( aggregate(@layer, 'sum', $area, filter:= "type"=@symbol_label)/10000 )
           )
 
 #. Press :guilabel:`OK`


### PR DESCRIPTION
Looks more legible and understandable than concat (with its isolated brackets)
_/me nitpicking_
