### PR TITLE
Consolidating github actions with best practices

### DIFF
--- a/.github/workflows/auto-label.yml
+++ b/.github/workflows/auto-label.yml
@@ -1,7 +1,3 @@
-
-
-
-
 name: "Set Issue Label for issues from main QGIS repo"
 on:
   issues:

--- a/.github/workflows/auto-label.yml
+++ b/.github/workflows/auto-label.yml
@@ -7,11 +7,23 @@ on:
   issues:
     types: [opened]
 
+permissions:
+  contents: read
+
 jobs:
   test:
+    permissions:
+      issues: write
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     runs-on: ubuntu-latest
     steps:
-      - uses: Naturalclar/issue-action@v2.0.2
+      - name: Harden Runner
+        uses: step-security/harden-runner@1f99358870fe1c846a3ccba386cc2b2246836776 # v2.2.1
+        with:
+          egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
+
+      - uses: Naturalclar/issue-action@dc881db370e1faa4bcc32ad5d3fadb6d905d8700 # v2.0.2
         with:
           title-or-body: "both"
           parameters: |
@@ -20,4 +32,4 @@ jobs:
               {"keywords": ["QGIS version: 3.32"], "labels": ["3.32"]},
               {"keywords": ["QGIS version: 3.34"], "labels": ["3.34"]}
             ]
-          github-token: "${{ secrets.GITHUB_TOKEN }}"
+          github-token: "${{ GH_TOKEN }}"

--- a/.github/workflows/auto-label.yml
+++ b/.github/workflows/auto-label.yml
@@ -27,8 +27,7 @@ jobs:
         with:
           title-or-body: "both"
           parameters: |
