### PR TITLE
Separate the supported_languages list with space instead of comma

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -155,7 +155,7 @@ if html_context['isTesting'] or html_context['outdated']:
 if html_context['isTesting']:
     tags.add('testing')
 
-supported_languages = cfg['supported_languages'].replace(' ', '').split(',')
+supported_languages = cfg['supported_languages'].split()
 version_list = cfg['version_list'].replace(' ', '').split(',')
 docs_url = 'https://docs.qgis.org/'
 

--- a/docs_conf.yml
+++ b/docs_conf.yml
@@ -1,4 +1,4 @@
 
 version_list: testing, latest, 3.22, 3.16, 3.10, 3.4, 2.18, 2.14, 2.8, 2.6, 2.2, 2.0, 1.8
 # Fill this list based on languages that are actually pulled from transifex
-supported_languages: en, cs, de, es, fr, hu, it, ja, ko, li, nl, pt_BR, pt_PT, ro, ru, zh-Hans
+supported_languages: en cs de es fr hu it ja ko li nl pt_BR pt_PT ro ru zh-Hans


### PR DESCRIPTION
First step towards a single list of languages as requested in #7452; at least now we can simply copy-paste from one variable to the other(s).

*Question*: Should I align the version list to this? mainly for homogenization purpose (for the list and the split call)