### PR TITLE
Fix python requirements

### DIFF
--- a/REQUIREMENTS.txt
+++ b/REQUIREMENTS.txt
@@ -9,4 +9,4 @@ sphinxext-rediraffe
 sphinx_togglebutton
 requests==2.25.1
 sphinx_copybutton
-
+transifex-client

--- a/REQUIREMENTS.txt
+++ b/REQUIREMENTS.txt
@@ -1,13 +1,12 @@
-# Memo: Should also be added to https://github.com/qgis/QGIS-Website/blob/master/REQUIREMENTS.txt
-# for docker image builds
-
-Sphinx
-sphinx-intl
-sphinx_rtd_theme
+Sphinx==4.5
+sphinx-intl==2.0.1
 sphinx-intl[transifex]
+icalendar
+PyYAML
+sphinx_rtd_theme
+pdflatex
 sphinxext-rediraffe
 sphinx_togglebutton
+requests==2.25.1
 sphinx_copybutton
-transifex-client
-PyYAML
-pdflatex
+


### PR DESCRIPTION
Goal:
Fixes issue with `docutils` dependency on fresh builds. This also makes the python environment match
the website. I just pulled the `REQUIREMENTS.txt` from the QGIS-Website repo and added back the missing `transifix-client` that is missing from the website version and therefore was removed.

Ticket(s): #
fix #8024
- [ ] Backport to LTR documentation is requested

Notes:
Some of the "deletions" are really just items being re-ordered. As stated above, the `transifix-client` item was the only one actually removed (and put back).