### PR TITLE
Fix typo in Getting Started

### DIFF
--- a/docs/user_manual/introduction/getting_started.rst
+++ b/docs/user_manual/introduction/getting_started.rst
@@ -172,7 +172,7 @@ Where :file:`qgis_sample_data` represents the path to the unzipped dataset.
 
          Select the Coordinate Reference System of data
 
-   #. Select the :guilabel:`NAD27 / Alaska Alberts` entry
+   #. Select the :guilabel:`NAD27 / Alaska Albers` entry
    #. Click :guilabel:`OK`
    #. Close the Data Source Manager window
 


### PR DESCRIPTION
fixed the name of projection Alaska Alber<b><strike>t</strike></b>s

Ticket(s): #
<!---
Indicate whether the fix should be backported to previous release.
Replace the space between square brackets by a `x` to make it checked.
-->
- [ ] Backport to LTR documentation is requested

<!---
Reviewing is a process done by community members, mostly on a volunteer basis.
We try to keep the overhead as small as possible and appreciate if you help us.
Please read carefully and ensure you comply with our writing guidelines at
https://docs.qgis.org/testing/en/docs/documentation_guidelines/index.html.
Feel free to ask in a comment or the (qgis-community-team mailing list)
[https://lists.osgeo.org/mailman/listinfo/qgis-community-team] if you have troubles with any item.
--->
