### PR TITLE
[3.22] Store translation statistics inside substitutions

### DIFF
--- a/docs/user_manual/preamble/translation_stats.rst
+++ b/docs/user_manual/preamble/translation_stats.rst
@@ -6,7 +6,7 @@
 Statistics of translation
 ===========================
 
-*(last update: 2023-02-28)*
+*Last update:* |today|
 
 .. list-table::
    :widths: auto
@@ -14,9 +14,9 @@ Statistics of translation
    * - Number of strings
      - Number of target languages
      - Overall Translation ratio
-   * - **33754**
-     - **58**
-     - **13.45%**
+   * - |total_strings|
+     - |nb_languages|
+     - |global_percentage|
 
 
 
@@ -30,124 +30,190 @@ Statistics of translation
      - Language
      - Translation ratio (%)
    * - Albanian
-     - 0.21
+     - |stats_sq|
      - Arabic
-     - 3.69
+     - |stats_ar|
      - Azerbaijani
-     - 0.02
+     - |stats_az|
    * - Basque
-     - 0.82
+     - |stats_eu|
      - Bengali
-     - 0.16
+     - |stats_bn|
      - Bulgarian
-     - 2.34
+     - |stats_bg|
    * - Burmese
-     - 0.09
+     - |stats_my|
      - Catalan
-     - 1.38
+     - |stats_ca|
      - Chinese Simplified
-     - 19.52
+     - |stats_zh-Hans|
    * - Chinese Traditional
-     - 0.58
+     - |stats_zh-Hant|
      - Croatian
-     - 0.1
+     - |stats_hr|
      - Czech
-     - 5.36
+     - |stats_cs|
    * - Danish
-     - 0.62
+     - |stats_da|
      - Dutch
-     - 100.0
+     - |stats_nl|
      - Estonian
-     - 1.23
+     - |stats_et|
    * - Finnish
-     - 1.65
+     - |stats_fi|
      - French
-     - 88.35
+     - |stats_fr|
      - Galician
-     - 0.43
+     - |stats_gl|
    * - Georgian
-     - 0.09
+     - |stats_ka|
      - German
-     - 21.2
+     - |stats_de|
      - Greek
-     - 0.35
+     - |stats_el|
    * - Hebrew
-     - 0.71
+     - |stats_he|
      - Hindi
-     - 0.28
+     - |stats_hi|
      - Hungarian
-     - 17.49
+     - |stats_hu|
    * - Igbo
-     - 0.01
+     - |stats_ig|
      - Indonesian
-     - 2.6
+     - |stats_id|
      - Italian
-     - 100.0
+     - |stats_it|
    * - Japanese
-     - 75.92
+     - |stats_ja|
      - Kabyle
-     - 0.09
+     - |stats_kab|
      - Korean
-     - 76.02
+     - |stats_ko|
    * - Lithuanian
-     - 6.58
+     - |stats_lt|
      - Macedonian
-     - 0.11
+     - |stats_mk|
      - Malay
-     - 0.04
+     - |stats_ms|
    * - Malayalam
-     - 0.09
+     - |stats_ml|
      - Marathi
-     - 0.18
+     - |stats_mr|
      - Mongolian
-     - 0.1
+     - |stats_mn|
    * - N'ko
-     - 1.69
+     - |stats_nqo|
      - Norwegian Bokmål
-     - 2.94
+     - |stats_nb|
      - Panjabi (Punjabi)
-     - 0.0
+     - |stats_pa|
    * - Persian
-     - 0.39
+     - |stats_fa|
      - Polish
-     - 1.66
+     - |stats_pl|
      - Portuguese (Brazil)
-     - 74.05
+     - |stats_pt_BR|
    * - Portuguese (Portugal)
-     - 7.69
+     - |stats_pt_PT|
      - Romanian
-     - 40.21
+     - |stats_ro|
      - Russian
-     - 12.42
+     - |stats_ru|
    * - Serbian
