### PR TITLE
Base64 string for Raster image marker and SVG marker symbologies

### DIFF
--- a/docs/user_manual/style_library/symbol_selector.rst
+++ b/docs/user_manual/style_library/symbol_selector.rst
@@ -229,8 +229,9 @@ Appropriate for point geometry features, marker symbols have several
 .. _raster_image_marker:
 
 * **Raster image marker**: use an image (:file:`PNG`, :file:`JPG`, :file:`BMP` ...)
-  as marker symbol. The image can be a file on the disk, a remote URL
-  or embedded in the style database (:ref:`more details <embedded_file_selector>`).
+  as marker symbol. The image can be a file on the disk, a remote URL, embedded
+  in the style database (:ref:`more details <embedded_file_selector>`) or it can
+  be encoded as a base64 string.
   Width and height of the image can be set independently or using the
   |lockedGray| :sup:`Lock aspect ratio`. The size can be set using any of the
   :ref:`common units <unit_selector>` or as a percentage of the image's original
@@ -243,8 +244,9 @@ Appropriate for point geometry features, marker symbols have several
   :menuselection:`Settings --> Options... --> System` menu) to render as marker
   symbol. Width and height of the symbol can be set independently or using the
   |lockedGray| :sup:`Lock aspect ratio`. Each SVG file colors and stroke can
-  also be adapted. The image can be a file on the disk, a remote URL or
-  embedded in the style database (:ref:`more details <embedded_file_selector>`).
+  also be adapted. The image can be a file on the disk, a remote URL, embedded
+  in the style database (:ref:`more details <embedded_file_selector>`) or it can
+  be encoded as a base64 string.
 
   The symbol can also be set with :guilabel:`Dynamic SVG parameters`.
   See :ref:`svg_symbol` section to parametrize an SVG symbol.


### PR DESCRIPTION
<!---
Include a few sentences describing the overall goals for this Pull Request.
 
A list of issues is at https://github.com/qgis/QGIS-Documentation/issues.
Add "fix #issuenumber" for each issue the PR fixes. The ticket(s) will be closed automatically.
If your PR doesn't fix entirely the ticket, only add the ticket(s) reference preceded by # character.
-->
Goal:

It is possible to specify a Raster image marker or an SVG marker as a base64 string (in the form `base64:` followed by the base64 encoded imgage).
This is useful when the user wants to use an image/svg stored in a BLOB field as a Raster image / SVG marker just using the Data Defined Override expression `'base64:' || to_base64("blob_image_field")`.

See thread at https://github.com/qgis/QGIS-Documentation/pull/4641/files#r1000413560.

Ticket(s): #
<!---
Indicate whether the fix should be backported to previous release.
Replace the space between square brackets by a `x` to make it checked.
-->
- [ ] Backport to LTR documentation is requested

<!---
Reviewing is a process done by community members, mostly on a volunteer basis.
We try to keep the overhead as small as possible and appreciate if you help us.
Please read carefully and ensure you comply with our writing guidelines at
https://docs.qgis.org/testing/en/docs/documentation_guidelines/index.html.
Feel free to ask in a comment or the (qgis-community-team mailing list)
[https://lists.osgeo.org/mailman/listinfo/qgis-community-team] if you have troubles with any item.
--->
