### PR TITLE
Fix email addresses

### DIFF
--- a/docs/training_manual/foreword/foreword.rst
+++ b/docs/training_manual/foreword/foreword.rst
@@ -117,14 +117,14 @@ of the core content and be published under the same license.
 
 Authors
 -------
-* Rüdiger Thiede (rudi@linfiniti.com) - Rudi has written the QGIS instructional
+* Rüdiger Thiede - Rudi has written the QGIS instructional
   materials and parts of the PostGIS materials.
-* Tim Sutton (tim@linfiniti.com) - Tim has overseen and guided the project and
+* Tim Sutton (tim@kartoza.com) - Tim has overseen and guided the project and
   co-authored the PostgreSQL and PostGIS parts. Tim also authored the custom
   sphinx theme used for this manual.
 * Horst Düster (horst.duester@kappasys.ch ) - Horst co-authored the PostgreSQL
   and PostGIS parts
-* Marcelle Sutton (marcelle@linfiniti.com) - Marcelle provided proof-reading
+* Marcelle Sutton - Marcelle provided proof-reading
   and editorial advice during the creation of this work.
 
 Individual Contributors


### PR DESCRIPTION
The contact addresses in the foreward are old and no longer relevant. @DelazJ maybe we should rework this forward - it is nice to keep the history but it would be good to acknowledge others who have contributed to the manual too.