-     - 0.1
+     - |stats_sr|
      - Slovak
-     - 1.2
+     - |stats_sk|
      - Slovenian
-     - 2.97
+     - |stats_sl|
    * - Spanish
-     - 99.71
+     - |stats_es|
      - Swedish
-     - 0.93
+     - |stats_sv|
      - Tagalog
-     - 0.09
+     - |stats_tl|
    * - Tamil
-     - 0.45
+     - |stats_ta|
      - Telugu
-     - 0.03
+     - |stats_te|
      - Thai
-     - 0.1
+     - |stats_th|
    * - Turkish
-     - 2.66
+     - |stats_tr|
      - Ukrainian
-     - 2.16
+     - |stats_uk|
      - Urdu
-     - 0.0
+     - |stats_ur|
    * - Vietnamese
-     - 0.22
+     - |stats_vi|
      -
      -
      -
      -
 
+
+.. list of substitutions for the statistics:
+
+.. |today| replace:: *2023-03-03*
+.. |total_strings| replace:: **33752**
+.. |nb_languages| replace:: **58**
+.. |global_percentage| replace:: **13.47%**
+
+.. |stats_sq| replace:: 0.21
+.. |stats_ar| replace:: 3.69
+.. |stats_az| replace:: 0.02
+.. |stats_eu| replace:: 0.82
+.. |stats_bn| replace:: 0.16
+.. |stats_bg| replace:: 2.34
+.. |stats_my| replace:: 0.09
+.. |stats_ca| replace:: 1.38
+.. |stats_zh-Hans| replace:: 19.52
+.. |stats_zh-Hant| replace:: 0.58
+.. |stats_hr| replace:: 0.1
+.. |stats_cs| replace:: 5.36
+.. |stats_da| replace:: 0.62
+.. |stats_nl| replace:: 100.0
+.. |stats_et| replace:: 1.23
+.. |stats_fi| replace:: 1.65
+.. |stats_fr| replace:: 88.82
+.. |stats_gl| replace:: 0.43
+.. |stats_ka| replace:: 0.09
+.. |stats_de| replace:: 21.72
+.. |stats_el| replace:: 0.35
+.. |stats_he| replace:: 0.71
+.. |stats_hi| replace:: 0.28
+.. |stats_hu| replace:: 17.49
+.. |stats_ig| replace:: 0.01
+.. |stats_id| replace:: 2.6
+.. |stats_it| replace:: 99.96
+.. |stats_ja| replace:: 75.93
+.. |stats_kab| replace:: 0.09
+.. |stats_ko| replace:: 76.03
+.. |stats_lt| replace:: 6.58
+.. |stats_mk| replace:: 0.11
+.. |stats_ms| replace:: 0.04
+.. |stats_ml| replace:: 0.09
+.. |stats_mr| replace:: 0.18
+.. |stats_mn| replace:: 0.1
+.. |stats_nqo| replace:: 1.69
+.. |stats_nb| replace:: 2.94
+.. |stats_pa| replace:: 0.0
+.. |stats_fa| replace:: 0.39
+.. |stats_pl| replace:: 1.67
+.. |stats_pt_BR| replace:: 74.2
+.. |stats_pt_PT| replace:: 7.69
+.. |stats_ro| replace:: 40.21
+.. |stats_ru| replace:: 12.42
+.. |stats_sr| replace:: 0.1
+.. |stats_sk| replace:: 1.2
+.. |stats_sl| replace:: 2.97
+.. |stats_es| replace:: 99.79
+.. |stats_sv| replace:: 0.93
+.. |stats_tl| replace:: 0.09
+.. |stats_ta| replace:: 0.45
+.. |stats_te| replace:: 0.03
+.. |stats_th| replace:: 0.1
+.. |stats_tr| replace:: 2.66
+.. |stats_uk| replace:: 2.16
+.. |stats_ur| replace:: 0.0
+.. |stats_vi| replace:: 0.22
 

