### PR TITLE
Move the layer metadata tab description to a more generic place

### DIFF
--- a/docs/user_manual/introduction/general_tools.rst
+++ b/docs/user_manual/introduction/general_tools.rst
@@ -2064,6 +2064,38 @@ you to fill:
   can live out of the QGIS project.
 * **notes**: instructions and comments regarding the layer in the current project
 
+.. index:: Metadata, Metadata editor, Keyword
+.. _metadatamenu:
+
+Metadata
+--------
+
+In the layer properties dialog, the |editMetadata| :guilabel:`Metadata` tab
+provides you with options to create and edit a metadata report on your layer.
+
+Information to fill concern:
+
+* the data :guilabel:`Identification`: basic attribution of the dataset (parent,
+  identifier, title, abstract, language...);
+* the :guilabel:`Categories` the data belongs to. Alongside the **ISO** categories,
+  you can add custom ones;
+* the :guilabel:`Keywords` to retrieve the data and associated concepts following
+  a standard based vocabulary;
+* the :guilabel:`Access` to the dataset (licenses, rights, fees, and constraints);
+* the :guilabel:`Extent` of the dataset, either spatial one (CRS, map extent,
+  altitudes) or temporal;
+* the :guilabel:`Contact` of the owner(s) of the dataset;
+* the :guilabel:`Links` to ancillary resources and related information;
+* the :guilabel:`History` of the dataset.
+
+A summary of the filled information is provided in the :guilabel:`Validation`
+tab and helps you identify potential issues related to the form. You can then
+either fix them or ignore them.
+
+Metadata are currently saved in the project file. They can also be saved in a
+:file:`.qmd` file alongside file based layers or in a local :file:`.sqlite`
+database for remote layers (e.g. PostGIS).
+
 
 .. index:: Variables, Expressions
 .. _`general_tools_variables`:
@@ -2665,6 +2697,8 @@ The values presented in the varying size assistant above will set the size
    :width: 1.5em
 .. |editCopy| image:: /static/common/mActionEditCopy.png
    :width: 1.5em
+.. |editMetadata| image:: /static/common/editmetadata.png
+   :width: 1.2em
 .. |editableEdits| image:: /static/common/mIconEditableEdits.png
    :width: 1em
 .. |expandNewTree| image:: /static/common/mActionExpandNewTree.png

--- a/docs/user_manual/introduction/general_tools.rst
+++ b/docs/user_manual/introduction/general_tools.rst
@@ -2052,6 +2052,19 @@ the layers (with the saved style) to the Layers Panel.
 You can also drag and drop :file:`.qlr` files from the system file manager into the map
 canvas.
 
+
+Documenting your data
+=====================
+
+In addition to displaying and symbolizing the data in the layers, QGIS allows
+you to fill:
+
+* **metadata**: information to help people find and understand the dataset,
+  how they can access and use it... these are properties of the datasource and
+  can live out of the QGIS project.
+* **notes**: instructions and comments regarding the layer in the current project
+
+
 .. index:: Variables, Expressions
 .. _`general_tools_variables`:
 

--- a/docs/user_manual/working_with_mesh/mesh_properties.rst
+++ b/docs/user_manual/working_with_mesh/mesh_properties.rst
@@ -297,6 +297,15 @@ as shown in :numref:`figure_mesh_symbology_grid`:
 The line width and color can be changed in this dialog, and both the grid renderings can be turned off.
 
 
+.. index:: Metadata, Metadata editor, Keyword
+.. _meshmetadata:
+
+Metadata Properties
+-------------------
+
+The |editMetadata| :guilabel:`Metadata` tab provides you with options
+to create and edit a metadata report on your layer.
+See :ref:`metadatamenu` for more information.
 
 
 .. Substitutions definitions - AVOID EDITING PAST THIS LINE
@@ -309,6 +318,8 @@ The line width and color can be changed in this dialog, and both the grid render
    :width: 1.5em
 .. |checkbox| image:: /static/common/checkbox.png
    :width: 1.3em
+.. |editMetadata| image:: /static/common/editmetadata.png
+   :width: 1.2em
 .. |general| image:: /static/common/general.png
    :width: 1.5em
 .. |meshcontours| image:: /static/common/meshcontours.png

--- a/docs/user_manual/working_with_mesh/mesh_properties.rst
+++ b/docs/user_manual/working_with_mesh/mesh_properties.rst
@@ -16,8 +16,8 @@ A mesh is an unstructured grid usually with temporal and other components.
 The spatial component contains a collection of vertices, edges and faces
 in 2D or 3D space:
 
