### PR TITLE
Simplify the plugins snippets page

### DIFF
--- a/docs/pyqgis_developer_cookbook/cheat_sheet.rst
+++ b/docs/pyqgis_developer_cookbook/cheat_sheet.rst
@@ -613,7 +613,7 @@ Advanced TOC
 .. testcode:: cheat_sheet
 
   root = QgsProject.instance().layerTreeRoot()
-  node = root.findLayer(iface.activeLayer().id())
+  node = root.findLayer(layer.id())
   new_state = Qt.Checked if node.isVisible() == Qt.Unchecked else Qt.Unchecked
   node.setItemVisibilityChecked(new_state)
 
@@ -656,7 +656,7 @@ Advanced TOC
     root = QgsProject.instance().layerTreeRoot()
 
     layer = QgsProject.instance().mapLayersByName('layer name you like')[0]
-    node = root.findLayer( layer.id())
+    node = root.findLayer(layer.id())
 
     index = model.node2index( node )
     ltv.setRowHidden( index.row(), index.parent(), True )

--- a/docs/pyqgis_developer_cookbook/cheat_sheet.rst
+++ b/docs/pyqgis_developer_cookbook/cheat_sheet.rst
@@ -606,12 +606,17 @@ Advanced TOC
     myGroup.insertChildNode(0, myLayer)
     parent.removeChildNode(myOriginalLayer)
 
-**Changing visibility**
+.. index:: Toggle layers
+
+**Toggling active layer visibility**
 
 .. testcode:: cheat_sheet
 
-    myGroup.setItemVisibilityChecked(False)
-    myLayer.setItemVisibilityChecked(False)
+  root = QgsProject.instance().layerTreeRoot()
+  node = root.findLayer(iface.activeLayer().id())
+  new_state = Qt.Checked if node.isVisible() == Qt.Unchecked else Qt.Unchecked
+  node.setItemVisibilityChecked(new_state)
+
 
 **Is group selected**
 

--- a/docs/pyqgis_developer_cookbook/plugins/snippets.rst
+++ b/docs/pyqgis_developer_cookbook/plugins/snippets.rst
@@ -76,52 +76,6 @@ The method that is called when CTRL+I is pressed
   def key_action_triggered(self):
     QMessageBox.information(self.iface.mainWindow(),"Ok", "You pressed Ctrl+I")
 
-.. index:: Plugins; Toggle layers
-
-How to toggle Layers
---------------------
-
-There is an API to access layers in the legend.
-Here is an example that toggles the visibility of the active layer
-
-
-.. testcode:: plugin_snippets
-
-  root = QgsProject.instance().layerTreeRoot()
-  node = root.findLayer(iface.activeLayer().id())
-  new_state = Qt.Checked if node.isVisible() == Qt.Unchecked else Qt.Unchecked
-  node.setItemVisibilityChecked(new_state)
-
-.. index:: Plugins; Access attributes of selected features
-
-How to access attribute table of selected features
---------------------------------------------------
-
-.. testcode:: plugin_snippets
-
-    def change_value(value):
-        """Change the value in the second column for all selected features.
-
-        :param value: The new value.
-        """
-        layer = iface.activeLayer()
-        if layer:
-            count_selected = layer.selectedFeatureCount()
-            if count_selected > 0:
-                layer.startEditing()
-                id_features = layer.selectedFeatureIds()
-                for i in id_features:
-                    layer.changeAttributeValue(i, 1, value) # 1 being the second column
-                layer.commitChanges()
-            else:
-                iface.messageBar().pushCritical("Error",
-                    "Please select at least one feature from current layer")
-        else:
-            iface.messageBar().pushCritical("Error", "Please select a layer")
-
-    # The method requires one parameter (the new value for the second
-    # field of the selected feature(s)) and can be called by
-    change_value(50)
 
 .. index:: Plugins; Customization
 


### PR DESCRIPTION
 Remove examples that do not necessarily belong to plugin development (and which are better served in other place)

This "Plugin development" chapter deserves more fixes/updates to current best practices... "knowers"...?

