### PR TITLE
Explain WMS request step size, fixes #1703

### DIFF
--- a/docs/user_manual/working_with_ogc/ogc_client_support.rst
+++ b/docs/user_manual/working_with_ogc/ogc_client_support.rst
@@ -300,9 +300,9 @@ You can define:
 
 * :guilabel:`Tile size` if you want to set tile sizes (e.g., 256x256)
   to split up the WMS request into multiple requests.
-* :guilabel:`Request step size` if you want to reduce the effect of cut labels at tile 
+* :guilabel:`Request step size`: if you want to reduce the effect of cut labels at tile 
   borders, increasing the step size creates larger requests, fewer tiles and fewer borders. 
-  The default value is is 2000.
+  The default value is 2000.
 * The :guilabel:`Maximum number of GetFeatureInfo results` from the server
 
 * Each WMS layer can be presented in multiple CRSs, depending on the capability of

--- a/docs/user_manual/working_with_ogc/ogc_client_support.rst
+++ b/docs/user_manual/working_with_ogc/ogc_client_support.rst
@@ -300,7 +300,9 @@ You can define:
 
 * :guilabel:`Tile size` if you want to set tile sizes (e.g., 256x256)
   to split up the WMS request into multiple requests.
-* The :guilabel:`Request step size`
+* :guilabel:`Request step size` if you want to reduce the effect of cut labels at tile 
+  borders, increasing the step size creates larger requests, fewer tiles and fewer borders. 
+  The default value is is 2000.
 * The :guilabel:`Maximum number of GetFeatureInfo results` from the server
 
 * Each WMS layer can be presented in multiple CRSs, depending on the capability of


### PR DESCRIPTION
For future reference: explanations from @jef-n:

* The tile size limits the request size.  the wms provider splits bigger requests into smaller ones of that size (to meet the wms server non-advertised limits).  by default there is no limit.   raster iterators produce requests (not only for wms) of 2000x2000 by default - and you can change that for wms to something higher to reduce cutting labels (as in redmine #16182 aka gh #24092)

* tile size just make the wms provider split the request.  and step size changes the default for the iteratators (not sure if those do overlapping requests)

* The iterator was written by Marco Hugentobler back in 2012

<!---
Include a few sentences describing the overall goals for this Pull Request.
 
A list of issues is at https://github.com/qgis/QGIS-Documentation/issues.
Add "fix #issuenumber" for each issue the PR fixes. The ticket(s) will be closed automatically.
If your PR doesn't fix entirely the ticket, only add the ticket(s) reference preceded by # character.
-->
Goal:

Ticket(s): #
<!---
Indicate whether the fix should be backported to previous release.
Replace the space between square brackets by a `x` to make it checked.
-->
- [x] Backport to LTR documentation is requested

<!---
Reviewing is a process done by community members, mostly on a volunteer basis.
We try to keep the overhead as small as possible and appreciate if you help us.
Please read carefully and ensure you comply with our writing guidelines at
https://docs.qgis.org/testing/en/docs/documentation_guidelines/index.html.
Feel free to ask in a comment or the (qgis-community-team mailing list)
[https://lists.osgeo.org/mailman/listinfo/qgis-community-team] if you have troubles with any item.
--->
