### PR TITLE
Formatting of tables in browser chapter

### DIFF
--- a/docs/user_manual/introduction/browser.rst
+++ b/docs/user_manual/introduction/browser.rst
@@ -9,8 +9,8 @@ The Browser panel
 
 
 .. contents::
-      :local:
-      :depth: 2
+   :local:
+   :depth: 2
 
 The QGIS Browser panel is a great tool for browsing, searching,
 inspecting, copying and loading QGIS resources.
@@ -263,14 +263,14 @@ each level of the dataset tree.
 |               +--------------------------------------------+--------------+--------------+------------+------------+------------+------------+
 |               | :menuselection:`Manage -->                 |              |              |            |            |            |            |
 |               | Delete Layer <layer_name>…`                | |checkbox|   | |checkbox|   | |checkbox| | |checkbox| | |checkbox| |            |
-|               |                                            |              |              |            |            |            |            |
-|               | :menuselection:`Manage -->                 |              |              |            |            |            |            |
+|               +--------------------------------------------+--------------+--------------+------------+------------+------------+------------+
+|               | :menuselection:`Manage -->                 | |checkbox|   | |checkbox|   | |checkbox| | |checkbox| | |checkbox| |            |
 |               | Delete Selected Layers`                    |              |              |            |            |            |            |
 |               +--------------------------------------------+--------------+--------------+------------+------------+------------+------------+
 |               | :menuselection:`Manage -->                 | |checkbox|   | |checkbox|   | |checkbox| | |checkbox| | |checkbox| |            |
-|               | Add Selected Layers to Project`            |              |              |            |            |            |            |
-|               |                                            |              |              |            |            |            |            |
-|               | :menuselection:`Manage -->                 |              |              |            |            |            |            |
+|               | Add Layer to Project`                      |              |              |            |            |            |            |
+|               +--------------------------------------------+--------------+--------------+------------+------------+------------+------------+
+|               | :menuselection:`Manage -->                 | |checkbox|   | |checkbox|   | |checkbox| | |checkbox| | |checkbox| |            |
 |               | Add Selected Layers to Project`            |              |              |            |            |            |            |
 |               +--------------------------------------------+--------------+--------------+------------+------------+------------+------------+
 |               | Open :guilabel:`Layer Properties…` dialog  | |checkbox|   | |checkbox|   | |checkbox| | |checkbox| | |checkbox| |            |
@@ -290,7 +290,7 @@ Tiles and Web Services
 | Level         | Context menu                                 |                                               Type of services                                       |
 |               |                                              +------------+-------------------+------------+------------+----------------+-------------+------------+
 |               |                                              | |wms|      | |vectorTileLayer| | |xyz|      | |wcs|      | |wfs|          | |afs|       | |geonode|  |
-|               |                                              | WMS/WMTS   | Vector Tiles      | XYZ Tiles  | WCS        | WFS / OGC      | ArcGIS REST | GeoNode    |
+|               |                                              | WMS / WMTS | Vector Tiles      | XYZ Tiles  | WCS        | WFS / OGC      | ArcGIS REST | GeoNode    |
 |               |                                              |            |                   |            |            | API - Features | Servers     |            |
 +===============+==============================================+============+===================+============+============+================+=============+============+
 | Top menu      | Create a :guilabel:`New Connection…`         | |checkbox| |                   | |checkbox| | |checkbox| | |checkbox|     | |checkbox|  | |checkbox| |


### PR DESCRIPTION
- split different options into rows, with label fix
Before:
![image](https://user-images.githubusercontent.com/7983394/151692947-836fce26-b3c9-4d92-a98a-6781f1d99067.png)
After
![image](https://user-images.githubusercontent.com/7983394/151693124-e9714540-9473-45b6-af08-64afb3b6c844.png)

- allows better columns display for the PDF output
Before
![image](https://user-images.githubusercontent.com/7983394/151693146-97d34397-597c-4c26-b253-fa772fe04510.png)
After
![image](https://user-images.githubusercontent.com/7983394/151693169-24caf310-3157-46eb-b03a-63dbfa22fec5.png)

