### PR TITLE
[Browser] Turn lists of database contextual menus into a table

### DIFF
--- a/docs/user_manual/introduction/browser.rst
+++ b/docs/user_manual/introduction/browser.rst
@@ -189,41 +189,41 @@ each level of the dataset tree.
 |               +--------------------------------------------+--------------+--------------+------------+------------+------------+------------+
 |               | :guilabel:`Load Connections…`              |              |              | |checkbox| | |checkbox| | |checkbox| |            |
 +---------------+--------------------------------------------+--------------+--------------+------------+------------+------------+------------+
-| Connection    | :guilabel:`Refresh` a connection           |              |              | |checkbox| | |checkbox| |            |            |
+| Connection    | :guilabel:`Refresh` a connection           |              |              | |checkbox| | |checkbox| | |checkbox| |            |
 | / Database    +--------------------------------------------+--------------+--------------+------------+------------+------------+------------+
-|               | :guilabel:`Edit Connection…` settings      |              |              | |checkbox| | |checkbox| |            |            |
+|               | :guilabel:`Edit Connection…` settings      |              |              | |checkbox| | |checkbox| | |checkbox| |            |
 |               +--------------------------------------------+--------------+--------------+------------+------------+------------+------------+
-|               | :guilabel:`Delete Connection…`             | |checkbox|   | |checkbox|   | |checkbox| | |checkbox| |            |            |
+|               | :guilabel:`Delete Connection…`             | |checkbox|   | |checkbox|   | |checkbox| | |checkbox| | |checkbox| |            |
 |               +--------------------------------------------+--------------+--------------+------------+------------+------------+------------+
 |               | :guilabel:`Delete` the database            | |checkbox|   | |checkbox|   |            |            |            |            |
 |               +--------------------------------------------+--------------+--------------+------------+------------+------------+------------+
 |               | :guilabel:`Compact Database (VACUUM)`      | |checkbox|   |              |            |            |            |            |
 |               +--------------------------------------------+--------------+--------------+------------+------------+------------+------------+
-|               | Create a :guilabel:`New Schema…`           |              |              | |checkbox| | |checkbox| |            |            |
+|               | Create a :guilabel:`New Schema…`           |              |              | |checkbox| | |checkbox| | |checkbox| |            |
 |               +--------------------------------------------+--------------+--------------+------------+------------+------------+------------+
 |               | Create a :guilabel:`New Table…`            | |checkbox|   |              | |checkbox| | |checkbox| |            |            |
 +---------------+--------------------------------------------+--------------+--------------+------------+------------+------------+------------+
-| Schema        | :guilabel:`Refresh` a schema               |              |              | |checkbox| | |checkbox| |            |            |
+| Schema        | :guilabel:`Refresh` a schema               |              |              | |checkbox| | |checkbox| | |checkbox| |            |
 |               +--------------------------------------------+--------------+--------------+------------+------------+------------+------------+
-|               | :guilabel:`Rename schema…`                 |              |              | |checkbox| | |checkbox| |            |            |
+|               | :guilabel:`Rename Schema…`                 |              |              | |checkbox| | |checkbox| | |checkbox| |            |
 |               +--------------------------------------------+--------------+--------------+------------+------------+------------+------------+
-|               | :guilabel:`Delete schema…`                 |              |              | |checkbox| | |checkbox| |            |            |
+|               | :guilabel:`Delete Schema…`                 |              |              | |checkbox| | |checkbox| | |checkbox| |            |
 |               +--------------------------------------------+--------------+--------------+------------+------------+------------+------------+
 |               | Create a :guilabel:`New Table…`            |              |              | |checkbox| | |checkbox| |            |            |
 +---------------+--------------------------------------------+--------------+--------------+------------+------------+------------+------------+
-| Table / Layer | :guilabel:`Rename Table…`                  | |checkbox|   |              | |checkbox| | |checkbox| |            |            |
+| Table / Layer | :guilabel:`Rename Table…`                  | |checkbox|   |              | |checkbox| | |checkbox| | |checkbox| |            |
 |               +--------------------------------------------+--------------+--------------+------------+------------+------------+------------+
-|               | :guilabel:`Truncate Table…`                |              |              | |checkbox| |            |            |            |
+|               | :guilabel:`Truncate Table…`                |              |              | |checkbox| |            | |checkbox| |            |
 |               +--------------------------------------------+--------------+--------------+------------+------------+------------+------------+
-|               | :menuselection:`Export Layer --> To file`  | |checkbox|   | |checkbox|   | |checkbox| | |checkbox| |            |            |
+|               | :menuselection:`Export Layer --> To file`  | |checkbox|   | |checkbox|   | |checkbox| | |checkbox| | |checkbox| |            |
 |               +--------------------------------------------+--------------+--------------+------------+------------+------------+------------+
-|               | :guilabel:`Add layer to Project`           | |checkbox|   | |checkbox|   | |checkbox| | |checkbox| |            |            |
+|               | :guilabel:`Add Layer to Project`           | |checkbox|   | |checkbox|   | |checkbox| | |checkbox| | |checkbox| |            |
 |               +--------------------------------------------+--------------+--------------+------------+------------+------------+------------+
-|               | :guilabel:`Delete layer` from the database | |checkbox|   | |checkbox|   | |checkbox| | |checkbox| |            |            |
+|               | :guilabel:`Delete Layer` from the database | |checkbox|   | |checkbox|   | |checkbox| | |checkbox| | |checkbox| |            |
 |               +--------------------------------------------+--------------+--------------+------------+------------+------------+------------+
-|               | Open :guilabel:`Layer properties…` dialog  | |checkbox|   | |checkbox|   | |checkbox| | |checkbox| |            |            |
+|               | Open :guilabel:`Layer Properties…` dialog  | |checkbox|   | |checkbox|   | |checkbox| | |checkbox| | |checkbox| |            |
 |               +--------------------------------------------+--------------+--------------+------------+------------+------------+------------+
