### PR TITLE
Using right term: embedding layers from external projects #7428

### DIFF
--- a/docs/user_manual/introduction/general_tools.rst
+++ b/docs/user_manual/introduction/general_tools.rst
@@ -307,7 +307,7 @@ symbols are:
 * |indicatorNonRemovable| to identify layers that are
   :ref:`required <project_layer_capabilities>` in the project, hence non removable
 * |indicatorEmbedded| to identify an :ref:`embedded group or layer
-  <nesting_projects>` and the path to their original project file
+  <embed_layers>` and the path to their original project file
 * |indicatorBadLayer| to identify a layer whose data source was not available
   at the project file opening (see :ref:`handle_broken_paths`).
   Click the icon to update the source path or select :guilabel:`Repair Data Source...`
@@ -623,10 +623,10 @@ load times.
 
 
 .. index:: Nesting projects, Embed layers and groups
-.. _nesting_projects:
+.. _embed_layers:
 
-Nesting Projects
-================
+Embedded Layers
+===============
 
 Sometimes, you'd like to keep some layers in different projects, but with the
 same style. You can either create a :ref:`default style <store_style>` for

--- a/docs/user_manual/introduction/general_tools.rst
+++ b/docs/user_manual/introduction/general_tools.rst
@@ -307,7 +307,7 @@ symbols are:
 * |indicatorNonRemovable| to identify layers that are
   :ref:`required <project_layer_capabilities>` in the project, hence non removable
 * |indicatorEmbedded| to identify an :ref:`embedded group or layer
-  <embed_layers>` and the path to their original project file
+  <nesting_projects>` and the path to their original project file
 * |indicatorBadLayer| to identify a layer whose data source was not available
   at the project file opening (see :ref:`handle_broken_paths`).
   Click the icon to update the source path or select :guilabel:`Repair Data Source...`
@@ -623,7 +623,7 @@ load times.
 
 
 .. index:: Nesting projects, Embed layers and groups
-.. _embed_layers:
+.. _nesting_projects:
 
 Embedding layers from external projects
 =======================================

--- a/docs/user_manual/introduction/general_tools.rst
+++ b/docs/user_manual/introduction/general_tools.rst
@@ -625,8 +625,8 @@ load times.
 .. index:: Nesting projects, Embed layers and groups
 .. _embed_layers:
 
-Embedded Layers
-===============
+Embedding layers from external projects
+=======================================
 
 Sometimes, you'd like to keep some layers in different projects, but with the
 same style. You can either create a :ref:`default style <store_style>` for

--- a/docs/user_manual/introduction/qgis_gui.rst
+++ b/docs/user_manual/introduction/qgis_gui.rst
@@ -159,7 +159,7 @@ The :menuselection:`Project` menu provides access and exit points for
      -
      -
      -
-   * - :guilabel:`Properties...`
+   * - |projectProperties| :guilabel:`Properties...`
      - :kbd:`Ctrl+Shift+P`
      -
      - :ref:`project_properties`
@@ -1215,15 +1215,15 @@ copy or paste layer properties (style, scale, CRS...).
      -
      -
      - :ref:`sec_attribute_table`
-   * - |openTableSelected| :menuselection:`--> Open Attribute Table (Selected Features)`
+   * - :menuselection:`-->` |openTableSelected| :menuselection:`Open Attribute Table (Selected Features)`
      - :kbd:`Shift+F6`
      - :guilabel:`Attributes`
      - :ref:`sec_attribute_table`
-   * - |openTableVisible| :menuselection:`--> Open Attribute Table (Visible Features)`
+   * - :menuselection:`-->` |openTableVisible| :menuselection:`Open Attribute Table (Visible Features)`
      - :kbd:`Ctrl+F6`
      - :guilabel:`Attributes`
      - :ref:`sec_attribute_table`
-   * - |openTableEdited| :menuselection:`--> Open Attribute Table (Edited and New Features)`
+   * - :menuselection:`-->` |openTableEdited| :menuselection:`Open Attribute Table (Edited and New Features)`
      -
      - :guilabel:`Attributes`
      - :ref:`sec_attribute_table`
@@ -3207,6 +3207,8 @@ Click the icon to open the Plugin Manager dialog.
 .. |processingModel| image:: /static/common/processingModel.png
    :width: 1.5em
 .. |processingResult| image:: /static/common/processingResult.png
+   :width: 1.5em
+.. |projectProperties| image:: /static/common/mActionProjectProperties.png
    :width: 1.5em
 .. |projectionEnabled| image:: /static/common/mIconProjectionEnabled.png
    :width: 1.5em


### PR DESCRIPTION
<!---
Using "embedding layers from external projects" instead of "nesting projects". General use of "embed" instead of "nesting" implemented.
 
A list of issues is at https://github.com/qgis/QGIS-Documentation/issues.
Add "fix #issuenumber" for each issue the PR fixes. The ticket(s) will be closed automatically.
If your PR doesn't fix entirely the ticket, only add the ticket(s) reference preceded by # character.
-->
Goal:

Ticket(s): #
<!---
Indicate whether the fix should be backported to previous release.
Replace the space between square brackets by a `x` to make it checked.
-->
- [ ] Backport to LTR documentation is requested

<!---
Reviewing is a process done by community members, mostly on a volunteer basis.
We try to keep the overhead as small as possible and appreciate if you help us.
Please read carefully and ensure you comply with our writing guidelines at
https://docs.qgis.org/testing/en/docs/documentation_guidelines/index.html.
Feel free to ask in a comment or the (qgis-community-team mailing list)
[https://lists.osgeo.org/mailman/listinfo/qgis-community-team] if you have troubles with any item.
--->
