### PR TITLE
Display correct version of docs

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -79,8 +79,8 @@ Please have a look into one of the documents below.
    :maxdepth: 2
    :caption: For Users
 
-   QGIS Desktop User Guide/Manual (QGIS Testing) <user_manual/index>
-   QGIS Server Guide/Manual (QGIS Testing) <server_manual/index>
+   QGIS Desktop User Guide/Manual (QGIS 3.22) <user_manual/index>
+   QGIS Server Guide/Manual (QGIS 3.22) <server_manual/index>
    Training Manual <training_manual/index>
    A Gentle Introduction to GIS <gentle_gis_introduction/index>
 
@@ -94,7 +94,7 @@ Please have a look into one of the documents below.
    :maxdepth: 2
    :caption: For Developers
 
-   PyQGIS Cookbook (QGIS Testing) <pyqgis_developer_cookbook/index>
+   PyQGIS Cookbook (QGIS 3.22) <pyqgis_developer_cookbook/index>
    Developers Guide <developers_guide/index>
 
 * :ref:`genindex`


### PR DESCRIPTION
Another manual change that we missed.
I wonder if the version number is really necessary here...