### PR TITLE
"Output extent" parameter for Raster calculator (qgis:rastercalculator) algorithm is optional

### DIFF
--- a/docs/user_manual/processing_algs/qgis/rasteranalysis.rst
+++ b/docs/user_manual/processing_algs/qgis/rasteranalysis.rst
@@ -1203,6 +1203,8 @@ Parameters
        the selected reference layer(s) will be used.
        The cell size will be the same for the X and Y axes.
    * - **Output extent (xmin, xmax, ymin, ymax)**
+
+       Optional
      - ``EXTENT``
      - [extent]
      - Extent of the output raster layer.


### PR DESCRIPTION
<!---
Include a few sentences describing the overall goals for this Pull Request.
 
A list of issues is at https://github.com/qgis/QGIS-Documentation/issues.
Add "fix #issuenumber" for each issue the PR fixes. The ticket(s) will be closed automatically.
If your PR doesn't fix entirely the ticket, only add the ticket(s) reference preceded by # character.
-->
Goal:
Specify that the "Output extent" parameter for Raster calculator (qgis:rastercalculator) algorithm is optional.

See: https://github.com/qgis/QGIS/blob/ac6732db42e8f0db8305b00a616430bd310c0360/python/plugins/processing/algs/qgis/RasterCalculator.py#L87-L89

<!---
Indicate whether the fix should be backported to previous release.
Replace the space between square brackets by a `x` to make it checked.
-->
- [x] Backport to LTR documentation is required

<!---
Reviewing is a process done by community members, mostly on a volunteer basis.
We try to keep the overhead as small as possible and appreciate if you help us.
Please read carefully and ensure you comply with our writing guidelines at
https://docs.qgis.org/testing/en/docs/documentation_guidelines/index.html.
Feel free to ask in a comment or the (qgis-community-team mailing list)
[https://lists.osgeo.org/mailman/listinfo/qgis-community-team] if you have troubles with any item.
--->
