### PR TITLE
added section on indentation/whitespace

### DIFF
--- a/docs/documentation_guidelines/writing.rst
+++ b/docs/documentation_guidelines/writing.rst
@@ -59,6 +59,79 @@ common to all lists:
 * Use period ( ``.`` ) as punctuation for list items that consist of several
   sentences or a single compound sentence
 
+Indentation
+-----------
+
+Indentation in ReStructuredText should be aligned with the list or markup *marker*. It is
+also possible to create block quotes with indentation. See the
+`Specification <https://docutils.sourceforge.io/docs/ref/rst/restructuredtext.html#indentation>`__
+
+.. code-block::
+
+   #. Three shall be the number of the spaces
+      and the number of the spaces shall be three
+   #. There can or cannot be whitelines
+
+   #. Between list items
+
+      * And nested lists
+      * Are also possible
+      * Just make sure
+      * That they have a whiteline
+      * above as well as below
+
+      And now we can write more
+
+   However, if there is an unindented paragraph, this will reset the numbering:
+
+   #. This item starts at 1 again
+
+      But you can have *indented* paragraphs, that do not reset the numbering.
+
+   #. This is now item 2.
+
+      .. admontion:: Conclusion
+         
+         :3 spaces: numbered lists (``#.``, ``1.``) and markup (``..``)
+         :2 spaces: bullet lists ``*``
+         :n spaces: There are other things such as option lists
+                    where it is preferred to also align the indentation
+                    to the marker.
+            
+         
+         and any combination of spaces when these are combined
+
+
+#. Three shall be the number of the spaces
+   and the number of the spaces shall be three
+#. There can or cannot be whitelines
+
+#. Between list items
+
+   * And nested lists
+   * Are also possible
+   * Just make sure
+   * That they have a whiteline
+   * above as well as below
+
+   And now we can write more
+
+However, if there is an unindented paragraph, this will reset the numbering:
+
+#. This item starts at 1 again
+
+   But you can have *indented* paragraphs, that do not reset the numbering.
+
+
+#. This is now item 2.
+
+      .. admonition:: Conclusion
+         
+         :3 spaces: numbered lists (``#.``, ``1.``) and markup (``..``)
+         :2 spaces: bullet lists ``*``
+
+         and any combination of spaces when these are combined
+
 Inline Tags
 -----------
 

--- a/docs/documentation_guidelines/writing.rst
+++ b/docs/documentation_guidelines/writing.rst
@@ -68,69 +68,22 @@ also possible to create block quotes with indentation. See the
 
 .. code-block::
 
-   #. Three shall be the number of the spaces
-      and the number of the spaces shall be three
-   #. There can or cannot be whitelines
+   #. In a numbered list, there should be 
+      three spaces when you break lines
+   #. And next items directly follow
 
-   #. Between list items
-
-      * And nested lists
+      * Nested lists
       * Are also possible
-      * Just make sure
-      * That they have a whiteline
-      * above as well as below
-
-      And now we can write more
+      * And when they also have
+        a line that is too long,
+        the text should be naturally
+        aligned
+      * and be in their own paragraph
 
    However, if there is an unindented paragraph, this will reset the numbering:
 
    #. This item starts at 1 again
 
-      But you can have *indented* paragraphs, that do not reset the numbering.
-
-   #. This is now item 2.
-
-      .. admontion:: Conclusion
-         
-         :3 spaces: numbered lists (``#.``, ``1.``) and markup (``..``)
-         :2 spaces: bullet lists ``*``
-         :n spaces: There are other things such as option lists
-                    where it is preferred to also align the indentation
-                    to the marker.
-            
-         
-         and any combination of spaces when these are combined
-
-
-#. Three shall be the number of the spaces
-   and the number of the spaces shall be three
-#. There can or cannot be whitelines
-
-#. Between list items
-
-   * And nested lists
-   * Are also possible
-   * Just make sure
-   * That they have a whiteline
-   * above as well as below
-
-   And now we can write more
-
-However, if there is an unindented paragraph, this will reset the numbering:
-
-#. This item starts at 1 again
-
-   But you can have *indented* paragraphs, that do not reset the numbering.
-
-
-#. This is now item 2.
-
-      .. admonition:: Conclusion
-         
-         :3 spaces: numbered lists (``#.``, ``1.``) and markup (``..``)
-         :2 spaces: bullet lists ``*``
-
-         and any combination of spaces when these are combined
 
 Inline Tags
 -----------


### PR DESCRIPTION
<!---
Include a few sentences describing the overall goals for this Pull Request.

A list of issues is at https://github.com/qgis/QGIS-Documentation/issues.
Add "fix #issuenumber" for each issue the PR fixes. The ticket(s) will be closed automatically.
If your PR doesn't fix entirely the ticket, only add the ticket(s) reference preceded by # character.
-->
Goal:

Specify the indentation behaviour of QGIS documentation. This had me confused for some time while working on my own derived tutorial. I may have over-done it a little bit, and am willing to shorten :)

Ticket(s): None yet
<!---
Indicate whether the fix should be backported to previous release.
Replace the space between square brackets by a `x` to make it checked.
-->
- [x] Backport to LTR documentation is requested

<!---
Reviewing is a process done by community members, mostly on a volunteer basis.
We try to keep the overhead as small as possible and appreciate if you help us.
Please read carefully and ensure you comply with our writing guidelines at
https://docs.qgis.org/testing/en/docs/documentation_guidelines/index.html.
Feel free to ask in a comment or the (qgis-community-team mailing list)
[https://lists.osgeo.org/mailman/listinfo/qgis-community-team] if you have troubles with any item.
--->
