### PR TITLE
Allow text buffer size, shadow offset and radius to be set in "percentage" units

### DIFF
--- a/docs/user_manual/introduction/general_tools.rst
+++ b/docs/user_manual/introduction/general_tools.rst
@@ -2579,6 +2579,11 @@ screen resolution, paper size, or the terrain). Available units are:
 * :guilabel:`Points`
 * :guilabel:`Pixels`
 * :guilabel:`Inches`
+* :guilabel:`Percentage`: This allows you to set these sizes as a percent of the font size. This is
+  useful for creation of text formats where the components
+  nicely scale as the text size is changed, instead of having
+  constant buffer/shadow sizes. So you don't need to adjust those sizes,
+  when the text size changes.
 * :guilabel:`Meters at Scale`: This allows you to always set the size in meters,
   regardless of what the underlying map units are (e.g. they can be in inches, feet,
   geographic degrees, ...). The size in meters is calculated based on the current project

--- a/docs/user_manual/introduction/general_tools.rst
+++ b/docs/user_manual/introduction/general_tools.rst
@@ -2579,8 +2579,8 @@ screen resolution, paper size, or the terrain). Available units are:
 * :guilabel:`Points`
 * :guilabel:`Pixels`
 * :guilabel:`Inches`
-* :guilabel:`Percentage`: This allows you to set these sizes as a percent of the font size. This is
-  useful for creation of text formats where the components
+* :guilabel:`Percentage`: allows you to set some properties as a percent of another one. For example, this is
+  useful for creation of text formats where the components (buffer size, shadow radius...)
   nicely scale as the text size is changed, instead of having
   constant buffer/shadow sizes. So you don't need to adjust those sizes,
   when the text size changes.


### PR DESCRIPTION
<!---
Allow text buffer size, shadow offset and radius to be set in "percentage" units

added in chapter: unit_selector


 
A list of issues is at https://github.com/qgis/QGIS-Documentation/issues.
Add "fix #issuenumber" for each issue the PR fixes. The ticket(s) will be closed automatically.
If your PR doesn't fix entirely the ticket, only add the ticket(s) reference preceded by # character.
-->
Goal: Fixes #7171

Ticket(s): #
<!---
Indicate whether the fix should be backported to previous release.
Replace the space between square brackets by a `x` to make it checked.
-->
- [ ] Backport to LTR documentation is requested

<!---
Reviewing is a process done by community members, mostly on a volunteer basis.
We try to keep the overhead as small as possible and appreciate if you help us.
Please read carefully and ensure you comply with our writing guidelines at
https://docs.qgis.org/testing/en/docs/documentation_guidelines/index.html.
Feel free to ask in a comment or the (qgis-community-team mailing list)
[https://lists.osgeo.org/mailman/listinfo/qgis-community-team] if you have troubles with any item.
--->
