### PR TITLE
Fix some typos in the FORCE_RASTER parameter (Export print/atlas layout as PDF)

### DIFF
--- a/docs/user_manual/processing_algs/qgis/cartography.rst
+++ b/docs/user_manual/processing_algs/qgis/cartography.rst
@@ -658,7 +658,7 @@ Advanced parameters
      - [boolean]
 
        Default: False
-     - forces all the items in the map to be rasterized.
+     - Forces all the items in the map to be rasterized.
        This parameter takes precedence over the ``FORCE_VECTOR`` parameter.
    * - **Append georeference information**
      - ``GEOREFERENCE``
@@ -834,7 +834,7 @@ Advanced parameters
      - [boolean]
 
        Default: False
-     - forces all the items in the map to be rasterized.
+     - Forces all the items in the map to be rasterized.
        This parameter takes precedence over the ``FORCE_VECTOR`` parameter.
    * - **Append georeference information**
      - ``GEOREFERENCE``
@@ -1085,10 +1085,10 @@ Advanced parameters
 
        |328|
      - ``FORCE_RASTER``
-     - [enumeration]
+     - [boolean]
 
        Default: False
-     - forces all the items in the map to be rasterized.
+     - Forces all the items in the map to be rasterized.
        This parameter takes precedence over the ``FORCE_VECTOR`` parameter.
    * - **Append georeference information**
      - ``GEOREFERENCE``


### PR DESCRIPTION
<!---
Include a few sentences describing the overall goals for this Pull Request.
 
A list of issues is at https://github.com/qgis/QGIS-Documentation/issues.
Add "fix #issuenumber" for each issue the PR fixes. The ticket(s) will be closed automatically.
If your PR doesn't fix entirely the ticket, only add the ticket(s) reference preceded by # character.
-->
Goal:

Fixes the capitalisation of the `FORCE_RASTER` parameter description in the "Export print layout as PDF", "Export atlas layout as PDF (multiple files)" and "Export atlas layout as PDF (single file)" processing algorithms and the the `FORCE_RASTER` parameter Type in the "Export print layout as PDF" processing algorithm.

Ticket(s): #
<!---
Indicate whether the fix should be backported to previous release.
Replace the space between square brackets by a `x` to make it checked.
-->
- [ ] Backport to LTR documentation is requested

<!---
Reviewing is a process done by community members, mostly on a volunteer basis.
We try to keep the overhead as small as possible and appreciate if you help us.
Please read carefully and ensure you comply with our writing guidelines at
https://docs.qgis.org/testing/en/docs/documentation_guidelines/index.html.
Feel free to ask in a comment or the (qgis-community-team mailing list)
[https://lists.osgeo.org/mailman/listinfo/qgis-community-team] if you have troubles with any item.
--->
