### PR TITLE
Typo, added "fields" to sentence

### DIFF
--- a/docs/user_manual/working_with_vector/vector_properties.rst
+++ b/docs/user_manual/working_with_vector/vector_properties.rst
@@ -3190,7 +3190,7 @@ provided :guilabel:`Configuration` options:
   if the range defined by their :guilabel:`Start field` and :guilabel:`Event duration field`
   values overlaps the map canvas temporal.
 * :guilabel:`Sart and end date/time from expressions`: features are rendered
-  if the time range specified by the :guilabel:`Start expression` and
+  if the time range specified by the fields :guilabel:`Start expression` and
   :guilabel:`End expression` overlaps the map canvas temporal.
 * :guilabel:`Redraw layer only`: the layer is redrawn at each new animation
   frame but no time-based filtering is applied to the features.


### PR DESCRIPTION
Line 3193 : "by the :guilabel:`Start expression` and :guilabel:`End expression` "  ==>> should probably be: "by the fields :guilabel:`Start expression` and  :guilabel:`End expression` "

Goal: Display correct documentation

- [x] Backport to LTR documentation is requested
--->
