### PR TITLE
Typo corrected

### DIFF
--- a/docs/developers_guide/localization.rst
+++ b/docs/developers_guide/localization.rst
@@ -62,7 +62,7 @@ Converting user input strings to numbers
 When converting strings from user input to numbers do not use
 ``QVariant::toDouble()``, ``QString::toDouble()`` or other ``::toDouble()``
 methods available in QT classes because these methods ignore locale settings.
-The same consideration applies to integral types and ``::toInt()`` ot
+The same consideration applies to integral types and ``::toInt()`` or
 ``::toLongLong()`` methods.
 
 ``QLocale().toDouble()`` or ``QLocale().toInt()`` and the others ``QLocale()``


### PR DESCRIPTION
Line 65 : "``::toInt()`` ot ``::toLongLong()`` methods."  ==> should probably be : "``::toInt()`` or ``::toLongLong()`` methods."


Goal: Display correct documentatiuon


- [x] Backport to LTR documentation is requested
