### PR TITLE
Remaining edit in place changes

### DIFF
--- a/docs/user_manual/processing_algs/qgis/cartography.rst
+++ b/docs/user_manual/processing_algs/qgis/cartography.rst
@@ -26,6 +26,7 @@ to avoid aligning isolated points to distant features.
  point symbols to follow the nearest road direction.
 
 |checkbox| Allows :ref:`features in-place modification <processing_inplace_edit>`
+of point features
 
 Parameters
 ..........

--- a/docs/user_manual/processing_algs/qgis/vectoranalysis.rst
+++ b/docs/user_manual/processing_algs/qgis/vectoranalysis.rst
@@ -275,6 +275,10 @@ Alternatively, a unique class field can be specified.
 If both options are used, the weight field will take precedence and
 the unique class field will be ignored.
 
+|checkbox| Allows
+:ref:`features in-place modification <processing_inplace_edit>` 
+of polygon features
+
 ``Default menu``: :menuselection:`Vector --> Analysis Tools`
 
 Parameters
@@ -1690,6 +1694,10 @@ of lines and the total number of them that cross each polygon.
 The resulting layer has the same features as the input polygon layer,
 but with two additional attributes containing the length and count of
 the lines across each polygon.
+
+|checkbox| Allows
+:ref:`features in-place modification <processing_inplace_edit>` 
+of polygon features
 
 **Default menu**: :menuselection:`Vector --> Analysis Tools`
 

--- a/docs/user_manual/processing_algs/qgis/vectorcreation.rst
+++ b/docs/user_manual/processing_algs/qgis/vectorcreation.rst
@@ -25,6 +25,7 @@ distances will offset them to the right.
    In blue the source layer, in red the offset one
 
 |checkbox| Allows :ref:`features in-place modification <processing_inplace_edit>`
+of line features
 
 .. seealso:: :ref:`qgisoffsetline`, :ref:`qgisarraytranslatedfeatures`
 
@@ -156,6 +157,7 @@ M values present in the geometry can also be translated.
 
 |checkbox| Allows
 :ref:`features in-place modification <processing_inplace_edit>`
+of point, line, and polygon features
 
 .. seealso:: :ref:`qgistranslategeometry`, :ref:`qgisarrayoffsetlines`
 

--- a/docs/user_manual/processing_algs/qgis/vectorgeneral.rst
+++ b/docs/user_manual/processing_algs/qgis/vectorgeneral.rst
@@ -98,6 +98,10 @@ layer string field.
 The output layer will have a point geometry reflecting the geocoded location
 as well as a number of attributes associated to the geocoded location.
 
+|checkbox| Allows
+:ref:`features in-place modification <processing_inplace_edit>` 
+of point features
+
 .. note:: This algorithm is compliant with the `usage policy
  <https://operations.osmfoundation.org/policies/nominatim/>`_ of the
  Nominatim geocoding service provided by the OpenStreetMap Foundation.
@@ -812,6 +816,7 @@ If the file is saved in a local folder, you can choose between many
 file formats.
 
 |checkbox| Allows :ref:`features in-place modification <processing_inplace_edit>`
+of point, line, and polygon features
 
 .. seealso:: :ref:`qgisdeleteduplicategeometries`,
    :ref:`qgisremovenullgeometries`
@@ -2192,6 +2197,7 @@ Reprojects a vector layer in a different CRS. The reprojected layer
 will have the same features and attributes of the input layer.
 
 |checkbox| Allows :ref:`features in-place modification <processing_inplace_edit>`
+of point, line, and polygon features
 
 .. seealso:: :ref:`qgisassignprojection`,
    :ref:`qgisdefinecurrentprojection`, :ref:`qgisfindprojection`
@@ -2442,6 +2448,10 @@ output features.
 Geometries and other attributes remain unchanged in the output.
 Optionally, the separator string can be a regular expression
 for added flexibility.
+
+|checkbox| Allows
+:ref:`features in-place modification <processing_inplace_edit>` 
+of point, line, and polygon features
 
 Parameters
 ..........

--- a/docs/user_manual/processing_algs/qgis/vectortable.rst
+++ b/docs/user_manual/processing_algs/qgis/vectortable.rst
@@ -336,6 +336,10 @@ The X/Y fields can be calculated in a different CRS to the layer
 (e.g. creating latitude/longitude fields for a layer in a projected
 CRS).
 
+|checkbox| Allows
+:ref:`features in-place modification <processing_inplace_edit>` 
+of point features
+
 Parameters
 ..........
 


### PR DESCRIPTION
<!---
Include a few sentences describing the overall goals for this Pull Request.
 
A list of issues is at https://github.com/qgis/QGIS-Documentation/issues.
Add "fix #issuenumber" for each issue the PR fixes. The ticket(s) will be closed automatically.
If your PR doesn't fix entirely the ticket, only add the ticket(s) reference preceded by # character.
-->
Goal: Finish the edit in place updates 
All of the remaining Edit in place additions and feature descriptions.
I think that is all of them although the new Roundness algo has edit in place functionality but it hasn't been added to the documentation yet.
I am getting a error in the vectortable.rst saying that it doesn't have a checkbox. I see that there is a checkbox in the Substitutions definitions at the bottom of the other files but this also says don't add things here so I'm leaving that unresolved and hoping it will resolve itself.
Ticket(s): #
<!---
Indicate whether the fix should be backported to previous release.
Replace the space between square brackets by a `x` to make it checked.
-->
- [ ] Backport to LTR documentation is requested

<!---
Reviewing is a process done by community members, mostly on a volunteer basis.
We try to keep the overhead as small as possible and appreciate if you help us.
Please read carefully and ensure you comply with our writing guidelines at
https://docs.qgis.org/testing/en/docs/documentation_guidelines/index.html.
Feel free to ask in a comment or the (qgis-community-team mailing list)
[https://lists.osgeo.org/mailman/listinfo/qgis-community-team] if you have troubles with any item.
--->