-|               | Open :guilabel:`File properties…` dialog   | |checkbox|   |              |            |            |            |            |
+|               | Open :guilabel:`File Properties…` dialog   | |checkbox|   |              |            |            |            |            |
 +---------------+--------------------------------------------+--------------+--------------+------------+------------+------------+------------+
 | Fields        | :guilabel:`Add New Field…`                 | |checkbox|   | |checkbox|   | |checkbox| | |checkbox| |            |            |
 +---------------+--------------------------------------------+--------------+--------------+------------+------------+------------+------------+

--- a/docs/user_manual/introduction/browser.rst
+++ b/docs/user_manual/introduction/browser.rst
@@ -163,58 +163,73 @@ From the context menu, you can also
 Your file system root directory / folder.
 
 
-Interacting with database entries
-.................................
+Database entries
+.................
 
 Depending on your OS and installed drivers, you might have access to different database
 types to use in QGIS. Below are listed the different entries of contextual menu at
 each level of the dataset tree.
 
-.. You might want to use https://www.tablesgenerator.com/text_tables to update the next one.
-    Particularly useful if you want to add, move columns
+.. You might want to use https://www.tablesgenerator.com/text_tables (Text tab) to update the next table.
+    Particularly useful if you need to add, resize or move columns
 
-+-------------+--------------------------------------------+------------------------------------------------------------------------------------------+
-| Level       | Context menu                               | Type of database                                                                         |
-|             |                                            +------------+------------+------------+------------+------------+------------+------------+
-|             |                                            | GeoPackage | SpatiaLite | PostGIS    | MSSQL      | Oracle     | DB2        | SAP HANA   |
-+=============+============================================+============+============+============+============+============+============+============+
-| Top menu    | Create a :guilabel:`New Connection…`       | |Checkbox| | |Checkbox| | |Checkbox| | |Checkbox| | |Checkbox| | |Checkbox| | |Checkbox| |
-|             | to an existing database                    |            |            |            |            |            |            |            |
-|             +--------------------------------------------+------------+------------+------------+------------+------------+------------+------------+
-|             | :guilabel:`Create Database…`               | |Checkbox| | |Checkbox| |            |            |            |            |            |
-+-------------+--------------------------------------------+------------+------------+------------+------------+------------+------------+------------+
-| Connection  | :guilabel:`Refresh` a connection           |            |            | |Checkbox| | |Checkbox| | |Checkbox| | |Checkbox| | |Checkbox| |
-| / Database  +--------------------------------------------+------------+------------+------------+------------+------------+------------+------------+
-|             | :guilabel:`Edit Connection…` settings      |            |            | |Checkbox| | |Checkbox| | |Checkbox| | |Checkbox| | |Checkbox| |
-|             +--------------------------------------------+------------+------------+------------+------------+------------+------------+------------+
-|             | :guilabel:`Delete Connection…`             | |Checkbox| | |Checkbox| | |Checkbox| | |Checkbox| | |Checkbox| | |Checkbox| | |Checkbox| |
-|             +--------------------------------------------+------------+------------+------------+------------+------------+------------+------------+
-|             | :guilabel:`Compact Database (VACUUM)`      | |Checkbox| |            |            |            |            |            |            |
-|             +--------------------------------------------+------------+------------+------------+------------+------------+------------+------------+
-|             | Create a :guilabel:`New Schema…`           |            |            | |Checkbox| |            |            |            |            |
-|             +--------------------------------------------+------------+------------+------------+------------+------------+------------+------------+
-|             | Create a :guilabel:`New Layer or Table…`   | |Checkbox| |            |            |            |            |            |            |
-+-------------+--------------------------------------------+------------+------------+------------+------------+------------+------------+------------+
-| Schema      | :guilabel:`Refresh` a schema               |            |            | |Checkbox| | |Checkbox| | |Checkbox| | |Checkbox| | |Checkbox| |
-|             +--------------------------------------------+------------+------------+------------+------------+------------+------------+------------+
-|             | :guilabel:`Rename schema…`                 |            |            | |Checkbox| | |Checkbox| | |Checkbox| | |Checkbox| | |Checkbox| |
-|             +--------------------------------------------+------------+------------+------------+------------+------------+------------+------------+
-|             | :guilabel:`Delete schema`                  |            |            | |Checkbox| | |Checkbox| | |Checkbox| | |Checkbox| | |Checkbox| |
-+-------------+--------------------------------------------+------------+------------+------------+------------+------------+------------+------------+
-| Table/Layer | :guilabel:`Rename Table…`                  | |Checkbox| |            | |Checkbox| | |Checkbox| | |Checkbox| | |Checkbox| |            |
-|             +--------------------------------------------+------------+------------+------------+------------+------------+------------+------------+
-|             | :guilabel:`Truncate Table…`                |            |            | |Checkbox| | |Checkbox| | |Checkbox| | |Checkbox| | |Checkbox| |
-|             +--------------------------------------------+------------+------------+------------+------------+------------+------------+------------+
-|             | :menuselection:`Export Layer --> To file`  | |Checkbox| | |Checkbox| | |Checkbox| | |Checkbox| | |Checkbox| | |Checkbox| | |Checkbox| |
-|             +--------------------------------------------+------------+------------+------------+------------+------------+------------+------------+
-|             | :guilabel:`Add layer to Project`           | |Checkbox| | |Checkbox| | |Checkbox| | |Checkbox| | |Checkbox| | |Checkbox| | |Checkbox| |
-|             +--------------------------------------------+------------+------------+------------+------------+------------+------------+------------+
-|             | :guilabel:`Delete layer` from the database | |Checkbox| | |Checkbox| | |Checkbox| | |Checkbox| | |Checkbox| | |Checkbox| |            |
-|             +--------------------------------------------+------------+------------+------------+------------+------------+------------+------------+
-|             | Open :guilabel:`Layer properties…` dialog  | |Checkbox| | |Checkbox| | |Checkbox| | |Checkbox| | |Checkbox| | |Checkbox| | |Checkbox| |
-|             +--------------------------------------------+------------+------------+------------+------------+------------+------------+------------+
-|             | Open :guilabel:`File properties…` dialog   | |Checkbox| |            |            |            |            |            |            |
-+-------------+--------------------------------------------+------------+------------+------------+------------+------------+------------+------------+
++---------------+--------------------------------------------+---------------------------------------------------------------------------------+
+| Level         | Context menu                               |                                 Type of database                                |
+|               |                                            +--------------+--------------+------------+------------+------------+------------+
+|               |                                            | |geoPackage| | |spatialite| | |postgis|  | |hana|     | |mssql|    | |oracle|   |
+|               |                                            | GeoPackage   | SpatiaLite   | PostGIS    | SAP HANA   | MSSQL      | Oracle     |
++===============+============================================+==============+==============+============+============+============+============+
+| Top menu      | Create a :guilabel:`New Connection…`       | |checkbox|   | |checkbox|   | |checkbox| | |checkbox| | |checkbox| | |checkbox| |
+|               | to an existing database                    |              |              |            |            |            |            |
+|               +--------------------------------------------+--------------+--------------+------------+------------+------------+------------+
+|               | :guilabel:`Create Database…`               | |checkbox|   | |checkbox|   |            |            |            |            |
+|               +--------------------------------------------+--------------+--------------+------------+------------+------------+------------+
+|               | :guilabel:`Save Connections…` details      |              |              | |checkbox| |            | |checkbox| |            |
+|               | to a file                                  |              |              |            |            |            |            |
+|               +--------------------------------------------+--------------+--------------+------------+------------+------------+------------+
+|               | :guilabel:`Load Connections…`              |              |              | |checkbox| |            | |checkbox| |            |
++---------------+--------------------------------------------+--------------+--------------+------------+------------+------------+------------+
+| Connection    | :guilabel:`Refresh` a connection           |              |              | |checkbox| |            |            |            |
+| / Database    +--------------------------------------------+--------------+--------------+------------+------------+------------+------------+
+|               | :guilabel:`Edit Connection…` settings      |              |              | |checkbox| |            |            |            |
+|               +--------------------------------------------+--------------+--------------+------------+------------+------------+------------+
+|               | :guilabel:`Delete Connection…`             | |checkbox|   | |checkbox|   | |checkbox| |            |            |            |
+|               +--------------------------------------------+--------------+--------------+------------+------------+------------+------------+
+|               | :guilabel:`Delete` the database            | |checkbox|   | |checkbox|   |            |            |            |            |
+|               +--------------------------------------------+--------------+--------------+------------+------------+------------+------------+
+|               | :guilabel:`Compact Database (VACUUM)`      | |checkbox|   |              |            |            |            |            |
+|               +--------------------------------------------+--------------+--------------+------------+------------+------------+------------+
+|               | Create a :guilabel:`New Schema…`           |              |              | |checkbox| |            |            |            |
+|               +--------------------------------------------+--------------+--------------+------------+------------+------------+------------+
+|               | Create a :guilabel:`New Table…`            | |checkbox|   |              | |checkbox| |            |            |            |
++---------------+--------------------------------------------+--------------+--------------+------------+------------+------------+------------+
+| Schema        | :guilabel:`Refresh` a schema               |              |              | |checkbox| |            |            |            |
+|               +--------------------------------------------+--------------+--------------+------------+------------+------------+------------+
+|               | :guilabel:`Rename schema…`                 |              |              | |checkbox| |            |            |            |
+|               +--------------------------------------------+--------------+--------------+------------+------------+------------+------------+
+|               | :guilabel:`Delete schema…`                 |              |              | |checkbox| |            |            |            |
+|               +--------------------------------------------+--------------+--------------+------------+------------+------------+------------+
+|               | Create a :guilabel:`New Table…`            |              |              | |checkbox| |            |            |            |
++---------------+--------------------------------------------+--------------+--------------+------------+------------+------------+------------+
+| Table / Layer | :guilabel:`Rename Table…`                  | |checkbox|   |              | |checkbox| |            |            |            |
+|               +--------------------------------------------+--------------+--------------+------------+------------+------------+------------+
+|               | :guilabel:`Truncate Table…`                |              |              | |checkbox| |            |            |            |
+|               +--------------------------------------------+--------------+--------------+------------+------------+------------+------------+
+|               | :menuselection:`Export Layer --> To file`  | |checkbox|   | |checkbox|   | |checkbox| |            |            |            |
+|               +--------------------------------------------+--------------+--------------+------------+------------+------------+------------+
+|               | :guilabel:`Add layer to Project`           | |checkbox|   | |checkbox|   | |checkbox| |            |            |            |
+|               +--------------------------------------------+--------------+--------------+------------+------------+------------+------------+
+|               | :guilabel:`Delete layer` from the database | |checkbox|   | |checkbox|   | |checkbox| |            |            |            |
+|               +--------------------------------------------+--------------+--------------+------------+------------+------------+------------+
+|               | Open :guilabel:`Layer properties…` dialog  | |checkbox|   | |checkbox|   | |checkbox| |            |            |            |
+|               +--------------------------------------------+--------------+--------------+------------+------------+------------+------------+
+|               | Open :guilabel:`File properties…` dialog   | |checkbox|   |              |            |            |            |            |
++---------------+--------------------------------------------+--------------+--------------+------------+------------+------------+------------+
+| Fields        | :guilabel:`Add New Field…`                 | |checkbox|   | |checkbox|   | |checkbox| |            |            |            |
++---------------+--------------------------------------------+--------------+--------------+------------+------------+------------+------------+
+| Field         | :guilabel:`Delete Field…`                  | |checkbox|   | |checkbox|   | |checkbox| |            |            |            |
++---------------+--------------------------------------------+--------------+--------------+------------+------------+------------+------------+
+
 
 WMS/WMTS
 ......................................................................
