### PR TITLE
Auto-pull translation statistics to master branch

### DIFF
--- a/.github/workflows/translation_statistics.yml
+++ b/.github/workflows/translation_statistics.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        target_branch: [release_3.28]
+        target_branch: [master, release_3.28]
     env:
       TRANSIFEX_PASSWORD: ${{ secrets.TRANSIFEX_PASSWORD }}
 
@@ -36,7 +36,23 @@ jobs:
     - name: Report statistics
       run: python3 ./scripts/load_tx_stats.py $TRANSIFEX_PASSWORD
 
-    - name: Commit changes
+    - name: Commit changes to LTR
+      if: ${{ matrix.target_branch }} != "master"
       uses: stefanzweifel/git-auto-commit-action@v4
       with:
-        commit_message: Update statistics of translation
+        commit-message: Update statistics of translation
+
+    - id: create_pr
+      if: ${{ matrix.target_branch }} == "master"
+      name: Create Pull Request for master
+      uses: peter-evans/create-pull-request@v4
+      with:
+        commit-message: Update statistics of translation
+        title: Update statistics of translation
+        delete-branch: true
+        labels: Translation
+
+    - name: Enable Pull Request Automerge
+      run: gh pr merge --rebase --auto "${{ steps.create_pr.outputs.pull-request-number }}"
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
It used to fail due to branch protection; let's then create a pr and auto-merge it to master
There might be a straighter approach but this one might work also (kind of tested on my repo)