### PR TITLE
Use imperative in environment custom variables methods description

### DIFF
--- a/docs/user_manual/introduction/qgis_configuration.rst
+++ b/docs/user_manual/introduction/qgis_configuration.rst
@@ -223,9 +223,9 @@ and the :guilabel:`Apply` method to use, among which:
 * :guilabel:`Overwrite`: replace any preexisting value of the variable
 * :guilabel:`If undefined`: use this value for the variable if not already defined at
   a higher level (e.g. OS or application levels)
-* :guilabel:`Unset`: removes the variable from the environment (the :guilabel:`Value` parameter is not used)
-* :guilabel:`Prepend`: prepends the value to the preexisting value of the variable
-* :guilabel:`Append`: appends the value to the preexisting value of the variable
+* :guilabel:`Unset`: remove the variable from the environment (the :guilabel:`Value` parameter is not used)
+* :guilabel:`Prepend`: prepend the value to the preexisting value of the variable
+* :guilabel:`Append`: append the value to the preexisting value of the variable
 * :guilabel:`Skip`: the item is kept in the list for future reference but unused
 
 Already defined environment variables are displayed in :guilabel:`Current environment


### PR DESCRIPTION
<!---
Include a few sentences describing the overall goals for this Pull Request.
 
A list of issues is at https://github.com/qgis/QGIS-Documentation/issues.
Add "fix #issuenumber" for each issue the PR fixes. The ticket(s) will be closed automatically.
If your PR doesn't fix entirely the ticket, only add the ticket(s) reference preceded by # character.
-->
Goal:
@DelazJ, I incorrectly used the present simple third person in https://github.com/qgis/QGIS-Documentation/pull/7684/commits/bab5782a9485570c4448bded89c0dd4c965f8442 instead of the imperative... my fault...

Ticket(s): #
<!---
Indicate whether the fix should be backported to previous release.
Replace the space between square brackets by a `x` to make it checked.
-->
- [ ] Backport to LTR documentation is requested

<!---
Reviewing is a process done by community members, mostly on a volunteer basis.
We try to keep the overhead as small as possible and appreciate if you help us.
Please read carefully and ensure you comply with our writing guidelines at
https://docs.qgis.org/testing/en/docs/documentation_guidelines/index.html.
Feel free to ask in a comment or the (qgis-community-team mailing list)
[https://lists.osgeo.org/mailman/listinfo/qgis-community-team] if you have troubles with any item.
--->