-            [ {"keywords": ["QGIS version: 3.28"], "labels": ["3.28"]},
-              {"keywords": ["QGIS version: 3.30"], "labels": ["3.30"]},
+            [ {"keywords": ["QGIS version: 3.30"], "labels": ["3.30"]},
               {"keywords": ["QGIS version: 3.32"], "labels": ["3.32"]},
               {"keywords": ["QGIS version: 3.34"], "labels": ["3.34"]}
             ]

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -5,13 +5,25 @@ on:
       - closed
       - labeled
 
+permissions:
+  contents: read
+
 jobs:
   backport:
+    env:
+      BACKPORT_TOKEN: ${{ secrets.BACKPORT_TOKEN }}
+    permissions:
+      pull-requests: write
     runs-on: ubuntu-latest
     name: Backport
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@1f99358870fe1c846a3ccba386cc2b2246836776 # v2.2.1
+        with:
+          egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
+
       - name: Backport Bot
         id: backport
-        uses: m-kuhn/backport@v1.2.7
+        uses: m-kuhn/backport@7f3cab83e4b3b26aefcffda21851c3dc3d389f45  #v1.2.7
         with:
-          github_token: ${{ secrets.BACKPORT_TOKEN }}
+          github_token: ${{ BACKPORT_TOKEN }}

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -52,4 +52,3 @@ jobs:
         name: ${{ matrix.format }} build
         path: build/${{ matrix.format }}
         retention-days: 15
-

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -30,10 +30,10 @@ jobs:
       uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # v3.5.0
       with:
         fetch-depth: 1
-    - name: Set up Python 3.7
+    - name: Set up Python 3.9
       uses: actions/setup-python@d27e3f3d7c64b4bbf8e4abfb9b63b83e846e0435 # v4.5.0
       with:
-        python-version: 3.7
+        python-version: 3.9
     - name: Install Requirements
       run: |
         if [[ ${{ matrix.format }} != "html" ]]; then

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -9,6 +9,9 @@ on:
     paths-ignore:
       - 'locale/**'
 
+permissions:  # added using https://github.com/step-security/secure-repo
+  contents: read
+
 jobs:
   build:
 
@@ -18,12 +21,17 @@ jobs:
         format: [html, pdf]
 
     steps:
+    - name: Harden Runner
+      uses: step-security/harden-runner@1f99358870fe1c846a3ccba386cc2b2246836776 # v2.2.1
+      with:
+        egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
+
     - name: Check out repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # v3.5.0
       with:
         fetch-depth: 1
     - name: Set up Python 3.7
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@d27e3f3d7c64b4bbf8e4abfb9b63b83e846e0435 # v4.5.0
       with:
         python-version: 3.7
     - name: Install Requirements
@@ -39,7 +47,7 @@ jobs:
       run: |
           make ${{ matrix.format }}
     - name: Upload ${{ matrix.format }} build artifact
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
       with:
         name: ${{ matrix.format }} build
         path: build/${{ matrix.format }}

--- a/.github/workflows/doctest.yml
+++ b/.github/workflows/doctest.yml
@@ -30,10 +30,10 @@ jobs:
     - uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # v3.5.0
       with:
         fetch-depth: 1
-    - name: Set up Python 3.7
+    - name: Set up Python 3.9
       uses: actions/setup-python@d27e3f3d7c64b4bbf8e4abfb9b63b83e846e0435 # v4.5.0
       with:
-        python-version: 3.7
+        python-version: 3.9
     - name: Pip upgrade
       run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/doctest.yml
+++ b/.github/workflows/doctest.yml
@@ -9,6 +9,9 @@ on:
     paths-ignore:
       - 'locale/**'
 
+permissions:  # added using https://github.com/step-security/secure-repo
+  contents: read
+
 jobs:
   doctest:
 
@@ -19,11 +22,16 @@ jobs:
       image: docker
 
     steps:
-    - uses: actions/checkout@v3
+    - name: Harden Runner
+      uses: step-security/harden-runner@1f99358870fe1c846a3ccba386cc2b2246836776 # v2.2.1
+      with:
+        egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
+
+    - uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # v3.5.0
       with:
         fetch-depth: 1
     - name: Set up Python 3.7
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@d27e3f3d7c64b4bbf8e4abfb9b63b83e846e0435 # v4.5.0
       with:
         python-version: 3.7
     - name: Pip upgrade
@@ -33,7 +41,7 @@ jobs:
       run: |
           make -f docker.mk doctest
     - name: Upload build artifact
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
       with:
         name: Doctest build
         path: ./build/doctest/output.txt

--- a/.github/workflows/pofiles.yml
+++ b/.github/workflows/pofiles.yml
@@ -34,10 +34,10 @@ jobs:
       with:
         ref: release_3.28
 
-    - name: Set up Python 3.7
+    - name: Set up Python 3.9
       uses: actions/setup-python@d27e3f3d7c64b4bbf8e4abfb9b63b83e846e0435 # v4.5.0
       with:
-        python-version: 3.7
+        python-version: 3.9
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/pofiles.yml
+++ b/.github/workflows/pofiles.yml
@@ -12,20 +12,30 @@ on:
 
   workflow_dispatch:
 
+permissions:  # added using https://github.com/step-security/secure-repo
+  contents: read
+
 jobs:
   prepare_translation:
 
+    permissions:
+      contents: write  # for stefanzweifel/git-auto-commit-action to push code in repo
     if: github.repository_owner == 'qgis'
     runs-on: ubuntu-latest
 
     steps:
+    - name: Harden Runner
+      uses: step-security/harden-runner@1f99358870fe1c846a3ccba386cc2b2246836776 # v2.2.1
+      with:
+        egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
+
     - name: checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # v3.5.0
       with:
         ref: release_3.28
 
     - name: Set up Python 3.7
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@d27e3f3d7c64b4bbf8e4abfb9b63b83e846e0435 # v4.5.0
       with:
         python-version: 3.7
 
@@ -44,7 +54,7 @@ jobs:
 
     - name: Commit the changes in the PO files      
       id: "auto-commit-action"
-      uses: stefanzweifel/git-auto-commit-action@v4
+      uses: stefanzweifel/git-auto-commit-action@3ea6ae190baf489ba007f7c92608f33ce20ef04a # v4.16.0
       with:
         commit_message: Update English PO files
 

--- a/.github/workflows/pull_minimized_translations.yml
+++ b/.github/workflows/pull_minimized_translations.yml
@@ -7,9 +7,14 @@ on:
 
   workflow_dispatch:
 
+permissions:  # added using https://github.com/step-security/secure-repo
+  contents: read
+
 jobs:
   pull_translation:
 
+    permissions:
+      contents: write  # for Git to git push
     if: github.repository_owner == 'qgis'
     runs-on: ubuntu-latest
     strategy:
@@ -20,8 +25,13 @@ jobs:
       TRANSIFEX_PASSWORD: ${{ secrets.TRANSIFEX_PASSWORD }}
 
     steps:
+    - name: Harden Runner
+      uses: step-security/harden-runner@1f99358870fe1c846a3ccba386cc2b2246836776 # v2.2.1
+      with:
+        egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
+
     - name: Check out repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # v3.5.0
       with:
         fetch-depth: 1
         ref: ${{ matrix.target_branch }}

--- a/.github/workflows/pull_minimized_translations.yml
+++ b/.github/workflows/pull_minimized_translations.yml
@@ -49,8 +49,8 @@ jobs:
     - name: Download and sanitize files and folders
       run: bash ./scripts/minimize_translation.sh
 
-#    - name: Show changes
-#      run: echo `git status`
+    # - name: Show changes
+    #   run: echo `git status`
 
     - name: Load translations if any
       run: |
@@ -64,22 +64,22 @@ jobs:
         fi
 
 
-#    - name: Pull source file using transifex client
- #     uses: transifex/cli-action@v1
-  #    with:
-   #       token: ${{ secrets.TRANSIFEX_PASSWORD }}
-    #      args: pull --force --mode onlytranslated -l fr 
+    # - name: Pull source file using transifex client
+    #   uses: transifex/cli-action@bc67c0ab1369ef941f0963d902c45d11688c8bc9 # v1
+    #   with:
+    #       token: ${{ secrets.TRANSIFEX_PASSWORD }}
+    #       args: pull --force --mode onlytranslated -l fr
 
-#    - name: Commit the changes in the PO files
- #     id: "auto-commit-action"
-#      uses: stefanzweifel/git-auto-commit-action@v4
- #     with:
- #       commit_message: 'Load translated strings'
+    # - name: Commit the changes in the PO files
+    #   id: "auto-commit-action"
+    #   uses: stefanzweifel/git-auto-commit-action@3ea6ae190baf489ba007f7c92608f33ce20ef04a # v4.16.0
+    #   with:
+    #     commit_message: 'Load translated strings'
 
-  #  - name: "Inform that changes have been made"
-   #   if: steps.auto-commit-action.outputs.changes_detected == 'true'
-    #  run: echo "Changes committed!"
+    # - name: "Inform that changes have been made"
+    #   if: steps.auto-commit-action.outputs.changes_detected == 'true'
+    #   run: echo "Changes committed!"
 
-#    - name: "Inform that no changes were performed"
- #     if: steps.auto-commit-action.outputs.changes_detected == 'false'
-  #    run: echo "No Changes detected!"
+    # - name: "Inform that no changes were performed"
+    #   if: steps.auto-commit-action.outputs.changes_detected == 'false'
+    #   run: echo "No Changes detected!"

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -14,7 +14,12 @@ jobs:
     if: github.repository_owner == 'qgis'
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/stale@v8
+    - name: Harden Runner
+      uses: step-security/harden-runner@1f99358870fe1c846a3ccba386cc2b2246836776 # v2.2.1
+      with:
+        egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
+
+    - uses: actions/stale@1160a2240286f5da8ec72b1c0816ce2481aabf84 # v8.0.0
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/translation_statistics.yml
+++ b/.github/workflows/translation_statistics.yml
@@ -7,9 +7,15 @@ on:
     - cron: '0 6 * * 2'
   workflow_dispatch:
 
+permissions:  # added using https://github.com/step-security/secure-repo
+  contents: read
+
 jobs:
   ReportTranslationStats:
 
+    permissions:
+      contents: write  # for stefanzweifel/git-auto-commit-action to push code in repo
+      pull-requests: write  # for peter-evans/create-pull-request to create a PR
     if: github.repository_owner == 'qgis'
     runs-on: ubuntu-latest
     strategy:
@@ -17,16 +23,22 @@ jobs:
         target_branch: [master, release_3.28]
     env:
       TRANSIFEX_PASSWORD: ${{ secrets.TRANSIFEX_PASSWORD }}
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     steps:
+    - name: Harden Runner
+      uses: step-security/harden-runner@1f99358870fe1c846a3ccba386cc2b2246836776 # v2.2.1
+      with:
+        egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
+
     - name: Check out repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # v3.5.0
       with:
         fetch-depth: 1
         ref: ${{ matrix.target_branch }}
 
     - name: Set up Python 3.7
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@d27e3f3d7c64b4bbf8e4abfb9b63b83e846e0435 # v4.5.0
       with:
         python-version: 3.7
 
@@ -38,14 +50,14 @@ jobs:
 
     - name: Commit changes to LTR
       if: github.ref != 'refs/heads/master'
-      uses: stefanzweifel/git-auto-commit-action@v4
+      uses: stefanzweifel/git-auto-commit-action@3ea6ae190baf489ba007f7c92608f33ce20ef04a # v4.16.0
       with:
         commit_message: Update statistics of translation
 
     - id: create_pr
       if: github.ref == 'refs/heads/master'
       name: Create Pull Request for master
-      uses: peter-evans/create-pull-request@v4
+      uses: peter-evans/create-pull-request@38e0b6e68b4c852a5500a94740f0e535e0d7ba54 # v4.2.4
       with:
         commit-message: Update statistics of translation
         title: Update statistics of translation
@@ -56,4 +68,4 @@ jobs:
       if: github.ref == 'refs/heads/master'
       run: gh pr merge --rebase --auto "${{ steps.create_pr.outputs.pull-request-number }}"
       env:
-        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GH_TOKEN: ${{ GH_TOKEN }}

--- a/.github/workflows/translation_statistics.yml
+++ b/.github/workflows/translation_statistics.yml
@@ -37,10 +37,10 @@ jobs:
         fetch-depth: 1
         ref: ${{ matrix.target_branch }}
 
-    - name: Set up Python 3.7
+    - name: Set up Python 3.9
       uses: actions/setup-python@d27e3f3d7c64b4bbf8e4abfb9b63b83e846e0435 # v4.5.0
       with:
-        python-version: 3.7
+        python-version: 3.9
 
     - name: Install dependencies
       run: python3 -m pip install requests

--- a/.github/workflows/translation_statistics.yml
+++ b/.github/workflows/translation_statistics.yml
@@ -48,14 +48,7 @@ jobs:
     - name: Report statistics
       run: python3 ./scripts/load_tx_stats.py $TRANSIFEX_PASSWORD
 
-    - name: Commit changes to LTR
-      if: github.ref != 'refs/heads/master'
-      uses: stefanzweifel/git-auto-commit-action@3ea6ae190baf489ba007f7c92608f33ce20ef04a # v4.16.0
-      with:
-        commit_message: Update statistics of translation
-
     - id: create_pr
-      if: github.ref == 'refs/heads/master'
       name: Create Pull Request for master
       uses: peter-evans/create-pull-request@38e0b6e68b4c852a5500a94740f0e535e0d7ba54 # v4.2.4
       with:
@@ -65,7 +58,6 @@ jobs:
         labels: Translation
 
     - name: Enable Pull Request Automerge
-      if: github.ref == 'refs/heads/master'
       run: gh pr merge --rebase --auto "${{ steps.create_pr.outputs.pull-request-number }}"
       env:
         GH_TOKEN: ${{ GH_TOKEN }}


### PR DESCRIPTION
[Apply security best practices to actions (inspired by https://github.com/qgis/QGIS/pull/49188 and done using https://app.stepsecurity.io/)
- Restrict permissions for GITHUB_TOKEN
- Add security agent for Github hosted runner
- Pin actions to a full length commit SHA
- I had to guess and apply some changes in backport and autolabel workflows as the actions we relied on are unknown by the service

Also raise Python version in actions to 3.9 and various cleanup.
Not 100% understanding (nor did I test) all the changes here so we'd need to monitor the repo behavior after this is merged. And of course, feedback/review welcome.