@@ -402,12 +417,24 @@ Resources
 .. |browserExpand| image:: /static/common/browser_expand.png
    :width: 1.5em
 .. |checkbox| image:: /static/common/checkbox.png
-   :width: 1.5em
+   :width: 1.3em
 .. |collapseTree| image:: /static/common/mActionCollapseTree.png
    :width: 1.5em
 .. |filterMap| image:: /static/common/mActionFilterMap.png
    :width: 1.5em
+.. |geoPackage| image:: /static/common/mGeoPackage.png
+   :width: 1.5em
+.. |hana| image:: /static/common/mIconHana.png
+   :width: 1.5em
 .. |metadata| image:: /static/common/metadata.png
+   :width: 1.5em
+.. |mssql| image:: /static/common/mIconMssql.png
    :width: 1.5em
 .. |options| image:: /static/common/mActionOptions.png
    :width: 1em
+.. |oracle| image:: /static/common/mIconOracle.png
+   :width: 1.5em
+.. |postgis| image:: /static/common/mIconPostgis.png
+   :width: 1.5em
+.. |spatialite| image:: /static/common/mIconSpatialite.png
+   :width: 1.5em

--- a/docs/user_manual/introduction/browser.rst
+++ b/docs/user_manual/introduction/browser.rst
@@ -124,6 +124,7 @@ context menu allows you to :guilabel:`Rename Favorite...` and
 
 Spatial Bookmarks
 ......................................................................
