### PR TITLE
Substitute "QSettings" with "Settings" in QGIS Configuration chapter

### DIFF
--- a/docs/user_manual/introduction/qgis_configuration.rst
+++ b/docs/user_manual/introduction/qgis_configuration.rst
@@ -182,7 +182,7 @@ and so on.
   is available then the *testing* doc, with features from newer and development
   versions, is used.
 
-**QSettings**
+**Settings**
 
 It helps you :guilabel:`Reset user interface to default settings (restart required)`
 if you made any :ref:`customization <sec_customization>`.
@@ -1608,7 +1608,7 @@ setups for different use cases as well.
 
    * unchecking |checkbox| :guilabel:`Enable customization` option in the
      Customization dialog or click the |selectAllTree| :sup:`Check All` button
-   * pressing the :guilabel:`Reset` button in the **QSettings** frame under
+   * pressing the :guilabel:`Reset` button in the **Settings** frame under
      :menuselection:`Settings --> Options` menu, :guilabel:`System` tab
    * launching QGIS at a command prompt with the following command line
      ``qgis --nocustomization``


### PR DESCRIPTION
<!---
Include a few sentences describing the overall goals for this Pull Request.
 
A list of issues is at https://github.com/qgis/QGIS-Documentation/issues.
Add "fix #issuenumber" for each issue the PR fixes. The ticket(s) will be closed automatically.
If your PR doesn't fix entirely the ticket, only add the ticket(s) reference preceded by # character.
-->
Goal:

Substitutes "QSettings" with "Settings" in QGIS Configuration chapter:
https://docs.qgis.org/testing/en/docs/user_manual/introduction/qgis_configuration.html#customization
https://docs.qgis.org/testing/en/docs/user_manual/introduction/qgis_configuration.html#system-settings

Ticket(s): #
<!---
Indicate whether the fix should be backported to previous release.
Replace the space between square brackets by a `x` to make it checked.
-->
- [x] Backport to LTR documentation is requested

<!---
Reviewing is a process done by community members, mostly on a volunteer basis.
We try to keep the overhead as small as possible and appreciate if you help us.
Please read carefully and ensure you comply with our writing guidelines at
https://docs.qgis.org/testing/en/docs/documentation_guidelines/index.html.
Feel free to ask in a comment or the (qgis-community-team mailing list)
[https://lists.osgeo.org/mailman/listinfo/qgis-community-team] if you have troubles with any item.
--->
