### PR TITLE
Correct spelling font-freefonts-otf to fonts-freefont-otf

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ make LANG=fr pdf
 For building PDFs in English you will need to install the XeLaTex compiler package `texlive-xetex` and GNU Freefont.
 
 ```
-sudo apt install texlive-xetex font-freefonts-otf
+sudo apt install texlive-xetex fonts-freefont-otf
 ```
 
 For building translated PDFs, you may have to install the texlive extra package


### PR DESCRIPTION
<!---
Include a few sentences describing the overall goals for this Pull Request.
 
A list of issues is at https://github.com/qgis/QGIS-Documentation/issues.
Add "fix #issuenumber" for each issue the PR fixes. The ticket(s) will be closed automatically.
If your PR doesn't fix entirely the ticket, only add the ticket(s) reference preceded by # character.
-->
Goal: The correct package for otf fonts is fonts-freefont-otf but the original doc had a spelling error with font-freefonts-otf. This has been corrected

Ticket(s): #
<!---
Indicate whether the fix should be backported to previous release.
Replace the space between square brackets by a `x` to make it checked.
-->
- [ ] Backport to LTR documentation is requested

<!---
Reviewing is a process done by community members, mostly on a volunteer basis.
We try to keep the overhead as small as possible and appreciate if you help us.
Please read carefully and ensure you comply with our writing guidelines at
https://docs.qgis.org/testing/en/docs/documentation_guidelines/index.html.
Feel free to ask in a comment or the (qgis-community-team mailing list)
[https://lists.osgeo.org/mailman/listinfo/qgis-community-team] if you have troubles with any item.
--->
