### PR TITLE
Typo's

### DIFF
--- a/docs/user_manual/working_with_raster/raster_properties.rst
+++ b/docs/user_manual/working_with_raster/raster_properties.rst
@@ -423,8 +423,8 @@ The scalar dataset elements are then assigned their color based on their class.
    their color :
 
    * :guilabel:`Discrete` (a ``<=`` symbol appears in the header of the
-     :guilabel:`Value` column): The color is taken from the closest color mapl
-     entry with equa or higher value
+     :guilabel:`Value` column): The color is taken from the closest color map
+     entry with equal or higher value
    * :guilabel:`Linear`: The color is linearly interpolated from the color map
      entries above and below the pixel value, meaning that to each dataset
      value corresponds a unique color
@@ -454,7 +454,7 @@ The scalar dataset elements are then assigned their color based on their class.
    * The button |symbologyAdd| :sup:`Add values manually` adds a value to the table.
    * The button |symbologyRemove| :sup:`Remove selected row` deletes selected values
      from the table.
-   * Double clicking in the :guilabel:`Value` lets you modify the class value.
+   * Double clicking in the :guilabel:`Value` column lets you modify the class value.
    * Double clicking in the :guilabel:`Color` column opens the dialog
      :guilabel:`Change color`, where you can select a color to apply for
      that value.


### PR DESCRIPTION
Line 426 - 427 : "color mapl entry with equa or higher value" should probably be; "color map entry with equal or higher value"  = misplaced letter "l " after "map"

Line 457 :             "in the :guilabel:`Value` lets" should probably be: "in the :guilabel:`Value` column lets"
                           **note**: adding "column" to be consistent with other items on the same page/list

Goal: Display correct documentation

- [x] Backport to LTR documentation is requested
