### PR TITLE
XYZ - added tilePixelRatio to xml

### DIFF
--- a/docs/user_manual/managing_data_source/opening_data.rst
+++ b/docs/user_manual/managing_data_source/opening_data.rst
@@ -1312,8 +1312,8 @@ The XML file for OpenStreetMap looks like this:
   <!DOCTYPE connections>
   <qgsXYZTilesConnections version="1.0">
     <xyztiles url="https://tile.openstreetmap.org/{z}/{x}/{y}.png"
-     zmin="0" zmax="19" password="" name="OpenStreetMap" username=""
-     authcfg="" referer=""/>
+     zmin="0" zmax="19" tilePixelRatio="0" password="" name="OpenStreetMap" 
+     username="" authcfg="" referer=""/>
   </qgsXYZTilesConnections>
 
 Once a connection to a XYZ tile service is set, it's possible to:


### PR DESCRIPTION
Wanted to upgrade the XYZ tab, but was up to date, just the
"tilePixelRatio" in the .xml File was missing (for the TileResolution).
I guess we can close #5284 ?

<!---
Include a few sentences describing the overall goals for this Pull Request.
 
A list of issues is at https://github.com/qgis/QGIS-Documentation/issues.
Add "fix #issuenumber" for each issue the PR fixes. The ticket(s) will be closed automatically.
If your PR doesn't fix entirely the ticket, only add the ticket(s) reference preceded by # character.
-->
Goal:

Ticket(s): #
<!---
Indicate whether the fix should be backported to previous release.
Replace the space between square brackets by a `x` to make it checked.
-->
- [ ] Backport to LTR documentation is requested

<!---
Reviewing is a process done by community members, mostly on a volunteer basis.
We try to keep the overhead as small as possible and appreciate if you help us.
Please read carefully and ensure you comply with our writing guidelines at
https://docs.qgis.org/testing/en/docs/documentation_guidelines/index.html.
Feel free to ask in a comment or the (qgis-community-team mailing list)
[https://lists.osgeo.org/mailman/listinfo/qgis-community-team] if you have troubles with any item.
--->
