### PR TITLE
Harmonize Cookbook chapters beginning

### DIFF
--- a/docs/pyqgis_developer_cookbook/authentication.rst
+++ b/docs/pyqgis_developer_cookbook/authentication.rst
@@ -1,5 +1,3 @@
-.. index:: Plugins; Developing, Python; Authentication infrastructure
-
 .. highlight:: python
    :linenothreshold: 5
 
@@ -7,9 +5,15 @@
 
     iface = start_qgis()
 
-The code snippets on this page need the following imports if you're outside the pyqgis console:
+.. index:: Plugins; Developing, Python; Authentication infrastructure
+.. _Authentication_Infrastructure:
 
-.. testcode:: auth
+*****************************
+Authentication infrastructure
+*****************************
+.. hint:: The code snippets on this page need the following imports if you're outside the pyqgis console:
+
+  .. testcode:: auth
 
     from qgis.core import (
       QgsApplication,
@@ -34,15 +38,10 @@ The code snippets on this page need the following imports if you're outside the 
 
     from qgis.PyQt.QtNetwork import QSslCertificate
 
-.. _Authentication_Infrastructure:
+.. only:: html
 
-
-*****************************
-Authentication infrastructure
-*****************************
-
-.. contents::
-   :local:
+   .. contents::
+      :local:
 
 
 .. _Authentication_Introduction:

--- a/docs/pyqgis_developer_cookbook/canvas.rst
+++ b/docs/pyqgis_developer_cookbook/canvas.rst
@@ -1,16 +1,20 @@
-.. index:: Map canvas
-
 .. highlight:: python
    :linenothreshold: 5
-
 
 .. testsetup:: canvas
 
     iface = start_qgis()
 
-The code snippets on this page need the following imports if you're outside the pyqgis console:
+.. index:: Map canvas
+.. _canvas:
 
-.. testcode:: canvas
+********************
+Using the Map Canvas
+********************
+
+.. hint:: The code snippets on this page need the following imports if you're outside the pyqgis console:
+
+  .. testcode:: canvas
 
     from qgis.PyQt.QtGui import (
         QColor,
@@ -34,16 +38,10 @@ The code snippets on this page need the following imports if you're outside the 
         QgsRubberBand,
     )
 
+.. only:: html
 
-.. _canvas:
-
-********************
-Using the Map Canvas
-********************
-
-
-.. contents::
-   :local:
+   .. contents::
+      :local:
 
 The Map canvas widget is probably the most important widget within QGIS because
 it shows the map composed from overlaid map layers and allows interaction with

--- a/docs/pyqgis_developer_cookbook/cheat_sheet.rst
+++ b/docs/pyqgis_developer_cookbook/cheat_sheet.rst
@@ -1,5 +1,3 @@
-.. _cheat-sheet:
-
 .. highlight:: python
    :linenothreshold: 5
 
@@ -19,9 +17,15 @@
 
     iface.attributesToolBar.return_value = toolbar
 
-The code snippets on this page need the following imports if you're outside the pyqgis console:
+.. _cheat-sheet:
 
-.. testcode:: cheat_sheet
+**********************
+Cheat sheet for PyQGIS
+**********************
+
+.. hint:: The code snippets on this page need the following imports if you're outside the pyqgis console:
+
+  .. testcode:: cheat_sheet
 
     from qgis.PyQt.QtCore import (
         QRectF,
@@ -36,15 +40,11 @@ The code snippets on this page need the following imports if you're outside the 
         QgsLayerTreeView,
     )
 
-
-**********************
-Cheat sheet for PyQGIS
-**********************
-
 .. only:: html
 
    .. contents::
       :local:
+
 
 User Interface
 ==============

--- a/docs/pyqgis_developer_cookbook/communicating.rst
+++ b/docs/pyqgis_developer_cookbook/communicating.rst
@@ -7,9 +7,14 @@
 
     iface = start_qgis()
 
-The code snippets on this page need the following imports if you're outside the pyqgis console:
 
-.. testcode:: communicating
+***************************
+Communicating with the user
+***************************
+
+.. hint:: The code snippets on this page need the following imports if you're outside the pyqgis console:
+
+  .. testcode:: communicating
 
     from qgis.core import (
         QgsMessageLog,
@@ -28,14 +33,10 @@ The code snippets on this page need the following imports if you're outside the 
         QDialogButtonBox,
     )
 
+.. only:: html
 
-
-***************************
-Communicating with the user
-***************************
-
-.. contents::
-   :local:
+   .. contents::
+      :local:
 
 This section shows some methods and elements that should be used to communicate
 with the user, in order to keep consistency in the User Interface.

--- a/docs/pyqgis_developer_cookbook/composer.rst
+++ b/docs/pyqgis_developer_cookbook/composer.rst
@@ -7,9 +7,15 @@
 
     iface = start_qgis()
 
-The code snippets on this page need the following imports:
+.. _layout:
 
-.. testcode:: composer
+**************************
+Map Rendering and Printing
+**************************
+
+.. hint:: The code snippets on this page need the following imports:
+
+  .. testcode:: composer
 
     import os
 
@@ -44,14 +50,10 @@ The code snippets on this page need the following imports:
         QSize,
     )
 
