### PR TITLE
Only number headings up to level 3

### DIFF
--- a/docs/developers_guide/index.rst
+++ b/docs/developers_guide/index.rst
@@ -11,7 +11,7 @@ steps to easily and efficiently contribute to QGIS code.
 
 .. toctree::
     :maxdepth: 1
-    :numbered:
+    :numbered: 3
 
     codingstandards
     hig

--- a/docs/documentation_guidelines/index.rst
+++ b/docs/documentation_guidelines/index.rst
@@ -29,7 +29,7 @@ project, you may find help at `Get Involved in the QGIS Community
 
 .. toctree::
    :maxdepth: 2
-   :numbered:
+   :numbered: 3
 
    first_contribution
    writing

--- a/docs/server_manual/index.rst
+++ b/docs/server_manual/index.rst
@@ -8,7 +8,7 @@ QGIS Server Guide/Manual
 
 .. toctree::
   :maxdepth: 2
-  :numbered:
+  :numbered: 3
 
   introduction
   getting_started

--- a/docs/training_manual/index.rst
+++ b/docs/training_manual/index.rst
@@ -7,7 +7,7 @@ QGIS Training Manual
 
 .. toctree::
    :maxdepth: 2
-   :numbered:
+   :numbered: 3
 
    foreword/index
    basic_map/index

--- a/docs/user_manual/index.rst
+++ b/docs/user_manual/index.rst
@@ -6,7 +6,7 @@ QGIS User Guide
 
 .. toctree::
     :maxdepth: 2
-    :numbered:
+    :numbered: 3
 
     preamble/preamble
     preamble/foreword


### PR DESCRIPTION
Level 4 and above will not be numbered

<!---
Include a few sentences describing the overall goals for this Pull Request.
 
A list of issues is at https://github.com/qgis/QGIS-Documentation/issues.
Add "fix #issuenumber" for each issue the PR fixes. The ticket(s) will be closed automatically.
If your PR doesn't fix entirely the ticket, only add the ticket(s) reference preceded by # character.
-->
Goal:

One downside of numbering the documentation even in HTML is that when there are too many sub-section levels (more than 3 IMHO) the pages and titles get too polluted and it does not bring any real benefit.

With this PR the numbering will stop at level 3, higher levels will still use heading, but will not be numbered.

After and before

![image](https://user-images.githubusercontent.com/3607161/147571106-cb8ba13a-f36a-42b6-b4f9-69a6d8356cff.png)


Ticket(s):  Superseeds #7212 
<!---
Indicate whether the fix should be backported to previous release.
Replace the space between square brackets by a `x` to make it checked.
-->
- [x] Backport to LTR documentation is requested

<!---
Reviewing is a process done by community members, mostly on a volunteer basis.
We try to keep the overhead as small as possible and appreciate if you help us.
Please read carefully and ensure you comply with our writing guidelines at
https://docs.qgis.org/testing/en/docs/documentation_guidelines/index.html.
Feel free to ask in a comment or the (qgis-community-team mailing list)
[https://lists.osgeo.org/mailman/listinfo/qgis-community-team] if you have trouble with any item.
--->