+
 This is where you will find your spatial bookmarks, organised
 into :guilabel:`Project Bookmarks` and :guilabel:`User Bookmarks`.
 
@@ -162,171 +163,58 @@ From the context menu, you can also
 Your file system root directory / folder.
 
 
-Geopackage
-......................................................................
-Geopackage files / databases.
-From the top level context menu, you can create a Geopackage
-file / database (:guilabel:`Create Database...`) or add an existing
-Geopackage file / database (:guilabel:`New Connection...`).
+Interacting with database entries
+.................................
 
-The context menu of each Geopackage lets you remove it from
-the list (:guilabel:`Remove connection...`), add a new layer
-or table to the Geopackage (:guilabel:`Create new Layer or Table...`),
-delete the Geopackage (:guilabel:`Delete <name of geopackage>`)
-and :guilabel:`Compact Database (VACUUM)`.
+Depending on your OS and installed drivers, you might have access to different database
+types to use in QGIS. Below are listed the different entries of contextual menu at
+each level of the dataset tree.
 
-For layer/table entries you can 
+.. You might want to use https://www.tablesgenerator.com/text_tables to update the next one.
+    Particularly useful if you want to add, move columns
 
-* rename it (:guilabel:`Rename Layer <layer name>...`)
-* export it (:menuselection:`Export Layer --> To file`)
-* add it to the project :guilabel:`Add Layer to Project`
-* delete it (:guilabel:`Delete Layer`)
-* inspect properties (:guilabel:`Layer Properties...`,
-  :guilabel:`File Properties...`)
-
-
-SpatiaLite
-......................................................................
-SpatiaLite database connections.
-
-From the top level context menu, you can create a SpatiaLite
-file / database (:guilabel:`Create Database...`) or add an
-existing SpatiaLite file / database (:guilabel:`New Connection...`).
-
-The context menu of each SpatiaLite file lets you delete it
-(:guilabel:`Delete`).
-
-For layer/table entries you can 
-
-* export it (:menuselection:`Export Layer --> To file`)
-* add it to the project :guilabel:`Add Layer to Project`
-* delete it (:guilabel:`Delete Layer`)
-* inspect properties (:guilabel:`Layer Properties...`)
-
-
-PostGIS
-......................................................................
-PostGIS database connections.
-
-From the top level context menu, you can add a new connection
-(:guilabel:`New Connection...`).
-
-The context menu of each connection lets you :guilabel:`Refresh` it,
-edit it :guilabel:`Edit connection...`, delete it
-(:guilabel:`Delete connection`) or :guilabel:`Create Schema...`.
-
-The context menu of each schema lets you :guilabel:`Refresh`,
-:guilabel:`Rename Schema...` or :guilabel:`Delete Schema`.
-
-For layers/tables you can 
-
-* rename it (:guilabel:`Rename Table...`)
-* remove its contents (:guilabel:`Truncate Table...`)
-* export it (:menuselection:`Export Layer --> To file`)
-* add it to the project (:guilabel:`Add Layer to Project`)
-* delete it (:guilabel:`Delete Layer`)
-* inspect its properties (:guilabel:`Layer Properties...`)
-
-
-.. You might want to use https://www.tablesgenerator.com/text_tables to resahpe the next one.
-
-+-------------+-------------------------------------------+-------------+-------------+-------------+-------------+-------------+-------------+
-| Level       | Context menu                              |                                Databases                                          |
-|             |                                           +-------------+-------------+-------------+-------------+-------------+-------------+
-|             |                                           | PostGIS     | MSSQL       | DB2         | SAP HANA    | Oracle      | GeoPackage  |
-+=============+===========================================+=============+=============+=============+=============+=============+=============+
-| Top menu    | Create a :guilabel:`New Connection…`      | |Checkbox|  | |Checkbox|  | |Checkbox|  | |Checkbox|  | |Checkbox|  | |Checkbox|  |
-|             +-------------------------------------------+-------------+-------------+-------------+-------------+-------------+-------------+
-|             | :guilabel:`Save Connections…`             | |Checkbox|  | |Checkbox|  | |Checkbox|  |             |             |             |
-|             +-------------------------------------------+-------------+-------------+-------------+-------------+-------------+-------------+
-|             | :guilabel:`Load Connections…`             | |Checkbox|  | |Checkbox|  | |Checkbox|  |             |             |             |
-|             +-------------------------------------------+-------------+-------------+-------------+-------------+-------------+-------------+
-|             | :guilabel:`Create Database…`              |             |             |             |             |             | |Checkbox|  |
-+-------------+-------------------------------------------+-------------+-------------+-------------+-------------+-------------+-------------+
-| Connection  | :guilabel:`Refresh` a connection          | |Checkbox|  | |Checkbox|  | |Checkbox|  | |Checkbox|  | |Checkbox|  |             |
-| / Database  +-------------------------------------------+-------------+-------------+-------------+-------------+-------------+-------------+
-|             | :guilabel:`Edit Connection…` settings     | |Checkbox|  | |Checkbox|  | |Checkbox|  | |Checkbox|  | |Checkbox|  |             |
-|             +-------------------------------------------+-------------+-------------+-------------+-------------+-------------+-------------+
-|             | :guilabel:`Delete Connection`             | |Checkbox|  | |Checkbox|  | |Checkbox|  | |Checkbox|  | |Checkbox|  |             |
-|             +-------------------------------------------+-------------+-------------+-------------+-------------+-------------+-------------+
-|             | Create a :guilabel:`New Schema…`          | |Checkbox|  |             |             |             |             |             |
-|             +-------------------------------------------+-------------+-------------+-------------+-------------+-------------+-------------+
-|             | Create a :guilabel:`New Table…`           | |Checkbox|  |             |             |             |             |             |
-+-------------+-------------------------------------------+-------------+-------------+-------------+-------------+-------------+-------------+
-| Schema      | :guilabel:`Create schema`                 | |Checkbox|  | |Checkbox|  | |Checkbox|  | |Checkbox|  | |Checkbox|  |             |
-|             +-------------------------------------------+-------------+-------------+-------------+-------------+-------------+-------------+
-|             | :guilabel:`Refresh` a schema              | |Checkbox|  | |Checkbox|  |             | |Checkbox|  | |Checkbox|  |             |
-|             +-------------------------------------------+-------------+-------------+-------------+-------------+-------------+-------------+
-|             | :guilabel:`Rename schema`                 | |Checkbox|  | |Checkbox|  | |Checkbox|  | |Checkbox|  | |Checkbox|  |             |
-|             +-------------------------------------------+-------------+-------------+-------------+-------------+-------------+-------------+
-|             | :guilabel:`Delete schema`                 | |Checkbox|  |             | |Checkbox|  | |Checkbox|  | |Checkbox|  |             |
-+-------------+-------------------------------------------+-------------+-------------+-------------+-------------+-------------+-------------+
-| Table/Layer | :guilabel:`Rename Table…`                 | |Checkbox|  | |Checkbox|  | |Checkbox|  |             | |Checkbox|  |             |
-|             +-------------------------------------------+-------------+-------------+-------------+-------------+-------------+-------------+
-|             | :guilabel:`Truncate Table…`               | |Checkbox|  | |Checkbox|  | |Checkbox|  | |Checkbox|  | |Checkbox|  |             |
-|             +-------------------------------------------+-------------+-------------+-------------+-------------+-------------+-------------+
-|             | :guilabel:`Export Layer to file`          | |Checkbox|  | |Checkbox|  | |Checkbox|  | |Checkbox|  | |Checkbox|  |             |
-|             +-------------------------------------------+-------------+-------------+-------------+-------------+-------------+-------------+
-|             | :guilabel:`Add layer to Project`          | |Checkbox|  | |Checkbox|  | |Checkbox|  | |Checkbox|  | |Checkbox|  |             |
-|             +-------------------------------------------+-------------+-------------+-------------+-------------+-------------+-------------+
-|             | :guilabel:`Delete layer`                  | |Checkbox|  | |Checkbox|  | |Checkbox|  |             | |Checkbox|  |             |
-|             +-------------------------------------------+-------------+-------------+-------------+-------------+-------------+-------------+
-|             | Open :guilabel:`Layer properties` dialog  | |Checkbox|  | |Checkbox|  | |Checkbox|  | |Checkbox|  | |Checkbox|  |             |
-+-------------+-------------------------------------------+-------------+-------------+-------------+-------------+-------------+-------------+
-
-
-
-
-
-
-
-MSSQL
-......................................................................
-Microsoft SQL Server connections.
-
-From the top level context menu, you can add a new connection
-(:guilabel:`New Connection...`).
-
-The context menu of each connection lets you :guilabel:`Refresh` it,
-edit it :guilabel:`Edit connection...`, delete it
-(:guilabel:`Delete connection`) or :guilabel:`Create Schema...`.
-
-The context menu of each schema lets you :guilabel:`Refresh`,
-:guilabel:`Rename Schema...` or :guilabel:`Delete Schema`.
-
-For layers/tables you can 
-
-* rename it (:guilabel:`Rename Table...`)
-* remove its contents (:guilabel:`Truncate Table...`)
-* export it (:menuselection:`Export Layer --> To file`)
-* add it to the project (:guilabel:`Add Layer to Project`)
-* delete it (:guilabel:`Delete Layer`)
-* inspect its properties (:guilabel:`Layer Properties...`)
-
-
-DB2
-......................................................................
-IBM DB2 database connections.
-
-From the top level context menu, you can add a new connection
-(:guilabel:`New Connection...`).
-
-The context menu of each connection lets you :guilabel:`Refresh` it,
-edit it :guilabel:`Edit connection...`, delete it
-(:guilabel:`Delete connection`) or :guilabel:`Create Schema...`.
-
-The context menu of each schema lets you :guilabel:`Refresh`,
-:guilabel:`Rename Schema...` or :guilabel:`Delete Schema`.
-
-For layers/tables you can 
-
-* rename it (:guilabel:`Rename Table...`)
-* remove its contents (:guilabel:`Truncate Table...`)
-* export it (:menuselection:`Export Layer --> To file`)
-* add it to the project (:guilabel:`Add Layer to Project`)
-* delete it (:guilabel:`Delete Layer`)
-* inspect its properties (:guilabel:`Layer Properties...`)
-
++-------------+--------------------------------------------+------------------------------------------------------------------------------------------+
+| Level       | Context menu                               | Type of database                                                                         |
+|             |                                            +------------+------------+------------+------------+------------+------------+------------+
+|             |                                            | GeoPackage | SpatiaLite | PostGIS    | MSSQL      | Oracle     | DB2        | SAP HANA   |
++=============+============================================+============+============+============+============+============+============+============+
+| Top menu    | Create a :guilabel:`New Connection…`       | |Checkbox| | |Checkbox| | |Checkbox| | |Checkbox| | |Checkbox| | |Checkbox| | |Checkbox| |
+|             | to an existing database                    |            |            |            |            |            |            |            |
+|             +--------------------------------------------+------------+------------+------------+------------+------------+------------+------------+
+|             | :guilabel:`Create Database…`               | |Checkbox| | |Checkbox| |            |            |            |            |            |
++-------------+--------------------------------------------+------------+------------+------------+------------+------------+------------+------------+
+| Connection  | :guilabel:`Refresh` a connection           |            |            | |Checkbox| | |Checkbox| | |Checkbox| | |Checkbox| | |Checkbox| |
+| / Database  +--------------------------------------------+------------+------------+------------+------------+------------+------------+------------+
+|             | :guilabel:`Edit Connection…` settings      |            |            | |Checkbox| | |Checkbox| | |Checkbox| | |Checkbox| | |Checkbox| |
+|             +--------------------------------------------+------------+------------+------------+------------+------------+------------+------------+
+|             | :guilabel:`Delete Connection…`             | |Checkbox| | |Checkbox| | |Checkbox| | |Checkbox| | |Checkbox| | |Checkbox| | |Checkbox| |
+|             +--------------------------------------------+------------+------------+------------+------------+------------+------------+------------+
+|             | :guilabel:`Compact Database (VACUUM)`      | |Checkbox| |            |            |            |            |            |            |
+|             +--------------------------------------------+------------+------------+------------+------------+------------+------------+------------+
+|             | Create a :guilabel:`New Schema…`           |            |            | |Checkbox| |            |            |            |            |
+|             +--------------------------------------------+------------+------------+------------+------------+------------+------------+------------+
+|             | Create a :guilabel:`New Layer or Table…`   | |Checkbox| |            |            |            |            |            |            |
++-------------+--------------------------------------------+------------+------------+------------+------------+------------+------------+------------+
+| Schema      | :guilabel:`Refresh` a schema               |            |            | |Checkbox| | |Checkbox| | |Checkbox| | |Checkbox| | |Checkbox| |
+|             +--------------------------------------------+------------+------------+------------+------------+------------+------------+------------+
+|             | :guilabel:`Rename schema…`                 |            |            | |Checkbox| | |Checkbox| | |Checkbox| | |Checkbox| | |Checkbox| |
+|             +--------------------------------------------+------------+------------+------------+------------+------------+------------+------------+
+|             | :guilabel:`Delete schema`                  |            |            | |Checkbox| | |Checkbox| | |Checkbox| | |Checkbox| | |Checkbox| |
++-------------+--------------------------------------------+------------+------------+------------+------------+------------+------------+------------+
+| Table/Layer | :guilabel:`Rename Table…`                  | |Checkbox| |            | |Checkbox| | |Checkbox| | |Checkbox| | |Checkbox| |            |
+|             +--------------------------------------------+------------+------------+------------+------------+------------+------------+------------+
+|             | :guilabel:`Truncate Table…`                |            |            | |Checkbox| | |Checkbox| | |Checkbox| | |Checkbox| | |Checkbox| |
+|             +--------------------------------------------+------------+------------+------------+------------+------------+------------+------------+
+|             | :menuselection:`Export Layer --> To file`  | |Checkbox| | |Checkbox| | |Checkbox| | |Checkbox| | |Checkbox| | |Checkbox| | |Checkbox| |
+|             +--------------------------------------------+------------+------------+------------+------------+------------+------------+------------+
+|             | :guilabel:`Add layer to Project`           | |Checkbox| | |Checkbox| | |Checkbox| | |Checkbox| | |Checkbox| | |Checkbox| | |Checkbox| |
+|             +--------------------------------------------+------------+------------+------------+------------+------------+------------+------------+
+|             | :guilabel:`Delete layer` from the database | |Checkbox| | |Checkbox| | |Checkbox| | |Checkbox| | |Checkbox| | |Checkbox| |            |
+|             +--------------------------------------------+------------+------------+------------+------------+------------+------------+------------+
+|             | Open :guilabel:`Layer properties…` dialog  | |Checkbox| | |Checkbox| | |Checkbox| | |Checkbox| | |Checkbox| | |Checkbox| | |Checkbox| |
+|             +--------------------------------------------+------------+------------+------------+------------+------------+------------+------------+
+|             | Open :guilabel:`File properties…` dialog   | |Checkbox| |            |            |            |            |            |            |
++-------------+--------------------------------------------+------------+------------+------------+------------+------------+------------+------------+
 
 WMS/WMTS
 ......................................................................

