### PR TITLE
[release_3.22] Reinstate nitpicking checks for docs build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ html:
 	if [ $(LANG) != "en" ]; then \
 		$(SPHINXBUILD) -b html "$(SOURCEDIR)" "$(BUILDDIR)/html/$(LANG)" $(SPHINXINTLOPTS) $(0); \
 	else \
-		$(SPHINXBUILD) -b html --keep-going "$(SOURCEDIR)" "$(BUILDDIR)/html/$(LANG)" $(SPHINXOPTS) $(0); \
+		$(SPHINXBUILD) -b html -nW --keep-going "$(SOURCEDIR)" "$(BUILDDIR)/html/$(LANG)" $(SPHINXOPTS) $(0); \
 	fi
 
 latex:


### PR DESCRIPTION
possible now that the PyQGIS 3.22 docs is released
reverts 017c31f2