### PR TITLE
Factorize the Processing output types list description

### DIFF
--- a/docs/user_manual/processing_algs/gdal/rasteranalysis.rst
+++ b/docs/user_manual/processing_algs/gdal/rasteranalysis.rst
@@ -101,10 +101,10 @@ Parameters
        Default: ``[Save to temporary file]``
      - Output raster layer. One of:
 
-       * Save to a Temporary File
-       * Save to File...
+       .. include:: ../qgis/qgis_algs_include.rst
+          :start-after: **file_output_types**
+          :end-before: **end_file_output_types**
 
-       The file encoding can also be changed here.
 
 Outputs
 .......
@@ -216,10 +216,10 @@ Parameters
        Default: ``[Save to temporary file]``
      - Output raster layer. One of:
 
-       * Save to a Temporary File
-       * Save to File...
+       .. include:: ../qgis/qgis_algs_include.rst
+          :start-after: **file_output_types**
+          :end-before: **end_file_output_types**
 
-       The file encoding can also be changed here.
 
 Outputs
 .......
@@ -342,10 +342,10 @@ Parameters
        Default: ``[Save to temporary file]``
      - Specification of the output raster layer. One of:
 
-       * Save to a Temporary File
-       * Save to File...
+       .. include:: ../qgis/qgis_algs_include.rst
+          :start-after: **file_output_types**
+          :end-before: **end_file_output_types**
 
-       The file encoding can also be changed here.
 
 Outputs
 .......
@@ -517,10 +517,10 @@ Parameters
      - Specify the output raster layer with interpolated values.
        One of:
 
-       * Save to a Temporary File
-       * Save to File...
+       .. include:: ../qgis/qgis_algs_include.rst
+          :start-after: **file_output_types**
+          :end-before: **end_file_output_types**
 
-       The file encoding can also be changed here.
 
 Outputs
 .......
@@ -671,10 +671,10 @@ Parameters
      - Specify the output raster layer with interpolated values.
        One of:
 
-       * Save to a Temporary File
-       * Save to File...
+       .. include:: ../qgis/qgis_algs_include.rst
+          :start-after: **file_output_types**
+          :end-before: **end_file_output_types**
 
-       The file encoding can also be changed here.
 
 Outputs
 .......
@@ -845,10 +845,10 @@ Parameters
      - Specify the output raster layer with interpolated values.
        One of:
 
-       * Save to a Temporary File
-       * Save to File...
+       .. include:: ../qgis/qgis_algs_include.rst
+          :start-after: **file_output_types**
+          :end-before: **end_file_output_types**
 
-       The file encoding can also be changed here.
 
 Outputs
 .......
@@ -977,10 +977,10 @@ Parameters
      - Specify the output raster layer with interpolated values.
        One of:
 
-       * Save to a Temporary File
-       * Save to File...
+       .. include:: ../qgis/qgis_algs_include.rst
+          :start-after: **file_output_types**
+          :end-before: **end_file_output_types**
 
-       The file encoding can also be changed here.
 
 Outputs
 .......
@@ -1133,10 +1133,10 @@ Parameters
        Default: ``[Save to temporary file]``
      - Specify the output raster layer. One of:
 
-       * Save to a Temporary File
-       * Save to File...
+       .. include:: ../qgis/qgis_algs_include.rst
+          :start-after: **file_output_types**
+          :end-before: **end_file_output_types**
 
-       The file encoding can also be changed here.
 
 Outputs
 .......
@@ -1278,10 +1278,10 @@ Parameters
      - Specify the output raster layer with interpolated values.
        One of:
 
-       * Save to a Temporary File
-       * Save to File...
+       .. include:: ../qgis/qgis_algs_include.rst
+          :start-after: **file_output_types**
+          :end-before: **end_file_output_types**
 
-       The file encoding can also be changed here.
 
 Outputs
 .......
@@ -1428,10 +1428,10 @@ Parameters
      - Specify the output raster layer with interpolated values.
        One of:
 
-       * Save to a Temporary File
-       * Save to File...
+       .. include:: ../qgis/qgis_algs_include.rst
+          :start-after: **file_output_types**
+          :end-before: **end_file_output_types**
 
-       The file encoding can also be changed here.
 
 Outputs
 .......
@@ -1534,10 +1534,10 @@ Parameters
        Default: ``[Save to temporary file]``
      - Specify the output raster layer. One of:
 
-       * Save to a Temporary File
-       * Save to File...
+       .. include:: ../qgis/qgis_algs_include.rst
+          :start-after: **file_output_types**
+          :end-before: **end_file_output_types**
 
-       The file encoding can also be changed here.
 
 Outputs
 .......
@@ -1706,10 +1706,10 @@ Parameters
        Default: ``[Save to temporary file]``
      - Specify the output raster layer. One of:
 
-       * Save to a Temporary File
-       * Save to File...
+       .. include:: ../qgis/qgis_algs_include.rst
+          :start-after: **file_output_types**
+          :end-before: **end_file_output_types**
 
-       The file encoding can also be changed here.
 
 Outputs
 .......
@@ -1801,10 +1801,10 @@ Parameters
        Default: ``[Save to temporary file]``
      - Specify the output raster layer. One of:
 
-       * Save to a Temporary File
-       * Save to File...
+       .. include:: ../qgis/qgis_algs_include.rst
+          :start-after: **file_output_types**
+          :end-before: **end_file_output_types**
 
-       The file encoding can also be changed here.
 
 Outputs
 .......
@@ -1904,10 +1904,10 @@ Parameters
        Default: ``[Save to temporary file]``
      - Specify the output raster layer. One of:
 
-       * Save to a Temporary File
-       * Save to File...
+       .. include:: ../qgis/qgis_algs_include.rst
+          :start-after: **file_output_types**
+          :end-before: **end_file_output_types**
 
-       The file encoding can also be changed here.
 
 Outputs
 .......
@@ -2022,10 +2022,10 @@ Parameters
        Default: ``[Save to temporary file]``
      - Specify the output raster layer. One of:
 
-       * Save to a Temporary File
-       * Save to File...
+       .. include:: ../qgis/qgis_algs_include.rst
+          :start-after: **file_output_types**
+          :end-before: **end_file_output_types**
 
-       The file encoding can also be changed here.
 
 Outputs
 .......
@@ -2115,10 +2115,10 @@ Parameters
        Default: ``[Save to temporary file]``
      - Specify the output raster layer. One of:
 
-       * Save to a Temporary File
-       * Save to File...
+       .. include:: ../qgis/qgis_algs_include.rst
+          :start-after: **file_output_types**
+          :end-before: **end_file_output_types**
 
-       The file encoding can also be changed here.
 
 Outputs
 .......
@@ -2208,10 +2208,10 @@ Parameters
        Default: ``[Save to temporary file]``
      - Specify the output raster layer. One of:
 
-       * Save to a Temporary File
-       * Save to File...
+       .. include:: ../qgis/qgis_algs_include.rst
+          :start-after: **file_output_types**
+          :end-before: **end_file_output_types**
 
-       The file encoding can also be changed here.
 
 Outputs
 .......

--- a/docs/user_manual/processing_algs/gdal/rasterconversion.rst
+++ b/docs/user_manual/processing_algs/gdal/rasterconversion.rst
@@ -53,10 +53,10 @@ Parameters
      - Specification of the output file.
        One of:
 
-       * Save to a Temporary File
-       * Save to File...
+       .. include:: ../qgis/qgis_algs_include.rst
+          :start-after: **file_output_types**
+          :end-before: **end_file_output_types**
 
-       The file encoding can also be changed here.
   
 Outputs
 .......
@@ -134,10 +134,10 @@ Parameters
      - Specification of the output file.
        One of:
 
-       * Save to a Temporary File
-       * Save to File...
+       .. include:: ../qgis/qgis_algs_include.rst
+          :start-after: **file_output_types**
+          :end-before: **end_file_output_types**
 
-       The file encoding can also be changed here.
   
 Outputs
 .......
@@ -232,10 +232,10 @@ Parameters
      - Specification of the output (polygon) vector layer.
        One of:
 
-       * Save to a Temporary File
-       * Save to File...
+       .. include:: ../qgis/qgis_algs_include.rst
+          :start-after: **file_output_types**
+          :end-before: **end_file_output_types**
 
-       The file encoding can also be changed here.
   
 Outputs
 .......
@@ -336,10 +336,10 @@ Parameters
        Default: Save to temporary file
      - Specification of the output raster. One of:
 
-       * Save to a Temporary File
-       * Save to File...
+       .. include:: ../qgis/qgis_algs_include.rst
+          :start-after: **file_output_types**
+          :end-before: **end_file_output_types**
 
-       The file encoding can also be changed here.
   
 Outputs
 .......
@@ -417,10 +417,10 @@ Parameters
        Default: ``[Save to temporary file]``
      - Specification of the output raster. One of:
 
-       * Save to a Temporary File
-       * Save to File...
+       .. include:: ../qgis/qgis_algs_include.rst
+          :start-after: **file_output_types**
+          :end-before: **end_file_output_types**
 
-       The file encoding can also be changed here.
 
 Outputs
 .......
@@ -545,10 +545,10 @@ Parameters
      - Specification of the output (translated) raster layer.
        One of:
 
-       * Save to a Temporary File
-       * Save to File...
+       .. include:: ../qgis/qgis_algs_include.rst
+          :start-after: **file_output_types**
+          :end-before: **end_file_output_types**
 
-       The file encoding can also be changed here.
 
 Outputs
 .......

--- a/docs/user_manual/processing_algs/gdal/rasterconversion.rst
+++ b/docs/user_manual/processing_algs/gdal/rasterconversion.rst
@@ -333,7 +333,7 @@ Parameters
      - ``OUTPUT``
      - [raster]
 
-       Default: Save to temporary file
+       Default:  ``[Save to temporary file]``
      - Specification of the output raster. One of:
 
        .. include:: ../qgis/qgis_algs_include.rst

--- a/docs/user_manual/processing_algs/gdal/rasterextraction.rst
+++ b/docs/user_manual/processing_algs/gdal/rasterextraction.rst
@@ -106,10 +106,9 @@ Parameters
      - Specification of the output raster layer.
        One of:
 
-       * Save to a Temporary File
-       * Save to File...
-
-       The file encoding can also be changed here
+       .. include:: ../qgis/qgis_algs_include.rst
+          :start-after: **file_output_types**
+          :end-before: **end_file_output_types**
 
 Outputs
 .......
@@ -283,10 +282,9 @@ Parameters
      - Specification of the output raster layer.
        One of:
 
-       * Save to a Temporary File
-       * Save to File...
-
-       The file encoding can also be changed here
+       .. include:: ../qgis/qgis_algs_include.rst
+          :start-after: **file_output_types**
+          :end-before: **end_file_output_types**
 
 Outputs
 .......
@@ -410,10 +408,10 @@ Parameters
      - Specification of the output vector layer.
        One of:
 
-       * Save to a Temporary File
-       * Save to File...
+       .. include:: ../qgis/qgis_algs_include.rst
+          :start-after: **file_output_types**
+          :end-before: **end_file_output_types**
 
-       The file encoding can also be changed here.
 
 Outputs
 .......
@@ -547,10 +545,10 @@ Parameters
      - Specification of the output vector layer.
        One of:
 
-       * Save to a Temporary File
-       * Save to File...
+       .. include:: ../qgis/qgis_algs_include.rst
+          :start-after: **file_output_types**
+          :end-before: **end_file_output_types**
 
-       The file encoding can also be changed here.
 
 Outputs
 .......

--- a/docs/user_manual/processing_algs/gdal/rasterextraction.rst
+++ b/docs/user_manual/processing_algs/gdal/rasterextraction.rst
@@ -102,7 +102,7 @@ Parameters
      - ``OUTPUT``
      - [raster]
 
-       Default: '[Save to temporary file]'
+       Default: ``[Save to temporary file]``
      - Specification of the output raster layer.
        One of:
 
@@ -278,7 +278,7 @@ Parameters
    * - **Clipped (mask)**
      - ``OUTPUT``
      - [raster]
-       Default: '[Save to temporary file]'
+       Default: ``[Save to temporary file]``
      - Specification of the output raster layer.
        One of:
 
@@ -404,7 +404,7 @@ Parameters
      - ``OUTPUT``
      - [vector: line]
 
-       Default: '[Save to temporary file]'
+       Default: ``[Save to temporary file]``
      - Specification of the output vector layer.
        One of:
 
@@ -541,7 +541,7 @@ Parameters
      - ``OUTPUT``
      - [vector: polygon]
 
-       Default: '[Save to temporary file]'
+       Default: ``[Save to temporary file]``
      - Specification of the output vector layer.
        One of:
 

--- a/docs/user_manual/processing_algs/gdal/rastermiscellaneous.rst
+++ b/docs/user_manual/processing_algs/gdal/rastermiscellaneous.rst
@@ -1178,11 +1178,9 @@ Parameters
      -
        One of:
 
-       * Skip Output
-       * Save to a Temporary File
-       * Save to File...
-
-       The file encoding can also be changed here.
+       .. include:: ../qgis/qgis_algs_include.rst
+          :start-after: **file_output_types_skip**
+          :end-before: **end_file_output_types_skip**
 
 Outputs
 .......

--- a/docs/user_manual/processing_algs/gdal/rastermiscellaneous.rst
+++ b/docs/user_manual/processing_algs/gdal/rastermiscellaneous.rst
@@ -1166,10 +1166,10 @@ Parameters
      - Specify the output folder for the tiles.
        One of:
 
-       * Save to Temporary Directory
-       * Save to Directory...
+       .. include:: ../qgis/qgis_algs_include.rst
+          :start-after: **directory_output_types**
+          :end-before: **end_directory_output_types**
 
-       The file encoding can also be changed here.
    * - **CSV file containing the tile(s) georeferencing information**
      - ``OUTPUT_CSV``
      - [file]

--- a/docs/user_manual/processing_algs/gdal/rastermiscellaneous.rst
+++ b/docs/user_manual/processing_algs/gdal/rastermiscellaneous.rst
@@ -241,10 +241,10 @@ Parameters
      - Specification of the output raster layer.
        One of:
 
-       * Save to a Temporary File
-       * Save to File...
+       .. include:: ../qgis/qgis_algs_include.rst
+          :start-after: **file_output_types**
+          :end-before: **end_file_output_types**
 
-       The file encoding can also be changed here.
 
 Outputs
 .......
@@ -575,10 +575,10 @@ Parameters
      - Specification of the output raster layer.
        One of:
 
-       * Save to a Temporary File
-       * Save to File...
+       .. include:: ../qgis/qgis_algs_include.rst
+          :start-after: **file_output_types**
+          :end-before: **end_file_output_types**
 
-       The file encoding can also be changed here.
 
 Outputs
 .......
@@ -680,10 +680,10 @@ Parameters
        Default: ``[Save to temporary file]``
      - Specify the output (sharpened) raster layer. One of:
 
-       * Save to a Temporary File
-       * Save to File...
+       .. include:: ../qgis/qgis_algs_include.rst
+          :start-after: **file_output_types**
+          :end-before: **end_file_output_types**
 
-       The file encoding can also be changed here.
 
 Outputs
 .......
@@ -889,10 +889,10 @@ Parameters
        Default: ``[Save to temporary file]``
      - Specify the output (calculated) raster layer. One of:
 
-       * Save to a Temporary File
-       * Save to File...
+       .. include:: ../qgis/qgis_algs_include.rst
+          :start-after: **file_output_types**
+          :end-before: **end_file_output_types**
 
-       The file encoding can also be changed here.
 
 Outputs
 .......
@@ -991,10 +991,10 @@ Parameters
      - Specify the HTML file for output.
        One of:
 
-       * Save to a Temporary File
-       * Save to File...
+       .. include:: ../qgis/qgis_algs_include.rst
+          :start-after: **file_output_types**
+          :end-before: **end_file_output_types**
 
-       The file encoding can also be changed here.
 
 Outputs
 .......
@@ -1303,10 +1303,10 @@ Parameters
      - Specify the polygon vector layer to write the index to.
        One of:
 
-       * Save to a Temporary File
-       * Save to File
+       .. include:: ../qgis/qgis_algs_include.rst
+          :start-after: **file_output_types**
+          :end-before: **end_file_output_types**
 
-       The file encoding can also be changed here.
 
 Outputs
 .......

--- a/docs/user_manual/processing_algs/gdal/rastermiscellaneous.rst
+++ b/docs/user_manual/processing_algs/gdal/rastermiscellaneous.rst
@@ -1175,8 +1175,7 @@ Parameters
      - [file]
 
        Default: ``[Skip output]``
-     -
-       One of:
+     - Specify the output file for the tiles. One of:
 
        .. include:: ../qgis/qgis_algs_include.rst
           :start-after: **file_output_types_skip**

--- a/docs/user_manual/processing_algs/gdal/rasterprojections.rst
+++ b/docs/user_manual/processing_algs/gdal/rasterprojections.rst
@@ -294,7 +294,7 @@ Parameters
      - ``OUTPUT``
      - [raster]
 
-       Default: '[Save to temporary file]'
+       Default: ``[Save to temporary file]``
      - Specification of the output raster layer.
        One of:
 

--- a/docs/user_manual/processing_algs/gdal/rasterprojections.rst
+++ b/docs/user_manual/processing_algs/gdal/rasterprojections.rst
@@ -298,10 +298,10 @@ Parameters
      - Specification of the output raster layer.
        One of:
 
-       * Save to a Temporary File
-       * Save to File...
+       .. include:: ../qgis/qgis_algs_include.rst
+          :start-after: **file_output_types**
+          :end-before: **end_file_output_types**
 
-       The file encoding can also be changed here.
 
 Outputs
 .......

--- a/docs/user_manual/processing_algs/gdal/vectorconversion.rst
+++ b/docs/user_manual/processing_algs/gdal/vectorconversion.rst
@@ -47,10 +47,9 @@ Parameters
      - Specification of the output vector layer.
        One of:
 
-       * Save to a Temporary File
-       * Save to File...
-
-       The file encoding can also be changed here.
+       .. include:: ../qgis/qgis_algs_include.rst
+          :start-after: **file_output_types**
+          :end-before: **end_file_output_types**
 
        For ``Save to File``, the output format has to be specified.
        All GDAL vector formats are supported.
@@ -394,10 +393,10 @@ Parameters
      - Specification of the output raster layer.
        One of:
 
-       * Save to a Temporary File
-       * Save to File...
+       .. include:: ../qgis/qgis_algs_include.rst
+          :start-after: **file_output_types**
+          :end-before: **end_file_output_types**
 
-       The file encoding can also be changed here
        For ``Save to File``, the output format has to be specified.
        All GDAL raster formats are supported.
        For ``Save to a Temporary File`` the QGIS default raster format

--- a/docs/user_manual/processing_algs/gdal/vectorconversion.rst
+++ b/docs/user_manual/processing_algs/gdal/vectorconversion.rst
@@ -389,7 +389,7 @@ Parameters
      - ``OUTPUT``
      - [raster]
 
-       Default: '[Save to temporary file]'
+       Default: ``[Save to temporary file]``
      - Specification of the output raster layer.
        One of:
 

--- a/docs/user_manual/processing_algs/gdal/vectorgeoprocessing.rst
+++ b/docs/user_manual/processing_algs/gdal/vectorgeoprocessing.rst
@@ -80,10 +80,10 @@ Parameters
         Default: ``[Save to temporary file]``
       - Specify the output buffer layer. One of:
 
-        * Save to a Temporary File
-        * Save to File...
+        .. include:: ../qgis/qgis_algs_include.rst
+           :start-after: **file_output_types**
+           :end-before: **end_file_output_types**
 
-        The file encoding can also be changed here.
 
 Outputs
 .......
@@ -156,10 +156,10 @@ Parameters
         Default: ``[Save to temporary file]``
       - Specify the output (clipped) layer. One of:
 
-        * Save to a Temporary File
-        * Save to File...
+        .. include:: ../qgis/qgis_algs_include.rst
+           :start-after: **file_output_types**
+           :end-before: **end_file_output_types**
 
-        The file encoding can also be changed here.
 
 Outputs
 .......
@@ -232,10 +232,10 @@ Parameters
         Default: ``[Save to temporary file]``
       - The output (masked) layer. One of:
 
-        * Save to a Temporary File
-        * Save to File...
+        .. include:: ../qgis/qgis_algs_include.rst
+           :start-after: **file_output_types**
+           :end-before: **end_file_output_types**
 
-        The file encoding can also be changed here.
 
 Outputs
 .......
@@ -358,10 +358,10 @@ Parameters
         Default: ``[Save to temporary file]``
       - Specify the output layer. One of:
 
-        * Save to a Temporary File
-        * Save to File...
+        .. include:: ../qgis/qgis_algs_include.rst
+           :start-after: **file_output_types**
+           :end-before: **end_file_output_types**
 
-        The file encoding can also be changed here.
 
 Outputs
 .......
@@ -441,10 +441,10 @@ Parameters
         Default: ``[Save to temporary file]``
       - Specify the output line layer. One of:
 
-        * Save to a Temporary File
-        * Save to File...
+        .. include:: ../qgis/qgis_algs_include.rst
+           :start-after: **file_output_types**
+           :end-before: **end_file_output_types**
 
-        The file encoding can also be changed here.
 
 Outputs
 .......
@@ -555,10 +555,10 @@ Parameters
         Default: ``[Save to temporary file]``
       - Specify the output buffer layer. One of:
 
-        * Save to a Temporary File
-        * Save to File...
+        .. include:: ../qgis/qgis_algs_include.rst
+           :start-after: **file_output_types**
+           :end-before: **end_file_output_types**
 
-        The file encoding can also be changed here.
 
 Outputs
 .......
@@ -639,10 +639,10 @@ Parameters
       - Specify the output point layer.
         One of:
 
