### PR TITLE
Fix Input downscaling default value in Raster Properties Dialog - Raster Symbology - Contours rendering

### DIFF
--- a/docs/user_manual/working_with_raster/raster_properties.rst
+++ b/docs/user_manual/working_with_raster/raster_properties.rst
@@ -336,7 +336,7 @@ Options:
   lines and generally labeled with a value along its course.
 * :guilabel:`Index contour symbol`: the symbol to apply to the index contour lines
 * :guilabel:`Input downscaling`: Indicates by how much the renderer will scale
-  down the request to the data provider. Default is ``1.0``, meaning no downscaling.
+  down the request to the data provider (default is ``4.0``).
 
   For example, if you generate contour lines on input raster block with the
   same size as the output raster block, the generated lines would contain too


### PR DESCRIPTION
<!---
Include a few sentences describing the overall goals for this Pull Request.
 
A list of issues is at https://github.com/qgis/QGIS-Documentation/issues.
Add "fix #issuenumber" for each issue the PR fixes. The ticket(s) will be closed automatically.
If your PR doesn't fix entirely the ticket, only add the ticket(s) reference preceded by # character.
-->
Goal:
Fixes the "Input downscaling" default value in Raster Properties Dialog - Raster Symbology - Contours rendering, changing it from `1.0` to `4.0`.

See https://github.com/qgis/QGIS-Documentation/pull/6538#discussion_r771754355
See https://github.com/qgis/QGIS/blob/6fbb4e8c88e283ad46036e8d90857d7b2c8bf0ea/src/ui/qgsrastercontourrendererwidget.ui#L130-L140


Ticket(s): #
<!---
Indicate whether the fix should be backported to previous release.
Replace the space between square brackets by a `x` to make it checked.
-->
- [x] Backport to LTR documentation is requested

<!---
Reviewing is a process done by community members, mostly on a volunteer basis.
We try to keep the overhead as small as possible and appreciate if you help us.
Please read carefully and ensure you comply with our writing guidelines at
https://docs.qgis.org/testing/en/docs/documentation_guidelines/index.html.
Feel free to ask in a comment or the (qgis-community-team mailing list)
[https://lists.osgeo.org/mailman/listinfo/qgis-community-team] if you have troubles with any item.
--->
