### PR TITLE
Workaround for https://github.com/qgis/QGIS/issues/48670

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -369,6 +369,12 @@ os.environ['QT_QPA_PLATFORM'] = 'offscreen'
 from qgis.testing import start_app
 from qgis.testing.mocked import get_iface
 
+# Workaround for https://github.com/qgis/QGIS/issues/48670
+from qgis.PyQt.QtCore import QSettings
+settings = QSettings()
+settings.setValue("cache/directory", "testdata")
+
+
 def start_qgis():
 
     save_stdout = sys.stdout
@@ -386,7 +392,8 @@ def start_qgis():
         QgsFeature,
         QgsGeometry,
         QgsApplication,
-        QgsLayerTreeModel
+        QgsLayerTreeModel,
+        QgsSettings,
     )
 
     from qgis.gui import (

--- a/docs/pyqgis_developer_cookbook/cheat_sheet.rst
+++ b/docs/pyqgis_developer_cookbook/cheat_sheet.rst
@@ -93,7 +93,7 @@ Settings
 .. testoutput:: cheat_sheet
   :hide:
 
-  qgis/symbolsListGroupsIndex
+  ...
 
 Toolbars
 ========


### PR DESCRIPTION
Fix the crash locally, note that the root cause of the crash was a serious bug recently introduced in QGIS.

This is the third time that a failure in the doctests helped to discover a crash in QGIS.