-        * Save to a Temporary File
-        * Save to File...
+        .. include:: ../qgis/qgis_algs_include.rst
+           :start-after: **file_output_types**
+           :end-before: **end_file_output_types**
 
-        The file encoding can also be changed here.
 
 Outputs
 .......

--- a/docs/user_manual/processing_algs/gdal/vectormiscellaneous.rst
+++ b/docs/user_manual/processing_algs/gdal/vectormiscellaneous.rst
@@ -51,10 +51,10 @@ Parameters
      - Specify the output layer containing only the duplicates.
        One of:
 
-       * Save to a Temporary File
-       * Save to File...
+       .. include:: ../qgis/qgis_algs_include.rst
+          :start-after: **file_output_types**
+          :end-before: **end_file_output_types**
 
-       The file encoding can also be changed here.
 
 Outputs
 ..........
@@ -138,10 +138,9 @@ Parameters
      - Specification of the output layer.
        One of:
 
-       * Save to a Temporary File
-       * Save to File...
-
-       The file encoding can also be changed here.
+       .. include:: ../qgis/qgis_algs_include.rst
+          :start-after: **file_output_types**
+          :end-before: **end_file_output_types**
 
        For ``Save to File``, the output format has to be specified.
        All GDAL vector formats are supported.
@@ -874,10 +873,10 @@ Parameters
      - Specify the output HTML file that includes the file
        information. One of:
 
-       * Save to a Temporary File
-       * Save to File...
+       .. include:: ../qgis/qgis_algs_include.rst
+          :start-after: **file_output_types**
+          :end-before: **end_file_output_types**
 
-       The file encoding can also be changed here.
        If no HTML-file is defined the output will be written
        to a temporary file
 

--- a/docs/user_manual/processing_algs/qgis/cartography.rst
+++ b/docs/user_manual/processing_algs/qgis/cartography.rst
@@ -662,8 +662,9 @@ Parameters
        Default: [Save to temporary file]
      - Name (including path) of the output file. One of:
 
-       * Save to a Temporary File
-       * Save to File...
+       .. include:: qgis_algs_include.rst
+          :start-after: **file_output_types**
+          :end-before: **end_file_output_types**
 
 Outputs
 .......
@@ -751,8 +752,9 @@ Parameters
        Default: [Save to temporary file]
      - Name (including path) of the output file. One of:
 
-       * Save to a Temporary File
-       * Save to File...
+       .. include:: qgis_algs_include.rst
+          :start-after: **file_output_types**
+          :end-before: **end_file_output_types**
 
 Outputs
 .......
@@ -871,8 +873,9 @@ Parameters
        Default: [Save to temporary file]
      - Name (including path) of the output file. One of:
 
-       * Save to a Temporary File
-       * Save to File...
+       .. include:: qgis_algs_include.rst
+          :start-after: **file_output_types**
+          :end-before: **end_file_output_types**
 
 Outputs
 .......

--- a/docs/user_manual/processing_algs/qgis/cartography.rst
+++ b/docs/user_manual/processing_algs/qgis/cartography.rst
@@ -958,12 +958,10 @@ the original map item CRS will be used.
        Default: ``[Create temporary layer]``
      - Specify the output vector layer for the extent(s). One of:
 
-       * Create Temporary Layer (``TEMPORARY_OUTPUT``)
-       * Save to File...
-       * Save to Geopackage...
-       * Save to PostGIS Table...
+       .. include:: qgis_algs_include.rst
+          :start-after: **layer_output_types**
+          :end-before: **end_layer_output_types**
 
-       The file encoding can also be changed here.
 
 Outputs
 .......
@@ -1150,12 +1148,10 @@ Parameters
        Default: ``[Create temporary layer]``
      - Specify the output layer. One of:
 
-       * Create Temporary Layer (``TEMPORARY_OUTPUT``)
-       * Save to File...
-       * Save to Geopackage...
-       * Save to PostGIS Table...
+       .. include:: qgis_algs_include.rst
+          :start-after: **layer_output_types**
+          :end-before: **end_layer_output_types**
 
-       The file encoding can also be changed here.
 
 Outputs
 .......

--- a/docs/user_manual/processing_algs/qgis/cartography.rst
+++ b/docs/user_manual/processing_algs/qgis/cartography.rst
@@ -270,13 +270,10 @@ Parameters
      - Output table for categories which do not match any symbol in
        the database. One of:
 
-       * Skip output
-       * Create Temporary Layer (``TEMPORARY_OUTPUT``)
-       * Save to File...
-       * Save to Geopackage...
-       * Save to PostGIS Table...
+       .. include:: qgis_algs_include.rst
+          :start-after: **layer_output_types_skip**
+          :end-before: **end_layer_output_types_skip**
 
-       The file encoding can also be changed here.
    * - **Non-matching symbol names**
 
        Optional
@@ -287,13 +284,10 @@ Parameters
      - Output table for symbols from the provided style database which
        do not match any category. One of:
 
-       * Skip output
-       * Create Temporary Layer (``TEMPORARY_OUTPUT``)
-       * Save to File...
-       * Save to Geopackage...
-       * Save to PostGIS Table...
+       .. include:: qgis_algs_include.rst
+          :start-after: **layer_output_types_skip**
+          :end-before: **end_layer_output_types_skip**
 
-       The file encoding can also be changed here.
 
 Outputs
 .......

--- a/docs/user_manual/processing_algs/qgis/database.rst
+++ b/docs/user_manual/processing_algs/qgis/database.rst
@@ -304,7 +304,7 @@ Parameters
    * - **Save only selected features**
      - ``SELECTED_FEATURES_ONLY``
      - [boolean]
-     
+
        Default: False
      - If a layer has a selection, setting this option to ``True``
        will result in only selected features being saved. For
@@ -312,8 +312,13 @@ Parameters
    * - **Destination GeoPackage**
      - ``OUTPUT``
      - [file]
-     - If not specified the GeoPackage will be saved in the
-       temporary folder.
+
+       Default: ``[Save to temporary file]``
+     - Specify where to store the GeoPackage file. One of
+
+       .. include:: qgis_algs_include.rst
+          :start-after: **file_output_types**
+          :end-before: **end_file_output_types**
 
 Outputs
 .......

--- a/docs/user_manual/processing_algs/qgis/filetools.rst
+++ b/docs/user_manual/processing_algs/qgis/filetools.rst
@@ -38,11 +38,9 @@ Parameters
      - Specification of the file destination.
        One of:
 
-       * Skip Output
-       * Save to a Temporary File
-       * Save to File...
-
-       The file encoding can also be changed here.
+       .. include:: qgis_algs_include.rst
+          :start-after: **file_output_types_skip**
+          :end-before: **end_file_output_types_skip**
        
 
 Outputs

--- a/docs/user_manual/processing_algs/qgis/interpolation.rst
+++ b/docs/user_manual/processing_algs/qgis/interpolation.rst
@@ -149,7 +149,6 @@ Parameters
           :start-after: **file_output_types**
           :end-before: **end_file_output_types**
 
-
 Outputs
 .......
 
@@ -353,7 +352,6 @@ Parameters
           :start-after: **file_output_types**
           :end-before: **end_file_output_types**
 
-
 Outputs
 .......
 
@@ -444,9 +442,6 @@ Parameters
        .. include:: qgis_algs_include.rst
           :start-after: **file_output_types**
           :end-before: **end_file_output_types**
-
-
-
 
 Outputs
 .......

--- a/docs/user_manual/processing_algs/qgis/interpolation.rst
+++ b/docs/user_manual/processing_algs/qgis/interpolation.rst
@@ -587,11 +587,9 @@ Parameters
        Default: ``[Skip output]``
      - The output TIN as a vector layer. One of:
 
-       * Skip Output
-       * Create Temporary Layer (``TEMPORARY_OUTPUT``)
-       * Save to File...
-       * Save to Geopackage...
-       * Save to PostGIS Table...
+       .. include:: qgis_algs_include.rst
+          :start-after: **layer_output_types_skip**
+          :end-before: **end_layer_output_types_skip**
 
 Outputs
 .......

--- a/docs/user_manual/processing_algs/qgis/interpolation.rst
+++ b/docs/user_manual/processing_algs/qgis/interpolation.rst
@@ -145,10 +145,10 @@ Parameters
      - Specify the output raster layer with kernel density values.
        One of:
 
-       * Save to a Temporary File
-       * Save to File...
+       .. include:: qgis_algs_include.rst
+          :start-after: **file_output_types**
+          :end-before: **end_file_output_types**
 
-       The file encoding can also be changed here.
 
 Outputs
 .......
@@ -349,10 +349,10 @@ Parameters
      - Raster layer of interpolated values.
        One of:
 
-       * Save to a Temporary File
-       * Save to File...
+       .. include:: qgis_algs_include.rst
+          :start-after: **file_output_types**
+          :end-before: **end_file_output_types**
 
-       The file encoding can also be changed here.
 
 Outputs
 .......
@@ -441,10 +441,11 @@ Parameters
        Default: ``[Save to temporary file]``
      - The output as a raster layer. One of:
 
-       * Save to a Temporary File
-       * Save to File...
+       .. include:: qgis_algs_include.rst
+          :start-after: **file_output_types**
+          :end-before: **end_file_output_types**
 
-       The file encoding can also be changed here.
+
 
 
 Outputs
@@ -575,10 +576,10 @@ Parameters
        Default: ``[Save to temporary file]``
      - The output TIN interpolation as a raster layer. One of:
 
-       * Save to a Temporary File
-       * Save to File...
+       .. include:: qgis_algs_include.rst
+          :start-after: **file_output_types**
+          :end-before: **end_file_output_types**
 
-       The file encoding can also be changed here.
    * - **Triangulation**
      - ``TRIANGULATION``
      - [vector: line]

--- a/docs/user_manual/processing_algs/qgis/layertools.rst
+++ b/docs/user_manual/processing_algs/qgis/layertools.rst
@@ -135,12 +135,9 @@ Parameters
      - Specify the polygon vector layer for the output extent.
        One of:
 
-       * Create Temporary Layer (``TEMPORARY_OUTPUT``)
-       * Save to File...
-       * Save to Geopackage...
-       * Save to PostGIS Table...
-
-       The file encoding can also be changed here.
+       .. include:: qgis_algs_include.rst
+          :start-after: **layer_output_types**
+          :end-before: **end_layer_output_types**
 
 Outputs
 .......

--- a/docs/user_manual/processing_algs/qgis/networkanalysis.rst
+++ b/docs/user_manual/processing_algs/qgis/networkanalysis.rst
@@ -83,13 +83,10 @@ Parameters
      - Specify the output line layer for the service area.
        One of:
 
-       * Skip output
-       * Create Temporary Layer (``TEMPORARY_OUTPUT``)
-       * Save to File...
-       * Save to Geopackage...
-       * Save to PostGIS Table...
+       .. include:: qgis_algs_include.rst
+          :start-after: **layer_output_types_skip**
+          :end-before: **end_layer_output_types_skip**
 
-       The file encoding can also be changed here.
    * - **Service area (boundary nodes)**
      - ``OUTPUT``
      - [vector: point]
@@ -98,13 +95,10 @@ Parameters
      - Specify the output point layer for the service area
        boundary nodes. One of:
 
-       * Skip output
-       * Create Temporary Layer (``TEMPORARY_OUTPUT``)
-       * Save to File...
-       * Save to Geopackage...
-       * Save to PostGIS Table...
+       .. include:: qgis_algs_include.rst
+          :start-after: **layer_output_types_skip**
+          :end-before: **end_layer_output_types_skip**
 
-       The file encoding can also be changed here.
 
 Outputs
 .......
@@ -203,13 +197,10 @@ Parameters
      - Specify the output line layer for the service area.
        One of:
 
-       * Skip output
-       * Create Temporary Layer (``TEMPORARY_OUTPUT``)
-       * Save to File...
-       * Save to Geopackage...
-       * Save to PostGIS Table...
+       .. include:: qgis_algs_include.rst
+          :start-after: **layer_output_types_skip**
+          :end-before: **end_layer_output_types_skip**
 
-       The file encoding can also be changed here.
    * - **Service area (boundary nodes)**
      - ``OUTPUT``
      - [vector: point]
@@ -218,13 +209,10 @@ Parameters
      - Specify the output point layer for the service area
        boundary nodes. One of:
 
-       * Skip output
-       * Create Temporary Layer (``TEMPORARY_OUTPUT``)
-       * Save to File...
-       * Save to Geopackage...
-       * Save to PostGIS Table...
+       .. include:: qgis_algs_include.rst
+          :start-after: **layer_output_types_skip**
+          :end-before: **end_layer_output_types_skip**
 
-       The file encoding can also be changed here.
 
 .. include:: qgis_algs_include.rst
   :start-after: **network_advanced_parameters_service_area**

--- a/docs/user_manual/processing_algs/qgis/networkanalysis.rst
+++ b/docs/user_manual/processing_algs/qgis/networkanalysis.rst
@@ -409,12 +409,10 @@ Parameters
      - Specify the output line layer for the shortest paths.
        One of:
 
-       * Create Temporary Layer (``TEMPORARY_OUTPUT``)
-       * Save to File...
-       * Save to Geopackage...
-       * Save to PostGIS Table...
+       .. include:: qgis_algs_include.rst
+          :start-after: **layer_output_types**
+          :end-before: **end_layer_output_types**
 
-       The file encoding can also be changed here.
 
 Outputs
 .......
@@ -581,12 +579,10 @@ Parameters
      - Specify the output line layer for the shortest paths.
        One of:
 
-       * Create Temporary Layer (``TEMPORARY_OUTPUT``)
-       * Save to File...
-       * Save to Geopackage...
-       * Save to PostGIS Table...
+       .. include:: qgis_algs_include.rst
+          :start-after: **layer_output_types**
+          :end-before: **end_layer_output_types**
 
-       The file encoding can also be changed here.
 
 Outputs
 .......
@@ -767,12 +763,10 @@ Parameters
      - Specify the output line layer for the shortest paths.
        One of:
 
-       * Create Temporary Layer (``TEMPORARY_OUTPUT``)
-       * Save to File...
-       * Save to Geopackage...
-       * Save to PostGIS Table...
+       .. include:: qgis_algs_include.rst
+          :start-after: **layer_output_types**
+          :end-before: **end_layer_output_types**
 
-       The file encoding can also be changed here.
 
 Outputs
 .......

--- a/docs/user_manual/processing_algs/qgis/plots.rst
+++ b/docs/user_manual/processing_algs/qgis/plots.rst
@@ -45,10 +45,11 @@ Parameters
        Default: ``[Save to temporary file]``
      - Specify the HTML file for the plot. One of:
 
-       * Save to a Temporary File
-       * Save to File...
+       .. include:: qgis_algs_include.rst
+          :start-after: **file_output_types**
+          :end-before: **end_file_output_types**
 
-       The file encoding can also be changed here.
+
 
 Outputs
 .......
@@ -126,10 +127,11 @@ Parameters
        Default: ``[Save to temporary file]``
      - Specify the HTML file for the plot. One of:
 
-       * Save to a Temporary File
-       * Save to File...
+       .. include:: qgis_algs_include.rst
+          :start-after: **file_output_types**
+          :end-before: **end_file_output_types**
 
-       The file encoding can also be changed here.
+
 
 Outputs
 .......
@@ -195,10 +197,11 @@ Parameters
        Default: ``[Save to temporary file]``
      - Specify the HTML file for the plot. One of:
 
-       * Save to a Temporary File
-       * Save to File...
+       .. include:: qgis_algs_include.rst
+          :start-after: **file_output_types**
+          :end-before: **end_file_output_types**
 
-       The file encoding can also be changed here.
+
 
 Outputs
 .......
@@ -267,10 +270,11 @@ Parameters
        Default: ``[Save to temporary file]``
      - Specify the HTML file for the plot. One of:
 
-       * Save to a Temporary File
-       * Save to File...
+       .. include:: qgis_algs_include.rst
+          :start-after: **file_output_types**
+          :end-before: **end_file_output_types**
 
-       The file encoding can also be changed here.
+
 
 Outputs
 .......
@@ -338,10 +342,11 @@ Parameters
        Default: ``[Save to temporary file]``
      - Specify the HTML file for the plot. One of:
 
-       * Save to a Temporary File
-       * Save to File...
+       .. include:: qgis_algs_include.rst
+          :start-after: **file_output_types**
+          :end-before: **end_file_output_types**
 
-       The file encoding can also be changed here.
+
 
 Outputs
 .......
@@ -411,10 +416,11 @@ Parameters
        Default: ``[Save to temporary file]``
      - Specify the HTML file for the plot. One of:
 
-       * Save to a Temporary File
-       * Save to File...
+       .. include:: qgis_algs_include.rst
+          :start-after: **file_output_types**
+          :end-before: **end_file_output_types**
 
-       The file encoding can also be changed here.
+
 
 Outputs
 .......
@@ -480,10 +486,11 @@ Parameters
        Default: ``[Save to temporary file]``
      - Specify the HTML file for the plot. One of:
 
-       * Save to a Temporary File
-       * Save to File...
+       .. include:: qgis_algs_include.rst
+          :start-after: **file_output_types**
+          :end-before: **end_file_output_types**
 
-       The file encoding can also be changed here.
+
 
 Outputs
 .......
@@ -553,10 +560,10 @@ Parameters
        Default: ``[Save to temporary file]``
      - Specify the HTML file for the plot. One of:
 
-       * Save to a Temporary File
-       * Save to File...
+       .. include:: qgis_algs_include.rst
+          :start-after: **file_output_types**
+          :end-before: **end_file_output_types**
 
-       The file encoding can also be changed here.
 
 Outputs
 .......

--- a/docs/user_manual/processing_algs/qgis/plots.rst
+++ b/docs/user_manual/processing_algs/qgis/plots.rst
@@ -49,8 +49,6 @@ Parameters
           :start-after: **file_output_types**
           :end-before: **end_file_output_types**
 
-
-
 Outputs
 .......
 
@@ -131,8 +129,6 @@ Parameters
           :start-after: **file_output_types**
           :end-before: **end_file_output_types**
 
-
-
 Outputs
 .......
 
@@ -200,8 +196,6 @@ Parameters
        .. include:: qgis_algs_include.rst
           :start-after: **file_output_types**
           :end-before: **end_file_output_types**
-
-
 
 Outputs
 .......
@@ -274,8 +268,6 @@ Parameters
           :start-after: **file_output_types**
           :end-before: **end_file_output_types**
 
-
-
 Outputs
 .......
 
@@ -345,8 +337,6 @@ Parameters
        .. include:: qgis_algs_include.rst
           :start-after: **file_output_types**
           :end-before: **end_file_output_types**
-
-
 
 Outputs
 .......
@@ -420,8 +410,6 @@ Parameters
           :start-after: **file_output_types**
           :end-before: **end_file_output_types**
 
-
-
 Outputs
 .......
 
@@ -489,8 +477,6 @@ Parameters
        .. include:: qgis_algs_include.rst
           :start-after: **file_output_types**
           :end-before: **end_file_output_types**
-
-
 
 Outputs
 .......
@@ -563,7 +549,6 @@ Parameters
        .. include:: qgis_algs_include.rst
           :start-after: **file_output_types**
           :end-before: **end_file_output_types**
-
 
 Outputs
 .......

--- a/docs/user_manual/processing_algs/qgis/qgis_algs_include.rst
+++ b/docs/user_manual/processing_algs/qgis/qgis_algs_include.rst
@@ -439,7 +439,7 @@ Algorithm Output Types
 ......................
 
 .. The following describes the different options for algorithm outputs,
- with variants including the "skip output" option
+ with variants including the "skip output" and the "append" options
 
 Directory
 ^^^^^^^^^
@@ -492,6 +492,19 @@ Layer
 The file encoding can also be changed here.
 
 **end_layer_output_types**
+
+
+**layer_output_types_append**
+
+* Create Temporary Layer (``TEMPORARY_OUTPUT``)
+* Save to File...
+* Save to Geopackage...
+* Save to Database Table...
+* Append to Layer...
+
+The file encoding can also be changed here.
+
+**end_layer_output_types_append**
 
 
 **layer_output_types_skip**

--- a/docs/user_manual/processing_algs/qgis/qgis_algs_include.rst
+++ b/docs/user_manual/processing_algs/qgis/qgis_algs_include.rst
@@ -433,3 +433,75 @@ See :ref:`processing_console` for details on how to run processing algorithms
 from the Python console.
 
 **end_algorithm_code_section**
+
+
+Algorithm Output Types
+......................
+
+.. The following describes the different options for algorithm outputs,
+ with variants including the "skip output" option
+
+Directory
+^^^^^^^^^
+
+**directory_output_types**
+
+* Save to a Temporary Directory
+* Save to Directory
+
+**end_directory_output_types**
+
+
+**directory_output_types_skip**
+
+* Skip Output
+* Save to a Temporary Directory
+* Save to Directory
+
+**end_directory_output_types_skip**
+
+File
+^^^^
+
+**file_output_types**
+
+* Save to a Temporary File
+* Save to File...
+
+**end_file_output_types**
+
+
+**file_output_types_skip**
+
+* Skip Output
+* Save to a Temporary File
+* Save to File...
+
+**end_file_output_types_skip**
+
+Layer
+^^^^^
+
+**layer_output_types**
+
+* Create Temporary Layer (``TEMPORARY_OUTPUT``)
+* Save to File...
+* Save to Geopackage...
+* Save to Database Table...
+
+The file encoding can also be changed here.
+
+**end_layer_output_types**
+
+
+**layer_output_types_skip**
+
+* Skip Output
+* Create Temporary Layer (``TEMPORARY_OUTPUT``)
+* Save to File...
+* Save to Geopackage...
+* Save to Database Table...
+
+The file encoding can also be changed here.
+
+**end_layer_output_types_skip**