--- a/docs/user_manual/introduction/browser.rst
+++ b/docs/user_manual/introduction/browser.rst
@@ -7,6 +7,12 @@
 The Browser panel
 ======================================================================
 
+.. only:: html
+
+   .. contents::
+      :local:
+      :depth: 2
+
 The QGIS Browser panel is a great tool for browsing, searching,
 inspecting, copying and loading QGIS resources.
 Only resources that QGIS knows how to handle are shown in the
@@ -220,6 +226,58 @@ For layers/tables you can
 * add it to the project (:guilabel:`Add Layer to Project`)
 * delete it (:guilabel:`Delete Layer`)
 * inspect its properties (:guilabel:`Layer Properties...`)
+
+
+.. You might want to use https://www.tablesgenerator.com/text_tables to resahpe the next one.
+
++-------------+-------------------------------------------+-------------+-------------+-------------+-------------+-------------+-------------+
+| Level       | Context menu                              |                                Databases                                          |
+|             |                                           +-------------+-------------+-------------+-------------+-------------+-------------+
+|             |                                           | PostGIS     | MSSQL       | DB2         | SAP HANA    | Oracle      | GeoPackage  |
++=============+===========================================+=============+=============+=============+=============+=============+=============+
+| Top menu    | Create a :guilabel:`New Connection…`      | |Checkbox|  | |Checkbox|  | |Checkbox|  | |Checkbox|  | |Checkbox|  | |Checkbox|  |
+|             +-------------------------------------------+-------------+-------------+-------------+-------------+-------------+-------------+
+|             | :guilabel:`Save Connections…`             | |Checkbox|  | |Checkbox|  | |Checkbox|  |             |             |             |
+|             +-------------------------------------------+-------------+-------------+-------------+-------------+-------------+-------------+
+|             | :guilabel:`Load Connections…`             | |Checkbox|  | |Checkbox|  | |Checkbox|  |             |             |             |
+|             +-------------------------------------------+-------------+-------------+-------------+-------------+-------------+-------------+
+|             | :guilabel:`Create Database…`              |             |             |             |             |             | |Checkbox|  |
++-------------+-------------------------------------------+-------------+-------------+-------------+-------------+-------------+-------------+
+| Connection  | :guilabel:`Refresh` a connection          | |Checkbox|  | |Checkbox|  | |Checkbox|  | |Checkbox|  | |Checkbox|  |             |
+| / Database  +-------------------------------------------+-------------+-------------+-------------+-------------+-------------+-------------+
+|             | :guilabel:`Edit Connection…` settings     | |Checkbox|  | |Checkbox|  | |Checkbox|  | |Checkbox|  | |Checkbox|  |             |
+|             +-------------------------------------------+-------------+-------------+-------------+-------------+-------------+-------------+
+|             | :guilabel:`Delete Connection`             | |Checkbox|  | |Checkbox|  | |Checkbox|  | |Checkbox|  | |Checkbox|  |             |
+|             +-------------------------------------------+-------------+-------------+-------------+-------------+-------------+-------------+
+|             | Create a :guilabel:`New Schema…`          | |Checkbox|  |             |             |             |             |             |
+|             +-------------------------------------------+-------------+-------------+-------------+-------------+-------------+-------------+
+|             | Create a :guilabel:`New Table…`           | |Checkbox|  |             |             |             |             |             |
++-------------+-------------------------------------------+-------------+-------------+-------------+-------------+-------------+-------------+
+| Schema      | :guilabel:`Create schema`                 | |Checkbox|  | |Checkbox|  | |Checkbox|  | |Checkbox|  | |Checkbox|  |             |
+|             +-------------------------------------------+-------------+-------------+-------------+-------------+-------------+-------------+
+|             | :guilabel:`Refresh` a schema              | |Checkbox|  | |Checkbox|  |             | |Checkbox|  | |Checkbox|  |             |
+|             +-------------------------------------------+-------------+-------------+-------------+-------------+-------------+-------------+
+|             | :guilabel:`Rename schema`                 | |Checkbox|  | |Checkbox|  | |Checkbox|  | |Checkbox|  | |Checkbox|  |             |
+|             +-------------------------------------------+-------------+-------------+-------------+-------------+-------------+-------------+
+|             | :guilabel:`Delete schema`                 | |Checkbox|  |             | |Checkbox|  | |Checkbox|  | |Checkbox|  |             |
++-------------+-------------------------------------------+-------------+-------------+-------------+-------------+-------------+-------------+
+| Table/Layer | :guilabel:`Rename Table…`                 | |Checkbox|  | |Checkbox|  | |Checkbox|  |             | |Checkbox|  |             |
+|             +-------------------------------------------+-------------+-------------+-------------+-------------+-------------+-------------+
+|             | :guilabel:`Truncate Table…`               | |Checkbox|  | |Checkbox|  | |Checkbox|  | |Checkbox|  | |Checkbox|  |             |
+|             +-------------------------------------------+-------------+-------------+-------------+-------------+-------------+-------------+
+|             | :guilabel:`Export Layer to file`          | |Checkbox|  | |Checkbox|  | |Checkbox|  | |Checkbox|  | |Checkbox|  |             |
+|             +-------------------------------------------+-------------+-------------+-------------+-------------+-------------+-------------+
+|             | :guilabel:`Add layer to Project`          | |Checkbox|  | |Checkbox|  | |Checkbox|  | |Checkbox|  | |Checkbox|  |             |
+|             +-------------------------------------------+-------------+-------------+-------------+-------------+-------------+-------------+
+|             | :guilabel:`Delete layer`                  | |Checkbox|  | |Checkbox|  | |Checkbox|  |             | |Checkbox|  |             |
+|             +-------------------------------------------+-------------+-------------+-------------+-------------+-------------+-------------+
+|             | Open :guilabel:`Layer properties` dialog  | |Checkbox|  | |Checkbox|  | |Checkbox|  | |Checkbox|  | |Checkbox|  |             |
++-------------+-------------------------------------------+-------------+-------------+-------------+-------------+-------------+-------------+
+
+
+
+
+
 
 
 MSSQL
