### PR TITLE
Server - Use "none" instead of "bash" for GEOMETRYNAME

### DIFF
--- a/docs/server_manual/services/wfs.rst
+++ b/docs/server_manual/services/wfs.rst
@@ -468,7 +468,7 @@ for features. Available values are:
 
 - ``extent``
 - ``centroid``
-- ``bash``
+- ``none``
 
 URL example:
 


### PR DESCRIPTION
@pblottiere https://github.com/qgis/QGIS-Documentation/commit/1906446b35efc776ff3138d3ed5cd6d09eb0fce5

This commit should be backported.