--- a/docs/user_manual/processing_algs/qgis/rasteranalysis.rst
+++ b/docs/user_manual/processing_algs/qgis/rasteranalysis.rst
@@ -1958,7 +1958,7 @@ Parameters
      - ``OUTPUT``
      - [raster]
 
-       Default: '[Save to temporary file]'
+       Default: ``[Save to temporary file]``
      - Specification of the output raster layer.
        One of:
 
@@ -1980,9 +1980,7 @@ Outputs
    * - **Reclassified raster**
      - ``OUTPUT``
      - [raster]
-
-       Default: '[Save to temporary file]'
-     - The output raster layer.
+     - Output raster layer with reclassified band values
 
 Python code
 ...........
@@ -2015,11 +2013,11 @@ Parameters
      - Name
      - Type
      - Description
-   * - **Input Point Layer**
+   * - **Input Layer**
      - ``INPUT``
      - [vector: point]
      - Point vector layer to use for  sampling
-   * - **Raster Layer to sample**
+   * - **Raster Layer**
      - ``RASTERCOPY``
      - [raster]
      - Raster layer to sample at the given point locations.
@@ -2027,9 +2025,9 @@ Parameters
      - ``COLUMN_PREFIX``
      - [string]
 
-       Default: 'rvalue'
+       Default: 'SAMPLE\_'
      - Prefix for the names of the added columns.
-   * - **Sampled Points**
+   * - **Sampled**
 
        Optional
      - ``OUTPUT``
@@ -2055,9 +2053,7 @@ Outputs
      - Name
      - Type
      - Description
-   * - **Sampled Points**
-
-       Optional
+   * - **Sampled**
      - ``OUTPUT``
      - [vector: point]
      - The output layer containing the sampled values.
@@ -2145,12 +2141,8 @@ Outputs
      - Type
      - Description
    * - **Output zones**
-
-       Optional
      - ``OUTPUT``
      - [vector: polygon]
-
-       Default: ``[Create temporary layer]``
      - The output vector polygon layer.
 
 Python code

--- a/docs/user_manual/processing_algs/qgis/rasteranalysis.rst
+++ b/docs/user_manual/processing_algs/qgis/rasteranalysis.rst
@@ -1293,11 +1293,9 @@ Parameters
        Default: ``[Save to temporary file]``
      - Specification of the output file:
 
-       * Skip Output
-       * Save to a Temporary File
-       * Save to File...
-
-       The file encoding can also be changed here.
+       .. include:: qgis_algs_include.rst
+          :start-after: **file_output_types_skip**
+          :end-before: **end_file_output_types_skip**
 
 Outputs
 .......
@@ -1402,11 +1400,10 @@ Parameters
        Default: ``[Save to temporary file]``
      - Specification of the output file:
 
-       * Skip Output
-       * Save to a Temporary File
-       * Save to File...
+       .. include:: qgis_algs_include.rst
+          :start-after: **file_output_types_skip**
+          :end-before: **end_file_output_types_skip**
 
-       The file encoding can also be changed here.
    * - **Unique values table**
      - ``OUTPUT_TABLE``
      - [table]

--- a/docs/user_manual/processing_algs/qgis/rasteranalysis.rst
+++ b/docs/user_manual/processing_algs/qgis/rasteranalysis.rst
@@ -2045,12 +2045,10 @@ Parameters
      - Specify the output layer containing the sampled values.
        One of:
 
-       * Create Temporary Layer (``TEMPORARY_OUTPUT``)
-       * Save to File...
-       * Save to GeoPackage...
-       * Save to PostGIS Table...
+       .. include:: qgis_algs_include.rst
+          :start-after: **layer_output_types**
+          :end-before: **end_layer_output_types**
 
-       The file encoding can also be changed here.
 
 Outputs
 .......
@@ -2136,12 +2134,10 @@ Parameters
      - Specify the output vector polygon layer.
        One of:
 
-       * Create Temporary Layer (``TEMPORARY_OUTPUT``)
-       * Save to File...
-       * Save to GeoPackage...
-       * Save to PostGIS Table...
+       .. include:: qgis_algs_include.rst
+          :start-after: **layer_output_types**
+          :end-before: **end_layer_output_types**
 
-       The file encoding can also be changed here.
 
 Outputs
 .......

--- a/docs/user_manual/processing_algs/qgis/rasteranalysis.rst
+++ b/docs/user_manual/processing_algs/qgis/rasteranalysis.rst
@@ -1411,13 +1411,10 @@ Parameters
        Default: ``[Skip output]``
      - Specification of the table for unique values:
 
-       * Skip Output
-       * Create Temporary Layer
-       * Save to File...
-       * Save to GeoPackage...
-       * Save to PostGIS Table......
+       .. include:: qgis_algs_include.rst
+          :start-after: **layer_output_types_skip**
+          :end-before: **end_layer_output_types_skip**
 
-       The file encoding can also be changed here.
 
 Outputs
 .......

--- a/docs/user_manual/processing_algs/qgis/rasteranalysis.rst
+++ b/docs/user_manual/processing_algs/qgis/rasteranalysis.rst
@@ -1693,13 +1693,10 @@ Parameters
        Default: ``[Skip output]``
      - Specification of the output table. One of:
 
-       * Skip output
-       * Create Temporary Layer (``TEMPORARY_OUTPUT``)
-       * Save to File...
-       * Save to Geopackage...
-       * Save to PostGIS Table...
+       .. include:: qgis_algs_include.rst
+          :start-after: **layer_output_types_skip**
+          :end-before: **end_layer_output_types_skip**
 
-       The file encoding can also be changed here.
 
 Outputs
 .......

--- a/docs/user_manual/processing_algs/qgis/rasteranalysis.rst
+++ b/docs/user_manual/processing_algs/qgis/rasteranalysis.rst
@@ -110,10 +110,11 @@ Parameters
      - [same as input]
      - Specification of the output raster. One of:
 
-       * Save to a Temporary File
-       * Save to File...
+       .. include:: qgis_algs_include.rst
+          :start-after: **file_output_types**
+          :end-before: **end_file_output_types**
 
-       The file encoding can also be changed here.
+
 
 Outputs
 .......
@@ -226,10 +227,11 @@ Parameters
      - [same as input]
      - Specification of the output raster. One of:
 
-       * Save to a Temporary File
-       * Save to File...
+       .. include:: qgis_algs_include.rst
+          :start-after: **file_output_types**
+          :end-before: **end_file_output_types**
 
-       The file encoding can also be changed here.
+
 
 Outputs
 .......
@@ -336,10 +338,11 @@ Parameters
      - [same as input]
      - Specification of the output raster. One of:
 
-       * Save to a Temporary File
-       * Save to File...
+       .. include:: qgis_algs_include.rst
+          :start-after: **file_output_types**
+          :end-before: **end_file_output_types**
 
-       The file encoding can also be changed here.
+
 
 Outputs
 .......
@@ -451,10 +454,10 @@ Parameters
      - [same as input]
      - Specification of the output raster. One of:
 
-       * Save to a Temporary File
-       * Save to File...
+       .. include:: qgis_algs_include.rst
+          :start-after: **file_output_types**
+          :end-before: **end_file_output_types**
 
-       The file encoding can also be changed here.
 
 Outputs
 .......
@@ -560,10 +563,9 @@ Parameters
      - [same as input]
      - Specification of the output raster. One of:
 
-       * Save to a Temporary File
-       * Save to File...
-
-       The file encoding can also be changed here.
+       .. include:: qgis_algs_include.rst
+          :start-after: **file_output_types**
+          :end-before: **end_file_output_types**
 
 Outputs
 .......
@@ -678,10 +680,9 @@ Parameters
      - [same as input]
      - Specification of the output raster. One of:
 
-       * Save to a Temporary File
-       * Save to File...
-
-       The file encoding can also be changed here.
+       .. include:: qgis_algs_include.rst
+          :start-after: **file_output_types**
+          :end-before: **end_file_output_types**
 
 Outputs
 .......
@@ -787,10 +788,9 @@ Parameters
      - [same as input]
      - Specification of the output raster. One of:
 
-       * Save to a Temporary File
-       * Save to File...
-
-       The file encoding can also be changed here.
+       .. include:: qgis_algs_include.rst
+          :start-after: **file_output_types**
+          :end-before: **end_file_output_types**
 
 Outputs
 .......
@@ -1225,10 +1225,9 @@ Parameters
        Default: ``[Save to temporary file]``
      - Specification of the output raster. One of:
 
-       * Save to a Temporary File
-       * Save to File...
-
-       The file encoding can also be changed here.
+       .. include:: qgis_algs_include.rst
+          :start-after: **file_output_types**
+          :end-before: **end_file_output_types**
 
 Outputs
 .......
@@ -1844,12 +1843,13 @@ Parameters
    * - **Reclassified raster**
      - ``OUTPUT``
      - [raster]
+
+       Default: ``[Save to temporary file]``
      - Specification of the output raster. One of:
 
-       * Save to a Temporary File
-       * Save to File...
-
-       The file encoding can also be changed here.
+       .. include:: qgis_algs_include.rst
+          :start-after: **file_output_types**
+          :end-before: **end_file_output_types**
 
 Outputs
 .......
@@ -1968,10 +1968,9 @@ Parameters
      - Specification of the output raster layer.
        One of:
 
-       * Save to a Temporary File
-       * Save to File...
-
-       The file encoding can also be changed here
+       .. include:: qgis_algs_include.rst
+          :start-after: **file_output_types**
+          :end-before: **end_file_output_types**
 
 Outputs
 .......

--- a/docs/user_manual/processing_algs/qgis/rastertools.rst
+++ b/docs/user_manual/processing_algs/qgis/rastertools.rst
@@ -328,9 +328,9 @@ Parameters
        Default: ``[Save to temporary file]``
      - Specification of the output HTML file. One of:
 
-       * Skip Output
-       * Save to a Temporary File
-       * Save to File...
+       .. include:: qgis_algs_include.rst
+          :start-after: **file_output_types_skip**
+          :end-before: **end_file_output_types_skip**
 
 Outputs
 .......
@@ -456,11 +456,10 @@ Parameters
        Default: ``[Save to temporary file]``
      - Specification of the output file. One of:
 
-       * Skip Output
-       * Save to a Temporary File
-       * Save to File...
+       .. include:: qgis_algs_include.rst
+          :start-after: **file_output_types_skip**
+          :end-before: **end_file_output_types_skip**
 
-       The file encoding can also be changed here.
 
 Outputs
 .......

--- a/docs/user_manual/processing_algs/qgis/rastertools.rst
+++ b/docs/user_manual/processing_algs/qgis/rastertools.rst
@@ -82,8 +82,8 @@ Parameters
    * - **Output layer**
      - ``OUTPUT``
      - [raster]
-       
-       Default: Save to temporary file
+
+       Default: ``[Save to temporary file]``
      - Specification of the output raster. One of:
 
        .. include:: qgis_algs_include.rst

--- a/docs/user_manual/processing_algs/qgis/rastertools.rst
+++ b/docs/user_manual/processing_algs/qgis/rastertools.rst
@@ -85,11 +85,10 @@ Parameters
        
        Default: Save to temporary file
      - Specification of the output raster. One of:
-       
-       * Save to a Temporary File
-       * Save to File...
-       
-       The file encoding can also be changed here.
+
+       .. include:: qgis_algs_include.rst
+          :start-after: **file_output_types**
+          :end-before: **end_file_output_types**
 
 Outputs
 .......
@@ -167,11 +166,10 @@ Parameters
      - ``OUTPUT``
      - [raster]
      - Specification of the output raster. One of:
-       
-       * Save to a Temporary File
-       * Save to File...
-       
-       The file encoding can also be changed here.
+
+       .. include:: qgis_algs_include.rst
+          :start-after: **file_output_types**
+          :end-before: **end_file_output_types**
 
 Outputs
 .......

--- a/docs/user_manual/processing_algs/qgis/rastertools.rst
+++ b/docs/user_manual/processing_algs/qgis/rastertools.rst
@@ -316,11 +316,10 @@ Parameters
        Default: ``[Save to temporary folder]``
      - Specification of the output raster. One of:
 
-       * Skip Output
-       * Save to a Temporary Directory
-       * Save to Directory...
+       .. include:: qgis_algs_include.rst
+          :start-after: **directory_output_types_skip**
+          :end-before: **end_directory_output_types_skip**
 
-       The file encoding can also be changed here.
    * - **Output html (Leaflet)**
      - ``OUTPUT_HTML``
      - [html]

--- a/docs/user_manual/processing_algs/qgis/vectoranalysis.rst
+++ b/docs/user_manual/processing_algs/qgis/vectoranalysis.rst
@@ -326,7 +326,13 @@ Parameters
    * - **Count**
      - ``OUTPUT``
      - [vector: polygon]
-     - Specification of the output layer
+
+       Default: ``[Create temporary layer]``
+     - Specification of the output layer. One of:
+
+       .. include:: qgis_algs_include.rst
+          :start-after: **layer_output_types_append**
+          :end-before: **end_layer_output_types_append**
 
 Outputs
 .......

--- a/docs/user_manual/processing_algs/qgis/vectoranalysis.rst
+++ b/docs/user_manual/processing_algs/qgis/vectoranalysis.rst
@@ -1196,12 +1196,10 @@ Parameters
        Default: ``[Create temporary layer]``
      - Specify the output vector layer. One of:
 
-       * Create Temporary Layer (``TEMPORARY_OUTPUT``)
-       * Save to File...
-       * Save to Geopackage...
-       * Save to PostGIS Table...
+       .. include:: qgis_algs_include.rst
+          :start-after: **layer_output_types**
+          :end-before: **end_layer_output_types**
 
-       The file encoding can also be changed here.
 
 Outputs
 .......

--- a/docs/user_manual/processing_algs/qgis/vectoranalysis.rst
+++ b/docs/user_manual/processing_algs/qgis/vectoranalysis.rst
@@ -44,9 +44,17 @@ Parameters
      - [tablefield: any]
      - Any supported table field to calculate the statistics
    * - **Statistics**
+
+       Optional
      - ``OUTPUT_HTML_FILE``
      - [html]
-     - HTML file for the calculated statistics
+
+       Default: ``[Save to temporary file]``
+     - Specification of the file for the calculated statistics. One of:
+
+       .. include:: qgis_algs_include.rst
+          :start-after: **file_output_types_skip**
+          :end-before: **end_file_output_types_skip**
 
 Outputs
 .......
@@ -191,7 +199,13 @@ Parameters
    * - **Climb layer**
      - ``OUTPUT``
      - [vector: line]
-     - The output (line) layer
+
+       Default: ``[Create temporary layer]``
+     - Specification of the output (line) layer. One of:
+
+       .. include:: qgis_algs_include.rst
+          :start-after: **layer_output_types**
+          :end-before: **end_layer_output_types**
 
 Outputs
 .......
@@ -500,7 +514,13 @@ Parameters
    * - **Distance matrix**
      - ``OUTPUT``
      - [vector: point]
-     -
+
+       Default: ``[Create temporary layer]``
+     - Specification of the output vector layer. One of:
+
+       .. include:: qgis_algs_include.rst
+          :start-after: **layer_output_types**
+          :end-before: **end_layer_output_types**
 
 Outputs
 .......
@@ -591,7 +611,14 @@ Parameters
    * - **Hub distance**
      - ``OUTPUT``
      - [vector: line]
-     - Line vector layer for the distance matrix output
+
+       Default: ``[Create temporary layer]``
+     - Specify the output line vector layer connecting the matching points.
+       One of:
+
+       .. include:: qgis_algs_include.rst
+          :start-after: **layer_output_types**
+          :end-before: **end_layer_output_types**
 
 Outputs
 .......
@@ -676,7 +703,14 @@ Parameters
    * - **Hub distance**
      - ``OUTPUT``
      - [vector: point]
-     - Point vector layer for the distance matrix output.
+
+       Default: ``[Create temporary layer]``
+     - Specify the output point vector layer with the nearest hub.
+       One of:
+
+       .. include:: qgis_algs_include.rst
+          :start-after: **layer_output_types**
+          :end-before: **end_layer_output_types**
 
 Outputs
 .......
@@ -692,8 +726,8 @@ Outputs
    * - **Hub distance**
      - ``OUTPUT``
      - [vector: point]
-     - Point vector layer with the attributes of the
-       input features, the identifier of their closest
+     - Point vector layer representing the center of the source features
+       with their attributes, the identifier of their closest
        feature and the calculated distance.
 
 Python code
@@ -816,7 +850,7 @@ Outputs
    * - **Hub lines**
      - ``OUTPUT``
      - [vector: line]
-     - The resulting line layer
+     - The resulting line layer connecting matching points in input layers
 
 Python code
 ...........
@@ -898,7 +932,7 @@ Outputs
      - ``OUTPUT``
      - [vector: any]
      - Vector layer containing the original features with
-       a field specifying the cluster they belong to
+       fields specifying the cluster they belong to and their number in it
 
 Python code
 ...........
@@ -939,14 +973,31 @@ Parameters
      - [tablefield: any]
      - Field to analyze
    * - **Unique values**
+
+       Optional
      - ``OUTPUT``
      - [table]
-     - Summary table layer with unique values
+
+       Default:``[Create temporary layer]``
+     - Specify the summary table layer with unique values. One of:
+
+       .. include:: qgis_algs_include.rst
+          :start-after: **layer_output_types_skip**
+          :end-before: **end_layer_output_types_skip**
+
    * - **HTML report**
+
+       Optional
      - ``OUTPUT_HTML_FILE``
      - [html]
+
+       Default:``[Save to temporary file]``
      - HTML report of unique values in the
-       :menuselection:`Processing --> Results viewer`
+       :menuselection:`Processing --> Results viewer`. One of:
+
+       .. include:: qgis_algs_include.rst
+          :start-after: **file_output_types_skip**
+          :end-before: **end_file_output_types_skip**
 
 Outputs
 .......
@@ -1035,7 +1086,13 @@ Parameters
    * - **Mean coordinates**
      - ``OUTPUT``
      - [vector: point]
-     - The (point vector) layer for the result
+
+       Default:``[Create temporary layer]``
+     - Specify the (point vector) layer for the result. One of:
+
+       .. include:: qgis_algs_include.rst
+          :start-after: **layer_output_types**
+          :end-before: **end_layer_output_types**
 
 Outputs
 .......
@@ -1107,10 +1164,18 @@ Parameters
      - [vector: point]
      - Point vector layer to calculate the statistics on
    * - **Nearest neighbour**
+
+       Optional
      - ``OUTPUT_HTML_FILE``
      - [html]
-     - HTML file for the computed statistics
 
+       Default:``[Save to temporary file]``
+     - Specification of the HTML file for the computed statistics.
+       One of:
+
+       .. include:: qgis_algs_include.rst
+          :start-after: **file_output_types_skip**
+          :end-before: **end_file_output_types_skip**
 
 Outputs
 .......
@@ -1200,7 +1265,6 @@ Parameters
           :start-after: **layer_output_types**
           :end-before: **end_layer_output_types**
 
-
 Outputs
 .......
 
@@ -1264,7 +1328,13 @@ Parameters
    * - **Statistics by category**
      - ``OUTPUT``
      - [table]
-     - Table for the generated statistics
+
+       Default: ``[Create temporary layer]``
+     - Specify the output table for the generated statistics. One of:
+
+       .. include:: qgis_algs_include.rst
+          :start-after: **layer_output_types**
+          :end-before: **end_layer_output_types**
 
 Outputs
 .......
@@ -1433,7 +1503,13 @@ Parameters
    * - **Line length**
      - ``OUTPUT``
      - [vector: polygon]
-     - The output polygon vector layer
+
+       Default: ``[Create temporary layer]``
+     - Specify the output polygon layer with generated statistics. One of:
+
+       .. include:: qgis_algs_include.rst
+          :start-after: **layer_output_types**
+          :end-before: **end_layer_output_types**
 
 Outputs
 .......

--- a/docs/user_manual/processing_algs/qgis/vectorcreation.rst
+++ b/docs/user_manual/processing_algs/qgis/vectorcreation.rst
@@ -200,9 +200,8 @@ Parameters
        The original features are also copied. One of:
 
        .. include:: qgis_algs_include.rst
-          :start-after: **layer_output_types**
-          :end-before: **end_layer_output_types**
-
+          :start-after: **layer_output_types_append**
+          :end-before: **end_layer_output_types_append**
 
 Outputs
 .......

--- a/docs/user_manual/processing_algs/qgis/vectorcreation.rst
+++ b/docs/user_manual/processing_algs/qgis/vectorcreation.rst
@@ -649,13 +649,10 @@ Parameters
      - Specify the table of unreadable or non-geotagged photos.
        One of:
 
-       * Skip Output
-       * Create Temporary Layer (``TEMPORARY_OUTPUT``)
-       * Save to File...
-       * Save to Geopackage...
-       * Save to PostGIS Table...
+       .. include:: qgis_algs_include.rst
+          :start-after: **layer_output_types_skip**
+          :end-before: **end_layer_output_types_skip**
 
-       The file encoding can also be changed here.
 
 Outputs
 .......

--- a/docs/user_manual/processing_algs/qgis/vectorcreation.rst
+++ b/docs/user_manual/processing_algs/qgis/vectorcreation.rst
@@ -772,11 +772,9 @@ Parameters
      - Specify the directory that will contain the description
        files of points and paths. One of:
 
-       * Skip Output
-       * Save to a Temporary Directory
-       * Save to Directory...
-
-       The file encoding can also be changed here.
+       .. include:: qgis_algs_include.rst
+          :start-after: **directory_output_types_skip**
+          :end-before: **end_directory_output_types_skip**
 
 
 Outputs

--- a/docs/user_manual/processing_algs/qgis/vectorcreation.rst
+++ b/docs/user_manual/processing_algs/qgis/vectorcreation.rst
@@ -90,12 +90,10 @@ Parameters
        Default: ``[Create temporary layer]``
      - Specify the output line layer with offset features. One of:
 
