### PR TITLE
Remove DISPLAY parameter from Apache qgis.demo.conf

### DIFF
--- a/docs/server_manual/getting_started.rst
+++ b/docs/server_manual/getting_started.rst
@@ -132,9 +132,6 @@ called :file:`qgis.demo.conf`, with this content:
    SetEnv PGSERVICEFILE /home/qgis/.pg_service.conf
    FcgidInitialEnv PGPASSFILE "/home/qgis/.pgpass"
 
-   # Tell QGIS Server instances to use a specific display number
-   FcgidInitialEnv DISPLAY ":99"
-
    # if qgis-server is installed from packages in debian based distros this is usually /usr/lib/cgi-bin/
    # run "locate qgis_mapserv.fcgi" if you don't know where qgis_mapserv.fcgi is
    ScriptAlias /cgi-bin/ /usr/lib/cgi-bin/


### PR DESCRIPTION
Goal:
Provide a working Apache `qgis.demo.conf` for setups where no X environment is available.

If there's no X environment, the current use of the `DISPLAY` parameter results in an _Internal Server Error_.

There's no information lost with this PR, the use of the `DISPLAY` parameter is explained later in the manual:
https://github.com/qgis/QGIS-Documentation/blob/master/docs/server_manual/getting_started.rst#with-apache



<!---
Indicate whether the fix should be backported to previous release.
Replace the space between square brackets by a `x` to make it checked.
-->
- [x] Backport to LTR documentation is required

<!---
Reviewing is a process done by community members, mostly on a volunteer basis.
We try to keep the overhead as small as possible and appreciate if you help us.
Please read carefully and ensure you comply with our writing guidelines at
https://docs.qgis.org/testing/en/docs/documentation_guidelines/index.html.
Feel free to ask in a comment or the (qgis-community-team mailing list)
[https://lists.osgeo.org/mailman/listinfo/qgis-community-team] if you have troubles with any item.
--->
