### PR TITLE
Add sphinx_copybutton extension

### DIFF
--- a/.github/workflows/pofiles.yml
+++ b/.github/workflows/pofiles.yml
@@ -32,7 +32,7 @@ jobs:
     - name: Install dependencies
       run: |
           python -m pip install --upgrade pip
-          pip install sphinx sphinx-intl sphinxext.rediraffe pyYAML sphinx_togglebutton
+          pip install sphinx sphinx-intl sphinxext.rediraffe pyYAML sphinx_togglebutton sphinx_copybutton
 
     - name: Generate English PO files
       id: "generate-po-files"

--- a/REQUIREMENTS.txt
+++ b/REQUIREMENTS.txt
@@ -4,6 +4,7 @@ sphinx_rtd_theme
 sphinx-intl[transifex]
 sphinxext-rediraffe
 sphinx_togglebutton
+sphinx_copybutton
 transifex-client
 PyYAML
 pdflatex

--- a/conf.py
+++ b/conf.py
@@ -57,6 +57,7 @@ extensions = [
     'sphinx.ext.extlinks',
     'sphinxext.rediraffe',
     'sphinx_togglebutton',
+    'sphinx_copybutton'
 ]
 
 # Add any paths that contain templates here, relative to this directory.


### PR DESCRIPTION
Goal:

Add the [sphinx_copybutton](https://sphinx-copybutton.readthedocs.io/en/latest/index.html) extension in order to facilitate the code copy of the cookbook.

![image](https://user-images.githubusercontent.com/2884884/213391580-4cc359d0-6498-4c2f-bc52-ca64faf578f6.png)



- [x] Backport to LTR documentation is requested

<!---
Reviewing is a process done by community members, mostly on a volunteer basis.
We try to keep the overhead as small as possible and appreciate if you help us.
Please read carefully and ensure you comply with our writing guidelines at
https://docs.qgis.org/testing/en/docs/documentation_guidelines/index.html.
Feel free to ask in a comment or the (qgis-community-team mailing list)
[https://lists.osgeo.org/mailman/listinfo/qgis-community-team] if you have troubles with any item.
--->
