### PR TITLE
Walk through instructions on how to develop using git

### DIFF
--- a/docs/developers_guide/git.rst
+++ b/docs/developers_guide/git.rst
@@ -1,131 +1,31 @@
 .. _git_access:
 
-*************
- GIT Access
-*************
+*********************
+ Development Process
+*********************
 
 .. contents::
    :local:
 
-QGIS source code is handled through the `git <https://git-scm.com>`_
-version control system and hosted at https://github.com/qgis/QGIS.
-This section describes how to get started using and contributing to
-the QGIS repository. Before you can do this, you need to:
+As common in open source projects, contributions of code and documentation
+to the project are highly appreciated. The QGIS community is very supportive.
+This section describes the procedure for developing and merging your contributions
+in the QGIS project.
 
-#. have a `GitHub account <https://github.com/join>`_
-#. have your own copy of the `QGIS repository <https://github.com/qgis/QGIS>`_
-   (see `fork <https://docs.github.com/en/github/getting-started-with-github/fork-a-repo#fork-an-example-repository>`_)
-#. have a :ref:`git client installed <installing_git>` on your system
-#. set up your `git environment <https://docs.github.com/en/github/getting-started-with-github/set-up-git#setting-up-git>`_
-#. and have fun!
-
-.. _installing_git:
-
-Installing git
-==============
-
-The git project provides recent versions of the software for most platforms.
-Follow the instructions at https://git-scm.com/downloads to get the copy
-corresponding to your OS and architecture.
-There, it's also possible to install a git GUI client to browse and manage
-your repositories (most of the time, it will install git if not yet available).
-
-
-Accessing the Repository
-=========================
-
-
-To clone QGIS master:
-
-.. code-block:: bash
-
-  git clone git://github.com/qgis/QGIS.git
-
-
-Check out a branch
+A git based project
 ===================
-
-To check out a branch, for example the release 2.6.1 branch do:
-
-.. code-block:: bash
-
-  cd QGIS
-  git fetch
-  git branch --track origin release-2_6_1
-  git checkout release-2_6_1
-
-To check out the master branch:
-
-.. code-block:: bash
-
-  cd QGIS
-  git checkout master
-
-.. note:: In QGIS we keep our most stable code in the current release branch.
-  ``master`` branch contains code for the so called 'unstable' release series. Periodically
-  we will branch a release off master, and then continue stabilisation and selective
-  incorporation of new features into master.
-
-  See the :source:`INSTALL <INSTALL.md>` file in the source tree for specific instructions
-  on building development versions.
-
-
-QGIS documentation sources
-===========================
-
-If you're interested in checking out QGIS documentation sources:
-
-.. code-block:: bash
-
-  git clone git@github.com:qgis/QGIS-Documentation.git
-
-You can also take a look at the readme included with the documentation repo
-for more information.
-
-
-QGIS website sources
-=====================
-
-If you're interested in checking out QGIS website sources:
-
-.. code-block:: bash
-
-  git clone git@github.com:qgis/QGIS-Website.git
-
-You can also take a look at the readme included with the website repo
-for more information.
-
-
-GIT Documentation
-==================
-
-
-See the following sites for information on becoming a GIT master.
-
-* https://git-scm.com/book/en/v2
-* http://gitready.com
-* https://help.github.com/en
-
-
-Development process
-===================
-
-As common in open source projects contributions of code and documentation
-to the project are highly appreciated. The QGIS community is very supportive. 
-
-
-Development in branches
------------------------
 
 The complexity of the QGIS source code has increased considerably during the
 last years. Therefore it is hard to anticipate the side effects that the
 addition of a feature will have. In the past, the QGIS project had very long
 release cycles because it was a lot of work to reestablish the stability of the
 software system after new features were added. To overcome these problems, QGIS
-switched to a development model where new features are coded in GIT branches
-first and merged to master (the main branch) when they are finished and stable.
-This section describes the procedure for branching and merging in the QGIS
-project.
+switched to a development model using the `git <https://git-scm.com>`_ version
+control system: new features are coded in the contributor branches first and
+merged to the QGIS master (the main branch) when they are finished and stable.
+
+QGIS source code is hosted at https://github.com/qgis/QGIS.
+
 
 Roles
 -----
@@ -135,70 +35,181 @@ allowed to contribute by forking the repository and have the role 'contributor'.
 Core developers are 'collaborators' and can merge branches into the upstream and
 official repository.
 
