### PR TITLE
Update Dockerfile for containerized deployment of qgis-server

### DIFF
--- a/docs/server_manual/containerized_deployment.rst
+++ b/docs/server_manual/containerized_deployment.rst
@@ -22,7 +22,7 @@ simple (simple Docker images) to sophisticated (Kubernetes and so on).
 
 .. note:: QGIS Debian-Ubuntu package downloads need a valid gpg authentication key.  
    Please refer to the `installation pages <https://www.qgis.org/fr/site/forusers/alldownloads.html#debian-ubuntu>`_ 
-   to update the following Dockerfile with the latest key and its fingerprint value
+   to update the following Dockerfile.
 
 .. _simple-docker-images:
 
@@ -36,7 +36,7 @@ it. To do so create a directory :file:`qgis-server` and within its directory:
 
 .. code-block:: dockerfile
 
-  FROM debian:buster-slim
+  FROM debian:bullseye-slim
   
   ENV LANG=en_EN.UTF-8
   
@@ -48,11 +48,13 @@ it. To do so create a directory :file:`qgis-server` and within its directory:
           wget \
           locales \
       && localedef -i en_US -f UTF-8 en_US.UTF-8 \
-      # Add the current key for package downloading - As the key changes every year at least
-      # Please refer to QGIS install documentation and replace it and its fingerprint value with the latest ones
-      && wget -O - https://qgis.org/downloads/qgis-2021.gpg.key | gpg --import \
-      && gpg --export --armor 46B5721DBBD2996A | apt-key add - \
-      && echo "deb http://qgis.org/debian buster main" >> /etc/apt/sources.list.d/qgis.list \
+      # Add the current key for package downloading
+      # Please refer to QGIS install documentation (https://www.qgis.org/fr/site/forusers/alldownloads.html#debian-ubuntu)
+      && mkdir -m755 -p /etc/apt/keyrings \
+      && wget -O /etc/apt/keyrings/qgis-archive-keyring.gpg https://download.qgis.org/downloads/qgis-archive-keyring.gpg \
+      # Add repository for latest version of qgis-server
+      # Please refer to QGIS repositories documentation if you want other version (https://qgis.org/en/site/forusers/alldownloads.html#repositories)
+      && echo "deb [signed-by=/etc/apt/keyrings/qgis-archive-keyring.gpg] https://qgis.org/debian bullseye main" | tee /etc/apt/sources.list.d/qgis.list \
       && apt-get update \
       && apt-get install --no-install-recommends --no-install-suggests --allow-unauthenticated -y \
           qgis-server \
@@ -66,7 +68,7 @@ it. To do so create a directory :file:`qgis-server` and within its directory:
   
   RUN useradd -m qgis
   
-  ENV TINI_VERSION v0.17.0
+  ENV TINI_VERSION v0.19.0
   ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /tini
   RUN chmod +x /tini
   


### PR DESCRIPTION
<!---
Include a few sentences describing the overall goals for this Pull Request.
 
A list of issues is at https://github.com/qgis/QGIS-Documentation/issues.
Add "fix #issuenumber" for each issue the PR fixes. The ticket(s) will be closed automatically.
If your PR doesn't fix entirely the ticket, only add the ticket(s) reference preceded by # character.
-->

<!---
Indicate whether the fix should be backported to previous release.
Replace the space between square brackets by a `x` to make it checked.
-->
- [x] Backport to LTR documentation is requested (LTR is 3.22 and 3.22 is not available on Debian Buster)

<!---
Reviewing is a process done by community members, mostly on a volunteer basis.
We try to keep the overhead as small as possible and appreciate if you help us.
Please read carefully and ensure you comply with our writing guidelines at
https://docs.qgis.org/testing/en/docs/documentation_guidelines/index.html.
Feel free to ask in a comment or the (qgis-community-team mailing list)
[https://lists.osgeo.org/mailman/listinfo/qgis-community-team] if you have troubles with any item.
--->

Deeper update than #7719

- Switch to Debian Bullseye (buster is oldstable)
- Do not use apt-key which will be deprecated in next Debian release.
- Add comment for qgis version (LTR, nightly, master, ...)
- Update tiny version