### PR TITLE
Fix some geometry conversion tools

### DIFF
--- a/docs/user_manual/processing_algs/qgis/vectorgeometry.rst
+++ b/docs/user_manual/processing_algs/qgis/vectorgeometry.rst
@@ -1323,11 +1323,14 @@ Convert geometry type
 Generates a new layer based on an existing one, with a different type
 of geometry.
 
+The attribute table of the output layer is the same as the one of
+the input layer.
+
 Not all conversions are possible. For instance, a line can be
 converted to a point, but a point cannot be converted to a
 line. A line can also be converted to a polygon.
 
-.. seealso:: :ref:`qgispolygonize`, :ref:`qgislinestopolygons`
+.. seealso:: :ref:`qgispolygonize`, :ref:`qgislinestopolygons`, :ref:`qgispolygonstolines`
 
 Parameters
 ..........
@@ -3734,12 +3737,12 @@ Lines to polygons
 Generates a polygon layer using as polygon rings the lines from an
 input line layer.
 
-The attribute table of the output layer is the same as the one from of
-the input line layer.
+The attribute table of the output layer is the same as the one of
+the input layer.
 
 **Default menu**: :menuselection:`Vector --> Geometry Tools`
 
-.. seealso:: :ref:`qgispolygonstolines`, :ref:`qgispolygonize`
+.. seealso:: :ref:`qgispolygonstolines`, :ref:`qgispolygonize`, :ref:`qgisconvertgeometrytype`
 
 Parameters
 ..........
@@ -4811,7 +4814,7 @@ line layer of **closed** features.
 .. note:: The line layer must have closed shapes in order to be
    transformed into a polygon.
 
-.. seealso:: :ref:`qgispolygonstolines`
+.. seealso:: :ref:`qgispolygonstolines`, :ref:`qgislinestopolygons`, :ref:`qgisconvertgeometrytype`
 
 Parameters
 ..........
@@ -4835,7 +4838,7 @@ Parameters
      - [boolean]
 
        Default: False
-     - Check to copy the original attributes of the input layer
+     - Check to keep the fields (only the table structure, not the values) of the input layer
    * - **Polygons from lines**
      - ``OUTPUT``
      - [vector: polygon]
@@ -4880,6 +4883,9 @@ Polygons to lines
 Takes a polygon layer and creates a line layer, with lines
 representing the boundaries of the polygons in the input layer.
 
+The attribute table of the output layer is the same as the one of
+the input layer.
+
 .. figure:: img/polygon_to_lines.png
    :align: center
 
@@ -4887,7 +4893,7 @@ representing the boundaries of the polygons in the input layer.
 
 **Default menu**: :menuselection:`Vector --> Geometry Tools`
 
-.. seealso:: :ref:`qgispolygonize`
+.. seealso:: :ref:`qgislinestopolygons`, :ref:`qgispolygonize`, :ref:`qgisconvertgeometrytype`
 
 Parameters
 ..........

--- a/docs/user_manual/processing_algs/qgis/vectorgeometry.rst
+++ b/docs/user_manual/processing_algs/qgis/vectorgeometry.rst
@@ -1330,8 +1330,8 @@ Not all conversions are possible. For instance, a line layer
 can be converted to a point layer, but a point layer cannot
 be converted to a line layer.
 
-.. seealso:: :ref:`qgispolygonize`, :ref:`qgislinestopolygons`, :ref:`qgispolygonstolines`
-  :ref:`qgispointstopath`
+.. seealso:: :ref:`qgispolygonize`, :ref:`qgislinestopolygons`, :ref:`qgispolygonstolines`,
+   :ref:`qgispointstopath`
 
 Parameters
 ..........

--- a/docs/user_manual/processing_algs/qgis/vectorgeometry.rst
+++ b/docs/user_manual/processing_algs/qgis/vectorgeometry.rst
@@ -1331,6 +1331,7 @@ can be converted to a point layer, but a point layer cannot
 be converted to a line layer.
 
 .. seealso:: :ref:`qgispolygonize`, :ref:`qgislinestopolygons`, :ref:`qgispolygonstolines`
+  :ref:`qgispointstopath`
 
 Parameters
 ..........

--- a/docs/user_manual/processing_algs/qgis/vectorgeometry.rst
+++ b/docs/user_manual/processing_algs/qgis/vectorgeometry.rst
@@ -1326,9 +1326,9 @@ of geometry.
 The attribute table of the output layer is the same as the one of
 the input layer.
 
-Not all conversions are possible. For instance, a line can be
-converted to a point, but a point cannot be converted to a
-line. A line can also be converted to a polygon.
+Not all conversions are possible. For instance, a line layer
+can be converted to a point layer, but a point layer cannot
+be converted to a line layer.
 
 .. seealso:: :ref:`qgispolygonize`, :ref:`qgislinestopolygons`, :ref:`qgispolygonstolines`
 


### PR DESCRIPTION
<!---
Include a few sentences describing the overall goals for this Pull Request.
 
A list of issues is at https://github.com/qgis/QGIS-Documentation/issues.
Add "fix #issuenumber" for each issue the PR fixes. The ticket(s) will be closed automatically.
If your PR doesn't fix entirely the ticket, only add the ticket(s) reference preceded by # character.
-->
Goal:
Fixes Convert geometry type, Lines to polygons, Polygonize and Polygons to lines tools documentation.

Ticket(s): https://github.com/qgis/QGIS/issues/44779
<!---
Indicate whether the fix should be backported to previous release.
Replace the space between square brackets by a `x` to make it checked.
-->
- [x] Backport to LTR documentation is requested

<!---
Reviewing is a process done by community members, mostly on a volunteer basis.
We try to keep the overhead as small as possible and appreciate if you help us.
Please read carefully and ensure you comply with our writing guidelines at
https://docs.qgis.org/testing/en/docs/documentation_guidelines/index.html.
Feel free to ask in a comment or the (qgis-community-team mailing list)
[https://lists.osgeo.org/mailman/listinfo/qgis-community-team] if you have troubles with any item.
--->
