### PR TITLE
Expand description of the global rendering settings

### DIFF
--- a/docs/user_manual/introduction/general_tools.rst
+++ b/docs/user_manual/introduction/general_tools.rst
@@ -689,20 +689,45 @@ Working with the map canvas
 ===========================
 
 .. index:: Rendering
+   single: Rendering; Suspending
 .. _`redraw_events`:
 
-Rendering
----------
+Controlling map rendering
+-------------------------
 
 By default, QGIS renders all visible layers whenever the map canvas is
 refreshed. The events that trigger a refresh of the map canvas include:
 
-*  adding a layer
-*  panning or zooming
-*  resizing the QGIS window
-*  changing the visibility of a layer or layers
+* changing the visibility of a layer
+* modifying symbology of a visible layer
+* adding a layer
+* panning or zooming
+* resizing the QGIS window
 
 QGIS allows you to control the rendering process in a number of ways.
+
+* at the :ref:`global level <rendering_options>`
+* per layer, using e.g. the :ref:`scale dependent rendering <label_scaledepend>`
+* or with dedicated tools in the GUI.
+
+To stop the map drawing, press the :kbd:`Esc` key. This will halt the refresh of
+the map canvas and leave the map partially drawn. It may however take a bit of time
+after pressing :kbd:`Esc` for the map drawing to halt.
+
+To suspend rendering, click the |checkbox| :guilabel:`Render` checkbox in the
+bottom-right corner of the status bar. When |checkbox| :guilabel:`Render`
+is unchecked, QGIS does not redraw the canvas in response to any of
+the usual triggers mentioned earlier. Examples of when you
+might want to suspend rendering include:
+
+* adding many layers and symbolizing them prior to drawing
+* adding one or more large layers and setting scale dependency before drawing
+* adding one or more large layers and zooming to a specific view before drawing
+* any combination of the above
+
+Checking the |checkbox| :guilabel:`Render` checkbox enables rendering and
+causes an immediate refresh of the map canvas.
+
 
 .. index:: Rendering scale dependent, Scale
 .. _`label_scaledepend`:
@@ -729,100 +754,6 @@ the current map canvas scale as boundary of the range visibility.
    its visibility scale range, the layer is greyed in the Layers panel and
    a new option :guilabel:`Zoom to Visible Scale` appears in the layer context menu.
    Select it and the map is zoomed to the layer's nearest visibility scale.
-
-
-.. _`label_controlmap`:
-
-Controlling Map Rendering
-.........................
-
-Map rendering can be controlled in various ways, as described below.
-
-.. index::
-   single: Rendering; Suspending
-.. _`label_suspendrender`:
-
-Suspending Rendering
-^^^^^^^^^^^^^^^^^^^^
-
-To suspend rendering, click the |checkbox| :guilabel:`Render` checkbox in the
-bottom-right corner of the status bar. When |checkbox| :guilabel:`Render`
-is not checked, QGIS does not redraw the canvas in response to any of
-the events described in the section :ref:`redraw_events`. Examples of when you
-might want to suspend rendering include:
-
-* adding many layers and symbolizing them prior to drawing
-* adding one or more large layers and setting scale dependency before drawing
-* adding one or more large layers and zooming to a specific view before drawing
-* any combination of the above
-
-Checking the |checkbox| :guilabel:`Render` checkbox enables rendering and
-causes an immediate refresh of the map canvas.
-
-
-.. index::
-   single: Rendering; Options
-   single: Layers; Initial visibility
-.. _`label_settinglayer`:
-
-Setting Layer Add Option
-^^^^^^^^^^^^^^^^^^^^^^^^
-
-You can set an option to always load new layers without drawing them. This
-means the layer will be added to the map, but its visibility checkbox in the
-legend will be unchecked by default. To set this option, choose menu option
-:menuselection:`Settings --> Options` and click on the :guilabel:`Rendering`
-tab. Uncheck |checkbox| :guilabel:`By default new layers added to the map
-should be displayed`. Any layer subsequently added to the map will be off
-(invisible) by default.
-
-
-.. index::
-   single: Rendering; Halting
-.. _label_stoprender:
-
-Stopping Rendering
-^^^^^^^^^^^^^^^^^^
-
-To stop the map drawing, press the :kbd:`Esc` key. This will halt the refresh of
-the map canvas and leave the map partially drawn. It may take a bit of time
-between pressing :kbd:`Esc` for the map drawing to halt.
-
-
-.. index::
-   single: Rendering; Quality
-.. _`label_renderquality`:
-
-Influence Rendering Quality
-^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-QGIS has an option to influence the rendering quality of the map. Choose menu
-option :menuselection:`Settings --> Options`, click on the :guilabel:`Rendering`
-tab and select or deselect |checkbox| :guilabel:`Make lines appear less jagged
-at the expense of some drawing performance`.
-
-.. index::
-   single: Rendering; Speed-up
-
-Speed-up rendering
-^^^^^^^^^^^^^^^^^^
-
-There are some settings that allow you to improve rendering speed. Open the QGIS options
-dialog using :menuselection:`Settings --> Options`, go to the :guilabel:`Rendering`
-tab and select or deselect the following checkboxes:
-
-* |checkbox| :guilabel:`Use render caching where possible to speed up redraws`.
-* |checkbox| :guilabel:`Render layers in parallel using many CPU cores` and then
-  set the |checkbox| :guilabel:`Max cores to use`.
-* The map renders in the background onto a separate image and each
-  |checkbox| :guilabel:`Map Update interval`, the content from this
-  (off-screen) image will be taken to update the visible screen representation.
-  However, if rendering finishes faster than this duration, it will be shown
-  instantaneously.
-* With |checkbox| :guilabel:`Enable Feature simplification by default for newly
-  added layers`, you simplify features' geometry (fewer nodes) and as a result,
-  they display more quickly.
-  Be aware that this can cause rendering inconsistencies.
 
 
 .. index:: Zoom, Pan, Map navigation