-       * Create Temporary Layer (``TEMPORARY_OUTPUT``)
-       * Save to File...
-       * Save to Geopackage...
-       * Save to PostGIS Table...
+       .. include:: qgis_algs_include.rst
+          :start-after: **layer_output_types**
+          :end-before: **end_layer_output_types**
 
-       The file encoding can also be changed here.
 
 Outputs
 .......
@@ -201,12 +199,10 @@ Parameters
        of the features.
        The original features are also copied. One of:
 
-       * Create Temporary Layer (``TEMPORARY_OUTPUT``)
-       * Save to File...
-       * Save to Geopackage...
-       * Save to PostGIS Table...
+       .. include:: qgis_algs_include.rst
+          :start-after: **layer_output_types**
+          :end-before: **end_layer_output_types**
 
-       The file encoding can also be changed here.
 
 Outputs
 .......
@@ -326,12 +322,10 @@ Parameters
        Default: ``[Create temporary layer]``
      - Resulting vector grid layer. One of:
 
-       * Create Temporary Layer (``TEMPORARY_OUTPUT``)
-       * Save to File...
-       * Save to Geopackage...
-       * Save to PostGIS Table...
+       .. include:: qgis_algs_include.rst
+          :start-after: **layer_output_types**
+          :end-before: **end_layer_output_types**
 
-       The file encoding can also be changed here.
 
 Outputs
 .......
@@ -420,12 +414,10 @@ Parameters
        Default: ``[Create temporary layer]``
      - Specify the resulting point layer. One of:
 
-       * Create Temporary Layer (``TEMPORARY_OUTPUT``)
-       * Save to File...
-       * Save to Geopackage...
-       * Save to PostGIS Table...
+       .. include:: qgis_algs_include.rst
+          :start-after: **layer_output_types**
+          :end-before: **end_layer_output_types**
 
-       The file encoding can also be changed here.
 
 Outputs
 .......
@@ -494,12 +486,10 @@ Parameters
        Default: ``[Create temporary layer]``
      - Resulting point layer with pixel centroids. One of:
 
-       * Create Temporary Layer (``TEMPORARY_OUTPUT``)
-       * Save to File...
-       * Save to Geopackage...
-       * Save to PostGIS Table...
+       .. include:: qgis_algs_include.rst
+          :start-after: **layer_output_types**
+          :end-before: **end_layer_output_types**
 
-       The file encoding can also be changed here.
 
 Outputs
 .......
@@ -568,12 +558,10 @@ Parameters
        Default: ``[Create temporary layer]``
      - Resulting point layer of pixel centroids. One of:
 
-       * Create Temporary Layer (``TEMPORARY_OUTPUT``)
-       * Save to File...
-       * Save to Geopackage...
-       * Save to PostGIS Table...
+       .. include:: qgis_algs_include.rst
+          :start-after: **layer_output_types**
+          :end-before: **end_layer_output_types**
 
-       The file encoding can also be changed here.
 
 Outputs
 .......
@@ -647,12 +635,10 @@ Parameters
      - Specify the point vector layer for the geotagged photos.
        One of:
 
-       * Create Temporary Layer (``TEMPORARY_OUTPUT``)
-       * Save to File...
-       * Save to Geopackage...
-       * Save to PostGIS Table...
+       .. include:: qgis_algs_include.rst
+          :start-after: **layer_output_types**
+          :end-before: **end_layer_output_types**
 
-       The file encoding can also be changed here.
    * - **Invalid photos table**
 
        Optional
@@ -775,12 +761,10 @@ Parameters
        Default: ``[Create temporary layer]``
      - Specify the line vector layer of the path. One of:
 
-       * Create Temporary Layer (``TEMPORARY_OUTPUT``)
-       * Save to File...
-       * Save to Geopackage...
-       * Save to PostGIS Table...
+       .. include:: qgis_algs_include.rst
+          :start-after: **layer_output_types**
+          :end-before: **end_layer_output_types**
 
-       The file encoding can also be changed here.
    * - **Directory for text output**
 
        Optional
@@ -897,12 +881,10 @@ Parameters
        Default: ``[Create temporary layer]``
      - The output random points. One of:
 
-       * Create Temporary Layer (``TEMPORARY_OUTPUT``)
-       * Save to File...
-       * Save to Geopackage...
-       * Save to PostGIS Table...
+       .. include:: qgis_algs_include.rst
+          :start-after: **layer_output_types**
+          :end-before: **end_layer_output_types**
 
-       The file encoding can also be changed here.
 
 Outputs
 .......
@@ -990,12 +972,10 @@ Parameters
        Default: ``[Create temporary layer]``
      - The output random points. One of:
 
-       * Create Temporary Layer (``TEMPORARY_OUTPUT``)
-       * Save to File...
-       * Save to Geopackage...
-       * Save to PostGIS Table...
+       .. include:: qgis_algs_include.rst
+          :start-after: **layer_output_types**
+          :end-before: **end_layer_output_types**
 
-       The file encoding can also be changed here.
 
 Outputs
 .......
@@ -1069,12 +1049,10 @@ Parameters
        Default: ``[Create temporary layer]``
      - The output random points. One of:
 
-       * Create Temporary Layer (``TEMPORARY_OUTPUT``)
-       * Save to File...
-       * Save to Geopackage...
-       * Save to PostGIS Table...
+       .. include:: qgis_algs_include.rst
+          :start-after: **layer_output_types**
+          :end-before: **end_layer_output_types**
 
-       The file encoding can also be changed here.
 
 Outputs
 .......
@@ -1220,12 +1198,10 @@ Parameters
        Default: ``[Create temporary layer]``
      - The output random points. One of:
 
-       * Create Temporary Layer (``TEMPORARY_OUTPUT``)
-       * Save to File...
-       * Save to Geopackage...
-       * Save to PostGIS Table...
+       .. include:: qgis_algs_include.rst
+          :start-after: **layer_output_types**
+          :end-before: **end_layer_output_types**
 
-       The file encoding can also be changed here.
 
 Outputs
 .......
@@ -1336,12 +1312,10 @@ Parameters
        Default: ``[Create temporary layer]``
      - The output random points. One of:
 
-       * Create Temporary Layer (``TEMPORARY_OUTPUT``)
-       * Save to File...
-       * Save to Geopackage...
-       * Save to PostGIS Table...
+       .. include:: qgis_algs_include.rst
+          :start-after: **layer_output_types**
+          :end-before: **end_layer_output_types**
 
-       The file encoding can also be changed here.
 
 Outputs
 .......
@@ -1487,12 +1461,10 @@ Parameters
        Default: ``[Create temporary layer]``
      - The output random points. One of:
 
-       * Create Temporary Layer (``TEMPORARY_OUTPUT``)
-       * Save to File...
-       * Save to Geopackage...
-       * Save to PostGIS Table...
+       .. include:: qgis_algs_include.rst
+          :start-after: **layer_output_types**
+          :end-before: **end_layer_output_types**
 
-       The file encoding can also be changed here.
 
 Outputs
 .......
@@ -1582,12 +1554,10 @@ Parameters
      - Specify the resulting point layer of pixels centroids.
        One of:
 
-       * Create Temporary Layer (``TEMPORARY_OUTPUT``)
-       * Save to File...
-       * Save to Geopackage...
-       * Save to PostGIS Table...
+       .. include:: qgis_algs_include.rst
+          :start-after: **layer_output_types**
+          :end-before: **end_layer_output_types**
 
-       The file encoding can also be changed here.
 
 Outputs
 .......
@@ -1659,12 +1629,10 @@ Parameters
      - Specify the resulting polygon layer of pixel extents.
        One of:
 
-       * Create Temporary Layer (``TEMPORARY_OUTPUT``)
-       * Save to File...
-       * Save to Geopackage...
-       * Save to PostGIS Table...
+       .. include:: qgis_algs_include.rst
+          :start-after: **layer_output_types**
+          :end-before: **end_layer_output_types**
 
-       The file encoding can also be changed here.
 
 Outputs
 .......
@@ -1765,12 +1733,10 @@ Parameters
        Default: ``[Create temporary layer]``
      - Specify the output regular point layer. One of:
 
-       * Create Temporary Layer (``TEMPORARY_OUTPUT``)
-       * Save to File...
-       * Save to Geopackage...
-       * Save to PostGIS Table...
+       .. include:: qgis_algs_include.rst
+          :start-after: **layer_output_types**
+          :end-before: **end_layer_output_types**
 
-       The file encoding can also be changed here.
 
 Outputs
 .......

--- a/docs/user_manual/processing_algs/qgis/vectorcreation.rst
+++ b/docs/user_manual/processing_algs/qgis/vectorcreation.rst
@@ -326,7 +326,6 @@ Parameters
           :start-after: **layer_output_types**
           :end-before: **end_layer_output_types**
 
-
 Outputs
 .......
 
@@ -418,7 +417,6 @@ Parameters
           :start-after: **layer_output_types**
           :end-before: **end_layer_output_types**
 
-
 Outputs
 .......
 
@@ -489,7 +487,6 @@ Parameters
        .. include:: qgis_algs_include.rst
           :start-after: **layer_output_types**
           :end-before: **end_layer_output_types**
-
 
 Outputs
 .......
@@ -562,7 +559,6 @@ Parameters
           :start-after: **layer_output_types**
           :end-before: **end_layer_output_types**
 
-
 Outputs
 .......
 
@@ -628,6 +624,8 @@ Parameters
        Default: False
      - If checked, the folder and its subfolders will be scanned
    * - **Photos**
+
+       Optional
      - ``OUTPUT``
      - [vector: point]
 
@@ -636,8 +634,8 @@ Parameters
        One of:
 
        .. include:: qgis_algs_include.rst
-          :start-after: **layer_output_types**
-          :end-before: **end_layer_output_types**
+          :start-after: **layer_output_types_skip**
+          :end-before: **end_layer_output_types_skip**
 
    * - **Invalid photos table**
 
@@ -652,7 +650,6 @@ Parameters
        .. include:: qgis_algs_include.rst
           :start-after: **layer_output_types_skip**
           :end-before: **end_layer_output_types_skip**
-
 
 Outputs
 .......
@@ -776,7 +773,6 @@ Parameters
           :start-after: **directory_output_types_skip**
           :end-before: **end_directory_output_types_skip**
 
-
 Outputs
 .......
 
@@ -879,7 +875,6 @@ Parameters
        .. include:: qgis_algs_include.rst
           :start-after: **layer_output_types**
           :end-before: **end_layer_output_types**
-
 
 Outputs
 .......
@@ -1047,7 +1042,6 @@ Parameters
        .. include:: qgis_algs_include.rst
           :start-after: **layer_output_types**
           :end-before: **end_layer_output_types**
-
 
 Outputs
 .......
@@ -1311,7 +1305,6 @@ Parameters
           :start-after: **layer_output_types**
           :end-before: **end_layer_output_types**
 
-
 Outputs
 .......
 
@@ -1486,7 +1479,7 @@ Outputs
      - [number]
      - Not including features with empty or no geometry
    * - **Total number of points generated**
-     - ``OUTPUT_POINTS``
+     - ``POINTS_GENERATED``
      - [number]
      - 
    * - **Number of missed points**
@@ -1552,7 +1545,6 @@ Parameters
        .. include:: qgis_algs_include.rst
           :start-after: **layer_output_types**
           :end-before: **end_layer_output_types**
-
 
 Outputs
 .......
@@ -1627,7 +1619,6 @@ Parameters
        .. include:: qgis_algs_include.rst
           :start-after: **layer_output_types**
           :end-before: **end_layer_output_types**
-
 
 Outputs
 .......
@@ -1731,7 +1722,6 @@ Parameters
        .. include:: qgis_algs_include.rst
           :start-after: **layer_output_types**
           :end-before: **end_layer_output_types**
-
 
 Outputs
 .......

--- a/docs/user_manual/processing_algs/qgis/vectorgeneral.rst
+++ b/docs/user_manual/processing_algs/qgis/vectorgeneral.rst
@@ -619,13 +619,10 @@ Parameters
      - Specify the output layer containing only the duplicates.
        One of:
 
-       * Skip output
-       * Create Temporary Layer (``TEMPORARY_OUTPUT``)
-       * Save to File...
-       * Save to Geopackage...
-       * Save to PostGIS Table...
+       .. include:: qgis_algs_include.rst
+          :start-after: **layer_output_types_skip**
+          :end-before: **end_layer_output_types_skip**
 
-       The file encoding can also be changed here.
 
 Outputs
 ..........
@@ -1323,13 +1320,10 @@ Parameters
        features from first layer.
        One of:
 
-       * Skip output
-       * Create Temporary Layer (``TEMPORARY_OUTPUT``)
-       * Save to File...
-       * Save to Geopackage...
-       * Save to PostGIS Table...
+       .. include:: qgis_algs_include.rst
+          :start-after: **layer_output_types_skip**
+          :end-before: **end_layer_output_types_skip**
 
-       The file encoding can also be changed here.
 
 Outputs
 ..........
@@ -1483,13 +1477,10 @@ Parameters
        features from first layer.
        One of:
 
-       * Skip output
-       * Create Temporary Layer (``TEMPORARY_OUTPUT``)
-       * Save to File...
-       * Save to Geopackage...
-       * Save to PostGIS Table...
+       .. include:: qgis_algs_include.rst
+          :start-after: **layer_output_types_skip**
+          :end-before: **end_layer_output_types_skip**
 
-       The file encoding can also be changed here.
 
 Outputs
 ..........
@@ -1752,13 +1743,10 @@ Parameters
      - Specify the vector layer containing the features that could
        not be joined. One of:
 
-       * Skip output
-       * Create Temporary Layer (``TEMPORARY_OUTPUT``)
-       * Save to File...
-       * Save to Geopackage...
-       * Save to PostGIS Table...
+       .. include:: qgis_algs_include.rst
+          :start-after: **layer_output_types_skip**
+          :end-before: **end_layer_output_types_skip**
 
-       The file encoding can also be changed here.
 
 Outputs
 .......

--- a/docs/user_manual/processing_algs/qgis/vectorgeneral.rst
+++ b/docs/user_manual/processing_algs/qgis/vectorgeneral.rst
@@ -2222,10 +2222,9 @@ Parameters
      - Specify the directory for the output layers.
        One of:
 
-       * Save to a Temporary Directory
-       * Save to Directory...
-
-       The file encoding can also be changed here.
+       .. include:: qgis_algs_include.rst
+          :start-after: **directory_output_types**
+          :end-before: **end_directory_output_types**
 
 Outputs
 ..........

--- a/docs/user_manual/processing_algs/qgis/vectorgeneral.rst
+++ b/docs/user_manual/processing_algs/qgis/vectorgeneral.rst
@@ -57,12 +57,10 @@ Parameters
      - Specify the output layer containing only the duplicates.
        One of:
 
-       * Create Temporary Layer (``TEMPORARY_OUTPUT``)
-       * Save to File...
-       * Save to Geopackage...
-       * Save to PostGIS Table...
+       .. include:: qgis_algs_include.rst
+          :start-after: **layer_output_types**
+          :end-before: **end_layer_output_types**
 
-       The file encoding can also be changed here.
 
 Outputs
 ..........
@@ -277,12 +275,10 @@ Parameters
        Default: ``[Create temporary layer]``
      - Specify the output layer. One of:
 
-       * Create Temporary Layer (``TEMPORARY_OUTPUT``)
-       * Save to File...
-       * Save to Geopackage...
-       * Save to PostGIS Table...
+       .. include:: qgis_algs_include.rst
+          :start-after: **layer_output_types**
+          :end-before: **end_layer_output_types**
 
-       The file encoding can also be changed here.
 
 Outputs
 ..........
@@ -526,12 +522,10 @@ Parameters
        Default: ``[Create temporary layer]``
      - Specify the output layer. One of:
 
-       * Create Temporary Layer (``TEMPORARY_OUTPUT``)
-       * Save to File...
-       * Save to Geopackage...
-       * Save to PostGIS Table...
+       .. include:: qgis_algs_include.rst
+          :start-after: **layer_output_types**
+          :end-before: **end_layer_output_types**
 
-       The file encoding can also be changed here.
 
 Outputs
 ..........
@@ -611,12 +605,10 @@ Parameters
      - Specify the output layer containing the unique features.
        One of:
 
-       * Create Temporary Layer (``TEMPORARY_OUTPUT``)
-       * Save to File...
-       * Save to Geopackage...
-       * Save to PostGIS Table...
+       .. include:: qgis_algs_include.rst
+          :start-after: **layer_output_types**
+          :end-before: **end_layer_output_types**
 
-       The file encoding can also be changed here.
    * - **Filtered (duplicates)**
 
        Optional
@@ -742,36 +734,30 @@ Parameters
      - Specify the output vector layer containing the unchanged
        features. One of:
 
-       * Create Temporary Layer (``TEMPORARY_OUTPUT``)
-       * Save to File...
-       * Save to Geopackage...
-       * Save to PostGIS Table...
+       .. include:: qgis_algs_include.rst
+          :start-after: **layer_output_types**
+          :end-before: **end_layer_output_types**
 
-       The file encoding can also be changed here.
    * - **Added features**
      - ``ADDED``
      - [vector: same as Original layer]
      - Specify the output vector layer containing the added features.
        One of:
 
-       * Create Temporary Layer (``TEMPORARY_OUTPUT``)
-       * Save to File...
-       * Save to Geopackage...
-       * Save to PostGIS Table...
+       .. include:: qgis_algs_include.rst
+          :start-after: **layer_output_types**
+          :end-before: **end_layer_output_types**
 
-       The file encoding can also be changed here.
    * - **Deleted features**
      - ``DELETED``
      - [vector: same as Original layer]
      - Specify the output vector layer containing the deleted
        features. One of:
 
-       * Create Temporary Layer (``TEMPORARY_OUTPUT``)
-       * Save to File...
-       * Save to Geopackage...
-       * Save to PostGIS Table...
+       .. include:: qgis_algs_include.rst
+          :start-after: **layer_output_types**
+          :end-before: **end_layer_output_types**
 
-       The file encoding can also be changed here.
 
 Outputs
 ..........
@@ -856,12 +842,10 @@ Parameters
      - [table]
      - Specify the output geometryless layer. One of:
 
-       * Create Temporary Layer (``TEMPORARY_OUTPUT``)
-       * Save to File...
-       * Save to Geopackage...
-       * Save to PostGIS Table...
+       .. include:: qgis_algs_include.rst
+          :start-after: **layer_output_types**
+          :end-before: **end_layer_output_types**
 
-       The file encoding can also be changed here.
 
 Outputs
 ..........
@@ -980,12 +964,10 @@ Parameters
        Default: ``[Create temporary layer]``
      - Specify the output layer created by the query. One of:
 
-       * Create Temporary Layer (``TEMPORARY_OUTPUT``)
-       * Save to File...
-       * Save to Geopackage...
-       * Save to PostGIS Table...
+       .. include:: qgis_algs_include.rst
+          :start-after: **layer_output_types**
+          :end-before: **end_layer_output_types**
 
-       The file encoding can also be changed here.
 
 Outputs
 ..........
@@ -1045,12 +1027,10 @@ Parameters
      - Specify the vector layer for the selected features.
        One of:
 
-       * Create Temporary Layer (``TEMPORARY_OUTPUT``)
-       * Save to File...
-       * Save to Geopackage...
-       * Save to PostGIS Table...
+       .. include:: qgis_algs_include.rst
+          :start-after: **layer_output_types**
+          :end-before: **end_layer_output_types**
 
-       The file encoding can also be changed here.
 
 Outputs
 ..........
@@ -1134,12 +1114,10 @@ Parameters
      - Specify the table (geometryless layer) for the CRS
        suggestions (EPSG codes). One of:
 
-       * Create Temporary Layer (``TEMPORARY_OUTPUT``)
-       * Save to File...
-       * Save to Geopackage...
-       * Save to PostGIS Table...
+       .. include:: qgis_algs_include.rst
+          :start-after: **layer_output_types**
+          :end-before: **end_layer_output_types**
 
-       The file encoding can also be changed here.
 
 Outputs
 ..........
@@ -1332,12 +1310,10 @@ Parameters
      - Specify the output vector layer for the join.
        One of:
 
-       * Create Temporary Layer (``TEMPORARY_OUTPUT``)
-       * Save to File...
-       * Save to Geopackage...
-       * Save to PostGIS Table...
+       .. include:: qgis_algs_include.rst
+          :start-after: **layer_output_types**
+          :end-before: **end_layer_output_types**
 
-       The file encoding can also be changed here.
    * - **Unjoinable features from first layer**
      - ``NON_MATCHING``
      - [same as input]
@@ -1494,12 +1470,10 @@ Parameters
      - Specify the output vector layer for the join.
        One of:
 
-       * Create Temporary Layer (``TEMPORARY_OUTPUT``)
-       * Save to File...
-       * Save to Geopackage...
-       * Save to PostGIS Table...
+       .. include:: qgis_algs_include.rst
+          :start-after: **layer_output_types**
+          :end-before: **end_layer_output_types**
 
-       The file encoding can also be changed here.
    * - **Unjoinable features from first layer**
      - ``NON_MATCHING``
      - [same as input]
@@ -1661,12 +1635,10 @@ Parameters
      - Specify the output vector layer for the join.
        One of:
 
-       * Create Temporary Layer (``TEMPORARY_OUTPUT``)
-       * Save to File...
-       * Save to Geopackage...
-       * Save to PostGIS Table...
+       .. include:: qgis_algs_include.rst
+          :start-after: **layer_output_types**
+          :end-before: **end_layer_output_types**
 
-       The file encoding can also be changed here.
 
 Outputs
 ..........
@@ -1768,12 +1740,10 @@ Parameters
      - Specify the vector layer containing the joined features.
        One of:
 
