### PR TITLE
Changed menu name

### DIFF
--- a/docs/server_manual/services/wms.rst
+++ b/docs/server_manual/services/wms.rst
@@ -177,7 +177,7 @@ In addition, QGIS Server introduced some options to select layers by:
 * the layer id
 
 The project option allowing to select layers by their
-id is in :menuselection:`OWS Server --> WMS capabilities` menu of the
+id is in :menuselection:`QGIS Server --> WMS` tab of the
 :menuselection:`Project --> Properties...` dialog.
 Check the :guilabel:`Use layer ids as names` checkbox to activate this option.
 


### PR DESCRIPTION
Line 180 :  ":menuselection:`OWS Server --> WMS capabilities` menu" ===> should probably be ":menuselection:`QGIS Server --> WMS` tab"

Goal: Display correct documentation

- [x] Backport to LTR documentation is requested
