### PR TITLE
Broken link fix

### DIFF
--- a/docs/developers_guide/qtcreator.rst
+++ b/docs/developers_guide/qtcreator.rst
@@ -34,8 +34,8 @@ Setting up your project
 
 We assume you have already got a local QGIS clone containing the
 source code, and have installed all needed build dependencies etc. There are
-detailed instructions for :ref:`git access <git_access>` and `dependency installation
-<https://github.com/qgis/QGIS/blob/master/INSTALL.md>`_.
+detailed instructions for :ref:`git access <git_access>` and
+:source:`dependency requirements <INSTALL.md>`.
 
 On our system we have checked out the code into ``$HOME/dev/cpp/QGIS`` and the
 rest of the article is written assuming that. You should update these paths as

--- a/docs/developers_guide/qtcreator.rst
+++ b/docs/developers_guide/qtcreator.rst
@@ -35,7 +35,7 @@ Setting up your project
 We assume you have already got a local QGIS clone containing the
 source code, and have installed all needed build dependencies etc. There are
 detailed instructions for :ref:`git access <git_access>` and `dependency installation
-<https://htmlpreview.github.io/?https://github.com/qgis/QGIS/blob/master/doc/INSTALL.html>`_.
+<https://github.com/qgis/QGIS/blob/master/INSTALL.md>`_.
 
 On our system we have checked out the code into ``$HOME/dev/cpp/QGIS`` and the
 rest of the article is written assuming that. You should update these paths as


### PR DESCRIPTION
I think this is the right link. Although It is a gitub .md file and not html like the original link. fix https://github.com/qgis/QGIS-Documentation/issues/7490

<!---
Include a few sentences describing the overall goals for this Pull Request.
 
A list of issues is at https://github.com/qgis/QGIS-Documentation/issues.
Add "fix #issuenumber" for each issue the PR fixes. The ticket(s) will be closed automatically.
If your PR doesn't fix entirely the ticket, only add the ticket(s) reference preceded by # character.
-->
Goal:

Ticket(s): #
<!---
Indicate whether the fix should be backported to previous release.
Replace the space between square brackets by a `x` to make it checked.
-->
- [ ] Backport to LTR documentation is requested

<!---
Reviewing is a process done by community members, mostly on a volunteer basis.
We try to keep the overhead as small as possible and appreciate if you help us.
Please read carefully and ensure you comply with our writing guidelines at
https://docs.qgis.org/testing/en/docs/documentation_guidelines/index.html.
Feel free to ask in a comment or the (qgis-community-team mailing list)
[https://lists.osgeo.org/mailman/listinfo/qgis-community-team] if you have troubles with any item.
--->