--- a/scripts/load_tx_stats.py
+++ b/scripts/load_tx_stats.py
@@ -112,16 +112,21 @@ def load_overall_stats():
             f"   * - Number of strings\n"
             f"     - Number of target languages\n"
             f"     - Overall Translation ratio\n"
-            f"   * - **{total_strings}**\n"
-            f"     - **{nb_languages}**\n"
-            f"     - **{global_percentage}%**\n"
+            f"   * - |total_strings|\n"
+            f"     - |nb_languages|\n"
+            f"     - |global_percentage|\n"
             "\n")
 
     return text
 
 
 def load_lang_stats(target_langs, nb_columns=1):
-    """Format statistics of translated languages into a multi-column table"""
+    """
+    Formats statistics of translated languages into a multi-column table
+    :param target_langs: list of languages available in the project
+    :param nb_columns: number of columns in the table
+    :return: a formatted table with full text language and percentage of translation
+    """
 
     text = (".. list-table::\n"
             "   :widths: auto\n"
@@ -141,7 +146,7 @@ def load_lang_stats(target_langs, nb_columns=1):
             else:
                 text += (f"     - {target_langs[lang]['name']}\n")
 
-            text += (f"     - {target_langs[lang]['percentage']}\n")
+            text += (f"     - |stats_{lang}|\n")
             i += 1
 
     # Add empty cells to keep a well formatted rst table
@@ -153,6 +158,26 @@ def load_lang_stats(target_langs, nb_columns=1):
 
     return text
 
+
+def load_lang_substitutions(target_langs):
+    """
+    Create list of substitutions for the statistics
+    :param target_langs: the list of available languages
+    :return: formated list of text substitutions
+    """
+
+    text = (f".. list of substitutions for the statistics:\n\n"
+            f".. |today| replace:: *{date.today()}*\n"
+            f".. |total_strings| replace:: **{total_strings}**\n"
+            f".. |nb_languages| replace:: **{nb_languages}**\n"
+            f".. |global_percentage| replace:: **{global_percentage}%**\n\n"
+            )
+
+    for lang in target_langs:
+        if lang != 'en':
+            text += (f".. |stats_{lang}| replace:: {target_langs[lang]['percentage']}\n")
+
+    return text
 
 # Store the stats as a table in a rst file
 statsfile = path.join(path.dirname(__file__),
@@ -167,10 +192,12 @@ with open(statsfile, 'w') as f:
             f"Statistics of translation\n"
             f"===========================\n\n"
 
-            f"*(last update: {date.today()})*"
+            f"*Last update:* |today|"
             f"\n\n"
             f"{load_overall_stats()}"
             f"\n\n"
             f"{load_lang_stats(language_rate, nb_columns=3)}"
             f"\n\n"
+            f"{load_lang_substitutions(language_rate)}"
+            f"\n"
             )


### PR DESCRIPTION
to avoid having to translate them at every iteration
Backports #8085

<!---
Include a few sentences describing the overall goals for this Pull Request.
 
A list of issues is at https://github.com/qgis/QGIS-Documentation/issues.
Add "fix #issuenumber" for each issue the PR fixes. The ticket(s) will be closed automatically.
If your PR doesn't fix entirely the ticket, only add the ticket(s) reference preceded by # character.
-->
Goal:

Ticket(s): #
<!---
Indicate whether the fix should be backported to previous release.
Replace the space between square brackets by a `x` to make it checked.
-->
- [ ] Backport to LTR documentation is requested

<!---
Reviewing is a process done by community members, mostly on a volunteer basis.
We try to keep the overhead as small as possible and appreciate if you help us.
Please read carefully and ensure you comply with our writing guidelines at
https://docs.qgis.org/testing/en/docs/documentation_guidelines/index.html.
Feel free to ask in a comment or the (qgis-community-team mailing list)
[https://lists.osgeo.org/mailman/listinfo/qgis-community-team] if you have troubles with any item.
--->
