### PR TITLE
Dedicate section for embedded file selector

### DIFF
--- a/docs/user_manual/introduction/general_tools.rst
+++ b/docs/user_manual/introduction/general_tools.rst
@@ -2295,6 +2295,31 @@ following symbol options, together with the features of the
 * :guilabel:`Copy Symbol` from the current item
 * :guilabel:`Paste Symbol` to the current item, speeding configuration
 
+.. index:: Embedded file
+.. _embedded_file_selector:
+
+Remote or embedded file selector
+--------------------------------
+
+Along with the file selector widget, the :guilabel:`...` button will sometimes
+show a drop-down arrow. This is usually available when using:
+
+* an SVG file in a symbol or a label
+* a raster image to customize symbols, labels, textures or decorations
+
+Pressing the arrow will provide you with a menu to:
+
+* load the file from the file system: the file is identified through the file path and
+  QGIS needs to resolve the path in order to display the corresponding image
+* load the file from a remote URL: as above, the image will only be loaded on
+  successful retrieval of the remote resource
+* embed the file into the item: the file is embedded inside
+  the current project, style database, or print layout template.
+  The file is then always rendered as part of the item.
+  This is a convenient way to create self-contained projects with custom symbols
+  which can be easily shared amongst different users and installations of QGIS.
+* extract the embedded file from the widget and save it on disk.
+
 .. index:: Font selection; Text format
 .. _font_selector:
 

--- a/docs/user_manual/introduction/qgis_configuration.rst
+++ b/docs/user_manual/introduction/qgis_configuration.rst
@@ -155,24 +155,8 @@ Add or Remove :guilabel:`Path(s) to search for Scalable Vector Graphic (SVG)
 symbols`. These SVG files are then available to symbolize or label the features
 or decorate your map composition.
 
-When using an SVG file in a symbol or a label, QGIS allows you to:
-
-* load the file from the file system: the file is identified through the file path and
-  QGIS needs to resolve the path in order to display the corresponding image
-* load the file from a remote URL: as above, the image will only be loaded on successful
-  retrieval of the remote resource
-* embed the SVG file into the item: the file is embedded inside
-  the current project, style database, or print layout template.
-  The SVG file is then always rendered as part of the item.
-  This is a convenient way to create self-contained projects with custom SVG symbols
-  which can be easily shared amongst different users and installations of QGIS.
-
-  It is also possible to extract the embedded SVG file from a symbol or label
-  and save it on disk.
-
-.. note:: The above mentioned options for loading and storing an SVG file in a project
- are also applicable to raster images you may want to use for customizing
- symbols, labels or decorations.
+Also read :ref:`embedded_file_selector` for different ways to refer to svg files
+in a QGIS path.
 
 **Plugin paths**
 

--- a/docs/user_manual/style_library/label_settings.rst
+++ b/docs/user_manual/style_library/label_settings.rst
@@ -226,7 +226,7 @@ the :guilabel:`Shape` type. It can be:
 * a regular shape such as :guilabel:`Rectangle`, :guilabel:`Square`,
   :guilabel:`Circle` or :guilabel:`Ellipse`
 * an :guilabel:`SVG` symbol from a file, a URL or embedded in the project
-  or style database (:ref:`more details <svg_paths>`)
+  or style database (:ref:`more details <embedded_file_selector>`)
 * or a :guilabel:`Marker Symbol` you can create or select from the
   :ref:`symbol library <vector_marker_symbols>`.
 

--- a/docs/user_manual/style_library/symbol_selector.rst
+++ b/docs/user_manual/style_library/symbol_selector.rst
@@ -216,7 +216,7 @@ Appropriate for point geometry features, marker symbols have several
 
 * **Raster image marker**: use an image (:file:`PNG`, :file:`JPG`, :file:`BMP` ...)
   as marker symbol. The image can be a file on the disk, a remote URL
-  or embedded in the style database (:ref:`more details <svg_paths>`).
+  or embedded in the style database (:ref:`more details <embedded_file_selector>`).
   Width and height of the image can be set independently or using the
   |lockedGray| :sup:`Lock aspect ratio`. The size can be set using any of the
   :ref:`common units <unit_selector>` or as a percentage of the image's original
@@ -230,7 +230,7 @@ Appropriate for point geometry features, marker symbols have several
   symbol. Width and height of the symbol can be set independently or using the
   |lockedGray| :sup:`Lock aspect ratio`. Each SVG file colors and stroke can
   also be adapted. The image can be a file on the disk, a remote URL or
-  embedded in the style database (:ref:`more details <svg_paths>`).
+  embedded in the style database (:ref:`more details <embedded_file_selector>`).
 
   See :ref:`svg_symbol` section to parametrize an SVG symbol.
 
@@ -411,7 +411,7 @@ symbol layer types:
 
 * **Raster image fill**: fills the polygon with tiles from a raster image (:file:`PNG`
   :file:`JPG`, :file:`BMP` ...). The image can be a file on the disk, a remote URL
-  or an embedded file encoded as a string (:ref:`more details <svg_paths>`).
+  or an embedded file encoded as a string (:ref:`more details <embedded_file_selector>`).
   Options include (data defined) opacity, image width, coordinate mode (object
   or viewport), rotation and offset. The image width can be set using any of the
   :ref:`common units <unit_selector>` or as a percentage of the original size.


### PR DESCRIPTION
With more and more (raster, 3D) features being "embeddable" in the project,
it looks weird to point to an SVG dedicated section (in config docs).
Let's make a generic section any data type could point to.