### PR TITLE
Some typo's and display

### DIFF
--- a/docs/user_manual/introduction/qgis_gui.rst
+++ b/docs/user_manual/introduction/qgis_gui.rst
@@ -834,7 +834,7 @@ actions like:
      -
      -
      - :ref:`label_legend`
-   * - :menuselection:`-->` :guilabel:`Toogle Selected Layers Independently`
+   * - :menuselection:`-->` :guilabel:`Toggle Selected Layers Independently`
      -
      -
      - :ref:`label_legend`
@@ -2131,7 +2131,7 @@ Click on the map view and you should be able to interact with it:
   button or the mouse wheel is held down. When the mouse is used, the distance
   and direction of the pan action are shown in the status bar at the bottom.
 * it can be zoomed in and out, with the dedicated |zoomIn| :sup:`Zoom In`
-  and |zoomIn| :sup:`Zoom Out` tools. Hold the :kbd:`Alt` key to switch from
+  and |zoomOut| :sup:`Zoom Out` tools. Hold the :kbd:`Alt` key to switch from
   one tool to the other. Zooming is also performed by rolling
   the wheel forward to zoom in and backwards to zoom out.
   The zoom is centered on the mouse cursor position. You can customize the
@@ -2276,7 +2276,7 @@ The :guilabel:`Temporal controller` panel has the following modes:
 
   * |unchecked| :guilabel:`Cumulative range`: all animation frames will
     have the same start date-time but different end dates and times.
-    This is useful is you wish to accumulate data in your temporal
+    This is useful if you wish to accumulate data in your temporal
     visualisation instead of showing a ‘moving time window’ across your data.
 
 .. _`create_temporal_animation`:
@@ -2290,7 +2290,7 @@ To create a temporal animation:
 
 #. Toggle on the |temporalNavigationAnimated| :sup:`Animated temporal
    navigation`, displaying the animation player widget
-#. Enter the :guilabel:`Time range` to consider. Using the close |refresh|
+#. Enter the :guilabel:`Time range` to consider. Using the refresh |refresh|
    button, this can be defined as:
 
    * :guilabel:`Set to full range` of all the time enabled layers
@@ -2766,7 +2766,7 @@ To create an animation:
    https://doc.qt.io/qt-5/qeasingcurve.html#EasingFunction-typedef).
 
    The animation can also be previewed by moving the time slider.
-   Keeping the :guilabel:`Loop` button checked will repeatedly run the
+   Keeping the :guilabel:`Loop` box checked will repeatedly run the
    animation while clicking |play| stops a running animation.
 
 Click |fileSave| :sup:`Export animation frames` to generate a series of images

--- a/docs/user_manual/introduction/qgis_gui.rst
+++ b/docs/user_manual/introduction/qgis_gui.rst
@@ -2290,7 +2290,7 @@ To create a temporal animation:
 
 #. Toggle on the |temporalNavigationAnimated| :sup:`Animated temporal
    navigation`, displaying the animation player widget
-#. Enter the :guilabel:`Time range` to consider. Using the refresh |refresh|
+#. Enter the :guilabel:`Time range` to consider. Using the |refresh|
    button, this can be defined as:
 
    * :guilabel:`Set to full range` of all the time enabled layers


### PR DESCRIPTION
Line 837 : ":menuselection:`-->` :guilabel:`Toogle Selected Layers Independently`" ==>  should probably be: ":menuselection:`-->` :guilabel:`Toggle Selected Layers Independently`"
Line 2134 :  "and |zoomIn| :sup:`Zoom Out`"  ==> should probably be : "and |zoomOut| :sup:`Zoom Out`"  (|zoomIn| used two times )
Line 2279 :  "This is useful is" ==> should probably be: "This is useful if"
Line 2293:  "Using the close |refresh| button" ==> should probably be : "Using the refresh |refresh| button"
line 2321 : "Keeping the |refresh| :sup:`Loop` button pressed" ==> should probably be : "Keeping the |unchecked| :sup:`Loop` box checked", because this "button" seems to be a "checkbox" instead
Line 2769 : "Keeping the :guilabel:`Loop` button checked will" ==> should probably be : 
""Keeping the :guilabel:`Loop` box checked will",  since 'Loop' is no button but a checkbox

<!---
Include a few sentences describing the overall goals for this Pull Request.
 
A list of issues is at https://github.com/qgis/QGIS-Documentation/issues.
Add "fix #issuenumber" for each issue the PR fixes. The ticket(s) will be closed automatically.
If your PR doesn't fix entirely the ticket, only add the ticket(s) reference preceded by # character.
-->
Goal:

Ticket(s): #
<!---
Indicate whether the fix should be backported to previous release.
Replace the space between square brackets by a `x` to make it checked.
-->
- [x] Backport to LTR documentation is requested

<!---
Reviewing is a process done by community members, mostly on a volunteer basis.
We try to keep the overhead as small as possible and appreciate if you help us.
Please read carefully and ensure you comply with our writing guidelines at
https://docs.qgis.org/testing/en/docs/documentation_guidelines/index.html.
Feel free to ask in a comment or the (qgis-community-team mailing list)
[https://lists.osgeo.org/mailman/listinfo/qgis-community-team] if you have troubles with any item.
--->