@@ -454,6 +512,8 @@ Resources
 .. |browserCollapse| image:: /static/common/browser_collapse.png
    :width: 1.5em
 .. |browserExpand| image:: /static/common/browser_expand.png
+   :width: 1.5em
+.. |checkbox| image:: /static/common/checkbox.png
    :width: 1.5em
 .. |collapseTree| image:: /static/common/mActionCollapseTree.png
    :width: 1.5em

--- a/docs/user_manual/introduction/browser.rst
+++ b/docs/user_manual/introduction/browser.rst
@@ -184,50 +184,50 @@ each level of the dataset tree.
 |               +--------------------------------------------+--------------+--------------+------------+------------+------------+------------+
 |               | :guilabel:`Create Database…`               | |checkbox|   | |checkbox|   |            |            |            |            |
 |               +--------------------------------------------+--------------+--------------+------------+------------+------------+------------+
-|               | :guilabel:`Save Connections…` details      |              |              | |checkbox| |            | |checkbox| |            |
+|               | :guilabel:`Save Connections…` details      |              |              | |checkbox| | |checkbox| | |checkbox| |            |
 |               | to a file                                  |              |              |            |            |            |            |
 |               +--------------------------------------------+--------------+--------------+------------+------------+------------+------------+
-|               | :guilabel:`Load Connections…`              |              |              | |checkbox| |            | |checkbox| |            |
+|               | :guilabel:`Load Connections…`              |              |              | |checkbox| | |checkbox| | |checkbox| |            |
 +---------------+--------------------------------------------+--------------+--------------+------------+------------+------------+------------+
