### PR TITLE
Update section on running qgis_mapserv.fcgi for the first time

### DIFF
--- a/docs/server_manual/getting_started.rst
+++ b/docs/server_manual/getting_started.rst
@@ -42,6 +42,8 @@ To test the installation, run:
  
 If you get the following output, the server is correctly installed
 
+.. note:: Depending on the version of QGIS, you might see slightly different output reported when your run ``qgis_mapserv.fcgi``
+
 .. code-block::
 
     QFSFileEngine::open: No file name specified
@@ -56,6 +58,29 @@ If you get the following output, the server is correctly installed
     <ServiceExceptionReport version="1.3.0" xmlns="https://www.opengis.net/ogc">
      <ServiceException code="Service configuration error">Service unknown or unsupported</ServiceException>
     </ServiceExceptionReport>
+
+.. note:: As seen below, QGIS 3.16.x reports a Status 400 code, which correctly identifies the request has failed because there is no active http session.  This is not a bug and indicates the server is functioning properly
+
+.. code-block::
+
+    Application path not initialized
+    Application path not initialized
+    Warning 1: Unable to find driver ECW to unload from GDAL_SKIP environment variable.
+    Warning 1: Unable to find driver ECW to unload from GDAL_SKIP environment variable.
+    Warning 1: Unable to find driver JP2ECW to unload from GDAL_SKIP environment variable.
+    "Loading native module /usr/lib/qgis/server/libdummy.so"
+    "Loading native module /usr/lib/qgis/server/liblandingpage.so"
+    "Loading native module /usr/lib/qgis/server/libwcs.so"
+    "Loading native module /usr/lib/qgis/server/libwfs.so"
+    "Loading native module /usr/lib/qgis/server/libwfs3.so"
+    "Loading native module /usr/lib/qgis/server/libwms.so"
+    "Loading native module /usr/lib/qgis/server/libwmts.so"
+    QFSFileEngine::open: No file name specified
+    Content-Length: 102
+    Content-Type: application/json
+    Server:  QGIS FCGI server - QGIS version 3.16.6-Hannover
+    Status:  400
+    [{"code":"Bad request error","description":"Requested URI does not match any registered API handler"}]
 
 Let's add a sample project. You can use your own, or one from
 `Training demo data <https://github.com/qgis/QGIS-Training-Data/>`_:

--- a/docs/server_manual/getting_started.rst
+++ b/docs/server_manual/getting_started.rst
@@ -42,7 +42,7 @@ To test the installation, run:
  
 If you get the following output, the server is correctly installed
 
-.. note:: Depending on the version of QGIS, you might see slightly different output reported when your run ``qgis_mapserv.fcgi``
+.. note:: Depending on the version of QGIS, you might see slightly different output reported when you run ``qgis_mapserv.fcgi``
 
 .. code-block::
 

--- a/docs/server_manual/getting_started.rst
+++ b/docs/server_manual/getting_started.rst
@@ -59,7 +59,9 @@ If you get the following output, the server is correctly installed
      <ServiceException code="Service configuration error">Service unknown or unsupported</ServiceException>
     </ServiceExceptionReport>
 
-.. note:: As seen below, QGIS 3.16.x reports a Status 400 code, which correctly identifies the request has failed because there is no active http session.  This is not a bug and indicates the server is functioning properly
+.. note:: As seen below, QGIS reports a Status 400 code, which correctly
+  identifies the request has failed because there is no active http session.
+  This is not a bug and indicates the server is functioning properly.
 
 .. code-block::
 


### PR DESCRIPTION
The existing documentation is confusing about what to expect when running `/usr/lib/cgi-bin/qgis_mapserv.fcgi` for the first time.  Since QGIS 3.16.x, the server will produce a 400 response that suggests it is not working, when in fact it is.  See my answer here: https://gis.stackexchange.com/a/394171/181982

<!---
Include a few sentences describing the overall goals for this Pull Request.
 
A list of issues is at https://github.com/qgis/QGIS-Documentation/issues.
Add "fix #issuenumber" for each issue the PR fixes. The ticket(s) will be closed automatically.
If your PR doesn't fix entirely the ticket, only add the ticket(s) reference preceded by # character.
-->
Goal:

Ticket(s): #
<!---
Indicate whether the fix should be backported to previous release.
Replace the space between square brackets by a `x` to make it checked.
-->
- [ ] Backport to LTR documentation is required

<!---
Reviewing is a process done by community members, mostly on a volunteer basis.
We try to keep the overhead as small as possible and appreciate if you help us.
Please read carefully and ensure you comply with our writing guidelines at
https://docs.qgis.org/testing/en/docs/documentation_guidelines/index.html.
Feel free to ask in a comment or the (qgis-community-team mailing list)
[https://lists.osgeo.org/mailman/listinfo/qgis-community-team] if you have troubles with any item.
--->