-       * Create Temporary Layer (``TEMPORARY_OUTPUT``)
-       * Save to File...
-       * Save to Geopackage...
-       * Save to PostGIS Table...
+       .. include:: qgis_algs_include.rst
+          :start-after: **layer_output_types**
+          :end-before: **end_layer_output_types**
 
-       The file encoding can also be changed here.
    * - **Unjoinable features from first layer**
      - ``NON_MATCHING``
      - [same as input]
@@ -1893,12 +1863,10 @@ Parameters
        Default: ``[Create temporary layer]``
      - Specify the output vector layer. One of:
 
-       * Create Temporary Layer (``TEMPORARY_OUTPUT``)
-       * Save to File...
-       * Save to Geopackage...
-       * Save to PostGIS Table...
+       .. include:: qgis_algs_include.rst
+          :start-after: **layer_output_types**
+          :end-before: **end_layer_output_types**
 
-       The file encoding can also be changed here.
 
 Outputs
 ..........
@@ -1976,12 +1944,10 @@ Parameters
        Default: ``[Create temporary layer]``
      - Specify the output vector layer. One of:
 
-       * Create Temporary Layer (``TEMPORARY_OUTPUT``)
-       * Save to File...
-       * Save to Geopackage...
-       * Save to PostGIS Table...
+       .. include:: qgis_algs_include.rst
+          :start-after: **layer_output_types**
+          :end-before: **end_layer_output_types**
 
-       The file encoding can also be changed here.
 
 Outputs
 ..........
@@ -2110,12 +2076,10 @@ Parameters
        Default: ``[Create temporary layer]``
      - Specify the output vector layer. One of:
 
-       * Create Temporary Layer (``TEMPORARY_OUTPUT``)
-       * Save to File...
-       * Save to Geopackage...
-       * Save to PostGIS Table...
+       .. include:: qgis_algs_include.rst
+          :start-after: **layer_output_types**
+          :end-before: **end_layer_output_types**
 
-       The file encoding can also be changed here.
 
 Outputs
 ..........
@@ -2194,12 +2158,10 @@ Parameters
        Default: ``Create temporary layer``
      - Specify output vector layer. One of:
 
-       * Create Temporary Layer (``TEMPORARY_OUTPUT``)
-       * Save to File...
-       * Save to Geopackage...
-       * Save to PostGIS Table...
+       .. include:: qgis_algs_include.rst
+          :start-after: **layer_output_types**
+          :end-before: **end_layer_output_types**
 
-       The file encoding can also be changed here.
 
 Outputs
 ..........

--- a/docs/user_manual/processing_algs/qgis/vectorgeometry.rst
+++ b/docs/user_manual/processing_algs/qgis/vectorgeometry.rst
@@ -196,9 +196,8 @@ Parameters
        One of:
 
        .. include:: qgis_algs_include.rst
-          :start-after: **layer_output_types**
-          :end-before: **end_layer_output_types**
-
+          :start-after: **layer_output_types_append**
+          :end-before: **end_layer_output_types_append**
    
 Outputs
 .......
@@ -427,9 +426,8 @@ Parameters
        One of:
 
        .. include:: qgis_algs_include.rst
-          :start-after: **layer_output_types**
-          :end-before: **end_layer_output_types**
-
+          :start-after: **layer_output_types_append**
+          :end-before: **end_layer_output_types_append**
 
 Outputs
 .......
@@ -499,9 +497,8 @@ Parameters
        One of:
 
        .. include:: qgis_algs_include.rst
-          :start-after: **layer_output_types**
-          :end-before: **end_layer_output_types**
-
+          :start-after: **layer_output_types_append**
+          :end-before: **end_layer_output_types_append**
 
 Outputs
 .......
@@ -646,9 +643,8 @@ Parameters
        One of:
 
        .. include:: qgis_algs_include.rst
-          :start-after: **layer_output_types**
-          :end-before: **end_layer_output_types**
-
+          :start-after: **layer_output_types_append**
+          :end-before: **end_layer_output_types_append**
 
 Outputs
 .......
@@ -734,9 +730,8 @@ Parameters
        One of:
 
        .. include:: qgis_algs_include.rst
-          :start-after: **layer_output_types**
-          :end-before: **end_layer_output_types**
-
+          :start-after: **layer_output_types_append**
+          :end-before: **end_layer_output_types_append**
 
 Outputs
 .......
@@ -1448,9 +1443,8 @@ Parameters
      - Specify the output vector layer. One of:
 
        .. include:: qgis_algs_include.rst
-          :start-after: **layer_output_types**
-          :end-before: **end_layer_output_types**
-
+          :start-after: **layer_output_types_append**
+          :end-before: **end_layer_output_types_append**
 
 Outputs
 .......
@@ -1588,7 +1582,6 @@ Parameters
           :start-after: **layer_output_types**
           :end-before: **end_layer_output_types**
 
-
 Outputs
 .......
 
@@ -1694,9 +1687,8 @@ Parameters
      - Specify the output vector layer. One of:
 
        .. include:: qgis_algs_include.rst
-          :start-after: **layer_output_types**
-          :end-before: **end_layer_output_types**
-
+          :start-after: **layer_output_types_append**
+          :end-before: **end_layer_output_types_append**
 
 Outputs
 .......
@@ -1845,9 +1837,8 @@ Parameters
      - Specify the output vector layer. One of:
 
        .. include:: qgis_algs_include.rst
-          :start-after: **layer_output_types**
-          :end-before: **end_layer_output_types**
-
+          :start-after: **layer_output_types_append**
+          :end-before: **end_layer_output_types_append**
 
 Outputs
 .......
@@ -1929,9 +1920,8 @@ Parameters
      - Specify the output vector layer. One of:
 
        .. include:: qgis_algs_include.rst
-          :start-after: **layer_output_types**
-          :end-before: **end_layer_output_types**
-
+          :start-after: **layer_output_types_append**
+          :end-before: **end_layer_output_types_append**
 
 Outputs
 .......
@@ -2020,9 +2010,8 @@ Parameters
      - Specify the output vector layer. One of:
 
        .. include:: qgis_algs_include.rst
-          :start-after: **layer_output_types**
-          :end-before: **end_layer_output_types**
-
+          :start-after: **layer_output_types_append**
+          :end-before: **end_layer_output_types_append**
 
 Outputs
 .......
@@ -2118,7 +2107,6 @@ Parameters
           :start-after: **layer_output_types**
           :end-before: **end_layer_output_types**
 
-
 Outputs
 .......
 
@@ -2209,9 +2197,8 @@ Parameters
        from the raster layer). One of:
 
        .. include:: qgis_algs_include.rst
-          :start-after: **layer_output_types**
-          :end-before: **end_layer_output_types**
-
+          :start-after: **layer_output_types_append**
+          :end-before: **end_layer_output_types_append**
 
 Outputs
 .......
@@ -2283,9 +2270,8 @@ Parameters
      - Specify the output vector layer. One of:
 
        .. include:: qgis_algs_include.rst
-          :start-after: **layer_output_types**
-          :end-before: **end_layer_output_types**
-
+          :start-after: **layer_output_types_append**
+          :end-before: **end_layer_output_types_append**
 
 Outputs
 .......
@@ -2371,7 +2357,6 @@ Parameters
           :start-after: **layer_output_types**
           :end-before: **end_layer_output_types**
 
-
 Outputs
 .......
 
@@ -2443,9 +2428,8 @@ Parameters
      - Specify the output vector layer. One of:
 
        .. include:: qgis_algs_include.rst
-          :start-after: **layer_output_types**
-          :end-before: **end_layer_output_types**
-
+          :start-after: **layer_output_types_append**
+          :end-before: **end_layer_output_types_append**
 
 Outputs
 .......
@@ -2528,9 +2512,8 @@ Parameters
      - Specify the output vector layer. One of:
 
        .. include:: qgis_algs_include.rst
-          :start-after: **layer_output_types**
-          :end-before: **end_layer_output_types**
-
+          :start-after: **layer_output_types_append**
+          :end-before: **end_layer_output_types_append**
 
 Outputs
 .......
@@ -2628,9 +2611,8 @@ Parameters
        One of:
 
        .. include:: qgis_algs_include.rst
-          :start-after: **layer_output_types**
-          :end-before: **end_layer_output_types**
-
+          :start-after: **layer_output_types_append**
+          :end-before: **end_layer_output_types_append**
 
 Outputs
 .......
@@ -2716,9 +2698,8 @@ Parameters
      - Specify the output vector layer. One of:
 
        .. include:: qgis_algs_include.rst
-          :start-after: **layer_output_types**
-          :end-before: **end_layer_output_types**
-
+          :start-after: **layer_output_types_append**
+          :end-before: **end_layer_output_types_append**
 
 Outputs
 .......
@@ -2795,9 +2776,8 @@ Parameters
      - Specify the output vector layer. One of:
 
        .. include:: qgis_algs_include.rst
-          :start-after: **layer_output_types**
-          :end-before: **end_layer_output_types**
-
+          :start-after: **layer_output_types_append**
+          :end-before: **end_layer_output_types_append**
 
 Outputs
 .......
@@ -2897,9 +2877,8 @@ Parameters
        One of:
 
        .. include:: qgis_algs_include.rst
-          :start-after: **layer_output_types**
-          :end-before: **end_layer_output_types**
-
+          :start-after: **layer_output_types_append**
+          :end-before: **end_layer_output_types_append**
 
 Outputs
 .......
@@ -2993,9 +2972,8 @@ Parameters
      - Specify the output vector layer. One of:
 
        .. include:: qgis_algs_include.rst
-          :start-after: **layer_output_types**
-          :end-before: **end_layer_output_types**
-
+          :start-after: **layer_output_types_append**
+          :end-before: **end_layer_output_types_append**
 
 Outputs
 .......
@@ -3092,9 +3070,8 @@ Parameters
      - Specify the output vector layer. One of:
 
        .. include:: qgis_algs_include.rst
-          :start-after: **layer_output_types**
-          :end-before: **end_layer_output_types**
-
+          :start-after: **layer_output_types_append**
+          :end-before: **end_layer_output_types_append**
 
 Outputs
 .......
@@ -3162,9 +3139,8 @@ Parameters
      - Specify the output vector layer. One of:
 
        .. include:: qgis_algs_include.rst
-          :start-after: **layer_output_types**
-          :end-before: **end_layer_output_types**
-
+          :start-after: **layer_output_types_append**
+          :end-before: **end_layer_output_types_append**
 
 Outputs
 .......
@@ -3225,9 +3201,8 @@ Parameters
      - Specify the output vector layer. One of:
 
        .. include:: qgis_algs_include.rst
-          :start-after: **layer_output_types**
-          :end-before: **end_layer_output_types**
-
+          :start-after: **layer_output_types_append**
+          :end-before: **end_layer_output_types_append**
 
 Outputs
 .......
@@ -3300,9 +3275,8 @@ Parameters
      - Specify the output line vector layer. One of:
 
        .. include:: qgis_algs_include.rst
-          :start-after: **layer_output_types**
-          :end-before: **end_layer_output_types**
-
+          :start-after: **layer_output_types_append**
+          :end-before: **end_layer_output_types_append**
 
 Outputs
 .......
@@ -3403,9 +3377,8 @@ Parameters
      - Specify the output vector layer. One of:
 
        .. include:: qgis_algs_include.rst
-          :start-after: **layer_output_types**
-          :end-before: **end_layer_output_types**
-
+          :start-after: **layer_output_types_append**
+          :end-before: **end_layer_output_types_append**
 
 Outputs
 .......
@@ -3485,9 +3458,8 @@ Parameters
      - Specify the output vector layer. One of:
 
        .. include:: qgis_algs_include.rst
-          :start-after: **layer_output_types**
-          :end-before: **end_layer_output_types**
-
+          :start-after: **layer_output_types_append**
+          :end-before: **end_layer_output_types_append**
 
 Outputs
 .......
@@ -3563,7 +3535,6 @@ Parameters
        .. include:: qgis_algs_include.rst
           :start-after: **layer_output_types**
           :end-before: **end_layer_output_types**
-
 
 Outputs
 .......
@@ -3648,9 +3619,8 @@ Parameters
      - Specify the output line vector layer. One of:
 
        .. include:: qgis_algs_include.rst
-          :start-after: **layer_output_types**
-          :end-before: **end_layer_output_types**
-
+          :start-after: **layer_output_types_append**
+          :end-before: **end_layer_output_types_append**
 
 Outputs
 .......
@@ -3715,9 +3685,8 @@ Parameters
      - Specify the output polygon vector layer. One of:
 
        .. include:: qgis_algs_include.rst
-          :start-after: **layer_output_types**
-          :end-before: **end_layer_output_types**
-
+          :start-after: **layer_output_types_append**
+          :end-before: **end_layer_output_types_append**
 
 Outputs
 .......
@@ -3782,9 +3751,8 @@ Parameters
      - Specify the output line vector layer. One of:
 
        .. include:: qgis_algs_include.rst
-          :start-after: **layer_output_types**
-          :end-before: **end_layer_output_types**
-
+          :start-after: **layer_output_types_append**
+          :end-before: **end_layer_output_types_append**
 
 Outputs
 .......
@@ -3885,7 +3853,6 @@ Parameters
           :start-after: **layer_output_types**
           :end-before: **end_layer_output_types**
 
-
 Outputs
 .......
 
@@ -3959,9 +3926,8 @@ Parameters
      - Specify the output polygon vector layer. One of:
 
        .. include:: qgis_algs_include.rst
-          :start-after: **layer_output_types**
-          :end-before: **end_layer_output_types**
-
+          :start-after: **layer_output_types_append**
+          :end-before: **end_layer_output_types_append**
 
 Outputs
 .......
@@ -4051,9 +4017,8 @@ Parameters
      - Specify the output polygon vector layer. One of:
 
        .. include:: qgis_algs_include.rst
-          :start-after: **layer_output_types**
-          :end-before: **end_layer_output_types**
-
+          :start-after: **layer_output_types_append**
+          :end-before: **end_layer_output_types_append**
 
 Outputs
 .......
@@ -4127,9 +4092,8 @@ Parameters
      - Specify the output polygon vector layer. One of:
 
        .. include:: qgis_algs_include.rst
-          :start-after: **layer_output_types**
-          :end-before: **end_layer_output_types**
-
+          :start-after: **layer_output_types_append**
+          :end-before: **end_layer_output_types_append**
 
 Outputs
 .......
@@ -4240,9 +4204,8 @@ Parameters
        One of:
 
        .. include:: qgis_algs_include.rst
-          :start-after: **layer_output_types**
-          :end-before: **end_layer_output_types**
-
+          :start-after: **layer_output_types_append**
+          :end-before: **end_layer_output_types_append**
 
 Outputs
 .......
@@ -4310,9 +4273,8 @@ Parameters
      - Specify the output polygon vector layer. One of:
 
        .. include:: qgis_algs_include.rst
-          :start-after: **layer_output_types**
-          :end-before: **end_layer_output_types**
-
+          :start-after: **layer_output_types_append**
+          :end-before: **end_layer_output_types_append**
 
 Outputs
 .......
@@ -4401,9 +4363,8 @@ Parameters
      - Specify the output polygon vector layer. One of:
 
        .. include:: qgis_algs_include.rst
-          :start-after: **layer_output_types**
-          :end-before: **end_layer_output_types**
-
+          :start-after: **layer_output_types_append**
+          :end-before: **end_layer_output_types_append**
 
 Outputs
 .......
@@ -4471,9 +4432,8 @@ Parameters
      - Specify the output point vector layer. One of:
 
        .. include:: qgis_algs_include.rst
-          :start-after: **layer_output_types**
-          :end-before: **end_layer_output_types**
-
+          :start-after: **layer_output_types_append**
+          :end-before: **end_layer_output_types_append**
 
 Outputs
 .......
@@ -4564,9 +4524,8 @@ Parameters
      - Specify the output vector layer. One of:
 
        .. include:: qgis_algs_include.rst
-          :start-after: **layer_output_types**
-          :end-before: **end_layer_output_types**
-
+          :start-after: **layer_output_types_append**
+          :end-before: **end_layer_output_types_append**
 
 Outputs
 .......
@@ -4653,7 +4612,6 @@ Parameters
           :start-after: **layer_output_types**
           :end-before: **end_layer_output_types**
 
-
 Outputs
 .......
 
@@ -4730,9 +4688,8 @@ Parameters
      - Specify the output polygon vector layer. One of:
 
        .. include:: qgis_algs_include.rst
-          :start-after: **layer_output_types**
-          :end-before: **end_layer_output_types**
-
+          :start-after: **layer_output_types_append**
+          :end-before: **end_layer_output_types_append**
 
 Outputs
 .......
@@ -4811,7 +4768,6 @@ Parameters
           :start-after: **layer_output_types**
           :end-before: **end_layer_output_types**
 
-
 Outputs
 .......
 
@@ -4877,9 +4833,8 @@ Parameters
      - Specify the output line vector layer. One of:
 
        .. include:: qgis_algs_include.rst
-          :start-after: **layer_output_types**
-          :end-before: **end_layer_output_types**
-
+          :start-after: **layer_output_types_append**
+          :end-before: **end_layer_output_types_append**
 
 Outputs
 .......
@@ -4952,9 +4907,8 @@ Parameters
      - Specify the output point vector layer. One of:
 
        .. include:: qgis_algs_include.rst
-          :start-after: **layer_output_types**
-          :end-before: **end_layer_output_types**
-
+          :start-after: **layer_output_types_append**
+          :end-before: **end_layer_output_types_append**
 
 Outputs
 .......
@@ -5024,9 +4978,8 @@ Parameters
      - Specify the output multipart vector layer. One of:
 
        .. include:: qgis_algs_include.rst
-          :start-after: **layer_output_types**
-          :end-before: **end_layer_output_types**
-
+          :start-after: **layer_output_types_append**
+          :end-before: **end_layer_output_types_append**
 
 Outputs
 .......
@@ -5128,9 +5081,8 @@ Parameters
      - Specify the output vector layer. One of:
 
        .. include:: qgis_algs_include.rst
-          :start-after: **layer_output_types**
-          :end-before: **end_layer_output_types**
-
+          :start-after: **layer_output_types_append**
+          :end-before: **end_layer_output_types_append**
 
 Outputs
 .......
@@ -5225,9 +5177,8 @@ Parameters
      - Specify the output vector layer. One of:
 
        .. include:: qgis_algs_include.rst
-          :start-after: **layer_output_types**
-          :end-before: **end_layer_output_types**
-
+          :start-after: **layer_output_types_append**
+          :end-before: **end_layer_output_types_append**
 
 Outputs
 .......
@@ -5389,9 +5340,8 @@ Parameters
        One of:
 
        .. include:: qgis_algs_include.rst
-          :start-after: **layer_output_types**
-          :end-before: **end_layer_output_types**
-
+          :start-after: **layer_output_types_append**
+          :end-before: **end_layer_output_types_append**
 
 Outputs
 .......
@@ -5473,9 +5423,8 @@ Parameters
        One of:
 
        .. include:: qgis_algs_include.rst
-          :start-after: **layer_output_types**
-          :end-before: **end_layer_output_types**
-
+          :start-after: **layer_output_types_append**
+          :end-before: **end_layer_output_types_append**
 
 Outputs
 .......
@@ -5550,9 +5499,8 @@ Parameters
        One of:
 
        .. include:: qgis_algs_include.rst
-          :start-after: **layer_output_types**
-          :end-before: **end_layer_output_types**
-
+          :start-after: **layer_output_types_append**
+          :end-before: **end_layer_output_types_append**
 
 Outputs
 .......
@@ -5627,9 +5575,8 @@ Parameters
        One of:
 
        .. include:: qgis_algs_include.rst
-          :start-after: **layer_output_types**
-          :end-before: **end_layer_output_types**
-
+          :start-after: **layer_output_types_append**
+          :end-before: **end_layer_output_types_append**
 
 Outputs
 .......
@@ -5706,9 +5653,8 @@ Parameters
        One of:
 
        .. include:: qgis_algs_include.rst
-          :start-after: **layer_output_types**
-          :end-before: **end_layer_output_types**
-
+          :start-after: **layer_output_types_append**
+          :end-before: **end_layer_output_types_append**
 
 Outputs
 .......
@@ -5801,9 +5747,8 @@ Parameters
        One of:
 
        .. include:: qgis_algs_include.rst
-          :start-after: **layer_output_types**
-          :end-before: **end_layer_output_types**
-
+          :start-after: **layer_output_types_append**
+          :end-before: **end_layer_output_types_append**
 
 Outputs
 .......
@@ -5880,9 +5825,8 @@ Parameters
        One of:
 
        .. include:: qgis_algs_include.rst
-          :start-after: **layer_output_types**
-          :end-before: **end_layer_output_types**
-
+          :start-after: **layer_output_types_append**
+          :end-before: **end_layer_output_types_append**
 
 Outputs
 .......
@@ -5979,9 +5923,8 @@ Parameters
        One of:
 
        .. include:: qgis_algs_include.rst
-          :start-after: **layer_output_types**
-          :end-before: **end_layer_output_types**
-
+          :start-after: **layer_output_types_append**
+          :end-before: **end_layer_output_types_append**
 
 Outputs
 .......
@@ -6092,9 +6035,8 @@ Parameters
        One of:
 
        .. include:: qgis_algs_include.rst
-          :start-after: **layer_output_types**
-          :end-before: **end_layer_output_types**
-
+          :start-after: **layer_output_types_append**
+          :end-before: **end_layer_output_types_append**
 
 Outputs
 .......
@@ -6207,9 +6149,8 @@ Parameters
        One of:
 
        .. include:: qgis_algs_include.rst
-          :start-after: **layer_output_types**
-          :end-before: **end_layer_output_types**
-
+          :start-after: **layer_output_types_append**
+          :end-before: **end_layer_output_types_append**
 
 Outputs
 .......
