### PR TITLE
Error corrected

### DIFF
--- a/docs/user_manual/processing_algs/qgis/rasteranalysis.rst
+++ b/docs/user_manual/processing_algs/qgis/rasteranalysis.rst
@@ -1732,7 +1732,7 @@ Lowest position in raster stack
 Evaluates on a cell-by-cell basis the position of the raster with the lowest value
 in a stack of rasters. Position counts start with 1 and range to the total number
 of input rasters. The order of the input rasters is relevant for the algorithm.
-If multiple rasters feature the highest value, the first raster will be used for
+If multiple rasters feature the lowest value, the first raster will be used for
 the position value.
 
 If multiband rasters are used in the data raster stack, the algorithm will


### PR DESCRIPTION
Line 1735 : "feature the highest value," should probably be "feature the lowest value," since the algorithm is "lowestpositioninrasterstack" and not "highestpositioninrasterstack"
 

Goal: Display correct documentation

Ticket(s): #

- [x] Backport to LTR documentation is requested
