### PR TITLE
Save QGIS project in PostgreSQL

### DIFF
--- a/docs/user_manual/managing_data_source/supported_data.rst
+++ b/docs/user_manual/managing_data_source/supported_data.rst
@@ -306,7 +306,7 @@ have trouble loading a PostgreSQL table into QGIS, the information below may
 help you understand QGIS messages and give you directions for modifying
 the PostgreSQL table or view definition to allow QGIS to load it.
 
-.. tip:: **Store QGIS Projects in PostgreSQL database**
+.. note::
 
    A PostgreSQL database can also store QGIS projects.
 

--- a/docs/user_manual/managing_data_source/supported_data.rst
+++ b/docs/user_manual/managing_data_source/supported_data.rst
@@ -306,6 +306,10 @@ have trouble loading a PostgreSQL table into QGIS, the information below may
 help you understand QGIS messages and give you directions for modifying
 the PostgreSQL table or view definition to allow QGIS to load it.
 
+.. tip:: **Store QGIS Projects in PostgreSQL database**
+
+   A PostgreSQL database can also store QGIS projects.
+
 Primary key
 ...........
 


### PR DESCRIPTION
Added a Tip to the PostGIS layers section.
It is documented in the "Working with Project Files" section (
https://docs.qgis.org/testing/en/docs/user_manual/introduction/project_files.html
) that one can save projects to a postgresql database, but i felt like
if the user is looking for postgis data information, its good to know
that you can also save project files there and that it is unlikely that
one will also check the "working with Project Files"-section in that
process.
Thoughts?

<!---
Include a few sentences describing the overall goals for this Pull Request.
 
A list of issues is at https://github.com/qgis/QGIS-Documentation/issues.
Add "fix #issuenumber" for each issue the PR fixes. The ticket(s) will be closed automatically.
If your PR doesn't fix entirely the ticket, only add the ticket(s) reference preceded by # character.
-->
Goal:

Ticket(s): #
<!---
Indicate whether the fix should be backported to previous release.
Replace the space between square brackets by a `x` to make it checked.
-->
- [ ] Backport to LTR documentation is requested

<!---
Reviewing is a process done by community members, mostly on a volunteer basis.
We try to keep the overhead as small as possible and appreciate if you help us.
Please read carefully and ensure you comply with our writing guidelines at
https://docs.qgis.org/testing/en/docs/documentation_guidelines/index.html.
Feel free to ask in a comment or the (qgis-community-team mailing list)
[https://lists.osgeo.org/mailman/listinfo/qgis-community-team] if you have troubles with any item.
--->
