### PR TITLE
fix Line Density algorithm ID

### DIFF
--- a/docs/user_manual/processing_algs/qgis/interpolation.rst
+++ b/docs/user_manual/processing_algs/qgis/interpolation.rst
@@ -465,7 +465,7 @@ Outputs
 Python code
 ...........
 
-**Algorithm ID**: ``qgis:linedensity``
+**Algorithm ID**: ``native:linedensity``
 
 .. include:: ../algs_include.rst
   :start-after: **algorithm_code_section**


### PR DESCRIPTION
This is just a quick fix of the algorithm ID for the Line Density algorithm. The algorithm is native - not a python implementation. 

<!---
Include a few sentences describing the overall goals for this Pull Request.
 
A list of issues is at https://github.com/qgis/QGIS-Documentation/issues.
Add "fix #issuenumber" for each issue the PR fixes. The ticket(s) will be closed automatically.
If your PR doesn't fix entirely the ticket, only add the ticket(s) reference preceded by # character.
-->
Goal: fix the broken algorithm ID of Line Density

<!---
Indicate whether the fix should be backported to previous release.
Replace the space between square brackets by a `x` to make it checked.
-->
- [x] Backport to LTR documentation is requested

<!---
Reviewing is a process done by community members, mostly on a volunteer basis.
We try to keep the overhead as small as possible and appreciate if you help us.
Please read carefully and ensure you comply with our writing guidelines at
https://docs.qgis.org/testing/en/docs/documentation_guidelines/index.html.
Feel free to ask in a comment or the (qgis-community-team mailing list)
[https://lists.osgeo.org/mailman/listinfo/qgis-community-team] if you have troubles with any item.
--->