--- a/docs/user_manual/introduction/qgis_configuration.rst
+++ b/docs/user_manual/introduction/qgis_configuration.rst
@@ -555,16 +555,20 @@ layers rendering in the map canvas.
 
    Rendering settings
 
-**Rendering behavior**
+**Rendering Behavior**
 
 * |checkbox| :guilabel:`By default new layers added to the map should be
   displayed`: unchecking this option can be handy when loading multiple layers
   to avoid each new layer being rendered in the canvas and slow down the process
-* |checkbox| :guilabel:`Maximum cores to use for map rendering`
-* :guilabel:`Map update interval (default to 250 ms)`
+* Set the :guilabel:`Maximum cores to use for map rendering`
+* The map canvas renders in the background onto a separate image and at each
+  :guilabel:`Map update interval` (defaults to 250 ms), the content from this
+  (off-screen) image will be taken to update the visible screen representation.
+  However, if rendering finishes faster than this duration, it will be shown
+  instantaneously.
 * :guilabel:`Magnification level` (see the :ref:`magnifier <magnifier>`)
 
-**Rendering quality**
+**Rendering Quality**
 
 * |checkbox| :guilabel:`Make lines appear less jagged at the expense of some
   drawing performance`
@@ -584,32 +588,37 @@ for rendering vector layers.
 
 .. _global_simplification:
 
-* |checkbox| :guilabel:`Enable feature simplification by default for newly added layers`
-* :guilabel:`Simplification threshold (higher values result in more simplification)` 
-* :guilabel:`Simplification algorithm`: This option performs a local
-  "on-the-fly" simplification on feature's and speeds up geometry rendering. It
-  doesn't change the geometry fetched from the data providers. This is important
-  when you have expressions that use the feature geometry (e.g. calculation of
-  area) - it ensures that these calculations are done on the original geometry,
-  not on the simplified one. For this purpose, QGIS provides three algorithms:
-  'Distance' (default), 'SnapToGrid' and 'Visvalingam'.
-* |unchecked| :guilabel:`Simplify on provider side if possible`: the geometries
-  are simplified by the provider (PostGIS, Oracle...) and unlike the
-  local-side simplification, geometry-based calculations may be affected
-* :guilabel:`Maximum scale at which the layer should be simplified (1:1 always simplifies)`
+* |checkbox| :guilabel:`Enable Feature Simplification by Default for Newly Added
+  Layers`: you simplify features' geometry (fewer nodes) and as a result, they
+  display more quickly. Be aware that this can cause rendering inconsistencies.
+  Available settings are:
 
-.. note:: Besides the global setting, feature simplification can be set for any
+  * :guilabel:`Simplification threshold (higher values result in more simplification)` 
+  * :guilabel:`Simplification algorithm`: This option performs a local
+    "on-the-fly" simplification on feature's and speeds up geometry rendering. It
+    doesn't change the geometry fetched from the data providers. This is important
+    when you have expressions that use the feature geometry (e.g. calculation of
+    area) - it ensures that these calculations are done on the original geometry,
+    not on the simplified one. For this purpose, QGIS provides three algorithms:
+    'Distance' (default), 'SnapToGrid' and 'Visvalingam'.
+  * |unchecked| :guilabel:`Simplify on provider side if possible`: the geometries
+    are simplified by the provider (PostGIS, Oracle...) and unlike the
+    local-side simplification, geometry-based calculations may be affected
+  * :guilabel:`Maximum scale at which the layer should be simplified
+    (1:1 always simplifies)`
+
+  .. note:: Besides the global setting, feature simplification can be set for any
    specific layer from its :menuselection:`Layer properties --> Rendering` menu.
 
