### PR TITLE
Hide the list of functions in the PDF build

### DIFF
--- a/docs/user_manual/working_with_vector/functions_list.rst
+++ b/docs/user_manual/working_with_vector/functions_list.rst
@@ -21,9 +21,11 @@ Aggregates Functions
 
 This group contains functions which aggregate values over layers and fields.
 
-.. contents::
-   :local:
-   :class: toc_columns
+.. only:: html
+
+   .. contents::
+      :local:
+      :class: toc_columns
 
 .. include:: expression_help/Aggregates.rst
    :start-after: :orphan:
@@ -46,9 +48,11 @@ list data structures). The order of values within the array matters, unlike the
 :ref:`'map' data structure <maps_functions>`, where the order of key-value pairs
 is irrelevant and values are identified by their keys.
 
-.. contents::
-   :local:
-   :class: toc_columns
+.. only:: html
+
+   .. contents::
+      :local:
+      :class: toc_columns
 
 .. include:: expression_help/Arrays.rst
    :start-after: :orphan:
@@ -65,9 +69,11 @@ Color Functions
 
 This group contains functions for manipulating colors.
 
-.. contents::
-   :local:
-   :class: toc_columns
+.. only:: html
+
+   .. contents::
+      :local:
+      :class: toc_columns
 
 .. include:: expression_help/Color.rst
    :start-after: :orphan:
@@ -102,9 +108,11 @@ Conditional Functions
 
 This group contains functions to handle conditional checks in expressions.
 
-.. contents::
-   :local:
-   :class: toc_columns
+.. only:: html
+
+   .. contents::
+      :local:
+      :class: toc_columns
 
 .. include:: expression_help/Conditionals.rst
    :start-after: :orphan:
@@ -118,9 +126,11 @@ Conversions Functions
 This group contains functions to convert one data type to another
 (e.g., string from/to integer, binary from/to string, string to date, ...).
 
-.. contents::
-   :local:
-   :class: toc_columns
+.. only:: html
+
+   .. contents::
+      :local:
+      :class: toc_columns
 
 .. include:: expression_help/Conversions.rst
    :start-after: :orphan:
@@ -156,9 +166,11 @@ This group shares several functions with the :ref:`conversion_functions`
      one of the date extraction functions (e.g., :ref:`day() <expression_function_Date_and_Time_day>`
      to get the interval expressed in days)
 
-.. contents::
-   :local:
-   :class: toc_columns
+.. only:: html
+
+   .. contents::
+      :local:
+      :class: toc_columns
 
 .. include:: expression_help/Date_and_Time.rst
    :start-after: :orphan:
@@ -214,9 +226,11 @@ To add a value to the expression you are writing, double-click on it in the list
 If the value is of a string type, it should be simple quoted, otherwise no quote
 is needed.
 
-.. contents::
-   :local:
-   :class: toc_columns
+.. only:: html
+
+   .. contents::
+      :local:
+      :class: toc_columns
 
 .. include:: expression_help/Fields_and_Values.rst
    :start-after: :orphan:
@@ -227,9 +241,11 @@ Files and Paths Functions
 
 This group contains functions which manipulate file and path names.
 
-.. contents::
-   :local:
-   :class: toc_columns
+.. only:: html
+
+   .. contents::
+      :local:
+      :class: toc_columns
 
 .. include:: expression_help/Files_and_Paths.rst
    :start-after: :orphan:
@@ -241,8 +257,11 @@ Form Functions
 This group contains functions that operate exclusively under the attribute form
 context. For example, in :ref:`field's widgets <vector_attributes_menu>` settings.
 
-.. contents::
-   :local:
+.. only:: html
+
+   .. contents::
+      :local:
+      :class: toc_columns
 
 .. include:: expression_help/Form.rst
    :start-after: :orphan:
@@ -253,9 +272,11 @@ Fuzzy Matching Functions
 
 This group contains functions for fuzzy comparisons between values.
 
-.. contents::
-   :local:
-   :class: toc_columns
+.. only:: html
+
+   .. contents::
+      :local:
+      :class: toc_columns
 
 .. include:: expression_help/Fuzzy_Matching.rst
    :start-after: :orphan:
@@ -266,9 +287,11 @@ General Functions
 
 This group contains general assorted functions.
 
-.. contents::
-   :local:
-   :class: toc_columns
+.. only:: html
+
+   .. contents::
+      :local:
+      :class: toc_columns
 
 .. include:: expression_help/General.rst
    :start-after: :orphan:
@@ -288,9 +311,11 @@ Geometry Functions
 This group contains functions that operate on geometry objects
 (e.g. buffer, transform, $area).
 
-.. contents::
-   :local:
-   :class: toc_columns
+.. only:: html
+
+   .. contents::
+      :local:
+      :class: toc_columns
 
 .. include:: expression_help/GeometryGroup.rst
    :start-after: :orphan:
@@ -621,9 +646,11 @@ Layout Functions
 
 This group contains functions to manipulate print layout items properties.
 
-.. contents::
-   :local:
-   :class: toc_columns
+.. only:: html
+
+   .. contents::
+      :local:
+      :class: toc_columns
 
 .. include:: expression_help/Layout.rst
    :start-after: :orphan:
@@ -645,9 +672,11 @@ such as when performing :ref:`aggregates <aggregates_function>`, :ref:`attribute
 
 It also provides some convenient functions to manipulate layers.
 
-.. contents::
-   :local:
-   :class: toc_columns
+.. only:: html
+
+   .. contents::
+      :local:
+      :class: toc_columns
 
 .. include:: expression_help/Map_Layers.rst
    :start-after: :orphan:
@@ -672,9 +701,11 @@ arrays). Unlike the :ref:`list data structure <array_functions>` where values
 order matters, the order of the key-value pairs in the map object is not relevant
 and values are identified by their keys.
 
-.. contents::
-   :local:
-   :class: toc_columns
+.. only:: html
+
+   .. contents::
+      :local:
+      :class: toc_columns
 
 .. include:: expression_help/Maps.rst
    :start-after: :orphan:
@@ -691,9 +722,11 @@ Mathematical Functions
 
 This group contains math functions (e.g., square root, sin and cos).
 
-.. contents::
-   :local:
-   :class: toc_columns
+.. only:: html
+
+   .. contents::
+      :local:
+      :class: toc_columns
 
 .. include:: expression_help/Math.rst
    :start-after: :orphan:
@@ -704,9 +737,11 @@ Meshes Functions
 
 This group contains functions which calculate or return mesh related values.
 
-.. contents::
-   :local:
-   :class: toc_columns
+.. only:: html
+
+   .. contents::
+      :local:
+      :class: toc_columns
 
 .. include:: expression_help/Meshes.rst
    :start-after: :orphan:
@@ -719,9 +754,11 @@ This group contains operators (e.g., +, -, \*).
 Note that for most of the mathematical functions below,
 if one of the inputs is NULL then the result is NULL.
 
-.. contents::
-   :local:
-   :class: toc_columns
+.. only:: html
+
+   .. contents::
+      :local:
+      :class: toc_columns
 
 .. include:: expression_help/Operators.rst
    :start-after: :orphan:
@@ -787,9 +824,11 @@ Record and Attributes Functions
 
 This group contains functions that operate on record identifiers.
 
-.. contents::
-   :local:
-   :class: toc_columns
+.. only:: html
+
+   .. contents::
+      :local:
+      :class: toc_columns
 
 .. include:: expression_help/Record_and_Attributes.rst
    :start-after: :orphan:
@@ -839,9 +878,11 @@ String Functions
 This group contains functions that operate on strings
 (e.g., that replace, convert to upper case).
 
-.. contents::
-   :local:
-   :class: toc_columns
+.. only:: html
+
+   .. contents::
+      :local:
+      :class: toc_columns
 
 .. include:: expression_help/String.rst
    :start-after: :orphan:


### PR DESCRIPTION
until we find how to render the list in multicolumns instead of a single long one (and we usually do not display local toc).
Fixes this kind of rendering (do not check the array's or geometry's)
![image](https://user-images.githubusercontent.com/7983394/137201464-2097b9dd-bfd8-4bb6-b59c-08fc5d0a50ab.png)
