### PR TITLE
Add back the option to control point pattern fill rotation

### DIFF
--- a/docs/user_manual/style_library/symbol_selector.rst
+++ b/docs/user_manual/style_library/symbol_selector.rst
@@ -489,8 +489,8 @@ symbol layer types:
   spacing between lines and an offset from the feature boundary.
 * **Point pattern fill**: fills the polygon with a hatching pattern of 
   :ref:`marker symbol layer <vector_marker_symbols>`. You can set the distance
-  and a displacement between rows of markers, and an offset from the
-  feature boundary; 
+  and a displacement between rows of markers, an offset from the
+  feature boundary and the angle of the pattern.
 * **Random marker fill**: fills the polygon with a :ref:`marker symbol 
   <vector_marker_symbols>` placed at random locations within the polygon
   boundary. You can set:


### PR DESCRIPTION
removed in #6997 (refs #7161)