### PR TITLE
Simplify makefile instructions for PDF outputs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,41 +69,20 @@ pdf: latex
 	# using the dvipdfmx command
 	# -interaction=batchmode in latex compiler and -q im dvipdfmx will hide errors
 	# for debugging you need to remove them
-	cd $(BUILDDIR)/latex/$(LANG); \
-	$(LATEXCOMPILER) -interaction=batchmode -shell-escape QGISDesktopUserGuide.tex; \
-	$(LATEXCOMPILER) -interaction=batchmode -shell-escape QGISDesktopUserGuide.tex; \
-	if [ "$(LATEXCOMPILER)" != "xelatex" ] && [ -f "QGISDesktopUserGuide.dvi" ]; then \
-		dvipdfmx -q QGISDesktopUserGuide.dvi; fi; \
-	$(LATEXCOMPILER) -interaction=batchmode -shell-escape QGISServerUserGuide.tex; \
-	$(LATEXCOMPILER) -interaction=batchmode -shell-escape QGISServerUserGuide.tex; \
-	if [ "$(LATEXCOMPILER)" != "xelatex" ] && [ -f "QGISServerUserGuide.dvi" ]; then \
-		dvipdfmx -q QGISServerUserGuide.dvi; fi; \
-	$(LATEXCOMPILER) -interaction=batchmode -shell-escape PyQGISDeveloperCookbook.tex; \
-	$(LATEXCOMPILER) -interaction=batchmode -shell-escape PyQGISDeveloperCookbook.tex; \
-	if [ "$(LATEXCOMPILER)" != "xelatex" ] && [ -f "PyQGISDeveloperCookbook.dvi" ]; then \
-		dvipdfmx -q PyQGISDeveloperCookbook.dvi; fi; \
-	$(LATEXCOMPILER) -interaction=batchmode -shell-escape QGISTrainingManual.tex; \
-	$(LATEXCOMPILER) -interaction=batchmode -shell-escape QGISTrainingManual.tex; \
-	if [ "$(LATEXCOMPILER)" != "xelatex" ] && [ -f "QGISTrainingManual.dvi" ]; then \
-		dvipdfmx -q QGISTrainingManual.dvi; fi; \
-	$(LATEXCOMPILER) -interaction=batchmode -shell-escape GentleGISIntroduction.tex; \
-	$(LATEXCOMPILER) -interaction=batchmode -shell-escape GentleGISIntroduction.tex; \
-	if [ "$(LATEXCOMPILER)" != "xelatex" ]  && [ -f "GentleGISIntroduction.dvi" ]; then \
-		dvipdfmx -q GentleGISIntroduction.dvi; fi; \
-	$(LATEXCOMPILER) -interaction=batchmode -shell-escape QGISDocumentationGuidelines.tex; \
-	$(LATEXCOMPILER) -interaction=batchmode -shell-escape QGISDocumentationGuidelines.tex; \
-	if [ "$(LATEXCOMPILER)" != "xelatex" ]  && [ -f "QGISDocumentationGuidelines.dvi" ]; then \
-		dvipdfmx -q QGISDocumentationGuidelines.dvi; fi;
-
-	# copy and rename PDF files to the pdf folder
+	# Then we copy and rename PDF files to the pdf folder
 	# || true allows the job to continue even if one of the files is missing
-	mkdir -p $(BUILDDIR)/pdf/$(LANG);
-	mv $(BUILDDIR)/latex/$(LANG)/QGISDesktopUserGuide.pdf $(BUILDDIR)/pdf/$(LANG)/QGIS-$(VERSION)-DesktopUserGuide-$(LANG).pdf || true;
-	mv $(BUILDDIR)/latex/$(LANG)/QGISServerUserGuide.pdf $(BUILDDIR)/pdf/$(LANG)/QGIS-$(VERSION)-ServerUserGuide-$(LANG).pdf || true;
-	mv $(BUILDDIR)/latex/$(LANG)/PyQGISDeveloperCookbook.pdf $(BUILDDIR)/pdf/$(LANG)/QGIS-$(VERSION)-PyQGISDeveloperCookbook-$(LANG).pdf || true;
-	mv $(BUILDDIR)/latex/$(LANG)/QGISTrainingManual.pdf $(BUILDDIR)/pdf/$(LANG)/QGIS-$(VERSION)-TrainingManual-$(LANG).pdf || true;
-	mv $(BUILDDIR)/latex/$(LANG)/GentleGISIntroduction.pdf $(BUILDDIR)/pdf/$(LANG)/QGIS-$(VERSION)-GentleGISIntroduction-$(LANG).pdf || true;
-	mv $(BUILDDIR)/latex/$(LANG)/QGISDocumentationGuidelines.pdf $(BUILDDIR)/pdf/$(LANG)/QGIS-$(VERSION)-DocumentationGuidelines-$(LANG).pdf || true;
+
+	for TEXFILE in $$(find $(BUILDDIR)/latex/$(LANG) -iname '*.tex' -exec basename {} .tex ';'); \
+		do \
+			cd $(BUILDDIR)/latex/$(LANG); \
+			echo $$TEXFILE; \
+			$(LATEXCOMPILER) -interaction=batchmode -shell-escape $$TEXFILE.tex; \
+			$(LATEXCOMPILER) -interaction=batchmode -shell-escape $$TEXFILE.tex; \
+			if [ "$(LATEXCOMPILER)" != "xelatex" ]  && [ -f "$$TEXFILE.dvi" ]; then \
+				dvipdfmx -q $$TEXFILE.dvi; fi; \
+			mkdir -p ../../pdf/$(LANG); \
+			mv $$TEXFILE.pdf ../../pdf/$(LANG)/QGIS-$(VERSION)-$$TEXFILE-$(LANG).pdf || true; \
+		done
 
 zip:
 	mkdir -p $(BUILDDIR)/zip;


### PR DESCRIPTION
#8181 reminds me of this branch I worked on some time ago to simplify PDF make commands. It should output same structure as today, just in a fewer lines.
I'd appreciate double-checks. @rduivenvoorde @SrNetoChan ?
(Ideally we should use the one-line [-M latexpdf](https://www.sphinx-doc.org/en/master/usage/builders/index.html#sphinx.builders.latex.LaTeXBuilder) call but I locally failed to have clean output with Japanese - maybe did I not have all the dependencies? I didn't find such a detailed page on the dependencies at that time).
<!---
Include a few sentences describing the overall goals for this Pull Request.
 
A list of issues is at https://github.com/qgis/QGIS-Documentation/issues.
Add "fix #issuenumber" for each issue the PR fixes. The ticket(s) will be closed automatically.
If your PR doesn't fix entirely the ticket, only add the ticket(s) reference preceded by # character.
-->
Goal:

Ticket(s): #
<!---
Indicate whether the fix should be backported to previous release.
Replace the space between square brackets by a `x` to make it checked.
-->
- [x] Backport to LTR documentation is requested

<!---
Reviewing is a process done by community members, mostly on a volunteer basis.
We try to keep the overhead as small as possible and appreciate if you help us.
Please read carefully and ensure you comply with our writing guidelines at
https://docs.qgis.org/testing/en/docs/documentation_guidelines/index.html.
Feel free to ask in a comment or the (qgis-community-team mailing list)
[https://lists.osgeo.org/mailman/listinfo/qgis-community-team] if you have troubles with any item.
--->
