### PR TITLE
More verbose CRS map units

### DIFF
--- a/docs/pyqgis_developer_cookbook/crs.rst
+++ b/docs/pyqgis_developer_cookbook/crs.rst
@@ -126,7 +126,7 @@ Output:
    Ellipsoid Acronym: EPSG:7030
    Proj String: +proj=longlat +datum=WGS84 +no_defs
    Is geographic: True
-   Map units: 6
+   Map units: DistanceUnit.Degrees
 
 .. index:: Projections
 


### PR DESCRIPTION
Fixes [doctest failure](https://github.com/qgis/QGIS-Documentation/actions/runs/4230121034/jobs/7347125537#step:6:576), probably due to https://github.com/qgis/QGIS/pull/51948

> Expected:
    QGIS CRS ID: 3452
    PostGIS SRID: 4326
    Description: WGS 84
    Projection Acronym: longlat
    Ellipsoid Acronym: EPSG:7030
    Proj String: +proj=longlat +datum=WGS84 +no_defs
    Is geographic: True
    Map units: 6
Got:
    QGIS CRS ID: 3452
    PostGIS SRID: 4326
    Description: WGS 84
    Projection Acronym: longlat
    Ellipsoid Acronym: EPSG:7030
    Proj String: +proj=longlat +datum=WGS84 +no_defs
    Is geographic: True
    Map units: DistanceUnit.Degrees
