### PR TITLE
Fixing Simplified Chinese build (take 2)

### DIFF
--- a/docker-world.sh
+++ b/docker-world.sh
@@ -24,7 +24,7 @@ git stash drop
 git pull
 
 # only languages which have translations in transifex
-: ${langs:=en ca da de es fa fi fr gl hu id it ja km_KH ko lt nl pl pt_BR pt_PT ro tr ru uk zh-Hans zh-Hant}
+: ${langs:=en cs de es fr hu it ja ko li nl pt_BR pt_PT ro ru zh-Hans}
 
 # if you only want to build one language, do:
 # $ langs=de ./docker-world.sh

--- a/docker-world.sh
+++ b/docker-world.sh
@@ -24,7 +24,7 @@ git stash drop
 git pull
 
 # only languages which have translations in transifex
-: ${langs:=en ca da de es fa fi fr gl hu id it ja km_KH ko lt nl pl pt_BR pt_PT ro tr ru uk zh_Hans zh_Hant}
+: ${langs:=en ca da de es fa fi fr gl hu id it ja km_KH ko lt nl pl pt_BR pt_PT ro tr ru uk zh-Hans zh-Hant}
 
 # if you only want to build one language, do:
 # $ langs=de ./docker-world.sh

--- a/docs_conf.yml
+++ b/docs_conf.yml
@@ -1,4 +1,4 @@
 
 version_list: testing, latest, 3.22, 3.16, 3.10, 3.4, 2.18, 2.14, 2.8, 2.6, 2.2, 2.0, 1.8
 # Fill this list based on languages that are actually pulled from transifex
-supported_languages: en, cs, de, es, fr, hu, it, ja, ko, li, nl, pt_BR, pt_PT, ro, ru, zh_Hans
+supported_languages: en, cs, de, es, fr, hu, it, ja, ko, li, nl, pt_BR, pt_PT, ro, ru, zh-Hans


### PR DESCRIPTION
Currently:
1. If you click on "zh_Hans" in the bottom left menu of https://docs.qgis.org/3.22/en/docs/index.html, it should open https://docs.qgis.org/3.22/zh_Hans/docs/index.html (as shown when hovering over the entry), but it instead opens https://docs.qgis.org/en/docs/index.html. This is because on the server, "zh_Hans" (with underscore) is  not listed among served languages and redirects to default "en"

1. If you instead write https://docs.qgis.org/3.22/zh-Hans/docs/index.html (note the hyphen), you get the correct url page (because the server exposes "zh-Hans" language) but the docs appears in English. I assume it's because the build folder is not filled with correct strings (an issue with symlink?)

Considering that https://docs.qgis.org/3.22/zh-Hans/docs/index.html was providing Chinese strings before #7427, this PR:
- reverts the changes in that PR so that "zh-Hans" folder is correctly populated
- and exposes "zh-Hans" in the bottom left menu so that people hit and open that docs directly --> No more exposure of "zh_Hans" to users.