+
+Environment
+------------
+
+To get started using and contributing to the QGIS repository, you need to:
+
+#. have a `GitHub account <https://github.com/join>`_
+#. make your own copy of the `QGIS repository <https://github.com/qgis/QGIS>`_
+   (see `fork <https://docs.github.com/en/github/getting-started-with-github/fork-a-repo#fork-an-example-repository>`_)
+#. have a :ref:`git client installed <installing_git>` on your system
+#. set up your `git environment <https://docs.github.com/en/github/getting-started-with-github/set-up-git#setting-up-git>`_
+#. and have fun!
+
+
+.. _installing_git:
+
+Installing git
+--------------
+
+The git project provides recent versions of the software for most platforms.
+Follow the instructions at https://git-scm.com/downloads to get and install
+the copy corresponding to your OS and architecture.
+There, it's also possible to install a git GUI client to browse and manage
+your repositories (most of the time, it will install git if not yet available).
+
+Development in branches
+=======================
+
 Contributions to development
 ----------------------------
 
-Once signed up on GitHub you can engage as a contributor. You can contribute by
-forking the repository and initiating a pull request. To do that follow these
-generic steps:
+Once signed up on GitHub and having forked the repository, you can engage as
+a contributor.
 
-1. Fork the repository on GitHub
-2. (Optional) Clone it onto your local computer and set up the build environment
-3. Create a new branch and do the edits for development
-4. Commit your changes and push your branch back to the remote fork on GitHub.
+.. note:: Contributions to QGIS code can be done from your forked repository on
+  the GitHub website. The new code will automatically be built by the test environment.
+  But this workflow can quickly reveal its limits when you want to provide complex
+  changes. Instructions below will assume a local clone.
+
+You can contribute by initiating a pull request. To do that follow these generic steps:
+
+#. :ref:`Clone your repository <access_repository>` onto your local computer and
+   set up the build environment
+#. Create a new branch and do the edits for development
+#. Commit your changes and push your branch back to the remote fork on GitHub.
    A pull request is then offered as web link (URL) right after.
-5. Open a pull request (PR) asking to pull the commit(s) from your branch into
+#. Open a pull request (PR) asking to pull the commit(s) from your branch into
    the master branch into the upstream repository.
-6. A review process is being started informing other contributors and collaborators
+#. A review process is being started informing other contributors and collaborators
    about your pull request. You should be reactive to their comments and suggestions.
 
-.. note:: Regarding (optional) step 2: Contributions to QGIS code can also be
-  done on the GitHub website without a local clone. The new code will automatically
-  be built by the build environment.
 
 .. note:: A more detailed Github's Fork & Pull Workflow is available at
   https://reflectoring.io/github-fork-and-pull/
 
+.. note:: Most of the QGIS projects (website, documentation, pyQGIS API, plugins...)
+ are available in the `project GitHub page <https://github.com/qgis>`_ and can
+ get contributions, following the same process.
+
+.. _access_repository:
+
+Accessing the Repository
+------------------------
+
+To be able to interact from your local disk with both your remote fork
+and the QGIS upstream repositories, you need to:
+
+#. Make a clone of your copy on your local disk
+
+   .. code-block:: bash
+
+     cd path/to/store/the/repository
+     git clone https://github.com/<yourName>/QGIS.git
+
+#. Connect the QGIS main repository (we will name it ``upstream``) to yours
+
+   .. code-block:: bash
+
+     git remote add upstream https://github.com/qgis/QGIS.git
+
+#. Check connected remote repositories
+
+   .. code-block:: bash
+
+     git remote -v
+     # origin	https://github.com/<YourName>/QGIS.git (fetch)
+     # origin	https://github.com/<YourName>/QGIS.git (push)
+     # upstream	https://github.com/qgis/QGIS.git (fetch)
+     # upstream	https://github.com/qgis/QGIS.git (push)
+
+   Your online repository is now accessible from your local drive and
+   you can interact with it using the name ``origin``.
+   Whenever you'd like to fetch changes from the qgis/QGIS repository,
+   use ``upstream``.
+
+.. note:: In QGIS we keep our most stable code in the current release branch.
+  ``master`` branch contains code for the so called 'unstable' release series. Periodically
+  we will branch a release off master, and then continue stabilisation and selective
+  incorporation of new features into master.
+
+  See the :source:`INSTALL <INSTALL.md>` file in the source tree for specific instructions
+  on building development versions.
 
 Procedure
 ---------
 
-- Initial announcement on mailing list:
+#. Initial announcement on mailing list or issues repo:
     Before starting, make an announcement on the developer mailing list to see if