-.. _layout:
+.. only:: html
 
-**************************
-Map Rendering and Printing
-**************************
-
-.. contents::
-   :local:
+   .. contents::
+      :local:
 
 There are generally two approaches when input data should be rendered as a map:
 either do it quick way using `QgsMapRendererJob` or produce more fine-tuned

--- a/docs/pyqgis_developer_cookbook/crs.rst
+++ b/docs/pyqgis_developer_cookbook/crs.rst
@@ -1,4 +1,3 @@
-
 .. highlight:: python
    :linenothreshold: 5
 
@@ -6,10 +5,15 @@
 
     iface = start_qgis()
 
+.. _crs:
 
-The code snippets on this page need the following imports if you're outside the pyqgis console:
+*******************
+Projections Support
+*******************
 
-.. testcode:: crs
+.. hint:: The code snippets on this page need the following imports if you're outside the pyqgis console:
+
+  .. testcode:: crs
 
     from qgis.core import (
         QgsCoordinateReferenceSystem,
@@ -18,12 +22,10 @@ The code snippets on this page need the following imports if you're outside the 
         QgsPointXY,
     )
 
-.. _crs:
+.. only:: html
 
-*******************
-Projections Support
-*******************
-
+   .. contents::
+      :local:
 
 .. index:: Coordinate reference systems
 

--- a/docs/pyqgis_developer_cookbook/expressions.rst
+++ b/docs/pyqgis_developer_cookbook/expressions.rst
@@ -1,14 +1,21 @@
+.. highlight:: python
+   :linenothreshold: 5
+
 .. testsetup:: expr
 
     iface = start_qgis()
 
 
-.. highlight:: python
-   :linenothreshold: 5
+.. index:: Expressions, Filtering, Calculating values
+.. _expressions:
 
-The code snippets on this page need the following imports if you're outside the pyqgis console:
+*********************************************
+Expressions, Filtering and Calculating Values
+*********************************************
 
-.. testcode:: expr
+.. hint:: The code snippets on this page need the following imports if you're outside the pyqgis console:
+
+  .. testcode:: expr
 
     from qgis.core import (
         edit,
@@ -25,16 +32,10 @@ The code snippets on this page need the following imports if you're outside the 
         QgsExpressionContextUtils
     )
 
-.. index:: Expressions, Filtering, Calculating values
+.. only:: html
 
-.. _expressions:
-
-*********************************************
-Expressions, Filtering and Calculating Values
-*********************************************
-
-.. contents::
-   :local:
+   .. contents::
+      :local:
 
 QGIS has some support for parsing of SQL-like expressions. Only a small subset
 of SQL syntax is supported. The expressions can be evaluated either as boolean

--- a/docs/pyqgis_developer_cookbook/geometry.rst
+++ b/docs/pyqgis_developer_cookbook/geometry.rst
@@ -18,10 +18,15 @@
         assert vlayer.isValid()
         QgsProject.instance().addMapLayers([vlayer])
 
+.. _geometry:
 
-The code snippets on this page need the following imports if you're outside the pyqgis console:
+*****************
+Geometry Handling
+*****************
 
-.. testcode:: geometry
+.. hint:: The code snippets on this page need the following imports if you're outside the pyqgis console:
+
+ .. testcode:: geometry
 
     from qgis.core import (
       QgsGeometry,
@@ -37,15 +42,10 @@ The code snippets on this page need the following imports if you're outside the 
       QgsCoordinateReferenceSystem
     )
 
-.. _geometry:
+.. only:: html
 
-
-*****************
-Geometry Handling
-*****************
-
-.. contents::
-   :local:
+   .. contents::
+      :local:
 
 Points, linestrings and polygons that represent a spatial feature are commonly
 referred to as geometries. In QGIS they are represented with the

--- a/docs/pyqgis_developer_cookbook/intro.rst
+++ b/docs/pyqgis_developer_cookbook/intro.rst
@@ -1,20 +1,21 @@
-.. _introduction:
-
-
 .. highlight:: python
    :linenothreshold: 5
 