-* **vertices** - XY(Z) points (in the layer's coordinate reference system)
-* **edges** - connect pairs of vertices
+* **vertices** - XY(Z) points (in the layer's coordinate reference system)
+* **edges** - connect pairs of vertices
 * **faces** - a face is a set of edges forming a closed shape - typically
   a triangle or a quadrilateral (quad), rarely polygons with more vertices
 
@@ -122,8 +122,14 @@ Information Properties
 
 The :guilabel:`Information` tab is read-only and represents an interesting
 place to quickly grab summarized information and metadata on the current layer.
-Provided information are (based on the provider of the layer) uri, vertex count,
-face count and dataset groups count.
+Provided information are:
+
+* based on the provider of the layer: name, path, extent, vertex, face, edges
+  and/or dataset groups count
+* the Coordinate Reference System: name, units, method, accuracy, reference
+  (i.e. whether it's static or dynamic)
+* extracted from filled :ref:`metadata <meshmetadata>`: access, extents,
+  links, contacts, history...
 
 Source Properties
 -----------------

--- a/docs/user_manual/working_with_raster/raster_properties.rst
+++ b/docs/user_manual/working_with_raster/raster_properties.rst
@@ -637,8 +637,7 @@ Metadata Properties
 
 The |editMetadata| :guilabel:`Metadata` tab provides you with options
 to create and edit a metadata report on your layer.
-See :ref:`vector layer metadata properties <vectormetadatamenu>` for
-more information.
+See :ref:`metadatamenu` for more information.
 
 .. _figure_raster_metadata:
 

--- a/docs/user_manual/working_with_raster/raster_properties.rst
+++ b/docs/user_manual/working_with_raster/raster_properties.rst
@@ -54,12 +54,14 @@ an interesting place to quickly grab summarized information and
 metadata for the current layer.
 Provided information are:
 
-* based on the provider of the layer (format of storage, path, data
-  type, extent, width/height, compression, pixel size, statistics on
-  bands, number of columns, rows and no-data values of the raster...);
-* picked from the :ref:`provided metadata <raster_metadata>`: access,
-  links, contacts, history... as well as dataset information (CRS,
-  Extent, bands...).
+* based on the provider of the layer: name, path;
+* the Coordinate Reference System: name, units, method, accuracy, reference
+  (i.e. whether it's static or dynamic)
+* read from layer properties: data type, extent, width/height, compression,
+  pixel size, statistics on bands, number of columns, rows and no-data values
+  of the raster...
+* picked from the :ref:`filled metadata <raster_metadata>`: access, extents,
+  links, contacts, history...
 
 .. _raster_sourcetab:
 

--- a/docs/user_manual/working_with_vector/vector_properties.rst
+++ b/docs/user_manual/working_with_vector/vector_properties.rst
@@ -3086,6 +3086,10 @@ More information on variables usage in the General Tools
 Metadata Properties
 ===================
 
+The |editMetadata| :guilabel:`Metadata` tab provides you with options
+to create and edit a metadata report on your layer.
+See :ref:`metadatamenu` for more information.
+
 
 .. index:: Dependencies
 .. _vectordependenciesmenu:

--- a/docs/user_manual/working_with_vector/vector_properties.rst
+++ b/docs/user_manual/working_with_vector/vector_properties.rst
@@ -3086,29 +3086,6 @@ More information on variables usage in the General Tools
 Metadata Properties
 ===================
 
-|editMetadata| The :guilabel:`Metadata` tab provides you with options to create
-and edit a metadata report on your layer. Information to fill concern:
-
-* the data :guilabel:`Identification`: basic attribution of the dataset (parent,
-  identifier, title, abstract, language...);
-* the :guilabel:`Categories` the data belongs to. Alongside the **ISO** categories,
-  you can add custom ones;
-* the :guilabel:`Keywords` to retrieve the data and associated concepts following
-  a standard based vocabulary;
-* the :guilabel:`Access` to the dataset (licenses, rights, fees, and constraints);
-* the :guilabel:`Extent` of the dataset, either spatial one (CRS, map extent,
-  altitudes) or temporal;
-* the :guilabel:`Contact` of the owner(s) of the dataset;
-* the :guilabel:`Links` to ancillary resources and related information;
-* the :guilabel:`History` of the dataset.
-
-A summary of the filled information is provided in the :guilabel:`Validation`
-tab and helps you identify potential issues related to the form. You can then
-either fix them or ignore them.
-
-Metadata are currently saved in the project file. They can also be saved in a
-:file:`.qmd` file alongside file based layers or in a local :file:`.sqlite`
-database for remote layers (e.g. PostGIS).
 
 .. index:: Dependencies
 .. _vectordependenciesmenu:

--- a/docs/user_manual/working_with_vector/vector_properties.rst
+++ b/docs/user_manual/working_with_vector/vector_properties.rst
@@ -79,11 +79,13 @@ Information Properties
 place to quickly grab summarized information and metadata on the current layer.
 Provided information are:
 
-* based on the provider of the layer (format of storage, path, geometry type,
-  data source encoding, extent...);
-* picked from the :ref:`filled metadata <vectormetadatamenu>` (access, links,
-  contacts, history...);
-* or related to its geometry (spatial extent, CRS...) or its attributes (number
+* based on the provider of the layer: format of storage, path, geometry type,
+  data source encoding, extent...
+* the Coordinate Reference System: name, units, method, accuracy, reference
+  (i.e. whether it's static or dynamic)
+* picked from the :ref:`filled metadata <vectormetadatamenu>`: access, extents,
+  links, contacts, history...
+* and related to its geometry (spatial extent, CRS...) or its attributes (number
   of fields, characteristics of each...).
 
 

--- a/docs/user_manual/working_with_vector_tiles/vector_tiles_properties.rst
+++ b/docs/user_manual/working_with_vector_tiles/vector_tiles_properties.rst
@@ -90,6 +90,16 @@ at the given zoom level. This makes it easier to work with complex vector stylin
 and to locate troublesome rules. Style and labelling can be dependent on the
 zoom level.
 
+.. index:: Metadata, Metadata editor, Keyword
+.. _vectortilesmetadatamenu:
+
+Metadata Properties
+-------------------
+
+The |editMetadata| :guilabel:`Metadata` tab provides you with options
+to create and edit a metadata report on your layer.
+See :ref:`metadatamenu` for more information.
+
 
 .. Substitutions definitions - AVOID EDITING PAST THIS LINE
    This will be automatically updated by the find_set_subst.py script.
@@ -99,6 +109,8 @@ zoom level.
 
 .. |addVectorTileLayer| image:: /static/common/mActionAddVectorTileLayer.png
    :width: 1.5em
+.. |editMetadata| image:: /static/common/editmetadata.png
+   :width: 1.2em
 .. |checkbox| image:: /static/common/checkbox.png
    :width: 1.3em
 .. |general| image:: /static/common/general.png

--- a/docs/user_manual/working_with_vector_tiles/vector_tiles_properties.rst
+++ b/docs/user_manual/working_with_vector_tiles/vector_tiles_properties.rst
@@ -55,12 +55,16 @@ Vector Tiles Dataset Properties
 Information Properties
 ----------------------
 
-The :guilabel:`Information` tab is read-only and represents an interesting place to quickly grab
-summarized information and metadata on the current layer.
+The :guilabel:`Information` tab is read-only and represents an interesting
+place to quickly grab summarized information and metadata on the current layer.
 Provided information are:
 
-* based on the provider of the layer (e.g. URI and number of Zoom levels)
-* related to its geometry (CRS, Spatial Extent)
+* based on the provider of the layer: name, URI, source type and path, number
+  of zoom levels
+* the Coordinate Reference System: name, units, method, accuracy, reference
+  (i.e. whether it's static or dynamic)
+* picked from the :ref:`filled metadata <vectortilesmetadatamenu>`: access,
+  extents, links, contacts, history...
 
 Symbology Properties
 --------------------
@@ -111,19 +115,5 @@ See :ref:`metadatamenu` for more information.
    :width: 1.5em
 .. |editMetadata| image:: /static/common/editmetadata.png
    :width: 1.2em
-.. |checkbox| image:: /static/common/checkbox.png
-   :width: 1.3em
-.. |general| image:: /static/common/general.png
-   :width: 1.5em
-.. |selectString| image:: /static/common/selectstring.png
-   :width: 2.5em
-.. |setProjection| image:: /static/common/mActionSetProjection.png
-   :width: 1.5em
-.. |signMinus| image:: /static/common/symbologyRemove.png
-   :width: 1.5em
-.. |signPlus| image:: /static/common/symbologyAdd.png
-   :width: 1.5em
-.. |slider| image:: /static/common/slider.png
 .. |symbology| image:: /static/common/symbology.png
    :width: 2em
-


### PR DESCRIPTION
instead of within the vector layer chapter and point to it.
Also adds/updates metadata and information tabs for these layer types (raster, vector, vector tile, mesh - fixes #6705).
This also makes room for layer notes...