### PR TITLE
WIP: Bold instead of title

### DIFF
--- a/docs/server_manual/services/wms.rst
+++ b/docs/server_manual/services/wms.rst
@@ -66,8 +66,7 @@ URL example:
 
 .. _`wms-getcapabilities-request`:
 
-REQUEST
-^^^^^^^
+**REQUEST**
 
 This parameter is ``GetCapabilities`` in case of the **GetCapabilities**
 request.


### PR DESCRIPTION
I'm really not a big fan of having an explicit title for each parameters of a request, it's way too overloaded and it's not useful...

![title2](https://user-images.githubusercontent.com/9266424/146026736-b4358b86-35fa-4ce4-b09f-690318028274.png)


@DelazJ what do you think about a simple "title" in bold instead?