### PR TITLE
Update Logging information

### DIFF
--- a/docs/server_manual/config.rst
+++ b/docs/server_manual/config.rst
@@ -25,7 +25,7 @@ To log requests sent to the server, you have to set the following environment
 variables:
 
 - :ref:`QGIS_SERVER_LOG_LEVEL <qgis_server_log_level>`
-- :ref:`QGIS_SERVER_LOG_FILE <qgis_server_log_file>`
+- :ref:`QGIS_SERVER_LOG_PROFILE <qgis_server_log_profile>`
 - :ref:`QGIS_SERVER_LOG_STDERR <qgis_server_log_stderr>`
 
 
@@ -151,7 +151,9 @@ several ways to define these variables. This is fully described in
      - 0
      - All
 
-   * - QGIS_SERVER_LOG_PROFILE
+   * - .. _qgis_server_log_profile:
+
+       QGIS_SERVER_LOG_PROFILE
      - Add detailed profile information to the logs, only effective when QGIS_SERVER_LOG_LEVEL=0
      - /qgis/server_log_profile
      - All

--- a/docs/server_manual/config.rst
+++ b/docs/server_manual/config.rst
@@ -22,11 +22,14 @@ Logging
 =======
 
 To log requests sent to the server, you have to set the following environment
-variables:
+variable:
+
+- :ref:`QGIS_SERVER_LOG_STDERR <qgis_server_log_stderr>`
+
+With the following variables the logging can be further customized:
 
 - :ref:`QGIS_SERVER_LOG_LEVEL <qgis_server_log_level>`
 - :ref:`QGIS_SERVER_LOG_PROFILE <qgis_server_log_profile>`
-- :ref:`QGIS_SERVER_LOG_STDERR <qgis_server_log_stderr>`
 
 
 .. _`qgis-server-envvar`:
@@ -229,7 +232,7 @@ several ways to define these variables. This is fully described in
        pg_service.conf file:
 
        .. code-block:: bash
-		
+
         PGSERVICEFILE=/etc/pg_service.conf \
 	QUERY_STRING="MAP=/home/qgis/projects/world.qgs&SERVICE=WMS&REQUEST=GetCapabilities" \
 	/usr/lib/cgi-bin/qgis_mapserv.fcgi


### PR DESCRIPTION
<!---
Include a few sentences describing the overall goals for this Pull Request.
 
A list of issues is at https://github.com/qgis/QGIS-Documentation/issues.
Add "fix #issuenumber" for each issue the PR fixes. The ticket(s) will be closed automatically.
If your PR doesn't fix entirely the ticket, only add the ticket(s) reference preceded by # character.
-->
Goal:

Update Logging information:

- `QGIS_SERVER_LOG_FILE` is deprecated
- `QGIS_SERVER_LOG_PROFILE` is not mentioned

- [x] Backport to LTR documentation is required
<!---
Reviewing is a process done by community members, mostly on a volunteer basis.
We try to keep the overhead as small as possible and appreciate if you help us.
Please read carefully and ensure you comply with our writing guidelines at
https://docs.qgis.org/testing/en/docs/documentation_guidelines/index.html.
Feel free to ask in a comment or the (qgis-community-team mailing list)
[https://lists.osgeo.org/mailman/listinfo/qgis-community-team] if you have troubles with any item.
--->
