### PR TITLE
Running Validity checks when exporting layout

### DIFF
--- a/docs/user_manual/print_composer/create_output.rst
+++ b/docs/user_manual/print_composer/create_output.rst
@@ -57,6 +57,11 @@ are:
 * :guilabel:`Exclude item from exports` in the :ref:`item properties
   <layout_Rendering_Mode>` panel
 
+Moreover, a number of predefined checks are automatically applied to the layout.
+Currently these checks include testing that scalebars are correctly linked to map items,
+and that map overview items are also correctly linked to a map.
+If the checks fail, you are shown a nice warning advising you of the issue.
+
 
 .. _export_layout_image:
 


### PR DESCRIPTION
* Mention automatic predefined layouts validity checks (fixes #3350)
* Add code samples for running various layout validity checks (fixes #3351, fixes #3291)