### PR TITLE
Normalize pdf output file name by removing QGIS prefix

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -247,19 +247,19 @@ latex_paper_size = 'a4'
 # Grouping the document tree into LaTeX files. List of tuples
 # (source start file, target name, title, author, documentclass [howto/manual]).
 latex_documents = [
-    ('docs/user_manual/index', 'QGISDesktopUserGuide.tex',
+    ('docs/user_manual/index', 'DesktopUserGuide.tex',
      f'QGIS Desktop {version} User Guide', u'QGIS Project', 'manual'),
-    ('docs/server_manual/index', 'QGISServerUserGuide.tex',
+    ('docs/server_manual/index', 'ServerUserGuide.tex',
         f'QGIS Server {version} User Guide', u'QGIS Project', 'manual'),
     ('docs/pyqgis_developer_cookbook/index', 'PyQGISDeveloperCookbook.tex',
         f'PyQGIS {version} developer cookbook', u'QGIS Project', 'manual'),
-    ('docs/training_manual/index', 'QGISTrainingManual.tex',
+    ('docs/training_manual/index', 'TrainingManual.tex',
         u'QGIS Training Manual', u'QGIS Project', 'manual'),
     ('docs/gentle_gis_introduction/index', 'GentleGISIntroduction.tex',
         u'Gentle GIS Introduction', u'QGIS Project', 'manual'),
-    ('docs/documentation_guidelines/index', 'QGISDocumentationGuidelines.tex',
+    ('docs/documentation_guidelines/index', 'DocumentationGuidelines.tex',
         u'QGIS Documentation Guidelines', u'QGIS Project', 'manual'),
-    #('docs/developers_guide/index', 'QGISDevelopersGuide.tex', u'QGIS Developers Guide', u'QGIS Project', 'manual'),
+    #('docs/developers_guide/index', 'DevelopersGuide.tex', u'QGIS Developers Guide', u'QGIS Project', 'manual'),
 ]
 
 # The name of an image file (relative to this directory) to place at the top of


### PR DESCRIPTION
Avoids redundant QGIS string in some docs output file name (QGIS-testing-**QGIS**ServerUserGuide-en.pdf instead of QGIS-testing-ServerUserGuide-en.pdf)
complements #8189 

<!---
Include a few sentences describing the overall goals for this Pull Request.
 
A list of issues is at https://github.com/qgis/QGIS-Documentation/issues.
Add "fix #issuenumber" for each issue the PR fixes. The ticket(s) will be closed automatically.
If your PR doesn't fix entirely the ticket, only add the ticket(s) reference preceded by # character.
-->
Goal:

Ticket(s): #
<!---
Indicate whether the fix should be backported to previous release.
Replace the space between square brackets by a `x` to make it checked.
-->
- [ ] Backport to LTR documentation is requested

<!---
Reviewing is a process done by community members, mostly on a volunteer basis.
We try to keep the overhead as small as possible and appreciate if you help us.
Please read carefully and ensure you comply with our writing guidelines at
https://docs.qgis.org/testing/en/docs/documentation_guidelines/index.html.
Feel free to ask in a comment or the (qgis-community-team mailing list)
[https://lists.osgeo.org/mailman/listinfo/qgis-community-team] if you have troubles with any item.
--->
