### PR TITLE
Indicate time zone offset next to page build time

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -40,7 +40,7 @@ master_doc = 'docs/index'
 # of the sidebar.
 html_logo = 'static/common/logo.png'
 
-html_last_updated_fmt = '%b %d, %Y %H:%M'
+html_last_updated_fmt = '%Y %b %d, %H:%M %z'
 
 
 # The version info for the project you're documenting, acts as replacement for


### PR DESCRIPTION
Fixes #8244 (based on [html_last_updated_fmt](https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-html_last_updated_fmt))
![image](https://user-images.githubusercontent.com/7983394/236671435-3e8ef2fa-c909-4feb-acd7-0e7e2d5fcc6f.png)


<!---
Include a few sentences describing the overall goals for this Pull Request.
 
A list of issues is at https://github.com/qgis/QGIS-Documentation/issues.
Add "fix #issuenumber" for each issue the PR fixes. The ticket(s) will be closed automatically.
If your PR doesn't fix entirely the ticket, only add the ticket(s) reference preceded by # character.
-->
Goal:

Ticket(s): #
<!---
Indicate whether the fix should be backported to previous release.
Replace the space between square brackets by a `x` to make it checked.
-->
- [x] Backport to LTR documentation is requested

<!---
Reviewing is a process done by community members, mostly on a volunteer basis.
We try to keep the overhead as small as possible and appreciate if you help us.
Please read carefully and ensure you comply with our writing guidelines at
https://docs.qgis.org/testing/en/docs/documentation_guidelines/index.html.
Feel free to ask in a comment or the (qgis-community-team mailing list)
[https://lists.osgeo.org/mailman/listinfo/qgis-community-team] if you have troubles with any item.
--->
