### PR TITLE
template parameter is required for GetPrint request

### DIFF
--- a/docs/server_manual/services.rst
+++ b/docs/server_manual/services.rst
@@ -854,6 +854,7 @@ URL example:
   &MAP=/home/qgis/projects/world.qgs
   &CRS=EPSG:4326
   &FORMAT=png
+  &TEMPLATE=Layout%201
   &map0:EXTENT=-180,-90,180,90
   &map0:LAYERS=mylayer1,mylayer2,mylayer3
   &map0:OPACITIES=125,200,125


### PR DESCRIPTION
TEMPLATE parameter is required : https://docs.qgis.org/3.16/fr/docs/server_manual/services.html#getprint

It should be backported.