### PR TITLE
Add "Offset" parameter to the "Drape" algorithms

### DIFF
--- a/docs/user_manual/processing_algs/qgis/vectorgeometry.rst
+++ b/docs/user_manual/processing_algs/qgis/vectorgeometry.rst
@@ -2342,7 +2342,7 @@ Parameters
        Default: 1.0
      - Scaling value: the band values are multiplied
        by this value.
-   * - **Offset**
+   * - **Offset** |326|
      - ``OFFSET``
      - [number |dataDefine|]
 
@@ -6028,7 +6028,7 @@ Parameters
        Default: 1.0
      - Scaling value: the band values are multiplied
        by this value.
-   * - **Offset**
+   * - **Offset** |326|
      - ``OFFSET``
      - [number |dataDefine|]
 

--- a/docs/user_manual/processing_algs/qgis/vectorgeometry.rst
+++ b/docs/user_manual/processing_algs/qgis/vectorgeometry.rst
@@ -2342,6 +2342,13 @@ Parameters
        Default: 1.0
      - Scaling value: the band values are multiplied
        by this value.
+   * - **Offset**
+     - ``OFFSET``
+     - [number |dataDefine|]
+
+       Default: 0.0
+     - Offset value: it is algebraically added to the band
+       values after applying the "Scale factor".
    * - **Updated**
      - ``OUTPUT``
      - [same as input]
@@ -6021,6 +6028,13 @@ Parameters
        Default: 1.0
      - Scaling value: the band values are multiplied
        by this value.
+   * - **Offset**
+     - ``OFFSET``
+     - [number |dataDefine|]
+
+       Default: 0.0
+     - Offset value: it is algebraically added to the band
+       values after applying the "Scale factor".
    * - **Updated**
      - ``OUTPUT``
      - [same as input]


### PR DESCRIPTION
<!---
Include a few sentences describing the overall goals for this Pull Request.
 
A list of issues is at https://github.com/qgis/QGIS-Documentation/issues.
Add "fix #issuenumber" for each issue the PR fixes. The ticket(s) will be closed automatically.
If your PR doesn't fix entirely the ticket, only add the ticket(s) reference preceded by # character.
-->
Goal:
Adds the "Offset" parameter to the "Drape (set Z value from raster)" (`native:setzfromraster`) and "Set M value from raster" (`native:setmfromraster`) processing algorithms.

Ticket(s): https://github.com/qgis/QGIS/pull/48772

Fixes https://github.com/qgis/QGIS-Documentation/issues/7641.

<!---
Indicate whether the fix should be backported to previous release.
Replace the space between square brackets by a `x` to make it checked.
-->
- [ ] Backport to LTR documentation is requested

<!---
Reviewing is a process done by community members, mostly on a volunteer basis.
We try to keep the overhead as small as possible and appreciate if you help us.
Please read carefully and ensure you comply with our writing guidelines at
https://docs.qgis.org/testing/en/docs/documentation_guidelines/index.html.
Feel free to ask in a comment or the (qgis-community-team mailing list)
[https://lists.osgeo.org/mailman/listinfo/qgis-community-team] if you have troubles with any item.
--->