-| Connection    | :guilabel:`Refresh` a connection           |              |              | |checkbox| |            |            |            |
+| Connection    | :guilabel:`Refresh` a connection           |              |              | |checkbox| | |checkbox| |            |            |
 | / Database    +--------------------------------------------+--------------+--------------+------------+------------+------------+------------+
-|               | :guilabel:`Edit Connection…` settings      |              |              | |checkbox| |            |            |            |
+|               | :guilabel:`Edit Connection…` settings      |              |              | |checkbox| | |checkbox| |            |            |
 |               +--------------------------------------------+--------------+--------------+------------+------------+------------+------------+
-|               | :guilabel:`Delete Connection…`             | |checkbox|   | |checkbox|   | |checkbox| |            |            |            |
+|               | :guilabel:`Delete Connection…`             | |checkbox|   | |checkbox|   | |checkbox| | |checkbox| |            |            |
 |               +--------------------------------------------+--------------+--------------+------------+------------+------------+------------+
 |               | :guilabel:`Delete` the database            | |checkbox|   | |checkbox|   |            |            |            |            |
 |               +--------------------------------------------+--------------+--------------+------------+------------+------------+------------+
 |               | :guilabel:`Compact Database (VACUUM)`      | |checkbox|   |              |            |            |            |            |
 |               +--------------------------------------------+--------------+--------------+------------+------------+------------+------------+
