### PR TITLE
OTB plugin: remove references to the "Activate" option

### DIFF
--- a/docs/user_manual/processing/3rdParty.rst
+++ b/docs/user_manual/processing/3rdParty.rst
@@ -628,7 +628,6 @@ To configure QGIS processing to find the OTB library:
 #. You can see OTB under "Providers":
 
    #. Expand the :guilabel:`OTB` tab
-   #. Tick the :guilabel:`Activate` option
    #. Set the :guilabel:`OTB folder`. This is the location of your OTB installation.
    #. Set the :guilabel:`OTB application folder`. This is the location of your OTB
       applications ( :file:`<PATH_TO_OTB_INSTALLATION>/lib/otb/applications`)
@@ -640,9 +639,6 @@ If settings are correct, OTB algorithms will be available in the
 Documentation of OTB settings available in QGIS Processing
 ...........................................................
 
-
-* **Activate**: This is a checkbox to activate or deactivate the OTB provider.
-  An invalid OTB setting will uncheck this when saved.
 
 * **OTB folder**: This is the directory where OTB is available. 
 


### PR DESCRIPTION
<!---
Include a few sentences describing the overall goals for this Pull Request.
 
A list of issues is at https://github.com/qgis/QGIS-Documentation/issues.
Add "fix #issuenumber" for each issue the PR fixes. The ticket(s) will be closed automatically.
If your PR doesn't fix entirely the ticket, only add the ticket(s) reference preceded by # character.
-->
Goal: remove references the the OTB plugin "Activate" option: it no longer exist since QGIS 3.22: https://github.com/qgis/QGIS/commit/f3d494abe6854ab498834b012a6f8f4efb1c2807#diff-50e42408a88dce497dd6358366d0144127d91500a98241528472e56b230490c2L54

Ticket(s): #
<!---
Indicate whether the fix should be backported to previous release.
Replace the space between square brackets by a `x` to make it checked.
-->
- [x] Backport to LTR documentation is requested

<!---
Reviewing is a process done by community members, mostly on a volunteer basis.
We try to keep the overhead as small as possible and appreciate if you help us.
Please read carefully and ensure you comply with our writing guidelines at
https://docs.qgis.org/testing/en/docs/documentation_guidelines/index.html.
Feel free to ask in a comment or the (qgis-community-team mailing list)
[https://lists.osgeo.org/mailman/listinfo/qgis-community-team] if you have troubles with any item.
--->