+.. _introduction:
 
 ************
 Introduction
 ************
 
+
 This document is intended to be both a tutorial and a reference
 guide. While it does not list all possible use cases, it should
 give a good overview of the principal functionality.
 
-.. contents::
-   :local:
+.. only:: html
+
+   .. contents::
+      :local:
 
 Python support was first introduced in QGIS 0.9.
 There are several ways to use Python in QGIS Desktop

--- a/docs/pyqgis_developer_cookbook/legend.rst
+++ b/docs/pyqgis_developer_cookbook/legend.rst
@@ -1,4 +1,3 @@
-
 .. highlight:: python
    :linenothreshold: 5
 
@@ -18,24 +17,25 @@
         assert vlayer.isValid()
         QgsProject.instance().addMapLayers([vlayer])
 
-The code snippets on this page need the following imports if you're outside the pyqgis console:
-
-.. testcode:: legend
-
-    from qgis.core import (
-        QgsProject,
-        QgsVectorLayer,
-    )
-
-
 .. _legendpy:
 
 *************************************
 Accessing the Table Of Contents (TOC)
 *************************************
 
-.. contents::
-   :local:
+.. hint:: The code snippets on this page need the following imports if you're outside the pyqgis console:
+
+  .. testcode:: legend
+
+    from qgis.core import (
+        QgsProject,
+        QgsVectorLayer,
+    )
+
+.. only:: html
+
+   .. contents::
+      :local:
 
 
 You can use different classes to access all the loaded layers in the TOC and

--- a/docs/pyqgis_developer_cookbook/loadlayer.rst
+++ b/docs/pyqgis_developer_cookbook/loadlayer.rst
@@ -1,4 +1,3 @@
-
 .. highlight:: python
    :linenothreshold: 5
 
@@ -25,17 +24,19 @@
 Loading Layers
 **************
 
-The code snippets on this page need the following imports:
+.. hint:: The code snippets on this page need the following imports:
 
-.. testcode:: loadlayer
+ .. testcode:: loadlayer
 
- import os # This is is needed in the pyqgis console also
- from qgis.core import (
-     QgsVectorLayer
- )
+  import os # This is is needed in the pyqgis console also
+  from qgis.core import (
+      QgsVectorLayer
+  )
 
-.. contents::
-   :local:
+.. only:: html
+
+   .. contents::
+      :local:
 
 Let's open some layers with data. QGIS recognizes vector and raster layers.
 Additionally, custom layer types are available, but we are not going to discuss

--- a/docs/pyqgis_developer_cookbook/loadproject.rst
+++ b/docs/pyqgis_developer_cookbook/loadproject.rst
@@ -1,4 +1,3 @@
-
 .. highlight:: python
    :linenothreshold: 5
 
@@ -8,9 +7,15 @@
 
     canvas = iface.mapCanvas()
 
-The code snippets on this page need the following imports if you're outside the pyqgis console:
+.. _loadproject:
 
-.. testcode:: loadproject
+****************
+Loading Projects
+****************
+
+.. hint:: The code snippets on this page need the following imports if you're outside the pyqgis console:
+
+  .. testcode:: loadproject
 
     from qgis.core import (
         QgsProject,
@@ -21,12 +26,10 @@ The code snippets on this page need the following imports if you're outside the 
         QgsLayerTreeMapCanvasBridge,
     )
 
+.. only:: html
 
-.. _loadproject:
-
-****************
-Loading Projects
-****************
+   .. contents::
+      :local:
 
 Sometimes you need to load an existing project from a plugin or (more often)
 when developing a standalone QGIS Python application (see: :ref:`pythonapplications`).

--- a/docs/pyqgis_developer_cookbook/network_analysis.rst
+++ b/docs/pyqgis_developer_cookbook/network_analysis.rst
@@ -1,7 +1,5 @@
-
 .. highlight:: python
    :linenothreshold: 5
-
 
 .. testsetup:: network_analysis
 
@@ -13,24 +11,25 @@
 
     vectorLayer = QgsVectorLayer('testdata/network.gpkg|layername=network_lines', 'lines')
 
-The code snippets on this page need the following imports if you're outside the pyqgis console:
-
-.. testcode:: network_analysis
-
-    from qgis.core import (
-      QgsVectorLayer,
-      QgsPointXY,
-    )
-
 .. _network-analysis:
 
 ************************
 Network analysis library
 ************************
 
+.. hint:: The code snippets on this page need the following imports if you're outside the pyqgis console:
 
