### PR TITLE
Fix FILE_TYPE parameter in "Split vector layer"

### DIFF
--- a/docs/user_manual/processing_algs/qgis/vectorgeneral.rst
+++ b/docs/user_manual/processing_algs/qgis/vectorgeneral.rst
@@ -2588,7 +2588,12 @@ Advanced parameters
        Optional
      - ``FILE_TYPE``
      - [enumeration]
-     - Select the extension of the output files
+
+       Default: ``gpkg`` in the dialog window
+     - Select the extension of the output files.
+       If not specified or invalid, the output files format will
+       be the one set in the "Default output vector layer extension"
+       Processing setting.
 
 Outputs
 ..........

--- a/docs/user_manual/processing_algs/qgis/vectorgeneral.rst
+++ b/docs/user_manual/processing_algs/qgis/vectorgeneral.rst
@@ -2584,6 +2584,8 @@ Advanced parameters
      - Type
      - Description
    * - **Output file type**
+
+       Optional
      - ``FILE_TYPE``
      - [enumeration]
      - Select the extension of the output files


### PR DESCRIPTION
<!---
Include a few sentences describing the overall goals for this Pull Request.
 
A list of issues is at https://github.com/qgis/QGIS-Documentation/issues.
Add "fix #issuenumber" for each issue the PR fixes. The ticket(s) will be closed automatically.
If your PR doesn't fix entirely the ticket, only add the ticket(s) reference preceded by # character.
-->
Goal:
The `FILE_TYPE` parameter of the "Split vector layer" (`native:splitvectorlayer`) algorithm is optional: see [[needs-docs] add optional parameter for output file type to the vector split algorithm](https://github.com/qgis/QGIS/commit/b99fe4e51f2cd79ad8922e765ad4d7125216259e) and [[processing] Fix FILE_TYPE parameter of the "Split Vector Layer" native algorithm](https://github.com/qgis/QGIS/pull/48781).

What is the best way to specify that the default for the `FILE_TYPE` parameter when the algorithm is executed from the GUI is 'gpkg' and when the algorithm is executed using Python it is the "Default output vector layer extension" set by the user in the Processing settings if available or it fallback to 'gpkg'?


Ticket(s): #
<!---
Indicate whether the fix should be backported to previous release.
Replace the space between square brackets by a `x` to make it checked.
-->
- [x] Backport to LTR documentation is requested

<!---
Reviewing is a process done by community members, mostly on a volunteer basis.
We try to keep the overhead as small as possible and appreciate if you help us.
Please read carefully and ensure you comply with our writing guidelines at
https://docs.qgis.org/testing/en/docs/documentation_guidelines/index.html.
Feel free to ask in a comment or the (qgis-community-team mailing list)
[https://lists.osgeo.org/mailman/listinfo/qgis-community-team] if you have troubles with any item.
--->
