### PR TITLE
Marker/hash line: allow offset along line in percent, and negative offsets along line  #7207

### DIFF
--- a/docs/user_manual/style_library/symbol_selector.rst
+++ b/docs/user_manual/style_library/symbol_selector.rst
@@ -373,20 +373,26 @@ layer types:
   <vector_marker_symbols>` over the length of a line.
 
   * The :guilabel:`Marker placement` can be set using a regular interval setting
+    (starting from the first vertex)
     and/or the line geometry property (on first or last vertex, inner vertices,
     the central point of the line or of each segment, or on every curve point).
   * When first or last vertex placement is enabled, the |checkbox|
     :guilabel:`Place on every part extremity` option will make the markers
     render also at the first or last vertex for every part of multipart geometries.
-  * :guilabel:`Offset along the line`: Allows offset along line to be specified in 
-    percent for marker line and hash line symbol layer types. 
-    Offsets are treated as percent of overall line length. 
-    When the "offset along line" setting for a marker line or hash line symbol layer 
-    is longer then the size of a closed ring, treat the offset as continuing to loop 
-    around the ring. E.g. setting the offset to 150% results in the offset being 
-    treated as 50% of the length of the closed ring.
-    If a negative offset along line is set for a marker or hash line symbol layer 
-    for a closed ring, then the offset is calculated backwards along the ring
+  * :guilabel:`Offset along line`: the markers placement can also be given
+    an offset along the line, in the ref:`unit <unit_selector>` of your choice
+    (millimeters, points, map unit, meters at scale, percentage, ...):
+
+    * A positive value offsets the markers symbols in the line direction (with
+      :guilabel:`On first vertex` and :guilabel:`With interval` placements)
+      and backwards (with :guilabel:`On last vertex` placement).
+    * A negative value on a not closed line will result in no offset (for
+      :guilabel:`On first vertex` and :guilabel:`On last vertex` placements)
+      or backwards offset of the symbols (from the last vertex).
+    * With a closed ring, QGIS treats the offset as continuing to loop around
+      the ring (forward or backward).
+      E.g. setting the offset to 150% (resp. -10% or -110%) results in the
+      offset being treated as 50% (resp. 90%) of the length of the closed ring.
 
   * The |checkbox| :guilabel:`Rotate marker to follow line direction` option
     sets whether each marker symbol should be oriented relative to the line

--- a/docs/user_manual/style_library/symbol_selector.rst
+++ b/docs/user_manual/style_library/symbol_selector.rst
@@ -378,8 +378,16 @@ layer types:
   * When first or last vertex placement is enabled, the |checkbox|
     :guilabel:`Place on every part extremity` option will make the markers
     render also at the first or last vertex for every part of multipart geometries.
-  * :guilabel:`Offset along the line`: the markers placement can also be given
-    an offset from the start, along the line
+  * :guilabel:`Offset along the line`: Allows offset along line to be specified in 
+    percent for marker line and hash line symbol layer types. 
+    Offsets are treated as percent of overall line length. 
+    When the "offset along line" setting for a marker line or hash line symbol layer 
+    is longer then the size of a closed ring, treat the offset as continuing to loop 
+    around the ring. E.g. setting the offset to 150% results in the offset being 
+    treated as 50% of the length of the closed ring.
+    If a negative offset along line is set for a marker or hash line symbol layer 
+    for a closed ring, then the offset is calculated backwards along the ring
+
   * The |checkbox| :guilabel:`Rotate marker to follow line direction` option
     sets whether each marker symbol should be oriented relative to the line
     direction or not.


### PR DESCRIPTION
Marker/hash line: allow offset along line in percent, and negative offsets along line  (fixes #7207):

Text updated

<!---
Include a few sentences describing the overall goals for this Pull Request.
 
A list of issues is at https://github.com/qgis/QGIS-Documentation/issues.
Add "fix #issuenumber" for each issue the PR fixes. The ticket(s) will be closed automatically.
If your PR doesn't fix entirely the ticket, only add the ticket(s) reference preceded by # character.
-->
Goal:

Ticket(s): #
<!---
Indicate whether the fix should be backported to previous release.
Replace the space between square brackets by a `x` to make it checked.
-->
- [ ] Backport to LTR documentation is requested

<!---
Reviewing is a process done by community members, mostly on a volunteer basis.
We try to keep the overhead as small as possible and appreciate if you help us.
Please read carefully and ensure you comply with our writing guidelines at
https://docs.qgis.org/testing/en/docs/documentation_guidelines/index.html.
Feel free to ask in a comment or the (qgis-community-team mailing list)
[https://lists.osgeo.org/mailman/listinfo/qgis-community-team] if you have troubles with any item.
--->