-.. contents::
-   :local:
+  .. testcode:: network_analysis
+
+    from qgis.core import (
+      QgsVectorLayer,
+      QgsPointXY,
+    )
+
+.. only:: html
+
+   .. contents::
+      :local:
 
 The network analysis library can be used to:
 

--- a/docs/pyqgis_developer_cookbook/pluginlayer.rst
+++ b/docs/pyqgis_developer_cookbook/pluginlayer.rst
@@ -1,11 +1,21 @@
-.. index:: Plugin layers
-
-.. _pluginlayer:
-
 .. highlight:: python
    :linenothreshold: 5
 
 .. testsetup:: pluginlayer
+
+   iface = start_qgis()
+
+
+.. index:: Plugin layers
+.. _pluginlayer:
+
+*******************
+Using Plugin Layers
+*******************
+
+.. hint:: The code snippets on this page need the following imports if you're outside the pyqgis console:
+
+  .. testcode:: pluginlayer
 
     from qgis.core import (
         QgsPluginLayer,
@@ -17,12 +27,10 @@
 
     from qgis.PyQt.QtGui import QImage
 
-    iface = start_qgis()
+.. only:: html
 
-
-*******************
-Using Plugin Layers
-*******************
+   .. contents::
+      :local:
 
 If your plugin uses its own methods to render a map layer, writing your own
 layer type based on :class:`QgsPluginLayer <qgis.core.QgsPluginLayer>` might be the best way to implement that.

--- a/docs/pyqgis_developer_cookbook/plugins/ide_debugging.rst
+++ b/docs/pyqgis_developer_cookbook/plugins/ide_debugging.rst
@@ -4,8 +4,10 @@
 IDE settings for writing and debugging plugins
 **********************************************
 
-.. contents::
-   :local:
+.. only:: html
+
+   .. contents::
+      :local:
 
 
 Although each programmer has his preferred IDE/Text editor, here are some

--- a/docs/pyqgis_developer_cookbook/plugins/plugins.rst
+++ b/docs/pyqgis_developer_cookbook/plugins/plugins.rst
@@ -6,8 +6,10 @@
 Structuring Python Plugins
 **************************
 
-.. contents::
-   :local:
+.. only:: html
+
+   .. contents::
+      :local:
 
 
 In order to create a plugin, here are some steps to follow:

--- a/docs/pyqgis_developer_cookbook/plugins/releasing.rst
+++ b/docs/pyqgis_developer_cookbook/plugins/releasing.rst
@@ -4,8 +4,10 @@
  Releasing your plugin
 ***********************
 
-.. contents::
-   :local:
+.. only:: html
+
+   .. contents::
+      :local:
 
 Once your plugin is ready and you think the plugin could be helpful for
 some people, do not hesitate to upload it to :ref:`official_pyqgis_repository`.

--- a/docs/pyqgis_developer_cookbook/plugins/snippets.rst
+++ b/docs/pyqgis_developer_cookbook/plugins/snippets.rst
@@ -1,4 +1,3 @@
-
 .. highlight:: python
    :linenothreshold: 5
 
@@ -7,16 +6,7 @@
     from qgis.core import (
         QgsProject,
     )
-
-    from qgis.gui import (
-        QgsOptionsWidgetFactory,
-        QgsOptionsPageWidget
-    )
-
-    from qgis.PyQt.QtCore import Qt
-    from qgis.PyQt.QtWidgets import QMessageBox, QAction, QHBoxLayout
-    from qgis.PyQt.QtGui import QIcon
-
+    
     import mock
 
     iface = start_qgis()
@@ -35,8 +25,27 @@
 Code Snippets
 *************
 
-.. contents::
-   :local:
+.. hint:: The code snippets on this page need the following imports if you're outside the pyqgis console:
+
+  .. testcode:: plugin_snippets
+
+    from qgis.core import (
+        QgsProject,
+    )
+
+    from qgis.gui import (
+        QgsOptionsWidgetFactory,
+        QgsOptionsPageWidget
+    )
+
+    from qgis.PyQt.QtCore import Qt
+    from qgis.PyQt.QtWidgets import QMessageBox, QAction, QHBoxLayout
+    from qgis.PyQt.QtGui import QIcon
+
+.. only:: html
+
+   .. contents::
+      :local:
 
 This section features code snippets to facilitate plugin development.
 

--- a/docs/pyqgis_developer_cookbook/processing.rst
+++ b/docs/pyqgis_developer_cookbook/processing.rst
@@ -1,4 +1,3 @@
-
 .. highlight:: python
    :linenothreshold: 5
 
@@ -17,8 +16,10 @@
 Writing a Processing plugin
 ****************************
 
-.. contents::
-   :local:
+.. only:: html
+
+   .. contents::
+      :local:
 
 Depending on the kind of plugin that you are going to develop, it might be a better
 option to add its functionality as a Processing algorithm (or a set of them).

--- a/docs/pyqgis_developer_cookbook/raster.rst
+++ b/docs/pyqgis_developer_cookbook/raster.rst
@@ -26,9 +26,18 @@
     QgsProject.instance().addMapLayers([rlayer, rlayer_multi])
     assert rlayer.isValid()
 
-The code snippets on this page need the following imports if you're outside the pyqgis console:
+.. _raster:
 
-.. testcode:: raster
+.. index::
+   pair: Raster; Raster layers
+
+*********************
+ Using Raster Layers
+*********************
+
+.. hint:: The code snippets on this page need the following imports if you're outside the pyqgis console:
+
+  .. testcode:: raster
 
     from qgis.core import (
         QgsRasterLayer,
@@ -46,14 +55,10 @@ The code snippets on this page need the following imports if you're outside the 
         QColor,
     )
 
-.. _raster:
+.. only:: html
 
-.. index::
-   pair: Raster; Raster layers
-
-*********************
- Using Raster Layers
-*********************
+   .. contents::
+      :local:
 
 .. index:: Raster layers; Details
 

--- a/docs/pyqgis_developer_cookbook/settings.rst
+++ b/docs/pyqgis_developer_cookbook/settings.rst
@@ -8,10 +8,16 @@
 
     iface = start_qgis()
 
+.. _settings:
 
-The code snippets on this page need the following imports if you're outside the pyqgis console:
+****************************
+Reading And Storing Settings
+****************************
 
-.. testcode:: settings
+
+.. hint:: The code snippets on this page need the following imports if you're outside the pyqgis console:
+
+  .. testcode:: settings
 
     from qgis.core import (
       QgsProject,
@@ -19,11 +25,10 @@ The code snippets on this page need the following imports if you're outside the 
       QgsVectorLayer
     )
 
-.. _settings:
+.. only:: html
 
-****************************
-Reading And Storing Settings
-****************************
+   .. contents::
+      :local:
 
 Many times it is useful for a plugin to save some variables so that the user
 does not have to enter or select them again next time the plugin is run.

--- a/docs/pyqgis_developer_cookbook/tasks.rst
+++ b/docs/pyqgis_developer_cookbook/tasks.rst
@@ -8,9 +8,15 @@
 
     iface = start_qgis()
 
-The code snippets on this page need the following imports if you're outside the pyqgis console:
+.. _tasks:
 
-.. testcode:: tasks
+******************************************
+Tasks - doing heavy work in the background
+******************************************
+
+.. hint:: The code snippets on this page need the following imports if you're outside the pyqgis console:
+
+  .. testcode:: tasks
 
     from qgis.core import (
       QgsProcessingContext,
@@ -23,11 +29,10 @@ The code snippets on this page need the following imports if you're outside the 
       QgsMessageLog,
     )
 
-.. _tasks:
+.. only:: html
 
-******************************************
-Tasks - doing heavy work in the background
-******************************************
+   .. contents::
+      :local:
 
 Introduction
 ------------

--- a/docs/pyqgis_developer_cookbook/vector.rst
+++ b/docs/pyqgis_developer_cookbook/vector.rst
@@ -1,4 +1,3 @@
-
 .. highlight:: python
    :linenothreshold: 5
 
@@ -8,9 +7,15 @@
 
     problem_occurred = False
 
-The code snippets on this page need the following imports if you're outside the pyqgis console:
+.. _vector:
 
-.. testcode:: vectors
+*******************
+Using Vector Layers
+*******************
+
+.. hint:: The code snippets on this page need the following imports if you're outside the pyqgis console:
+
+  .. testcode:: vectors
 
     from qgis.core import (
       QgsApplication,
@@ -47,14 +52,10 @@ The code snippets on this page need the following imports if you're outside the 
         QColor,
     )
 
-.. _vector:
+.. only:: html
 
-*******************
-Using Vector Layers
-*******************
-
-.. contents::
-   :local:
+   .. contents::
+      :local:
 
 This section summarizes various actions that can be done with vector layers.
 


### PR DESCRIPTION
Display table of contents for all, and only in html docs
Highlight the page testcode and place it after the page title and before the inline TOC (Currently it's sometimes before the page title, or just after or after the toc). things are now harmonized and predictable. refs #3561