@@ -6340,7 +6281,6 @@ Parameters
           :start-after: **layer_output_types**
           :end-before: **end_layer_output_types**
 
-
 Outputs
 .......
 
@@ -6437,9 +6377,8 @@ Parameters
        One of:
 
        .. include:: qgis_algs_include.rst
-          :start-after: **layer_output_types**
-          :end-before: **end_layer_output_types**
-
+          :start-after: **layer_output_types_append**
+          :end-before: **end_layer_output_types_append**
 
 Outputs
 .......
@@ -6506,9 +6445,8 @@ Parameters
        One of:
 
        .. include:: qgis_algs_include.rst
-          :start-after: **layer_output_types**
-          :end-before: **end_layer_output_types**
-
+          :start-after: **layer_output_types_append**
+          :end-before: **end_layer_output_types_append**
 
 Outputs
 .......
@@ -6599,9 +6537,8 @@ Parameters
        One of:
 
        .. include:: qgis_algs_include.rst
-          :start-after: **layer_output_types**
-          :end-before: **end_layer_output_types**
-
+          :start-after: **layer_output_types_append**
+          :end-before: **end_layer_output_types_append**
 
 Outputs
 .......
@@ -6669,9 +6606,8 @@ Parameters
        One of:
 
        .. include:: qgis_algs_include.rst
-          :start-after: **layer_output_types**
-          :end-before: **end_layer_output_types**
-
+          :start-after: **layer_output_types_append**
+          :end-before: **end_layer_output_types_append**
 
 Outputs
 .......
@@ -6761,9 +6697,8 @@ Parameters
        One of:
 
        .. include:: qgis_algs_include.rst
-          :start-after: **layer_output_types**
-          :end-before: **end_layer_output_types**
-
+          :start-after: **layer_output_types_append**
+          :end-before: **end_layer_output_types_append**
 
 Outputs
 .......
@@ -6834,9 +6769,8 @@ Parameters
        One of:
 
        .. include:: qgis_algs_include.rst
-          :start-after: **layer_output_types**
-          :end-before: **end_layer_output_types**
-
+          :start-after: **layer_output_types_append**
+          :end-before: **end_layer_output_types_append**
 
 Outputs
 .......
@@ -6938,7 +6872,6 @@ Parameters
           :start-after: **layer_output_types**
           :end-before: **end_layer_output_types**
 
-
 Outputs
 .......
 
@@ -7034,9 +6967,8 @@ Parameters
        One of:
 
        .. include:: qgis_algs_include.rst
-          :start-after: **layer_output_types**
-          :end-before: **end_layer_output_types**
-
+          :start-after: **layer_output_types_append**
+          :end-before: **end_layer_output_types_append**
 
 Outputs
 .......
@@ -7215,9 +7147,8 @@ Parameters
        One of:
 
        .. include:: qgis_algs_include.rst
-          :start-after: **layer_output_types**
-          :end-before: **end_layer_output_types**
-
+          :start-after: **layer_output_types_append**
+          :end-before: **end_layer_output_types_append**
 
 Outputs
 .......

--- a/docs/user_manual/processing_algs/qgis/vectorgeometry.rst
+++ b/docs/user_manual/processing_algs/qgis/vectorgeometry.rst
@@ -841,13 +841,10 @@ Parameters
      - Specify the vector layer to contain a copy of the valid
        features of the source layer. One of:
 
-       * Skip output
-       * Create Temporary Layer (``TEMPORARY_OUTPUT``)
-       * Save to File...
-       * Save to Geopackage...
-       * Save to PostGIS Table...
+       .. include:: qgis_algs_include.rst
+          :start-after: **layer_output_types_skip**
+          :end-before: **end_layer_output_types_skip**
 
-       The file encoding can also be changed here.
    * - **Invalid output**
      - ``INVALID_OUTPUT``
      - [same as input]
@@ -857,13 +854,10 @@ Parameters
        the source layer with the field  ``_errors`` listing the
        summary of the error(s) found. One of:
 
-       * Skip output
-       * Create Temporary Layer (``TEMPORARY_OUTPUT``)
-       * Save to File...
-       * Save to Geopackage...
-       * Save to PostGIS Table...
+       .. include:: qgis_algs_include.rst
+          :start-after: **layer_output_types_skip**
+          :end-before: **end_layer_output_types_skip**
 
-       The file encoding can also be changed here.
    * - **Error output**
      - ``ERROR_OUTPUT``
      - [vector: point]
@@ -873,13 +867,10 @@ Parameters
        problems detected with the ``message`` field describing
        the error(s) found. One of:
 
-       * Skip output
-       * Create Temporary Layer (``TEMPORARY_OUTPUT``)
-       * Save to File...
-       * Save to Geopackage...
-       * Save to PostGIS Table...
+       .. include:: qgis_algs_include.rst
+          :start-after: **layer_output_types_skip**
+          :end-before: **end_layer_output_types_skip**
 
-       The file encoding can also be changed here.
 
 Outputs
 .......
@@ -5323,13 +5314,10 @@ Parameters
      - Specify the output vector layer for the NULL (and empty) geometries.
        One of:
 
-       * Skip Output
-       * Create Temporary Layer (``TEMPORARY_OUTPUT``)
-       * Save to File...
-       * Save to Geopackage...
-       * Save to PostGIS Table...
+       .. include:: qgis_algs_include.rst
+          :start-after: **layer_output_types_skip**
+          :end-before: **end_layer_output_types_skip**
 
-       The file encoding can also be changed here.
 
 Outputs
 .......

--- a/docs/user_manual/processing_algs/qgis/vectorgeometry.rst
+++ b/docs/user_manual/processing_algs/qgis/vectorgeometry.rst
@@ -5295,6 +5295,8 @@ Parameters
      - 
    * - **Non null geometries**
      - ``OUTPUT``
+
+       Optional
      - [same as input]
 
        Default: ``[Create temporary layer]``
@@ -5303,10 +5305,12 @@ Parameters
        One of:
 
        .. include:: qgis_algs_include.rst
-          :start-after: **layer_output_types**
-          :end-before: **end_layer_output_types**
+          :start-after: **layer_output_types_skip**
+          :end-before: **end_layer_output_types_skip**
 
    * - **Null geometries**
+
+       Optional
      - ``NULL_OUTPUT``
      - [same as input]
 
@@ -5317,7 +5321,6 @@ Parameters
        .. include:: qgis_algs_include.rst
           :start-after: **layer_output_types_skip**
           :end-before: **end_layer_output_types_skip**
-
 
 Outputs
 .......
@@ -7177,7 +7180,7 @@ line geometries as the diameter of the buffer at each vertex.
    Variable buffer example
 
 .. seealso:: :ref:`qgistaperedbuffer`, :ref:`qgisbuffer`,
-   :ref:`qgissetmvalue`
+   :ref:`qgissetmvalue`, :ref:`qgisvariabledistancebuffer`
 
 Parameters
 ..........
@@ -7293,8 +7296,6 @@ Parameters
        .. include:: qgis_algs_include.rst
           :start-after: **layer_output_types**
           :end-before: **end_layer_output_types**
-
-
 
 Outputs
 .......

--- a/docs/user_manual/processing_algs/qgis/vectorgeometry.rst
+++ b/docs/user_manual/processing_algs/qgis/vectorgeometry.rst
@@ -66,12 +66,10 @@ Parameters
      - Specify the output (input copy with geometry) layer.
        One of:
 
-       * Create Temporary Layer (``TEMPORARY_OUTPUT``)
-       * Save to File...
-       * Save to Geopackage...
-       * Save to PostGIS Table...
+       .. include:: qgis_algs_include.rst
+          :start-after: **layer_output_types**
+          :end-before: **end_layer_output_types**
 
-       The file encoding can also be changed here.
 
 Outputs
 .......
@@ -197,12 +195,10 @@ Parameters
      - Specify the output vector layer.
        One of:
 
-       * Create Temporary Layer (``TEMPORARY_OUTPUT``)
-       * Save to File...
-       * Save to Geopackage...
-       * Save to PostGIS Table...
+       .. include:: qgis_algs_include.rst
+          :start-after: **layer_output_types**
+          :end-before: **end_layer_output_types**
 
-       The file encoding can also be changed here.
    
 Outputs
 .......
@@ -352,12 +348,10 @@ Parameters
      - Specify the output (aggregate) layer
        One of:
 
-       * Create Temporary Layer (``TEMPORARY_OUTPUT``)
-       * Save to File...
-       * Save to Geopackage...
-       * Save to PostGIS Table...
+       .. include:: qgis_algs_include.rst
+          :start-after: **layer_output_types**
+          :end-before: **end_layer_output_types**
 
-       The file encoding can also be changed here.
 
 Outputs
 .......
@@ -432,12 +426,10 @@ Parameters
      - Specify the output (boundary) layer.
        One of:
 
-       * Create Temporary Layer (``TEMPORARY_OUTPUT``)
-       * Save to File...
-       * Save to Geopackage...
-       * Save to PostGIS Table...
+       .. include:: qgis_algs_include.rst
+          :start-after: **layer_output_types**
+          :end-before: **end_layer_output_types**
 
-       The file encoding can also be changed here.
 
 Outputs
 .......
@@ -506,12 +498,10 @@ Parameters
      - Specify the output (bounding box) layer.
        One of:
 
-       * Create Temporary Layer (``TEMPORARY_OUTPUT``)
-       * Save to File...
-       * Save to Geopackage...
-       * Save to PostGIS Table...
+       .. include:: qgis_algs_include.rst
+          :start-after: **layer_output_types**
+          :end-before: **end_layer_output_types**
 
-       The file encoding can also be changed here.
 
 Outputs
 .......
@@ -655,12 +645,10 @@ Parameters
      - Specify the output (buffer) layer.
        One of:
 
-       * Create Temporary Layer (``TEMPORARY_OUTPUT``)
-       * Save to File...
-       * Save to Geopackage...
-       * Save to PostGIS Table...
+       .. include:: qgis_algs_include.rst
+          :start-after: **layer_output_types**
+          :end-before: **end_layer_output_types**
 
-       The file encoding can also be changed here.
 
 Outputs
 .......
@@ -745,12 +733,10 @@ Parameters
      - Specify the output (centroid) layer.
        One of:
 
-       * Create Temporary Layer (``TEMPORARY_OUTPUT``)
-       * Save to File...
-       * Save to Geopackage...
-       * Save to PostGIS Table...
+       .. include:: qgis_algs_include.rst
+          :start-after: **layer_output_types**
+          :end-before: **end_layer_output_types**
 
-       The file encoding can also be changed here.
 
 Outputs
 .......
@@ -1145,12 +1131,10 @@ Outputs
      - Specify the output vector layer for the collected geometries.
        One of:
 
-       * Create Temporary Layer (``TEMPORARY_OUTPUT``)
-       * Save to File...
-       * Save to Geopackage...
-       * Save to PostGIS Table...
+       .. include:: qgis_algs_include.rst
+          :start-after: **layer_output_types**
+          :end-before: **end_layer_output_types**
 
-       The file encoding can also be changed here.
 
 Python code
 ...........
@@ -1218,12 +1202,10 @@ Parameters
        Default: ``[Create temporary layer]``
      - Specify the output vector layer. One of:
 
-       * Create Temporary Layer (``TEMPORARY_OUTPUT``)
-       * Save to File...
-       * Save to Geopackage...
-       * Save to PostGIS Table...
+       .. include:: qgis_algs_include.rst
+          :start-after: **layer_output_types**
+          :end-before: **end_layer_output_types**
 
-       The file encoding can also be changed here.
 
 Outputs
 .......
@@ -1317,12 +1299,10 @@ Parameters
        Default: ``[Create temporary layer]``
      - Specify the output vector layer. One of:
 
-       * Create Temporary Layer (``TEMPORARY_OUTPUT``)
-       * Save to File...
-       * Save to Geopackage...
-       * Save to PostGIS Table...
+       .. include:: qgis_algs_include.rst
+          :start-after: **layer_output_types**
+          :end-before: **end_layer_output_types**
 
-       The file encoding can also be changed here.
 
 Outputs
 .......
@@ -1400,12 +1380,10 @@ Parameters
      - Specify the output vector layer.
        One of:
 
-       * Create Temporary Layer (``TEMPORARY_OUTPUT``)
-       * Save to File...
-       * Save to Geopackage...
-       * Save to PostGIS Table...
+       .. include:: qgis_algs_include.rst
+          :start-after: **layer_output_types**
+          :end-before: **end_layer_output_types**
 
-       The file encoding can also be changed here.
 
 Outputs
 .......
@@ -1478,12 +1456,10 @@ Parameters
        Default: ``[Create temporary layer]``
      - Specify the output vector layer. One of:
 
-       * Create Temporary Layer (``TEMPORARY_OUTPUT``)
-       * Save to File...
-       * Save to Geopackage...
-       * Save to PostGIS Table...
+       .. include:: qgis_algs_include.rst
+          :start-after: **layer_output_types**
+          :end-before: **end_layer_output_types**
 
-       The file encoding can also be changed here.
 
 Outputs
 .......
@@ -1546,12 +1522,10 @@ Parameters
        Default: ``[Create temporary layer]``
      - Specify the output vector layer. One of:
 
-       * Create Temporary Layer (``TEMPORARY_OUTPUT``)
-       * Save to File...
-       * Save to Geopackage...
-       * Save to PostGIS Table...
+       .. include:: qgis_algs_include.rst
+          :start-after: **layer_output_types**
+          :end-before: **end_layer_output_types**
 
-       The file encoding can also be changed here.
 
 Outputs
 .......
@@ -1619,12 +1593,10 @@ Parameters
      - Specify the output layer.
        One of:
 
-       * Create Temporary Layer (``TEMPORARY_OUTPUT``)
-       * Save to File...
-       * Save to Geopackage...
-       * Save to PostGIS Table...
+       .. include:: qgis_algs_include.rst
+          :start-after: **layer_output_types**
+          :end-before: **end_layer_output_types**
 
-       The file encoding can also be changed here.
 
 Outputs
 .......
@@ -1730,12 +1702,10 @@ Parameters
        Default: ``[Create temporary layer]``
      - Specify the output vector layer. One of:
 
-       * Create Temporary Layer (``TEMPORARY_OUTPUT``)
-       * Save to File...
-       * Save to Geopackage...
-       * Save to PostGIS Table...
+       .. include:: qgis_algs_include.rst
+          :start-after: **layer_output_types**
+          :end-before: **end_layer_output_types**
 
-       The file encoding can also be changed here.
 
 Outputs
 .......
@@ -1799,12 +1769,10 @@ Parameters
        Default: ``[Create temporary layer]``
      - Specify the output vector layer. One of:
 
-       * Create Temporary Layer (``TEMPORARY_OUTPUT``)
-       * Save to File...
-       * Save to Geopackage...
-       * Save to PostGIS Table...
+       .. include:: qgis_algs_include.rst
+          :start-after: **layer_output_types**
+          :end-before: **end_layer_output_types**
 
-       The file encoding can also be changed here.
 
 Outputs
 .......
@@ -1885,12 +1853,10 @@ Parameters
        Default: ``[Create temporary layer]``
      - Specify the output vector layer. One of:
 
-       * Create Temporary Layer (``TEMPORARY_OUTPUT``)
-       * Save to File...
-       * Save to Geopackage...
-       * Save to PostGIS Table...
+       .. include:: qgis_algs_include.rst
+          :start-after: **layer_output_types**
+          :end-before: **end_layer_output_types**
 
-       The file encoding can also be changed here.
 
 Outputs
 .......
@@ -1971,12 +1937,10 @@ Parameters
        Default: ``[Create temporary layer]``
      - Specify the output vector layer. One of:
 
-       * Create Temporary Layer (``TEMPORARY_OUTPUT``)
-       * Save to File...
-       * Save to Geopackage...
-       * Save to PostGIS Table...
+       .. include:: qgis_algs_include.rst
+          :start-after: **layer_output_types**
+          :end-before: **end_layer_output_types**
 
-       The file encoding can also be changed here.
 
 Outputs
 .......
@@ -2064,12 +2028,10 @@ Parameters
        Default: ``[Create temporary layer]``
      - Specify the output vector layer. One of:
 
-       * Create Temporary Layer (``TEMPORARY_OUTPUT``)
-       * Save to File...
-       * Save to Geopackage...
-       * Save to PostGIS Table...
+       .. include:: qgis_algs_include.rst
+          :start-after: **layer_output_types**
+          :end-before: **end_layer_output_types**
 
-       The file encoding can also be changed here.
 
 Outputs
 .......
@@ -2161,12 +2123,10 @@ Parameters
        Default: ``[Create temporary layer]``
      - Specify the output vector layer. One of:
 
-       * Create Temporary Layer (``TEMPORARY_OUTPUT``)
-       * Save to File...
-       * Save to Geopackage...
-       * Save to PostGIS Table...
+       .. include:: qgis_algs_include.rst
+          :start-after: **layer_output_types**
+          :end-before: **end_layer_output_types**
 
-       The file encoding can also be changed here.
 
 Outputs
 .......
@@ -2257,12 +2217,10 @@ Parameters
      - Specify the output vector layer (with Z values
        from the raster layer). One of:
 
-       * Create Temporary Layer (``TEMPORARY_OUTPUT``)
-       * Save to File...
-       * Save to Geopackage...
-       * Save to PostGIS Table...
+       .. include:: qgis_algs_include.rst
+          :start-after: **layer_output_types**
+          :end-before: **end_layer_output_types**
 
-       The file encoding can also be changed here.
 
 Outputs
 .......
@@ -2333,12 +2291,10 @@ Parameters
        Default: ``[Create temporary layer]``
      - Specify the output vector layer. One of:
 
-       * Create Temporary Layer (``TEMPORARY_OUTPUT``)
-       * Save to File...
-       * Save to Geopackage...
-       * Save to PostGIS Table...
+       .. include:: qgis_algs_include.rst
+          :start-after: **layer_output_types**
+          :end-before: **end_layer_output_types**
 
-       The file encoding can also be changed here.
 
 Outputs
 .......
@@ -2420,12 +2376,10 @@ Parameters
        Default: ``[Create temporary layer]``
      - Specify the output vector layer. One of:
 
-       * Create Temporary Layer (``TEMPORARY_OUTPUT``)
-       * Save to File...
-       * Save to Geopackage...
-       * Save to PostGIS Table...
+       .. include:: qgis_algs_include.rst
+          :start-after: **layer_output_types**
+          :end-before: **end_layer_output_types**
 
-       The file encoding can also be changed here.
 
 Outputs
 .......
@@ -2497,12 +2451,10 @@ Parameters
        Default: ``[Create temporary layer]``
      - Specify the output vector layer. One of:
 
-       * Create Temporary Layer (``TEMPORARY_OUTPUT``)
-       * Save to File...
-       * Save to Geopackage...
-       * Save to PostGIS Table...
+       .. include:: qgis_algs_include.rst
+          :start-after: **layer_output_types**
+          :end-before: **end_layer_output_types**
 
-       The file encoding can also be changed here.
 
 Outputs
 .......
@@ -2584,12 +2536,10 @@ Parameters
        Default: ``[Create temporary layer]``
      - Specify the output vector layer. One of:
 
-       * Create Temporary Layer (``TEMPORARY_OUTPUT``)
-       * Save to File...
-       * Save to Geopackage...
-       * Save to PostGIS Table...
+       .. include:: qgis_algs_include.rst
+          :start-after: **layer_output_types**
+          :end-before: **end_layer_output_types**
 
-       The file encoding can also be changed here.
 
 Outputs
 .......
@@ -2686,12 +2636,10 @@ Parameters
      - Specify the output layer.
        One of:
 
-       * Create Temporary Layer (``TEMPORARY_OUTPUT``)
-       * Save to File...
-       * Save to Geopackage...
-       * Save to PostGIS Table...
+       .. include:: qgis_algs_include.rst
+          :start-after: **layer_output_types**
+          :end-before: **end_layer_output_types**
 
-       The file encoding can also be changed here.
 
 Outputs
 .......
@@ -2776,12 +2724,10 @@ Parameters
        Default: ``[Create temporary layer]``
      - Specify the output vector layer. One of:
 
-       * Create Temporary Layer (``TEMPORARY_OUTPUT``)
-       * Save to File...
-       * Save to Geopackage...
-       * Save to PostGIS Table...
+       .. include:: qgis_algs_include.rst
+          :start-after: **layer_output_types**
+          :end-before: **end_layer_output_types**
 
-       The file encoding can also be changed here.
 
 Outputs
 .......
@@ -2857,12 +2803,10 @@ Parameters
        Default: ``[Create temporary layer]``
      - Specify the output vector layer. One of:
 
-       * Create Temporary Layer (``TEMPORARY_OUTPUT``)
-       * Save to File...
-       * Save to Geopackage...
-       * Save to PostGIS Table...
+       .. include:: qgis_algs_include.rst
+          :start-after: **layer_output_types**
+          :end-before: **end_layer_output_types**
 
-       The file encoding can also be changed here.
 
 Outputs
 .......
@@ -2961,12 +2905,10 @@ Parameters
      - Specify the output layer.
        One of:
 
-       * Create Temporary Layer (``TEMPORARY_OUTPUT``)
-       * Save to File...
-       * Save to Geopackage...
-       * Save to PostGIS Table...
+       .. include:: qgis_algs_include.rst
+          :start-after: **layer_output_types**
+          :end-before: **end_layer_output_types**
 
-       The file encoding can also be changed here.
 
 Outputs
 .......
@@ -3059,12 +3001,10 @@ Parameters
        Default: ``[Create temporary layer]``
      - Specify the output vector layer. One of:
 
