### PR TITLE
fix wrong parameter name in gdal:cliprasterbymasklayer

### DIFF
--- a/docs/user_manual/processing_algs/gdal/rasterextraction.rst
+++ b/docs/user_manual/processing_algs/gdal/rasterextraction.rst
@@ -159,7 +159,7 @@ Parameters
      - [raster]
      - The input raster
    * - **Mask layer**
-     - ``EXTENT``
+     - ``MASK``
      - [vector: polygon]
      - Vector mask for clipping the raster
    * - **Source CRS**


### PR DESCRIPTION
The ``gdal:cliprasterbymasklayer`` algorithm has one of its paramaters named wrong in the documentation.
This PR replaces the "EXTENT" with the correct "MASK" parameter name.

<!---
Include a few sentences describing the overall goals for this Pull Request.
 
A list of issues is at https://github.com/qgis/QGIS-Documentation/issues.
Add "fix #issuenumber" for each issue the PR fixes. The ticket(s) will be closed automatically.
If your PR doesn't fix entirely the ticket, only add the ticket(s) reference preceded by # character.
-->

<!---
Indicate whether the fix should be backported to previous release.
Replace the space between square brackets by a `x` to make it checked.
-->
- [x] Backport to LTR documentation is requested

<!---
Reviewing is a process done by community members, mostly on a volunteer basis.
We try to keep the overhead as small as possible and appreciate if you help us.
Please read carefully and ensure you comply with our writing guidelines at
https://docs.qgis.org/testing/en/docs/documentation_guidelines/index.html.
Feel free to ask in a comment or the (qgis-community-team mailing list)
[https://lists.osgeo.org/mailman/listinfo/qgis-community-team] if you have troubles with any item.
--->
