### PR TITLE
add flag info

### DIFF
--- a/docs/pyqgis_developer_cookbook/loadproject.rst
+++ b/docs/pyqgis_developer_cookbook/loadproject.rst
@@ -158,3 +158,24 @@ Both methods return an ``id`` that can be used to remove the pre-processor
 or writer they added.
 See :meth:`removePathPreprocessor() <qgis.core.QgsPathResolver.removePathPreprocessor>`
 and :meth:`removePathWriter() <qgis.core.QgsPathResolver.removePathWriter>`.
+
+
+Using flags to speed up things
+==============================
+
+In some instances where you may not need to use a fully fonctionnal project, but only
+ want to access it for a specific reason, flags may be helpful. A full list of flags is available under
+ :meth: 'ProjectReadFlag <qgis.core.QgsPRoject.ProjectReadFlag>` . Multiple flags can be added together.
+ 
+As an example if we do not need to have functionnal layers and simply want to access of modify a project. 
+A flag can be used to bypass the data validation step and prevent the bad layer dialog from appearing.
+The following can be done:
+
+   .. testcode:: loadproject
+
+  readflags = QgsProject.ReadFlags()
+  readflags |= QgsProject.FlagDontResolveLayer
+  project = QgsProject()
+  project.read('c:/Users/ClintBarton/Documents/Projects', readflags)
+ 
+To add more flags the python | (Bitwise OR) operator must be used to append a new flags.

--- a/docs/pyqgis_developer_cookbook/loadproject.rst
+++ b/docs/pyqgis_developer_cookbook/loadproject.rst
@@ -167,8 +167,9 @@ In some instances where you may not need to use a fully fonctionnal project, but
 want to access it for a specific reason, flags may be helpful. A full list of flags is available under
 :class:`ProjectReadFlag <qgis.core.Qgis.ProjectReadFlag>`. Multiple flags can be added together.
  
-As an example if we do not need to have functionnal layers and simply want to access of modify a project. 
-A flag can be used to bypass the data validation step and prevent the bad layer dialog from appearing.
+As an example, if we do not care about actual layers and data and simply want to
+access a project (e.g. for layout or 3D view settings), we can use ``FlagDontResolveLayer``
+to bypass the data validation step and prevent the bad layer dialog from appearing.
 The following can be done:
 
 .. testcode:: loadproject

--- a/docs/pyqgis_developer_cookbook/loadproject.rst
+++ b/docs/pyqgis_developer_cookbook/loadproject.rst
@@ -164,8 +164,8 @@ Using flags to speed up things
 ==============================
 
 In some instances where you may not need to use a fully fonctionnal project, but only
- want to access it for a specific reason, flags may be helpful. A full list of flags is available under
- :meth:`ProjectReadFlag <qgis.core.Qgis.ProjectReadFlag>`. Multiple flags can be added together.
+want to access it for a specific reason, flags may be helpful. A full list of flags is available under
+:class:`ProjectReadFlag <qgis.core.Qgis.ProjectReadFlag>`. Multiple flags can be added together.
  
 As an example if we do not need to have functionnal layers and simply want to access of modify a project. 
 A flag can be used to bypass the data validation step and prevent the bad layer dialog from appearing.

--- a/docs/pyqgis_developer_cookbook/loadproject.rst
+++ b/docs/pyqgis_developer_cookbook/loadproject.rst
@@ -165,13 +165,13 @@ Using flags to speed up things
 
 In some instances where you may not need to use a fully fonctionnal project, but only
  want to access it for a specific reason, flags may be helpful. A full list of flags is available under
- :meth: 'ProjectReadFlag <qgis.core.QgsPRoject.ProjectReadFlag>` . Multiple flags can be added together.
+ :meth:`ProjectReadFlag <qgis.core.QgsPRoject.ProjectReadFlag>` . Multiple flags can be added together.
  
 As an example if we do not need to have functionnal layers and simply want to access of modify a project. 
 A flag can be used to bypass the data validation step and prevent the bad layer dialog from appearing.
 The following can be done:
 
-   .. testcode:: loadproject
+.. testcode:: loadproject
 
   readflags = QgsProject.ReadFlags()
   readflags |= QgsProject.FlagDontResolveLayer

--- a/docs/pyqgis_developer_cookbook/loadproject.rst
+++ b/docs/pyqgis_developer_cookbook/loadproject.rst
@@ -165,7 +165,7 @@ Using flags to speed up things
 
 In some instances where you may not need to use a fully fonctionnal project, but only
  want to access it for a specific reason, flags may be helpful. A full list of flags is available under
- :meth:`ProjectReadFlag <qgis.core.QgsPRoject.ProjectReadFlag>` . Multiple flags can be added together.
+ :meth:`ProjectReadFlag <qgis.core.Qgis.ProjectReadFlag>`. Multiple flags can be added together.
  
 As an example if we do not need to have functionnal layers and simply want to access of modify a project. 
 A flag can be used to bypass the data validation step and prevent the bad layer dialog from appearing.
@@ -173,9 +173,9 @@ The following can be done:
 
 .. testcode:: loadproject
 
-  readflags = QgsProject.ReadFlags()
-  readflags |= QgsProject.FlagDontResolveLayer
+  readflags = Qgis.ProjectReadFlags()
+  readflags |= Qgis.FlagDontResolveLayer
   project = QgsProject()
-  project.read('c:/Users/ClintBarton/Documents/Projects', readflags)
+  project.read('C:/Users/ClintBarton/Documents/Projects/mysweetproject.qgs', readflags)
  
-To add more flags the python | (Bitwise OR) operator must be used to append a new flags.
+To add more flags the python Bitwise OR operator (``|``) must be used.

--- a/docs/pyqgis_developer_cookbook/loadproject.rst
+++ b/docs/pyqgis_developer_cookbook/loadproject.rst
@@ -18,6 +18,7 @@ Loading Projects
   .. testcode:: loadproject
 
     from qgis.core import (
+        Qgis,
         QgsProject,
         QgsPathResolver
     )

--- a/docs/pyqgis_developer_cookbook/loadproject.rst
+++ b/docs/pyqgis_developer_cookbook/loadproject.rst
@@ -176,7 +176,7 @@ The following can be done:
 .. testcode:: loadproject
 
   readflags = Qgis.ProjectReadFlags()
-  readflags |= Qgis.FlagDontResolveLayer
+  readflags |= Qgis.FlagDontResolveLayers
   project = QgsProject()
   project.read('C:/Users/ClintBarton/Documents/Projects/mysweetproject.qgs', readflags)
  


### PR DESCRIPTION
As mentionned this is a quick PR to add information about flag usage when reading a project in pyqgis.

This might not be common, but I think it's good to have it out here.

Fixes #7634
