### PR TITLE
Capital C instead of lower case

### DIFF
--- a/docs/user_manual/processing_algs/qgis/rasteranalysis.rst
+++ b/docs/user_manual/processing_algs/qgis/rasteranalysis.rst
@@ -335,7 +335,7 @@ Python code
 
 .. _qgiscellstackpercentrankfromrasterlayer:
 
-cell stack percentrank from raster layer
+Cell stack percentrank from raster layer
 ----------------------------------------
 
 Calculates the cell-wise percentrank value of a stack of rasters based


### PR DESCRIPTION
Line 338 : "cell stack percentrank from raster layer" should be "Cell stack percentrank from raster layer"as it addresses the title of the algorithm


Goal: Display correct documentation

- [x] Backport to LTR documentation is requested
