### PR TITLE
Use correct syntax for the issue auto-label script

### DIFF
--- a/.github/workflows/auto-label.yml
+++ b/.github/workflows/auto-label.yml
@@ -13,24 +13,11 @@ jobs:
     steps:
       - uses: Naturalclar/issue-action@v2.0.2
         with:
-          keywords: '["QGIS Version: 3.22"]'
-          labels: '["3.22"]'
-          github-token: "${{ secrets.GITHUB_TOKEN }}"
-
-      - uses: Naturalclar/issue-action@v2.0.2
-        with:
-          keywords: '["QGIS Version: 3.24"]'
-          labels: '["3.24"]'
-          github-token: "${{ secrets.GITHUB_TOKEN }}"
-
-      - uses: Naturalclar/issue-action@v2.0.2
-        with:
-          keywords: '["QGIS Version: 3.26"]'
-          labels: '["3.26"]'
-          github-token: "${{ secrets.GITHUB_TOKEN }}"
-
-      - uses: Naturalclar/issue-action@v2.0.2
-        with:
-          keywords: '["QGIS Version: 3.28"]'
-          labels: '["3.28"]'
+          title-or-body: "body"
+          parameters: |
+            '[ {"keywords": ["QGIS version: 3.22"], "labels": ["3.22"]},
+               {"keywords": ["QGIS version: 3.24"], "labels": ["3.24"]},
+               {"keywords": ["QGIS version: 3.26"], "labels": ["3.26"]},
+               {"keywords": ["QGIS version: 3.28"], "labels": ["3.28"]}
+            ]'
           github-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
Issue reports created from the code repo are not automatically assigned a version label. Seems that Naturalclar/issue-action has modified its syntax sometime ago (https://github.com/Naturalclar/issue-action#example)