### PR TITLE
Fix bugs

### DIFF
--- a/docs/pyqgis_developer_cookbook/canvas.rst
+++ b/docs/pyqgis_developer_cookbook/canvas.rst
@@ -338,7 +338,7 @@ default entries when you right-click over the map canvas.
         subMenu = menu.addMenu('My Menu')
         action = subMenu.addAction('My Action')
         action.triggered.connect(lambda *args:
-                                 print(f'Action triggered at {event.x},{event.y()}'))
+                                 print(f'Action triggered at {event.x()},{event.y()}'))
 
     canvas.contextMenuAboutToShow.connect(populateContextMenu)
     canvas.show()
@@ -404,10 +404,10 @@ described before to show the selected rectangle as it is being defined.
       if startPoint.x() == endPoint.x() or startPoint.y() == endPoint.y():
         return
 
-      point1 = QgsPoint(startPoint.x(), startPoint.y())
-      point2 = QgsPoint(startPoint.x(), endPoint.y())
-      point3 = QgsPoint(endPoint.x(), endPoint.y())
-      point4 = QgsPoint(endPoint.x(), startPoint.y())
+      point1 = QgsPointXY(startPoint.x(), startPoint.y())
+      point2 = QgsPointXY(startPoint.x(), endPoint.y())
+      point3 = QgsPointXY(endPoint.x(), endPoint.y())
+      point4 = QgsPointXY(endPoint.x(), startPoint.y())
 
       self.rubberBand.addPoint(point1, False)
       self.rubberBand.addPoint(point2, False)


### PR DESCRIPTION
Line 341: parenthesis were missing, therefore a reference to a function was printed instead of the result of that function
Line 407-410: GgsRubberBand.addPoint expects QgsPointXY (intead of QgsPoint) https://qgis.org/pyqgis/master/gui/QgsRubberBand.html#qgis.gui.QgsRubberBand.addPoint

<!---
Include a few sentences describing the overall goals for this Pull Request.
 
A list of issues is at https://github.com/qgis/QGIS-Documentation/issues.
Add "fix #issuenumber" for each issue the PR fixes. The ticket(s) will be closed automatically.
If your PR doesn't fix entirely the ticket, only add the ticket(s) reference preceded by # character.
-->
Goal:

Ticket(s): #
<!---
Indicate whether the fix should be backported to previous release.
Replace the space between square brackets by a `x` to make it checked.
-->
- [ ] Backport to LTR documentation is requested

<!---
Reviewing is a process done by community members, mostly on a volunteer basis.
We try to keep the overhead as small as possible and appreciate if you help us.
Please read carefully and ensure you comply with our writing guidelines at
https://docs.qgis.org/testing/en/docs/documentation_guidelines/index.html.
Feel free to ask in a comment or the (qgis-community-team mailing list)
[https://lists.osgeo.org/mailman/listinfo/qgis-community-team] if you have troubles with any item.
--->
