### PR TITLE
fix: BBOX Required for the GetMap request

### DIFF
--- a/docs/server_manual/services.rst
+++ b/docs/server_manual/services.rst
@@ -78,7 +78,7 @@ WMS 1.1.1 and 1.3.0 specifications:
    ":ref:`LAYERS <wms-layers>` ", "No", "Layers to display"
    ":ref:`STYLES <wms-styles>`", "No", "Layers' style"
    ":ref:`SRS / CRS <wms-srs>`", "Yes", "Coordinate reference system"
-   ":ref:`BBOX <wms-bbox>`", "No", "Map extent"
+   ":ref:`BBOX <wms-bbox>`", "Yes", "Map extent"
    ":ref:`WIDTH <wms-width>`", "Yes", "Width of the image in pixels"
    ":ref:`HEIGHT <wms-height>`", "Yes", "Height of the image in pixels"
    ":ref:`FORMAT <wms-getmap-format>`", "No", "Image format"


### PR DESCRIPTION
according to the OGC WMS 1.1.1 and 1.3.0 specifications:
**7.3.3.6 BBOX**
`If the WMS server has declared that a Layer is not subsettable, as described in 7.2.4.7.5, then the client shall specify exactly the declared Bounding Box values in the GetMap request and the server may issue a service exception otherwise.`

- [x] Backport to LTR documentation is requested
