### PR TITLE
Shadow not Mask part of Text

### DIFF
--- a/docs/user_manual/style_library/label_settings.rst
+++ b/docs/user_manual/style_library/label_settings.rst
@@ -91,13 +91,13 @@ item, you will be given the following options:
      - |checkbox|
      - |checkbox|
    * - :guilabel:`Mask`
-     - |checkbox|
+     - 
      - |checkbox|
    * - :guilabel:`Background`
      - |checkbox|
      - |checkbox|
    * - :guilabel:`Shadow`
-     -
+     - |checkbox|
      - |checkbox|
    * - :guilabel:`Callout`
      -


### PR DESCRIPTION
The table showing the difference between text and label settings was not correct.

<!---
Include a few sentences describing the overall goals for this Pull Request.
 
A list of issues is at https://github.com/qgis/QGIS-Documentation/issues.
Add "fix #issuenumber" for each issue the PR fixes. The ticket(s) will be closed automatically.
If your PR doesn't fix entirely the ticket, only add the ticket(s) reference preceded by # character.
-->
Goal:

Ticket(s): #
<!---
Indicate whether the fix should be backported to previous release.
Replace the space between square brackets by a `x` to make it checked.
-->
- [x] Backport to LTR documentation is requested

<!---
Reviewing is a process done by community members, mostly on a volunteer basis.
We try to keep the overhead as small as possible and appreciate if you help us.
Please read carefully and ensure you comply with our writing guidelines at
https://docs.qgis.org/testing/en/docs/documentation_guidelines/index.html.
Feel free to ask in a comment or the (qgis-community-team mailing list)
[https://lists.osgeo.org/mailman/listinfo/qgis-community-team] if you have troubles with any item.
--->