-       * Create Temporary Layer (``TEMPORARY_OUTPUT``)
-       * Save to File...
-       * Save to Geopackage...
-       * Save to PostGIS Table...
+       .. include:: qgis_algs_include.rst
+          :start-after: **layer_output_types**
+          :end-before: **end_layer_output_types**
 
-       The file encoding can also be changed here.
 
 Outputs
 .......
@@ -3160,12 +3100,10 @@ Parameters
        Default: ``[Create temporary layer]``
      - Specify the output vector layer. One of:
 
-       * Create Temporary Layer (``TEMPORARY_OUTPUT``)
-       * Save to File...
-       * Save to Geopackage...
-       * Save to PostGIS Table...
+       .. include:: qgis_algs_include.rst
+          :start-after: **layer_output_types**
+          :end-before: **end_layer_output_types**
 
-       The file encoding can also be changed here.
 
 Outputs
 .......
@@ -3232,12 +3170,10 @@ Parameters
        Default: ``[Create temporary layer]``
      - Specify the output vector layer. One of:
 
-       * Create Temporary Layer (``TEMPORARY_OUTPUT``)
-       * Save to File...
-       * Save to Geopackage...
-       * Save to PostGIS Table...
+       .. include:: qgis_algs_include.rst
+          :start-after: **layer_output_types**
+          :end-before: **end_layer_output_types**
 
-       The file encoding can also be changed here.
 
 Outputs
 .......
@@ -3297,12 +3233,10 @@ Parameters
        Default: ``[Create temporary layer]``
      - Specify the output vector layer. One of:
 
-       * Create Temporary Layer (``TEMPORARY_OUTPUT``)
-       * Save to File...
-       * Save to Geopackage...
-       * Save to PostGIS Table...
+       .. include:: qgis_algs_include.rst
+          :start-after: **layer_output_types**
+          :end-before: **end_layer_output_types**
 
-       The file encoding can also be changed here.
 
 Outputs
 .......
@@ -3374,12 +3308,10 @@ Parameters
        Default: ``[Create temporary layer]``
      - Specify the output line vector layer. One of:
 
-       * Create Temporary Layer (``TEMPORARY_OUTPUT``)
-       * Save to File...
-       * Save to Geopackage...
-       * Save to PostGIS Table...
+       .. include:: qgis_algs_include.rst
+          :start-after: **layer_output_types**
+          :end-before: **end_layer_output_types**
 
-       The file encoding can also be changed here.
 
 Outputs
 .......
@@ -3479,12 +3411,10 @@ Parameters
        Default: ``[Create temporary layer]``
      - Specify the output vector layer. One of:
 
-       * Create Temporary Layer (``TEMPORARY_OUTPUT``)
-       * Save to File...
-       * Save to Geopackage...
-       * Save to PostGIS Table...
+       .. include:: qgis_algs_include.rst
+          :start-after: **layer_output_types**
+          :end-before: **end_layer_output_types**
 
-       The file encoding can also be changed here.
 
 Outputs
 .......
@@ -3563,12 +3493,10 @@ Parameters
        Default: ``[Create temporary layer]``
      - Specify the output vector layer. One of:
 
-       * Create Temporary Layer (``TEMPORARY_OUTPUT``)
-       * Save to File...
-       * Save to Geopackage...
-       * Save to PostGIS Table...
+       .. include:: qgis_algs_include.rst
+          :start-after: **layer_output_types**
+          :end-before: **end_layer_output_types**
 
-       The file encoding can also be changed here.
 
 Outputs
 .......
@@ -3641,12 +3569,10 @@ Parameters
        Default: ``[Create temporary layer]``
      - Specify the output polygon vector layer. One of:
 
-       * Create Temporary Layer (``TEMPORARY_OUTPUT``)
-       * Save to File...
-       * Save to Geopackage...
-       * Save to PostGIS Table...
+       .. include:: qgis_algs_include.rst
+          :start-after: **layer_output_types**
+          :end-before: **end_layer_output_types**
 
-       The file encoding can also be changed here.
 
 Outputs
 .......
@@ -3730,12 +3656,10 @@ Parameters
        Default: ``[Create temporary layer]``
      - Specify the output line vector layer. One of:
 
-       * Create Temporary Layer (``TEMPORARY_OUTPUT``)
-       * Save to File...
-       * Save to Geopackage...
-       * Save to PostGIS Table...
+       .. include:: qgis_algs_include.rst
+          :start-after: **layer_output_types**
+          :end-before: **end_layer_output_types**
 
-       The file encoding can also be changed here.
 
 Outputs
 .......
@@ -3799,12 +3723,10 @@ Parameters
        Default: ``[Create temporary layer]``
      - Specify the output polygon vector layer. One of:
 
-       * Create Temporary Layer (``TEMPORARY_OUTPUT``)
-       * Save to File...
-       * Save to Geopackage...
-       * Save to PostGIS Table...
+       .. include:: qgis_algs_include.rst
+          :start-after: **layer_output_types**
+          :end-before: **end_layer_output_types**
 
-       The file encoding can also be changed here.
 
 Outputs
 .......
@@ -3868,12 +3790,10 @@ Parameters
        Default: ``[Create temporary layer]``
      - Specify the output line vector layer. One of:
 
-       * Create Temporary Layer (``TEMPORARY_OUTPUT``)
-       * Save to File...
-       * Save to Geopackage...
-       * Save to PostGIS Table...
+       .. include:: qgis_algs_include.rst
+          :start-after: **layer_output_types**
+          :end-before: **end_layer_output_types**
 
-       The file encoding can also be changed here.
 
 Outputs
 .......
@@ -3970,12 +3890,10 @@ Parameters
        Default: ``[Create temporary layer]``
      - Specify the output polygon vector layer. One of:
 
-       * Create Temporary Layer (``TEMPORARY_OUTPUT``)
-       * Save to File...
-       * Save to Geopackage...
-       * Save to PostGIS Table...
+       .. include:: qgis_algs_include.rst
+          :start-after: **layer_output_types**
+          :end-before: **end_layer_output_types**
 
-       The file encoding can also be changed here.
 
 Outputs
 .......
@@ -4049,12 +3967,10 @@ Parameters
        Default: ``[Create temporary layer]``
      - Specify the output polygon vector layer. One of:
 
-       * Create Temporary Layer (``TEMPORARY_OUTPUT``)
-       * Save to File...
-       * Save to Geopackage...
-       * Save to PostGIS Table...
+       .. include:: qgis_algs_include.rst
+          :start-after: **layer_output_types**
+          :end-before: **end_layer_output_types**
 
-       The file encoding can also be changed here.
 
 Outputs
 .......
@@ -4143,12 +4059,10 @@ Parameters
        Default: ``[Create temporary layer]``
      - Specify the output polygon vector layer. One of:
 
-       * Create Temporary Layer (``TEMPORARY_OUTPUT``)
-       * Save to File...
-       * Save to Geopackage...
-       * Save to PostGIS Table...
+       .. include:: qgis_algs_include.rst
+          :start-after: **layer_output_types**
+          :end-before: **end_layer_output_types**
 
-       The file encoding can also be changed here.
 
 Outputs
 .......
@@ -4221,12 +4135,10 @@ Parameters
        Default: ``[Create temporary layer]``
      - Specify the output polygon vector layer. One of:
 
-       * Create Temporary Layer (``TEMPORARY_OUTPUT``)
-       * Save to File...
-       * Save to Geopackage...
-       * Save to PostGIS Table...
+       .. include:: qgis_algs_include.rst
+          :start-after: **layer_output_types**
+          :end-before: **end_layer_output_types**
 
-       The file encoding can also be changed here.
 
 Outputs
 .......
@@ -4336,12 +4248,10 @@ Parameters
      - Specify the output (offset) layer.
        One of:
 
-       * Create Temporary Layer (``TEMPORARY_OUTPUT``)
-       * Save to File...
-       * Save to Geopackage...
-       * Save to PostGIS Table...
+       .. include:: qgis_algs_include.rst
+          :start-after: **layer_output_types**
+          :end-before: **end_layer_output_types**
 
-       The file encoding can also be changed here.
 
 Outputs
 .......
@@ -4408,12 +4318,10 @@ Parameters
        Default: ``[Create temporary layer]``
      - Specify the output polygon vector layer. One of:
 
-       * Create Temporary Layer (``TEMPORARY_OUTPUT``)
-       * Save to File...
-       * Save to Geopackage...
-       * Save to PostGIS Table...
+       .. include:: qgis_algs_include.rst
+          :start-after: **layer_output_types**
+          :end-before: **end_layer_output_types**
 
-       The file encoding can also be changed here.
 
 Outputs
 .......
@@ -4501,12 +4409,10 @@ Parameters
        Default: ``[Create temporary layer]``
      - Specify the output polygon vector layer. One of:
 
-       * Create Temporary Layer (``TEMPORARY_OUTPUT``)
-       * Save to File...
-       * Save to Geopackage...
-       * Save to PostGIS Table...
+       .. include:: qgis_algs_include.rst
+          :start-after: **layer_output_types**
+          :end-before: **end_layer_output_types**
 
-       The file encoding can also be changed here.
 
 Outputs
 .......
@@ -4573,12 +4479,10 @@ Parameters
        Default: ``[Create temporary layer]``
      - Specify the output point vector layer. One of:
 
-       * Create Temporary Layer (``TEMPORARY_OUTPUT``)
-       * Save to File...
-       * Save to Geopackage...
-       * Save to PostGIS Table...
+       .. include:: qgis_algs_include.rst
+          :start-after: **layer_output_types**
+          :end-before: **end_layer_output_types**
 
-       The file encoding can also be changed here.
 
 Outputs
 .......
@@ -4668,12 +4572,10 @@ Parameters
        Default: ``[Create temporary layer]``
      - Specify the output vector layer. One of:
 
-       * Create Temporary Layer (``TEMPORARY_OUTPUT``)
-       * Save to File...
-       * Save to Geopackage...
-       * Save to PostGIS Table...
+       .. include:: qgis_algs_include.rst
+          :start-after: **layer_output_types**
+          :end-before: **end_layer_output_types**
 
-       The file encoding can also be changed here.
 
 Outputs
 .......
@@ -4756,12 +4658,10 @@ Parameters
        Default: ``[Create temporary layer]``
      - Specify the output vector layer. One of:
 
-       * Create Temporary Layer (``TEMPORARY_OUTPUT``)
-       * Save to File...
-       * Save to Geopackage...
-       * Save to PostGIS Table...
+       .. include:: qgis_algs_include.rst
+          :start-after: **layer_output_types**
+          :end-before: **end_layer_output_types**
 
-       The file encoding can also be changed here.
 
 Outputs
 .......
@@ -4838,12 +4738,10 @@ Parameters
        Default: ``[Create temporary layer]``
      - Specify the output polygon vector layer. One of:
 
-       * Create Temporary Layer (``TEMPORARY_OUTPUT``)
-       * Save to File...
-       * Save to Geopackage...
-       * Save to PostGIS Table...
+       .. include:: qgis_algs_include.rst
+          :start-after: **layer_output_types**
+          :end-before: **end_layer_output_types**
 
-       The file encoding can also be changed here.
 
 Outputs
 .......
@@ -4918,12 +4816,10 @@ Parameters
        Default: ``[Create temporary layer]``
      - Specify the output polygon vector layer. One of:
 
-       * Create Temporary Layer (``TEMPORARY_OUTPUT``)
-       * Save to File...
-       * Save to Geopackage...
-       * Save to PostGIS Table...
+       .. include:: qgis_algs_include.rst
+          :start-after: **layer_output_types**
+          :end-before: **end_layer_output_types**
 
-       The file encoding can also be changed here.
 
 Outputs
 .......
@@ -4989,12 +4885,10 @@ Parameters
        Default: ``[Create temporary layer]``
      - Specify the output line vector layer. One of:
 
-       * Create Temporary Layer (``TEMPORARY_OUTPUT``)
-       * Save to File...
-       * Save to Geopackage...
-       * Save to PostGIS Table...
+       .. include:: qgis_algs_include.rst
+          :start-after: **layer_output_types**
+          :end-before: **end_layer_output_types**
 
-       The file encoding can also be changed here.
 
 Outputs
 .......
@@ -5066,12 +4960,10 @@ Parameters
        Default: ``[Create temporary layer]``
      - Specify the output point vector layer. One of:
 
-       * Create Temporary Layer (``TEMPORARY_OUTPUT``)
-       * Save to File...
-       * Save to Geopackage...
-       * Save to PostGIS Table...
+       .. include:: qgis_algs_include.rst
+          :start-after: **layer_output_types**
+          :end-before: **end_layer_output_types**
 
-       The file encoding can also be changed here.
 
 Outputs
 .......
@@ -5140,12 +5032,10 @@ Parameters
        Default: ``[Create temporary layer]``
      - Specify the output multipart vector layer. One of:
 
-       * Create Temporary Layer (``TEMPORARY_OUTPUT``)
-       * Save to File...
-       * Save to Geopackage...
-       * Save to PostGIS Table...
+       .. include:: qgis_algs_include.rst
+          :start-after: **layer_output_types**
+          :end-before: **end_layer_output_types**
 
-       The file encoding can also be changed here.
 
 Outputs
 .......
@@ -5246,12 +5136,10 @@ Parameters
        Default: ``[Create temporary layer]``
      - Specify the output vector layer. One of:
 
-       * Create Temporary Layer (``TEMPORARY_OUTPUT``)
-       * Save to File...
-       * Save to Geopackage...
-       * Save to PostGIS Table...
+       .. include:: qgis_algs_include.rst
+          :start-after: **layer_output_types**
+          :end-before: **end_layer_output_types**
 
-       The file encoding can also be changed here.
 
 Outputs
 .......
@@ -5345,12 +5233,10 @@ Parameters
        Default: ``[Create temporary layer]``
      - Specify the output vector layer. One of:
 
-       * Create Temporary Layer (``TEMPORARY_OUTPUT``)
-       * Save to File...
-       * Save to Geopackage...
-       * Save to PostGIS Table...
+       .. include:: qgis_algs_include.rst
+          :start-after: **layer_output_types**
+          :end-before: **end_layer_output_types**
 
-       The file encoding can also be changed here.
 
 Outputs
 .......
@@ -5425,12 +5311,10 @@ Parameters
        non-empty) geometries.
        One of:
 
-       * Create Temporary Layer (``TEMPORARY_OUTPUT``)
-       * Save to File...
-       * Save to Geopackage...
-       * Save to PostGIS Table...
+       .. include:: qgis_algs_include.rst
+          :start-after: **layer_output_types**
+          :end-before: **end_layer_output_types**
 
-       The file encoding can also be changed here.
    * - **Null geometries**
      - ``NULL_OUTPUT``
      - [same as input]
@@ -5513,12 +5397,10 @@ Parameters
      - Specify the output line vector layer.
        One of:
 
-       * Create Temporary Layer (``TEMPORARY_OUTPUT``)
-       * Save to File...
-       * Save to Geopackage...
-       * Save to PostGIS Table...
+       .. include:: qgis_algs_include.rst
+          :start-after: **layer_output_types**
+          :end-before: **end_layer_output_types**
 
-       The file encoding can also be changed here.
 
 Outputs
 .......
@@ -5599,12 +5481,10 @@ Parameters
      - Specify the output vector layer (with rotated geometries).
        One of:
 
-       * Create Temporary Layer (``TEMPORARY_OUTPUT``)
-       * Save to File...
-       * Save to Geopackage...
-       * Save to PostGIS Table...
+       .. include:: qgis_algs_include.rst
+          :start-after: **layer_output_types**
+          :end-before: **end_layer_output_types**
 
-       The file encoding can also be changed here.
 
 Outputs
 .......
@@ -5678,12 +5558,10 @@ Parameters
      - Specify the output vector layer (with segmentized geometries).
        One of:
 
-       * Create Temporary Layer (``TEMPORARY_OUTPUT``)
-       * Save to File...
-       * Save to Geopackage...
-       * Save to PostGIS Table...
+       .. include:: qgis_algs_include.rst
+          :start-after: **layer_output_types**
+          :end-before: **end_layer_output_types**
 
-       The file encoding can also be changed here.
 
 Outputs
 .......
@@ -5757,12 +5635,10 @@ Parameters
      - Specify the output vector layer (with segmentized geometries).
        One of:
 
-       * Create Temporary Layer (``TEMPORARY_OUTPUT``)
-       * Save to File...
-       * Save to Geopackage...
-       * Save to PostGIS Table...
+       .. include:: qgis_algs_include.rst
+          :start-after: **layer_output_types**
+          :end-before: **end_layer_output_types**
 
-       The file encoding can also be changed here.
 
 Outputs
 .......
@@ -5838,12 +5714,10 @@ Parameters
      - Specify the output vector layer.
        One of:
 
-       * Create Temporary Layer (``TEMPORARY_OUTPUT``)
-       * Save to File...
-       * Save to Geopackage...
-       * Save to PostGIS Table...
+       .. include:: qgis_algs_include.rst
+          :start-after: **layer_output_types**
+          :end-before: **end_layer_output_types**
 
-       The file encoding can also be changed here.
 
 Outputs
 .......
@@ -5935,12 +5809,10 @@ Parameters
      - Specify the output vector layer (with updated M values).
        One of:
 
-       * Create Temporary Layer (``TEMPORARY_OUTPUT``)
-       * Save to File...
-       * Save to Geopackage...
-       * Save to PostGIS Table...
+       .. include:: qgis_algs_include.rst
+          :start-after: **layer_output_types**
+          :end-before: **end_layer_output_types**
 
-       The file encoding can also be changed here.
 
 Outputs
 .......
@@ -6016,12 +5888,10 @@ Parameters
      - Specify the output vector layer.
        One of:
 
-       * Create Temporary Layer (``TEMPORARY_OUTPUT``)
-       * Save to File...
-       * Save to Geopackage...
-       * Save to PostGIS Table...
+       .. include:: qgis_algs_include.rst
+          :start-after: **layer_output_types**
+          :end-before: **end_layer_output_types**
 
-       The file encoding can also be changed here.
 
 Outputs
 .......
@@ -6117,12 +5987,10 @@ Parameters
      - Specify the output (simplified) vector layer.
        One of:
 
-       * Create Temporary Layer (``TEMPORARY_OUTPUT``)
-       * Save to File...
-       * Save to Geopackage...
-       * Save to PostGIS Table...
+       .. include:: qgis_algs_include.rst
+          :start-after: **layer_output_types**
+          :end-before: **end_layer_output_types**
 
-       The file encoding can also be changed here.
 
 Outputs
 .......
@@ -6232,12 +6100,10 @@ Parameters
      - Specify the output (buffer) layer.
        One of:
 
-       * Create Temporary Layer (``TEMPORARY_OUTPUT``)
-       * Save to File...
-       * Save to Geopackage...
-       * Save to PostGIS Table...
+       .. include:: qgis_algs_include.rst
+          :start-after: **layer_output_types**
+          :end-before: **end_layer_output_types**
 
-       The file encoding can also be changed here.
 
 Outputs
 .......
@@ -6349,12 +6215,10 @@ Parameters
      - Specify the output (smoothed) layer.
        One of:
 
-       * Create Temporary Layer (``TEMPORARY_OUTPUT``)
-       * Save to File...
-       * Save to Geopackage...
-       * Save to PostGIS Table...
+       .. include:: qgis_algs_include.rst
+          :start-after: **layer_output_types**
+          :end-before: **end_layer_output_types**
 
-       The file encoding can also be changed here.
 
 Outputs
 .......
@@ -6481,12 +6345,10 @@ Parameters
      - Specify the output (snapped) layer.
        One of:
 
-       * Create Temporary Layer (``TEMPORARY_OUTPUT``)
-       * Save to File...
-       * Save to Geopackage...
-       * Save to PostGIS Table...
+       .. include:: qgis_algs_include.rst
+          :start-after: **layer_output_types**
+          :end-before: **end_layer_output_types**
 
-       The file encoding can also be changed here.
 
 Outputs
 .......
@@ -6583,12 +6445,10 @@ Parameters
      - Specify the output (snapped) layer.
        One of:
 
-       * Create Temporary Layer (``TEMPORARY_OUTPUT``)
-       * Save to File...
-       * Save to Geopackage...
-       * Save to PostGIS Table...
+       .. include:: qgis_algs_include.rst
+          :start-after: **layer_output_types**
+          :end-before: **end_layer_output_types**
 
-       The file encoding can also be changed here.
 
 Outputs
 .......
@@ -6654,12 +6514,10 @@ Parameters
      - Specify the output line vector layer.
        One of:
 
-       * Create Temporary Layer (``TEMPORARY_OUTPUT``)
-       * Save to File...
-       * Save to Geopackage...
-       * Save to PostGIS Table...
+       .. include:: qgis_algs_include.rst
+          :start-after: **layer_output_types**
+          :end-before: **end_layer_output_types**
 
-       The file encoding can also be changed here.
 
 Outputs
 .......
@@ -6749,12 +6607,10 @@ Parameters
      - Specify the output (subdivided) vector layer.
        One of:
 
-       * Create Temporary Layer (``TEMPORARY_OUTPUT``)
-       * Save to File...
-       * Save to Geopackage...
-       * Save to PostGIS Table...
+       .. include:: qgis_algs_include.rst
+          :start-after: **layer_output_types**
+          :end-before: **end_layer_output_types**
 
-       The file encoding can also be changed here.
 
 Outputs
 .......
@@ -6821,12 +6677,10 @@ Parameters
      - Specify the output vector layer.
        One of:
 
-       * Create Temporary Layer (``TEMPORARY_OUTPUT``)
-       * Save to File...
-       * Save to Geopackage...
-       * Save to PostGIS Table...
+       .. include:: qgis_algs_include.rst
+          :start-after: **layer_output_types**
+          :end-before: **end_layer_output_types**
 
-       The file encoding can also be changed here.
 
 Outputs
 .......