-    another developer is already working on the same feature. Also contact the
-    technical advisor of the project steering committee (PSC). If the new feature
-    requires any changes to the QGIS architecture, a request for comment (RFC) is
-    needed.
+    another developer is already working on the same feature. You can also mention
+    your interest as a comment in the issue report if one exists in the repo.
+    If the new feature requires any changes to the QGIS architecture, a `QGIS
+    Enhancement Proposal (QEP) <https://github.com/qgis/QGIS-Enhancement-Proposals/>`_
+    is needed.
 
-Create a branch:
-Create a new GIT branch for the development of the new feature.
+#. Create a branch in your local repository:
+    Create a new git branch for the development of the new feature, based on latest
+    state of the master branch.
 
-.. code-block:: bash
+    .. code-block:: bash
 
-  git checkout -b newfeature
+      git fetch upstream master
+      git checkout -b newfeature upstream/master
 
-Now you can start developing. If you plan to do extensive on that branch, would
-like to share the work with other developers, and have write access to the
-upstream repo, you can push your repo up to the QGIS official repo by doing:
+#. Now you can start developing:
+    Code your changes in your local disk with your usual IDE.
+    Remember to write tests suite for your modifications, when appropriate.
 
-.. code-block:: bash
+#. Commit your changes to the git repo:
+    When making a commit, put a descriptive comment and rather do
+    several small commits if the changes across a number of files are unrelated.
+    Conversely we prefer you to group related changes into a single commit.
 
-  git push origin newfeature
+    .. code-block:: bash
+
+      git add path/to/your/files
+      git commit -m "Add a comment describing your nice feature"
+
+#. Now, you may want to share your work with QGIS community members.
+   Push your new feature up to your online fork repository by doing:
+
+   .. code-block:: bash
+
+     git push origin newfeature
+
+   .. note:: If the branch already exists, your changes will be pushed into it,
+     otherwise, it is created.
+
+#. :ref:`Submit your changes <submit_patch>` with a pull-request
+    With opening the pull-request, the automated test suite is triggered and
+    checks whether your changes follow the coding guidelines of QGIS and do
+    not break any existing feature.
+    You'd need to fix any reported issues before your branch is merged upstream.
+
+    .. tip:: We use `GitHub actions <https://docs.github.com/en/actions>`_
+      to manage the tests to be run on the repository. For convenience, you can
+      enable the actions on your repository so that the tests are run when you
+      push the changes. You'd then open the pull request after they all passed,
+      making the review process more efficient.
+
+#. Rebase to upstream master regularly:
+    It is recommended to rebase to incorporate the changes in master to the
+    branch on a regular basis. This makes it easier to merge the branch back to
+    master later. After a rebase you need to ``git push -f`` to your forked repo.
+
+    .. code-block:: bash
+
+      git pull --rebase upstream master
+      git push -f origin newfeature
 
 
-.. note:: If the branch already exists your changes will be pushed into it.
+.. note:: See the following sites for information on becoming a GIT master.
 
-  Rebase to master regularly:
-  It is recommended to rebase to incorporate the changes in master to the
-  branch on a regular basis. This makes it easier to merge the branch back to
-  master later. After a rebase you need to ``git push -f`` to your forked repo.
-
-.. note:: Never ``git push -f`` to the origin repository! Only use this for your working branch.
-
-.. code-block:: bash
-
-  git rebase master
-
+ * https://git-scm.com/book/en/v2
+ * http://gitready.com
+ * https://help.github.com/en
 
 Testing before merging back to master
 --------------------------------------
@@ -379,9 +390,3 @@ Always check that everything compiles before making any commits / pull
 requests. Try to be aware of possible breakages your commits may cause for
 people building on other platforms and with older / newer versions of
 libraries.
-
-When making a commit, your editor (as defined in $EDITOR environment variable)
-will appear and you should make a comment at the top of the file (above the
-area that says 'don't change this'). Put a descriptive comment and rather do
-several small commits if the changes across a number of files are unrelated.
-Conversely we prefer you to group related changes into a single commit.


### PR DESCRIPTION
* Align terms (origin, upstream) with the GitHub help. Fixes https://github.com/qgis/QGIS-Website/issues/359
* Reorder instructions to avoid repetition, and make the learning process smoother
* Remove confusing instructions regarding core devs: let's target the contributor lambda and explain the situations he may face. And I hope that before someone is given write access to the repo, we ensure he has enough knowledge and practice with git.

This is just a cleanup. There might be more details to provide to (first time) contributors for a better onboarding: tests, backport process, review...