### PR TITLE
Fix raster type output

### DIFF
--- a/docs/pyqgis_developer_cookbook/raster.rst
+++ b/docs/pyqgis_developer_cookbook/raster.rst
@@ -114,7 +114,7 @@ The following code assumes ``rlayer`` is a
 
 .. testoutput:: raster
 
-    0
+    RasterLayerType.GrayOrUndefined
 
 .. testcode:: raster
 


### PR DESCRIPTION
Fixes doctest build (https://github.com/qgis/QGIS-Documentation/actions/runs/3752875442/jobs/6375530260#step:6:571), probably an api change