### PR TITLE
Typo prevents proper format

### DIFF
--- a/docs/training_manual/create_vector_data/forms.rst
+++ b/docs/training_manual/create_vector_data/forms.rst
@@ -35,7 +35,7 @@ map, rather than needing to search for a specific street in the
    of the fields values and other general information about the
    clicked feature.
 #. At the top of the panel, check the :guilabel:`Auto open form for single feature results`
-   checkbox in the |options| sup:`Identify Settings` menu.
+   checkbox in the |options| :sup:`Identify Settings` menu.
 #. Now, click again on any street in the map. Along the previous
    :guilabel:`Identify Results` dialog, you'll see the now-familiar
    form:


### PR DESCRIPTION
Line 38:  "|options| sup:`Identify Settings` menu." should be: "|options| :sup:`Identify Settings` menu." Placed colon before "sup:" to let the proper format reflect on the page.


Goal: Display correct documentation

- [x] Backport to LTR documentation is requested
