### PR TITLE
Include note on MacBook horizontal scrolling with mouse may not work

### DIFF
--- a/docs/user_manual/working_with_vector/attribute_table.rst
+++ b/docs/user_manual/working_with_vector/attribute_table.rst
@@ -112,6 +112,8 @@ Calculator` (see :ref:`calculate_fields_values`).
 
 The attribute table support :kbd:`Shift+Mouse Wheel` scrolling in attribute table to switch to a horizontal scrolling action instead of vertical.
 
+.. note:: When it does not work on Apple MacBook, use the trackpad instead!
+
 .. _attribute_table_view:
 
 Table view vs Form view


### PR DESCRIPTION
I found out that horizontal scrolling with the scroll wheel and shift does not work for my MacBook Pro. But you can use the trackpad instead. This is a platform issue and I do not consider it a bug. Therefore I added a Note. fix #8186

<!---
Include a few sentences describing the overall goals for this Pull Request.
 
A list of issues is at https://github.com/qgis/QGIS-Documentation/issues.
Add "fix #issuenumber" for each issue the PR fixes. The ticket(s) will be closed automatically.
If your PR doesn't fix entirely the ticket, only add the ticket(s) reference preceded by # character.
-->
Goal:

Ticket(s): #
<!---
Indicate whether the fix should be backported to previous release.
Replace the space between square brackets by a `x` to make it checked.
-->
- [ ] Backport to LTR documentation is requested

<!---
Reviewing is a process done by community members, mostly on a volunteer basis.
We try to keep the overhead as small as possible and appreciate if you help us.
Please read carefully and ensure you comply with our writing guidelines at
https://docs.qgis.org/testing/en/docs/documentation_guidelines/index.html.
Feel free to ask in a comment or the (qgis-community-team mailing list)
[https://lists.osgeo.org/mailman/listinfo/qgis-community-team] if you have troubles with any item.
--->