@@ -6915,12 +6769,10 @@ Parameters
      - Specify the output (buffer) layer.
        One of:
 
-       * Create Temporary Layer (``TEMPORARY_OUTPUT``)
-       * Save to File...
-       * Save to Geopackage...
-       * Save to PostGIS Table...
+       .. include:: qgis_algs_include.rst
+          :start-after: **layer_output_types**
+          :end-before: **end_layer_output_types**
 
-       The file encoding can also be changed here.
 
 Outputs
 .......
@@ -6990,12 +6842,10 @@ Parameters
      - Specify the output layer.
        One of:
 
-       * Create Temporary Layer (``TEMPORARY_OUTPUT``)
-       * Save to File...
-       * Save to Geopackage...
-       * Save to PostGIS Table...
+       .. include:: qgis_algs_include.rst
+          :start-after: **layer_output_types**
+          :end-before: **end_layer_output_types**
 
-       The file encoding can also be changed here.
 
 Outputs
 .......
@@ -7093,12 +6943,10 @@ Parameters
      - Specify the output line layer.
        One of:
 
-       * Create Temporary Layer (``TEMPORARY_OUTPUT``)
-       * Save to File...
-       * Save to Geopackage...
-       * Save to PostGIS Table...
+       .. include:: qgis_algs_include.rst
+          :start-after: **layer_output_types**
+          :end-before: **end_layer_output_types**
 
-       The file encoding can also be changed here.
 
 Outputs
 .......
@@ -7194,12 +7042,10 @@ Parameters
      - Specify the output vector layer.
        One of:
 
-       * Create Temporary Layer (``TEMPORARY_OUTPUT``)
-       * Save to File...
-       * Save to Geopackage...
-       * Save to PostGIS Table...
+       .. include:: qgis_algs_include.rst
+          :start-after: **layer_output_types**
+          :end-before: **end_layer_output_types**
 
-       The file encoding can also be changed here.
 
 Outputs
 .......
@@ -7377,12 +7223,10 @@ Parameters
      - Specify the output (buffer) layer.
        One of:
 
-       * Create Temporary Layer (``TEMPORARY_OUTPUT``)
-       * Save to File...
-       * Save to Geopackage...
-       * Save to PostGIS Table...
+       .. include:: qgis_algs_include.rst
+          :start-after: **layer_output_types**
+          :end-before: **end_layer_output_types**
 
-       The file encoding can also be changed here.
 
 Outputs
 .......
@@ -7458,12 +7302,10 @@ Parameters
      - Specify the output layer (with the Voronoi polygons).
        One of:
 
-       * Create Temporary Layer (``TEMPORARY_OUTPUT``)
-       * Save to File...
-       * Save to Geopackage...
-       * Save to PostGIS Table...
+       .. include:: qgis_algs_include.rst
+          :start-after: **layer_output_types**
+          :end-before: **end_layer_output_types**
 
-       The file encoding can also be changed here.
 
 
 Outputs

--- a/docs/user_manual/processing_algs/qgis/vectoroverlay.rst
+++ b/docs/user_manual/processing_algs/qgis/vectoroverlay.rst
@@ -540,7 +540,6 @@ Parameters
           :start-after: **layer_output_types**
           :end-before: **end_layer_output_types**
 
-
 Outputs
 .......
 

--- a/docs/user_manual/processing_algs/qgis/vectoroverlay.rst
+++ b/docs/user_manual/processing_algs/qgis/vectoroverlay.rst
@@ -73,12 +73,10 @@ Parameters
        that are inside the overlay (clipping) layer.
        One of:
 
-       * Create Temporary Layer
-       * Save to File...
-       * Save to Geopackage...
-       * Save to PostGIS Table......
+       .. include:: qgis_algs_include.rst
+          :start-after: **layer_output_types**
+          :end-before: **end_layer_output_types**
 
-       The file encoding can also be changed here.
 
 Outputs
 .......
@@ -166,12 +164,10 @@ Parameters
        input layer that are not inside the overlay layer.
        One of:
 
-       * Create Temporary Layer
-       * Save to File...
-       * Save to Geopackage...
-       * Save to PostGIS Table......
+       .. include:: qgis_algs_include.rst
+          :start-after: **layer_output_types**
+          :end-before: **end_layer_output_types**
 
-       The file encoding can also be changed here.
 
 Outputs
 .......
@@ -248,12 +244,10 @@ Parameters
        that are inside the clip extent.
        One of:
 
-       * Create Temporary Layer
-       * Save to File...
-       * Save to Geopackage...
-       * Save to PostGIS Table......
+       .. include:: qgis_algs_include.rst
+          :start-after: **layer_output_types**
+          :end-before: **end_layer_output_types**
 
-       The file encoding can also be changed here.
 
 Outputs
 .......
@@ -363,12 +357,10 @@ Parameters
        overlay layer.
        One of:
 
-       * Create Temporary Layer
-       * Save to File...
-       * Save to Geopackage...
-       * Save to PostGIS Table......
+       .. include:: qgis_algs_include.rst
+          :start-after: **layer_output_types**
+          :end-before: **end_layer_output_types**
 
-       The file encoding can also be changed here.
 
 Outputs
 .......
@@ -466,12 +458,10 @@ Parameters
        lines from the input and overlay layers.
        One of:
 
-       * Create Temporary Layer
-       * Save to File...
-       * Save to Geopackage...
-       * Save to PostGIS Table......
+       .. include:: qgis_algs_include.rst
+          :start-after: **layer_output_types**
+          :end-before: **end_layer_output_types**
 
-       The file encoding can also be changed here.
 
 Outputs
 .......
@@ -546,12 +536,10 @@ Parameters
        from the input layer.
        One of:
 
-       * Create Temporary Layer
-       * Save to File...
-       * Save to Geopackage...
-       * Save to PostGIS Table......
+       .. include:: qgis_algs_include.rst
+          :start-after: **layer_output_types**
+          :end-before: **end_layer_output_types**
 
-       The file encoding can also be changed here.
 
 Outputs
 .......
@@ -642,12 +630,10 @@ Parameters
        the other layer.
        One of:
 
-       * Create Temporary Layer
-       * Save to File...
-       * Save to Geopackage...
-       * Save to PostGIS Table......
+       .. include:: qgis_algs_include.rst
+          :start-after: **layer_output_types**
+          :end-before: **end_layer_output_types**
 
-       The file encoding can also be changed here.
 
 Outputs
 .......
@@ -757,12 +743,10 @@ Parameters
        features from the input layer and the overlay layer.
        One of:
 
-       * Create Temporary Layer
-       * Save to File...
-       * Save to Geopackage...
-       * Save to PostGIS Table......
+       .. include:: qgis_algs_include.rst
+          :start-after: **layer_output_types**
+          :end-before: **end_layer_output_types**
 
-       The file encoding can also be changed here.
 
 Outputs
 .......

--- a/docs/user_manual/processing_algs/qgis/vectorselection.rst
+++ b/docs/user_manual/processing_algs/qgis/vectorselection.rst
@@ -87,11 +87,9 @@ Parameters
        features.
        One of:
 
-       * Skip Output
-       * Create Temporary Layer (``TEMPORARY_OUTPUT``)
-       * Save to File...
-       * Save to Geopackage...
-       * Save to PostGIS Table...
+       .. include:: qgis_algs_include.rst
+          :start-after: **layer_output_types_skip**
+          :end-before: **end_layer_output_types_skip**
 
 Outputs
 .......
@@ -180,11 +178,9 @@ Parameters
        features.
        One of:
 
-       * Skip Output
-       * Create Temporary Layer (``TEMPORARY_OUTPUT``)
-       * Save to File...
-       * Save to Geopackage...
-       * Save to PostGIS Table...
+       .. include:: qgis_algs_include.rst
+          :start-after: **layer_output_types_skip**
+          :end-before: **end_layer_output_types_skip**
 
 Outputs
 .......

--- a/docs/user_manual/processing_algs/qgis/vectorselection.rst
+++ b/docs/user_manual/processing_algs/qgis/vectorselection.rst
@@ -74,12 +74,10 @@ Parameters
      - Specify the output vector layer for matching features.
        One of:
 
-       * Create Temporary Layer (``TEMPORARY_OUTPUT``)
-       * Save to File...
-       * Save to Geopackage...
-       * Save to PostGIS Table...
+       .. include:: qgis_algs_include.rst
+          :start-after: **layer_output_types**
+          :end-before: **end_layer_output_types**
 
-       The file encoding can also be changed here.
    * - **Extracted (non-matching)**
      - ``FAIL_OUTPUT``
      - [same as input]
@@ -169,12 +167,10 @@ Parameters
      - Specify the output vector layer for matching features.
        One of:
 
-       * Create Temporary Layer (``TEMPORARY_OUTPUT``)
-       * Save to File...
-       * Save to Geopackage...
-       * Save to PostGIS Table...
+       .. include:: qgis_algs_include.rst
+          :start-after: **layer_output_types**
+          :end-before: **end_layer_output_types**
 
-       The file encoding can also be changed here.
    * - **Non-matching**
      - ``FAIL_OUTPUT``
      - [same as input]
@@ -289,10 +285,9 @@ Parameters
        features in the comparison layer.
        One of:
 
-       * Create Temporary Layer (``TEMPORARY_OUTPUT``)
-       * Save to File...
-       * Save to Geopackage...
-       * Save to PostGIS Table...
+       .. include:: qgis_algs_include.rst
+          :start-after: **layer_output_types**
+          :end-before: **end_layer_output_types**
 
 Outputs
 .......
@@ -376,12 +371,9 @@ Parameters
        selected features.
        One of:
 
-       * Create Temporary Layer (``TEMPORARY_OUTPUT``)
-       * Save to File...
-       * Save to Geopackage...
-       * Save to PostGIS Table...
-
-       Vector layer containing randomly selected features
+       .. include:: qgis_algs_include.rst
+          :start-after: **layer_output_types**
+          :end-before: **end_layer_output_types**
 
 Outputs
 .......
@@ -471,12 +463,10 @@ Parameters
        selected features.
        One of:
 
-       * Create Temporary Layer (``TEMPORARY_OUTPUT``)
-       * Save to File...
-       * Save to Geopackage...
-       * Save to PostGIS Table...
+       .. include:: qgis_algs_include.rst
+          :start-after: **layer_output_types**
+          :end-before: **end_layer_output_types**
 
-       The file encoding can also be changed here.
 
 Outputs
 .......

--- a/docs/user_manual/processing_algs/qgis/vectortable.rst
+++ b/docs/user_manual/processing_algs/qgis/vectortable.rst
@@ -43,19 +43,19 @@ Parameters
    * - **Field name**
      - ``FIELD_NAME``
      - [string]
-       
+
        Default: 'AUTO'
      - Name of the field with autoincremental values
    * - **Start values at**
-       
+
        Optional
      - ``START``
      - [number]
-       
+
        Default: 0
      - Choose the initial number of the incremental count
    * - **Group values by**
-       
+
        Optional
      - ``GROUP_FIELDS``
      - [tablefield: any] [list]
@@ -64,7 +64,7 @@ Parameters
        for each value returned by the combination of these
        fields.
    * - **Sort expression**
-       
+
        Optional
      - ``SORT_EXPRESSION``
      - [expression]
@@ -73,7 +73,7 @@ Parameters
    * - **Sort ascending**
      - ``SORT_ASCENDING``
      - [boolean]
-       
+
        Default: True
      - When a ``sort expression`` is set, use this option
        to control the order in which features are assigned
@@ -81,7 +81,7 @@ Parameters
    * - **Sort nulls first**
      - ``SORT_NULLS_FIRST``
      - [boolean]
-       
+
        Default: False
      - When a ``sort expression`` is set, use this option
        to set whether *Null* values are counted first or
@@ -89,18 +89,15 @@ Parameters
    * - **Incremented**
      - ``OUTPUT``
      - [same as input]
-       
+
        Default: ``[Create temporary layer]``
      - Specify the output vector layer with the auto increment
        field.
        One of:
-      
-       * Create Temporary Layer (``TEMPORARY_OUTPUT``)
-       * Save to File...
-       * Save to Geopackage...
-       * Save to PostGIS Table...
-      
-       The file encoding can also be changed here.
+
+       .. include:: qgis_algs_include.rst
+          :start-after: **layer_output_types_append**
+          :end-before: **end_layer_output_types_append**
 
 Outputs
 .......
@@ -191,13 +188,10 @@ Parameters
        Default: ``[Create temporary layer]``
      - Specify the output vector layer.
        One of:
-       
-       * Create Temporary Layer (``TEMPORARY_OUTPUT``)
-       * Save to File...
-       * Save to Geopackage...
-       * Save to PostGIS Table......
-       
-       The file encoding can also be changed here.
+
+       .. include:: qgis_algs_include.rst
+          :start-after: **layer_output_types_append**
+          :end-before: **end_layer_output_types_append**
 
 Outputs
 .......
@@ -293,7 +287,6 @@ Parameters
           :start-after: **layer_output_types_skip**
           :end-before: **end_layer_output_types_skip**
 
-
 Outputs
 .......
 
@@ -373,11 +366,8 @@ Parameters
        One of:
 
        .. include:: qgis_algs_include.rst
-          :start-after: **layer_output_types**
-          :end-before: **end_layer_output_types**
-
-.. warning: has append
-
+          :start-after: **layer_output_types_append**
+          :end-before: **end_layer_output_types_append**
 
 Outputs
 .......
@@ -492,7 +482,6 @@ Parameters
           :start-after: **layer_output_types**
           :end-before: **end_layer_output_types**
 
-
 Outputs
 .......
 
@@ -548,17 +537,14 @@ Parameters
    * - **Remaining fields**
      - ``OUTPUT``
      - [same as input]
-       
+
        Default: ``[Create temporary layer]``
      - Specify the output vector layer with the remaining fields.
        One of:
-       
-       * Create Temporary Layer
-       * Save to File...
-       * Save to Geopackage...
-       * Save to PostGIS Table......
-       
-       The file encoding can also be changed here.
+
+       .. include:: qgis_algs_include.rst
+          :start-after: **layer_output_types_append**
+          :end-before: **end_layer_output_types_append**
 
 Outputs
 .......
@@ -814,6 +800,10 @@ Parameters
        Default: ``[Create temporary layer]``
      - Specification of the output layer.
 
+       .. include:: qgis_algs_include.rst
+          :start-after: **layer_output_types_append**
+          :end-before: **end_layer_output_types_append**
+
 Outputs
 .......
 
@@ -933,8 +923,8 @@ Parameters
        One of:
        
        .. include:: qgis_algs_include.rst
-          :start-after: **layer_output_types**
-          :end-before: **end_layer_output_types**
+          :start-after: **layer_output_types_append**
+          :end-before: **end_layer_output_types_append**
 
 
 Outputs
@@ -1007,8 +997,8 @@ Parameters
        One of:
        
        .. include:: qgis_algs_include.rst
-          :start-after: **layer_output_types**
-          :end-before: **end_layer_output_types**
+          :start-after: **layer_output_types_append**
+          :end-before: **end_layer_output_types_append**
 
 
 Outputs
@@ -1079,8 +1069,8 @@ Parameters
      - Specify the output layer. One of:
        
        .. include:: qgis_algs_include.rst
-          :start-after: **layer_output_types**
-          :end-before: **end_layer_output_types**
+          :start-after: **layer_output_types_append**
+          :end-before: **end_layer_output_types_append**
 
 
 Outputs

--- a/docs/user_manual/processing_algs/qgis/vectortable.rst
+++ b/docs/user_manual/processing_algs/qgis/vectortable.rst
@@ -965,8 +965,8 @@ Python code
 
 .. _qgisrenametablefield:
 
-Rename vector field
--------------------
+Rename field
+------------
 Renames an existing field from a vector layer.
 
 The original layer is not modified. A new layer is generated where

--- a/docs/user_manual/processing_algs/qgis/vectortable.rst
+++ b/docs/user_manual/processing_algs/qgis/vectortable.rst
@@ -380,12 +380,12 @@ Parameters
      - Specify the output layer.
        One of:
 
-       * Create Temporary Layer
-       * Save to File...
-       * Save to Geopackage...
-       * Save to PostGIS Table...
+       .. include:: qgis_algs_include.rst
+          :start-after: **layer_output_types**
+          :end-before: **end_layer_output_types**
 
-       The file encoding can also be changed here.
+.. warning: has append
+
 
 Outputs
 .......
@@ -496,12 +496,10 @@ Parameters
      - Specify the vector layer with the new calculated
        field. One of:
        
-       * Create Temporary Layer
-       * Save to File...
-       * Save to Geopackage...
-       * Save to PostGIS Table......
-       
-       The file encoding can also be changed here.
+       .. include:: qgis_algs_include.rst
+          :start-after: **layer_output_types**
+          :end-before: **end_layer_output_types**
+
 
 Outputs
 .......
@@ -652,12 +650,9 @@ Parameters
        Default: ``[Create temporary layer]``
      - Specify the output vector layer. One of:
        
-       * Create Temporary Layer
-       * Save to File...
-       * Save to Geopackage...
-       * Save to PostGIS Table......
-       
-       The file encoding can also be changed here.
+       .. include:: qgis_algs_include.rst
+          :start-after: **layer_output_types**
+          :end-before: **end_layer_output_types**
 
 Outputs
 .......
@@ -720,14 +715,13 @@ Parameters
    * - **Destination folder**
      - ``FOLDER``
      - [folder]
-       
-       Default: ``[Save to a temporary folder]``
-     - Folder in which to store the output files.  One of:
-       
-       * Save to a Temporary Directory
-       * Save to Directory...
-       
-       The file encoding can also be changed here.
+
+       Default: ``[Save to temporary folder]``
+     - Folder in which to store the output files. One of:
+
+       .. include:: qgis_algs_include.rst
+          :start-after: **directory_output_types**
+          :end-before: **end_directory_output_types**
 
 Outputs
 .......
@@ -946,12 +940,10 @@ Parameters
      - Specification of the output layer.
        One of:
        
-       * Create Temporary Layer
-       * Save to File...
-       * Save to Geopackage...
-       * Save to PostGIS Table......
-       
-       The file encoding can also be changed here.
+       .. include:: qgis_algs_include.rst
+          :start-after: **layer_output_types**
+          :end-before: **end_layer_output_types**
+
 
 Outputs
 .......
@@ -1022,12 +1014,10 @@ Parameters
      - Specification of the output layer.
        One of:
        
-       * Create Temporary Layer
-       * Save to File...
-       * Save to Geopackage...
-       * Save to PostGIS Table......
-       
-       The file encoding can also be changed here.
+       .. include:: qgis_algs_include.rst
+          :start-after: **layer_output_types**
+          :end-before: **end_layer_output_types**
+
 
 Outputs
 .......
@@ -1096,12 +1086,10 @@ Parameters
        Default: ``[Create Temporary Layer]``
      - Specify the output layer. One of:
        
-       * Create Temporary Layer
-       * Save to File...
-       * Save to Geopackage...
-       * Save to PostGIS Table......
-       
-       The file encoding can also be changed here.
+       .. include:: qgis_algs_include.rst
+          :start-after: **layer_output_types**
+          :end-before: **end_layer_output_types**
+
 
 Outputs
 .......

--- a/docs/user_manual/processing_algs/qgis/vectortable.rst
+++ b/docs/user_manual/processing_algs/qgis/vectortable.rst
@@ -275,14 +275,11 @@ Parameters
        Default: ``[Create temporary layer]``
      - Vector layer with the numeric field containing indexes.
        One of:
-      
-       * Skip Output
-       * Create Temporary Layer
-       * Save to File...
-       * Save to Geopackage...
-       * Save to PostGIS Table......
-       
-       The file encoding can also be changed here.
+
+       .. include:: qgis_algs_include.rst
+          :start-after: **layer_output_types_skip**
+          :end-before: **end_layer_output_types_skip**
+
    * - **Class summary**
      - ``SUMMARY_OUTPUT``
      - [table]
@@ -291,14 +288,11 @@ Parameters
      - Specify the table to contain the summary of the class field
        mapped to the corresponding unique value.
        One of:
-      
-       * Skip Output
-       * Create Temporary Layer
-       * Save to File...
-       * Save to Geopackage...
-       * Save to PostGIS Table......
-       
-       The file encoding can also be changed here.
+
+       .. include:: qgis_algs_include.rst
+          :start-after: **layer_output_types_skip**
+          :end-before: **end_layer_output_types_skip**
+
 
 Outputs
 .......

--- a/docs/user_manual/processing_algs/qgis/vectortable.rst
+++ b/docs/user_manual/processing_algs/qgis/vectortable.rst
@@ -312,8 +312,6 @@ Outputs
    * - **Class summary**
      - ``SUMMARY_OUTPUT``
      - [table]
-       
-       Default: ``[Skip Output]``
      - Table with summary of the class field mapped to the
        corresponding unique value.  
 
@@ -813,7 +811,7 @@ Parameters
      - ``OUTPUT``
      - [vector: any]
        
-       Default: ``[Save to temporary file]``
+       Default: ``[Create temporary layer]``
      - Specification of the output layer.
 
 Outputs


### PR DESCRIPTION
The Processing output parameter has got some improvements over the years, namely:
- ability to save to any database type and not only to PostGIS (#5160)
- append results to an existing layer (#5241)

Instead of trying to update each individual alg output with correct options/text, this first-step PR proposes to rely on the sphinx `.. include::` role, ie set the (variants of)text in [one place](https://github.com/qgis/QGIS-Documentation/compare/master...DelazJ:processingOutputtypes?expand=1#diff-2e852d3e2a90789ba4798c61b3b1aafc7e9c49f251ba5d82c488917089a64a3a) and call them in the algs. This way, descriptions are harmonized, can be easily extended/updated and doing this helped fix some incoherence.

~~Only covered the PostGIS --> DB rename. A follow-up PR for the Append.~~ Both covered now.