### PR TITLE
Expand and customize the introduction of QGIS documentation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,8 @@ LANG            = en
 # currently we are building for the following languages, if you want yours to be build: ask!
 LANGUAGES       = en # bg cs de es fi fr id it ja ko nl pt_BR pt_PT ro ru tr zh_Hant zh_Hans
 SPHINXOPTS      =
-SPHINXINTLOPTS  = $(SPHINXOPTS) -D language=$(LANG)
+# Use the tag i18n to filter text based on whether we are translating or not
+SPHINXINTLOPTS  = $(SPHINXOPTS) -D language=$(LANG) -t i18n
 SPHINXBUILD     ?= sphinx-build
 SPHINXINTL      ?= sphinx-intl
 SOURCEDIR       = .

--- a/conf.py
+++ b/conf.py
@@ -150,6 +150,10 @@ html_context = {
 if html_context['isTesting'] or html_context['outdated']:
   html_css_files = ['css/qgis_topbar.css']
 
+# Add custom tag to allow display of text based on the branch status
+if html_context['isTesting']:
+  tags.add('testing')
+
 supported_languages = cfg['supported_languages'].replace(' ','').split(',')
 version_list = cfg['version_list'].replace(' ','').split(',')
 docs_url = 'https://docs.qgis.org/'

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,9 +1,74 @@
 
+**********************************
+ Documentation for QGIS |version|
+**********************************
 
-Documentation for QGIS |version|
---------------------------------
+.. only:: not i18n
 
-QGIS has a lot of documentation, partly translated. 
+  .. note:: QGIS documentation is available in various languages and versions.
+      Expand the :guilabel:`QGIS Documentation` menu at the bottom of the
+      sidebar to see the list.
+
+.. only:: not testing
+
+  .. tip:: This is the documentation for the QGIS |version| Long Term Release.
+      Looking for the documentation of more recent versions, including the
+      development branch? Have a look at the `testing docs <https://docs.qgis.org/en/testing>`_.
+      You can also browse the documentation for the previous stable
+      versions at https://docs.qgis.org/.
+
+.. only:: i18n
+
+  .. note:: This documentation is translated from the original English version
+    by community members on `Transifex <https://transifex.com/qgis/qgis-documentation>`_.
+
+    Depending on the translation effort's completion level, you may
+    find paragraphs or whole pages which are still in English. You can
+    help the community by providing new translations or reviewing existing
+    ones on Transifex.
+
+    For the time being, localized translations are only available for
+    the Long Term releases branch, but should be suitable to learn
+    how to use QGIS nevertheless.
+
+Welcome to the official documentation of `QGIS <https://qgis.org>`_,
+the free and open source community-driven GIS software!
+If you are new to this documentation, the table of contents below
+and in the sidebar should let you easily access the documentation
+for your topic of interest. You can also use the search function
+in the top left corner.
+
+.. todo: Actually, it could be nice to refactor the first chapters of the docs
+ (preamble, foreword, features, conventions) to minimize repetition and have
+ an introductory chapter for the whole documentation, not within User manual.
+ Also we can consider adding an overview of how the docs is structured and what
+ people should expect to find in each document (inspired by
+ https://docs.godotengine.org/en/stable/about/introduction.html#doc-about-intro).
+
+
+Besides the online documentation, the QGIS project also provides materials that
+you can download for offline reading. They are accessible from the
+:guilabel:`QGIS Documentation` menu at the bottom of the sidebar, as:
+
+* HTML zipped files that you can extract and :ref:`use as paths <doc_config_path>`
+  from within the software
+* PDF files
+
+.. note:: QGIS is an open source project developed by a community of contributors.
+    The documentation team can always use your feedback and help to improve
+    the tutorials and features description. If you don't understand something,
+    or cannot find what you are looking for in the docs, help us make the
+    documentation better by letting us know:
+
+    * Submit an issue or pull request on the `GitHub repository
+      <https://github.com/qgis/QGIS-Documentation/>`_,
+    * Help us `translate the documentation
+      <https://qgis.org/en/site/getinvolved/translate.html>`_ into your language
+    * Or talk to us on either the `qgis-community-team
+      <https://lists.osgeo.org/mailman/listinfo/qgis-community-team>`_ mailing-list,
+      the `#qgis <http://webchat.freenode.net/?channels=#qgis>`_ channel on IRC
+      or the `#qgis:matrix.org <http://matrix.to/#/#qgis:matrix.org>`_ room!
+
 
 Please have a look into one of the documents below.
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -3,12 +3,6 @@
  Documentation for QGIS |version|
 **********************************
 
-.. only:: not i18n
-
-  .. note:: QGIS documentation is available in various languages and versions.
-      Expand the :guilabel:`QGIS Documentation` menu at the bottom of the
-      sidebar to see the list.
-
 .. only:: testing
 
   .. attention::  You are reading the testing version of QGIS documentation,
@@ -18,11 +12,13 @@
 
 .. only:: not testing
 
-  .. tip:: This is the documentation for the QGIS |version| Long Term Release.
-      Looking for the documentation of more recent versions, including the
-      development branch? Have a look at the `testing docs <https://docs.qgis.org/en/testing>`_.
-      You can also browse the documentation for the previous stable
-      versions at https://docs.qgis.org/.
+  .. hint:: Looking for documentation of versions newer than the
+    |version| Long Term Release? Have a look at the
+    `testing docs <https://docs.qgis.org/en/testing>`_.
+
+.. note:: QGIS documentation is available in various languages and versions.
+  Expand the :guilabel:`QGIS Documentation` menu at the bottom of the
+  sidebar to see the list.
 
 .. only:: i18n
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -9,6 +9,13 @@
       Expand the :guilabel:`QGIS Documentation` menu at the bottom of the
       sidebar to see the list.
 
+.. only:: testing
+
+  .. attention::  You are reading the testing version of QGIS documentation,
+    an ongoing work which targets the latest changes in the software and may
+    document features not available or compatible with QGIS |CURRENT| Long
+    Term Release.
+
 .. only:: not testing
 
   .. tip:: This is the documentation for the QGIS |version| Long Term Release.
@@ -95,3 +102,12 @@ Please have a look into one of the documents below.
    Developers Guide <developers_guide/index>
 
 * :ref:`genindex`
+
+
+.. Substitutions definitions - AVOID EDITING PAST THIS LINE
+   This will be automatically updated by the find_set_subst.py script.
+   If you need to create a new substitution manually,
+   please add it also to the substitutions.txt file in the
+   source folder.
+
+.. |CURRENT| replace:: 3.16

--- a/docs/user_manual/introduction/qgis_configuration.rst
+++ b/docs/user_manual/introduction/qgis_configuration.rst
@@ -163,6 +163,8 @@ in a QGIS path.
 Add or Remove :guilabel:`Path(s) to search for additional C++
 plugin libraries`.
 
+.. _doc_config_path:
+
 **Documentation paths**
 
 Add or Remove :guilabel:`Documentation Path(s)` to use for QGIS help. By default,


### PR DESCRIPTION
with some details on what QGIS is, how to contribute and what to expect from the docs
This is highly inspired from the godot-engine project: see [en](https://docs.godotengine.org/en/stable/index.html) vs [fr](https://docs.godotengine.org/fr/stable/index.html) vs [latest](https://docs.godotengine.org/en/latest/index.html). You don't get the same text depending on what version or language you are reading.

Feedback are more than expected