### PR TITLE
Improve clip explanation for a quicker understanding

### DIFF
--- a/docs/user_manual/processing_algs/qgis/vectoroverlay.rst
+++ b/docs/user_manual/processing_algs/qgis/vectoroverlay.rst
@@ -12,7 +12,7 @@ Vector overlay
 
 Clip
 ----
-Clips a vector layer using the features of an additional polygon
+Clips a vector layer using the geometric features of an additional polygon
 layer.
 
 Only the parts of the features in the input layer that fall within the


### PR DESCRIPTION
Extend explanation for a quicker understanding:

The current explanation disorients the reader (especially novices) referring about features which could include attributes, geometry and might seem abstract to the user. Yet only the feature's geometric properties are considered for that geometric overlay function.
This is why I suggest to add the "geometric" predicate to the text.