### PR TITLE
Fix the "Slope" QGIS algorithm map description

### DIFF
--- a/docs/user_manual/processing_algs/qgis/rasterterrainanalysis.rst
+++ b/docs/user_manual/processing_algs/qgis/rasterterrainanalysis.rst
@@ -516,9 +516,6 @@ Slope
 Calculates the slope from an input raster layer. The slope is the
 angle of inclination of the terrain and is expressed in **degrees**.
 
-In the following picture you can see to the left the DTM layer with
-the elevation of the terrain while to the right the calculated slope:
-
 .. figure:: img/slope.png
    :align: center
 


### PR DESCRIPTION
<!---
Include a few sentences describing the overall goals for this Pull Request.
 
A list of issues is at https://github.com/qgis/QGIS-Documentation/issues.
Add "fix #issuenumber" for each issue the PR fixes. The ticket(s) will be closed automatically.
If your PR doesn't fix entirely the ticket, only add the ticket(s) reference preceded by # character.
-->
Goal:

The "Slope" QGIS algorithm has the following line in the description:

`In the following picture you can see to the left the DTM layer with the elevation of the terrain while to the right the calculated slope:`

Anyway, the picture only shows the slope and not the DTM.

I propose to remove the whole line. Alternatively the line could be rewritten as:

`In the following picture you can see the calculated slope:`

Ticket(s): #
<!---
Indicate whether the fix should be backported to previous release.
Replace the space between square brackets by a `x` to make it checked.
-->
- [x] Backport to LTR documentation is requested

<!---
Reviewing is a process done by community members, mostly on a volunteer basis.
We try to keep the overhead as small as possible and appreciate if you help us.
Please read carefully and ensure you comply with our writing guidelines at
https://docs.qgis.org/testing/en/docs/documentation_guidelines/index.html.
Feel free to ask in a comment or the (qgis-community-team mailing list)
[https://lists.osgeo.org/mailman/listinfo/qgis-community-team] if you have troubles with any item.
--->
