### PR TITLE
Fix some server ENV variables default values

### DIFF
--- a/docs/server_manual/config.rst
+++ b/docs/server_manual/config.rst
@@ -121,14 +121,14 @@ several ways to define these variables. This is fully described in
 
        QGIS_SERVER_LANDING_PAGE_PROJECTS_DIRECTORIES
      - Directories used by the landing page service to find .qgs and .qgz projects
-     - /qgis/server_projects_directories
+     - ""
      - All
 
    * - .. _qgis_server_landing_page_projects_pg_connections:
 
        QGIS_SERVER_LANDING_PAGE_PROJECTS_PG_CONNECTIONS
      - PostgreSQL connection strings used by the landing page service to find projects
-     - /qgis/server_projects_pg_connections
+     - ""
      - All
 
    * - .. _qgis_server_log_file:
@@ -158,7 +158,7 @@ several ways to define these variables. This is fully described in
 
        QGIS_SERVER_LOG_PROFILE
      - Add detailed profile information to the logs, only effective when QGIS_SERVER_LOG_LEVEL=0
-     - /qgis/server_log_profile
+     - false
      - All
 
    * - .. _qgis_server_log_stderr:
@@ -234,7 +234,7 @@ several ways to define these variables. This is fully described in
        .. code-block:: bash
 
         PGSERVICEFILE=/etc/pg_service.conf \
-	QUERY_STRING="MAP=/home/qgis/projects/world.qgs&SERVICE=WMS&REQUEST=GetCapabilities" \
+	QUERY_STRING="MAP=/home/projects/world.qgs&SERVICE=WMS&REQUEST=GetCapabilities" \
 	/usr/lib/cgi-bin/qgis_mapserv.fcgi
 
        The result should be either the content of the GetCapabilities response or,


### PR DESCRIPTION
The following ENV vars had wrong default values in the docs
QGIS_SERVER_LANDING_PAGE_PROJECTS_PG_CONNECTIONS
QGIS_SERVER_LANDING_PAGE_PROJECTS_DIRECTORIES
QGIS_SERVER_LOG_PROFILE

- [x] Backport to LTR documentation is requested

<!---
Reviewing is a process done by community members, mostly on a volunteer basis.
We try to keep the overhead as small as possible and appreciate if you help us.
Please read carefully and ensure you comply with our writing guidelines at
https://docs.qgis.org/testing/en/docs/documentation_guidelines/index.html.
Feel free to ask in a comment or the (qgis-community-team mailing list)
[https://lists.osgeo.org/mailman/listinfo/qgis-community-team] if you have troubles with any item.
--->