-**Curve segmentation**
+* :guilabel:`Curve Segmentation`
 
-* :guilabel:`Segmentation tolerance`: this setting controls the way circular arcs
-  are rendered. **The smaller** maximum angle (between the two consecutive vertices
-  and the curve center, in degrees) or maximum difference (distance between the
-  segment of the two vertices and the curve line, in map units), the **more
-  straight line** segments will be used during rendering.
-* :guilabel:`Tolerance type`: it can be *Maximum angle* or *Maximum difference*
-  between approximation and curve.
+  * :guilabel:`Segmentation tolerance`: this setting controls the way circular arcs
+    are rendered. **The smaller** maximum angle (between the two consecutive vertices
+    and the curve center, in degrees) or maximum difference (distance between the
+    segment of the two vertices and the curve line, in map units), the **more
+    straight line** segments will be used during rendering.
+  * :guilabel:`Tolerance type`: it can be *Maximum angle* or *Maximum difference*
+    between approximation and curve.
 
 Raster rendering settings
 .........................
@@ -654,7 +663,7 @@ For each, you can set:
 * the :guilabel:`Limits (minimum/maximum)` to apply, with values such as 'Cumulative
   pixel count cut', 'Minimum/Maximum', 'Mean +/- standard deviation'.
 
-For rasters rendering, you can also define the following options:
+The :guilabel:`Contrast Enhancement` options also include:
 
 * :guilabel:`Cumulative pixel count cut limits`
 * :guilabel:`Standard deviation multiplier`

--- a/docs/user_manual/introduction/qgis_gui.rst
+++ b/docs/user_manual/introduction/qgis_gui.rst
@@ -2922,8 +2922,7 @@ the Coordinate option and the |extents| :guilabel:`Extents` option
 that displays the coordinates of the current bottom-left and top-right
 corners of the map view in map units.
 
-Next to the coordinate display you will find the :guilabel:`Scale`
-display.
+Next to the coordinate display you will find the :guilabel:`Scale` display.
 It shows the scale of the map view. There is a scale selector, which
 allows you to choose between
 :ref:`predefined and custom scales <predefinedscales>`.
@@ -2940,7 +2939,7 @@ The magnification level is expressed as a percentage.
 If the :guilabel:`Magnifier` has a level of 100%, then the current map
 is not magnified, i.e. is rendered at accurate scale relative to the monitor's resolution (DPI).
 A default magnification value can be defined within
-:menuselection:`Settings --> Options --> Rendering --> Rendering behavior`,
+:menuselection:`Settings --> Options --> Rendering --> Rendering Behavior`,
 which is very useful for high-resolution screens to enlarge small
 symbols. In addition, a setting in :menuselection:`Settings --> Options --> Canvas & Legend --> DPI` 
 controls whether QGIS respects each monitor's physical DPI or uses the overall system logical DPI.
@@ -2948,14 +2947,14 @@ controls whether QGIS respects each monitor's physical DPI or uses the overall s
 To the right of the magnifier tool you can define a current clockwise
 rotation for your map view in degrees.
 
-On the right side of the status bar, there is a small checkbox which
-can be used temporarily to prevent layers being rendered to the map
-view (see section :ref:`redraw_events`).
+On the right side of the status bar, the |checkbox| :guilabel:`Render`
+checkbox can be used to temporarily suspend the map view rendering
+(see section :ref:`redraw_events`).
 
-To the right of the render functions, you find the |projectionEnabled|
-:guilabel:`EPSG:code` button showing the current project CRS. Clicking
-on this opens the :guilabel:`Project Properties` dialog and lets you
-apply another CRS to the map view.
+To the right of the |checkbox| :guilabel:`Render` function, you find the
+|projectionEnabled| :guilabel:`EPSG:code` button showing the current project CRS.
+Clicking on this opens the :guilabel:`Project Properties` dialog and lets you
+reproject the map view or adjust any other project property.
 
 .. index::
    single: Scale calculate
@@ -2974,7 +2973,7 @@ apply another CRS to the map view.
    specifies (e.g., ``+units=us-ft``).
 
    Note that CRS choice on startup can be set in
-   :menuselection:`Settings --> Options --> CRS`.
+   :menuselection:`Settings --> Options --> CRS Handling`.
 
 Messaging
 ---------


### PR DESCRIPTION
moving duplicate global rendering options in general tools to configuration page and removing outdated options
Also adjust list formatting as well as the map rendering features on the status bar

While a step towards #7811 this pr mainly starts the cleanup of the [working with map canvas](https://docs.qgis.org/testing/en/docs/user_manual/introduction/general_tools.html#working-with-the-map-canvas) section