### PR TITLE
docs(pyqgis): add missing environments variables

### DIFF
--- a/docs/pyqgis_developer_cookbook/intro.rst
+++ b/docs/pyqgis_developer_cookbook/intro.rst
@@ -312,7 +312,7 @@ QGIS installation path:
 
 * on Linux: :command:`export PYTHONPATH=/<qgispath>/share/qgis/python`
 * on Windows: :command:`set PYTHONPATH=c:\\<qgispath>\\python`
-* on macOS: :command:`export PYTHONPATH=/<qgispath>/Contents/Resources/python`
+* on macOS: :command:`export PYTHONPATH=/Applications/QGIS$QGIS_VERSION.app/Contents/Resources/python; export QT_QPA_PLATFORM_PLUGIN_PATH=/Applications/QGIS$QGIS_VERSION.app/Contents/PlugIns/platforms/; export DYLD_INSERT_LIBRARIES=/Applications/QGIS$QGIS_VERSION.app/Contents/MacOS/lib/libsqlite3.dylib`
 
 Now, the path to the PyQGIS modules is known, but they depend on
 the ``qgis_core`` and ``qgis_gui`` libraries (the Python modules serve


### PR DESCRIPTION
Based on Peter's answer in https://github.com/qgis/QGIS/issues/40378

<!---
Include a few sentences describing the overall goals for this Pull Request.
 
A list of issues is at https://github.com/qgis/QGIS-Documentation/issues.
Add "fix #issuenumber" for each issue the PR fixes. The ticket(s) will be closed automatically.
If your PR doesn't fix entirely the ticket, only add the ticket(s) reference preceded by # character.
-->
Goal:
Easier start in using PyQgis with the standalone QGIS.app-macOS-Version

Ticket(s): #
<!---
Indicate whether the fix should be backported to previous release.
Replace the space between square brackets by a `x` to make it checked.
-->
- [ ] Backport to LTR documentation is required

<!---
Reviewing is a process done by community members, mostly on a volunteer basis.
We try to keep the overhead as small as possible and appreciate if you help us.
Please read carefully and ensure you comply with our writing guidelines at
https://docs.qgis.org/testing/en/docs/documentation_guidelines/index.html.
Feel free to ask in a comment or the (qgis-community-team mailing list)
[https://lists.osgeo.org/mailman/listinfo/qgis-community-team] if you have troubles with any item.
--->
Disclaimer: I haven't tested whether the issue also affects the non-standalone QGIS installation, since using the macOS standalone App-Bundle is so much more convenient to use (🙏)