-|               | Create a :guilabel:`New Schema…`           |              |              | |checkbox| |            |            |            |
+|               | Create a :guilabel:`New Schema…`           |              |              | |checkbox| | |checkbox| |            |            |
 |               +--------------------------------------------+--------------+--------------+------------+------------+------------+------------+
-|               | Create a :guilabel:`New Table…`            | |checkbox|   |              | |checkbox| |            |            |            |
+|               | Create a :guilabel:`New Table…`            | |checkbox|   |              | |checkbox| | |checkbox| |            |            |
 +---------------+--------------------------------------------+--------------+--------------+------------+------------+------------+------------+
-| Schema        | :guilabel:`Refresh` a schema               |              |              | |checkbox| |            |            |            |
+| Schema        | :guilabel:`Refresh` a schema               |              |              | |checkbox| | |checkbox| |            |            |
 |               +--------------------------------------------+--------------+--------------+------------+------------+------------+------------+
-|               | :guilabel:`Rename schema…`                 |              |              | |checkbox| |            |            |            |
+|               | :guilabel:`Rename schema…`                 |              |              | |checkbox| | |checkbox| |            |            |
 |               +--------------------------------------------+--------------+--------------+------------+------------+------------+------------+
-|               | :guilabel:`Delete schema…`                 |              |              | |checkbox| |            |            |            |
+|               | :guilabel:`Delete schema…`                 |              |              | |checkbox| | |checkbox| |            |            |
 |               +--------------------------------------------+--------------+--------------+------------+------------+------------+------------+
-|               | Create a :guilabel:`New Table…`            |              |              | |checkbox| |            |            |            |
+|               | Create a :guilabel:`New Table…`            |              |              | |checkbox| | |checkbox| |            |            |
 +---------------+--------------------------------------------+--------------+--------------+------------+------------+------------+------------+
-| Table / Layer | :guilabel:`Rename Table…`                  | |checkbox|   |              | |checkbox| |            |            |            |
+| Table / Layer | :guilabel:`Rename Table…`                  | |checkbox|   |              | |checkbox| | |checkbox| |            |            |
 |               +--------------------------------------------+--------------+--------------+------------+------------+------------+------------+
 |               | :guilabel:`Truncate Table…`                |              |              | |checkbox| |            |            |            |
 |               +--------------------------------------------+--------------+--------------+------------+------------+------------+------------+
-|               | :menuselection:`Export Layer --> To file`  | |checkbox|   | |checkbox|   | |checkbox| |            |            |            |
+|               | :menuselection:`Export Layer --> To file`  | |checkbox|   | |checkbox|   | |checkbox| | |checkbox| |            |            |
 |               +--------------------------------------------+--------------+--------------+------------+------------+------------+------------+
-|               | :guilabel:`Add layer to Project`           | |checkbox|   | |checkbox|   | |checkbox| |            |            |            |
+|               | :guilabel:`Add layer to Project`           | |checkbox|   | |checkbox|   | |checkbox| | |checkbox| |            |            |
 |               +--------------------------------------------+--------------+--------------+------------+------------+------------+------------+
-|               | :guilabel:`Delete layer` from the database | |checkbox|   | |checkbox|   | |checkbox| |            |            |            |
+|               | :guilabel:`Delete layer` from the database | |checkbox|   | |checkbox|   | |checkbox| | |checkbox| |            |            |
 |               +--------------------------------------------+--------------+--------------+------------+------------+------------+------------+
-|               | Open :guilabel:`Layer properties…` dialog  | |checkbox|   | |checkbox|   | |checkbox| |            |            |            |
+|               | Open :guilabel:`Layer properties…` dialog  | |checkbox|   | |checkbox|   | |checkbox| | |checkbox| |            |            |
 |               +--------------------------------------------+--------------+--------------+------------+------------+------------+------------+
 |               | Open :guilabel:`File properties…` dialog   | |checkbox|   |              |            |            |            |            |
 +---------------+--------------------------------------------+--------------+--------------+------------+------------+------------+------------+
-| Fields        | :guilabel:`Add New Field…`                 | |checkbox|   | |checkbox|   | |checkbox| |            |            |            |
+| Fields        | :guilabel:`Add New Field…`                 | |checkbox|   | |checkbox|   | |checkbox| | |checkbox| |            |            |
 +---------------+--------------------------------------------+--------------+--------------+------------+------------+------------+------------+
-| Field         | :guilabel:`Delete Field…`                  | |checkbox|   | |checkbox|   | |checkbox| |            |            |            |
+| Field         | :guilabel:`Delete Field…`                  | |checkbox|   | |checkbox|   | |checkbox| | |checkbox| |            |            |
 +---------------+--------------------------------------------+--------------+--------------+------------+------------+------------+------------+
 
 


### PR DESCRIPTION
Instead of repeating texts for each of the supported database in the Browser panel (see from [this section](https://docs.qgis.org/3.16/en/docs/user_manual/introduction/browser.html#geopackage)), this PR suggests to display their contextual menu in a matrix, so no repetition but ability to compare what is available, where...
![image](https://user-images.githubusercontent.com/7983394/124114090-70e04080-da6c-11eb-8ce6-e45d366306f8.png)

Remove the DB2 entry
Still looking for help to fill MSSQL, Oracle and SAP HANA that I do not have available. Maybe @stefanuhrig @troopa81 @vcloarec ?. Thanks

Fixes #4406