### PR TITLE
Expose the layout map item's temporal range properties

### DIFF
--- a/docs/user_manual/print_composer/composer_items/composer_map.rst
+++ b/docs/user_manual/print_composer/composer_items/composer_map.rst
@@ -208,6 +208,24 @@ view, keeping the same scale. With the |moveItemContent| tool enabled, use the
 mouse wheel to zoom in or out, modifying the scale of the shown map. Combine
 the movement with :kbd:`Ctrl` key pressed to have a smaller zoom.
 
+.. index:: Temporal, Print layout
+.. _mapitem_temporalrange:
+
+Temporal range
+--------------
+
+The :guilabel:`Temporal range` group of the map item properties panel provides the
+options to control layers rendering in the map item based on a temporal range.
+Only layers whose temporal properties overlap with the time range set by the
+:guilabel:`Start` and :guilabel:`End` dates are displayed in the map item.
+
+The associated data-defined widgets help make the time range dynamic, and
+allow outputting temporal :ref:`atlases <atlas_generation>`, i.e. automated maps
+with fixed spatial extent and whose contents vary based on time. For example,
+using as coverage layer a csv file with a start and end pair of fields and
+a number of rows representing date ranges, enable both the temporal range
+and control by atlas in the map item properties and hit atlas export.
+
 .. index:: Atlas
 .. _controlled_atlas:
 

--- a/docs/user_manual/print_composer/composer_items/composer_map.rst
+++ b/docs/user_manual/print_composer/composer_items/composer_map.rst
@@ -197,10 +197,11 @@ following functionalities (see :numref:`figure_layout_map_extents`):
 The **Extents** area displays ``X`` and ``Y`` coordinates of the area shown
 in the map item. Each of these values can be manually replaced, modifying the
 map canvas area displayed and/or map item size.
-Clicking the :guilabel:`Set to Map Canvas Extent` button sets the extent of the
-layout map item to the extent of the main map canvas.
-The button :guilabel:`View Extent in Map Canvas` does exactly the opposite; it
-updates the extent of the main map canvas to the extent of the layout map item.
+The extent can also be modified using tools at the top of the map item panel
+such as:
+
+* |setToCanvasExtent| :sup:`Set map canvas to match main canvas extent`
+* |setToCanvasScale| :sup:`Set map scale to match main canvas scale`
 
 You can also alter a map item extent using the |moveItemContent| :sup:`Move
 item content` tool: click-and-drag within the map item to modify its current


### PR DESCRIPTION
Fixes #5454
also remove left-over from old GUI in the Extents group