### PR TITLE
updated identify results panel documentation as per fix #43757

### DIFF
--- a/docs/user_manual/introduction/general_tools.rst
+++ b/docs/user_manual/introduction/general_tools.rst
@@ -1946,6 +1946,8 @@ example, from the context menu you can:
 * Toggle feature selection: Add identified feature to selection
 * Copy attribute value: Copy only the value of the attribute that you click on
 * Copy feature attributes: Copy the attributes of the feature
+* Select features by attribute value: Select all features in the shapefile that 
+match the selected attribute
 * Clear result: Remove results in the window
 * Clear highlights: Remove features highlighted on the map
 * Highlight all


### PR DESCRIPTION
Documentation for QGIS feature introduced here: qgis/QGIS#47477
Documentation issue fixes #7416

Within user_manual > introduction > general_tools.rst:
Added detail under "The Identify Results dialog" header (for its context menu), explaining what the "select features by attribute value" command does, and that it exists

All changes done under updated-identify-results-panel-documentation-fix-#43757 branch

Let me know if you have any questions!