### PR TITLE
update instructions for aligning rasters

### DIFF
--- a/docs/training_manual/complete_analysis/analysis_exercise.rst
+++ b/docs/training_manual/complete_analysis/analysis_exercise.rst
@@ -243,26 +243,36 @@ have to be aligned.
 
 First we change the resolution of our rainfall data to 30 meters
 (pixel size):
+	
+#. In the :guilabel:`Layers` panel, ensure that
+   ``Rainfall_clipped`` is the active layer (i.e., it is highlighted by
+   having been clicked on)
+#. Click on the :menuselection:`Raster --> Projections --> Warp (Reproject)...`
+   menu item to open the :guilabel:`Warp (Reproject)` dialog
+#. Under :guilabel:`Resampling method to use`, select :guilabel:`Bilinear` from the drop down menu
+#. Set :guilabel:`Output file resolution in target georeferenced units` to ``30`` 
+#. Scroll down to :guilabel:`Reprojected` and save the output in your
+   :file:`rainfall/reprojected` directory as :file:`Rainfall30.tif`.
+#. Make sure that |checkbox|
+   :guilabel:`Open output file after running algorithm` is checked
 
-#. Right-click on the ``Rainfall_clipped`` layer and select
-   :menuselection:`Export--> Save As...` in the context menu.
-#. Under :guilabel:`Resolution`, set the :guilabel:`Horizontal` and
-   :guilabel:`Vertical` resolutions to ``30`` (meters).
-#. Save the file as :file:`Rainfall30.tif` in
-   :file:`rainfall/reprojected` (:guilabel:`File name`)
 
 Then we align the DEM:
 
-#. Right-click on the ``DEM_clipped`` layer and select
-   :menuselection:`Export--> Save As...` in the context menu
-#. For :guilabel:`CRS`, choose *WGS 84 / UTM zone 33S* (EPSG code
-   ``32733``)
-#. Under :guilabel:`Resolution`, set the :guilabel:`Horizontal` and
-   :guilabel:`Vertical` resolutions to ``30`` (in meters).
-#. Under :guilabel:`Extent`, click on
-   :guilabel:`Calculate from Layer` and choose ``Rainfall30``
-#. Save the file as :file:`DEM30.tif` in :file:`DEM/reprojected`
-   (:guilabel:`File name`)
+#. In the :guilabel:`Layers` panel, ensure that
+   ``DEM_clipped`` is the active layer (i.e., it is highlighted by
+   having been clicked on)
+#. Click on the :menuselection:`Raster --> Projections --> Warp (Reproject)...`
+   menu item to open the :guilabel:`Warp (Reproject)` dialog
+#. Under :guilabel:`Target CRS`, select :guilabel:`Project CRS: EPSG:32733 - WGS 84 / UTM zone 33S` from the drop down menu
+#. Under :guilabel:`Resampling method to use`, select :guilabel:`Bilinear` from the drop down menu
+#. Set :guilabel:`Output file resolution in target georeferenced units` to ``30``
+#. Scroll down to :guilabel:`Georeferenced extents of output file to be created`. Use the button to the right of the text box to select :menuselection:`Calculate from Layer --> Rainfall30`.
+#. Scroll down to :guilabel:`Reprojected` and save the output in your
+   :file:`DEM/reprojected` directory as :file:`DEM30.tif`.
+#. Make sure that |checkbox|
+   :guilabel:`Open output file after running algorithm` is checked
+   
 
 In order to properly see what's going on, the symbology for the
 layers needs to be changed.


### PR DESCRIPTION
<!---
Include a few sentences describing the overall goals for this Pull Request.
 
A list of issues is at https://github.com/qgis/QGIS-Documentation/issues.
Add "fix #issuenumber" for each issue the PR fixes. The ticket(s) will be closed automatically.
If your PR doesn't fix entirely the ticket, only add the ticket(s) reference preceded by # character.
-->
Goal: Update instructions for aligning rasters in training manual exercise 8.4. Instruct users to use the Warp (reproject) tool rather than 'save>export' from the ToC.

Ticket(s): fix  #7342 

<!---
Indicate whether the fix should be backported to previous release.
Replace the space between square brackets by a `x` to make it checked.
-->
- [x] Backport to LTR documentation is requested

<!---
Reviewing is a process done by community members, mostly on a volunteer basis.
We try to keep the overhead as small as possible and appreciate if you help us.
Please read carefully and ensure you comply with our writing guidelines at
https://docs.qgis.org/testing/en/docs/documentation_guidelines/index.html.
Feel free to ask in a comment or the (qgis-community-team mailing list)
[https://lists.osgeo.org/mailman/listinfo/qgis-community-team] if you have troubles with any item.
--->
