### PR TITLE
Update qgis_process documentation to show how arrays may be passed

### DIFF
--- a/docs/user_manual/processing/standalone.rst
+++ b/docs/user_manual/processing/standalone.rst
@@ -40,7 +40,7 @@ The command ``help`` can be used to get further information about commands or al
 
    qgis_process help qgis:regularpoints
 
-Where a paramater accepts a list of values, set the same variable multiple times.
+Where a parameter accepts a list of values, set the same variable multiple times.
 
 .. code-block:: bash
 

--- a/docs/user_manual/processing/standalone.rst
+++ b/docs/user_manual/processing/standalone.rst
@@ -39,3 +39,9 @@ The command ``help`` can be used to get further information about commands or al
 .. code-block:: bash
 
    qgis_process help qgis:regularpoints
+
+Where a paramater accepts a list of values, set the same variable multiple times.
+
+.. code-block:: bash
+
+   qgis_process run native:mergevectorlayers -- LAYERS=input1.shp LAYERS=input2.shp OUTPUT=merged.shp


### PR DESCRIPTION
https://github.com/qgis/QGIS/pull/34617#issuecomment-703939137 shows this is unclear for users, especially since the qgis processing GUI doesn't show the command line to use, so including this in the documentation would be helpful for users.

- [x] Backport to LTR documentation is required
not required, but it could be