### PR TITLE
Fix Loop checkbox in temporal navigation

### DIFF
--- a/docs/user_manual/map_views/map_view.rst
+++ b/docs/user_manual/map_views/map_view.rst
@@ -262,7 +262,7 @@ To create a temporal animation:
          Temporal navigation through a layer
 
    The animation can also be previewed by moving the time slider.
-   Keeping the |refresh| :sup:`Loop` button pressed will repeatedly run the
+   Checking the |unchecked| :guilabel:`Loop` checkbox will repeatedly run the
    animation while clicking |play| stops a running animation.
    A full set of video player buttons is available.
 


### PR DESCRIPTION
There is a |refresh| button on temporal navigation panel but for different use. _Loop_ is a checkbox.
