### PR TITLE
Add 'Results group name' parameter to Configuration section

### DIFF
--- a/docs/user_manual/processing/configuration.rst
+++ b/docs/user_manual/processing/configuration.rst
@@ -47,7 +47,7 @@ The :guilabel:`General` block contains a number of interesting parameters.
   :guilabel:`Layers` panel, set a group name for this parameter. The group
   may exist already or not. QGIS will add all output layers to such a group.
   By default, this parameter is empty, so all output layers are added to 
-  different places in the :guilabel:`Layers` panel, depending on the layer
+  different places in the :guilabel:`Layers` panel, depending on the item
   that is active when running an algorithm.
   Note that output layers will be loaded to the :guilabel:`Layers` panel 
   only if :guilabel:`Open output file after running algorithm` is checked 

--- a/docs/user_manual/processing/configuration.rst
+++ b/docs/user_manual/processing/configuration.rst
@@ -42,6 +42,16 @@ The :guilabel:`General` block contains a number of interesting parameters.
   Notice that, if the output is saved to a temporary file, the filename
   of this temporary file is usually a long and meaningless one intended
   to avoid collision with other already existing filenames.
+* :guilabel:`Results group name`.
+  If you want to obtain all processing result layers in a group in the
+  :guilabel:`Layers` panel, set a group name for this parameter. The group
+  may exist already or not. QGIS will add all output layers to such a group.
+  By default, this parameter is empty, so all output layers are added to 
+  different places in the :guilabel:`Layers` panel, depending on the layer
+  that is active when running an algorithm.
+  Note that output layers will be loaded to the :guilabel:`Layers` panel 
+  only if :guilabel:`Open output file after running algorithm` is checked 
+  in the algorithm dialog.
 * :guilabel:`Show algorithms with known issues`
 * :guilabel:`Show layer CRS definition in selection boxes`
 * :guilabel:`Show tooltip when there are disabled providers`


### PR DESCRIPTION
Goal:
Add `Results group name` parameter to Processing Configuration section.
This parameter is available since QGIS 3.16 (see https://github.com/qgis/QGIS/pull/37595) .

- [x] Backport to LTR documentation is requested

