### PR TITLE
Fix "Delete duplicates by attribute" algorithm ID

### DIFF
--- a/docs/user_manual/processing_algs/qgis/vectorgeneral.rst
+++ b/docs/user_manual/processing_algs/qgis/vectorgeneral.rst
@@ -498,7 +498,7 @@ the result layer.
 
 .. seealso:: :ref:`qgisdropgeometries`,
    :ref:`qgisremovenullgeometries`,
-   :ref:`qgisdeleteduplicatesbyattribute`
+   :ref:`qgisremoveduplicatesbyattribute`
 
 Parameters
 ..........
@@ -560,7 +560,7 @@ Python code
   :end-before: **end_algorithm_code_section**
 
 
-.. _qgisdeleteduplicatesbyattribute:
+.. _qgisremoveduplicatesbyattribute:
 
 Delete duplicates by attribute
 -----------------------------------
@@ -660,7 +660,7 @@ Outputs
 Python code
 ...........
 
-**Algorithm ID**: ``native:deleteduplicatesbyattribute``
+**Algorithm ID**: ``native:removeduplicatesbyattribute``
 
 .. include:: ../algs_include.rst
   :start-after: **algorithm_code_section**


### PR DESCRIPTION
<!---
Include a few sentences describing the overall goals for this Pull Request.
 
A list of issues is at https://github.com/qgis/QGIS-Documentation/issues.
Add "fix #issuenumber" for each issue the PR fixes. The ticket(s) will be closed automatically.
If your PR doesn't fix entirely the ticket, only add the ticket(s) reference preceded by # character.
-->
Goal:
Fixes the "Delete duplicates by attribute" (https://github.com/qgis/QGIS/commit/4e9da6f1906c6ba6076742e9aa3d49bebd1965b6 - https://github.com/qgis/QGIS/pull/8355) algorithm ID.
The correct algorithm ID is "removeduplicatesbyattribute".
See https://github.com/qgis/QGIS/blob/22c16f206778b80571479985e59f44c34b1ae0a7/src/analysis/processing/qgsalgorithmremoveduplicatesbyattribute.cpp#L22-L30

This PR needs to be backported to 3.16 and 3.22 branches.

<!---
Indicate whether the fix should be backported to previous release.
Replace the space between square brackets by a `x` to make it checked.
-->
- [x] Backport to LTR documentation is requested

<!---
Reviewing is a process done by community members, mostly on a volunteer basis.
We try to keep the overhead as small as possible and appreciate if you help us.
Please read carefully and ensure you comply with our writing guidelines at
https://docs.qgis.org/testing/en/docs/documentation_guidelines/index.html.
Feel free to ask in a comment or the (qgis-community-team mailing list)
[https://lists.osgeo.org/mailman/listinfo/qgis-community-team] if you have troubles with any item.
--->
