### PR TITLE
[TM] Line, not fill, for linestring features symbology

### DIFF
--- a/docs/training_manual/complete_analysis/analysis_exercise.rst
+++ b/docs/training_manual/complete_analysis/analysis_exercise.rst
@@ -284,7 +284,7 @@ Changing the symbology of vector layers
    :guilabel:`Streets` layer
 #. Select :guilabel:`Properties` from the menu that appears
 #. Switch to the :guilabel:`Symbology` tab in the dialog that appears
-#. Click on the :guilabel:`Fill` entry in the top widget
+#. Click on the :guilabel:`Line` entry in the top widget
 #. Select a symbol in the list below or set a new one (color,
    transparency, ...)
 #. Click :guilabel:`OK` to close the :guilabel:`Layer Properties`


### PR DESCRIPTION
Fixes #8317

<!---
Include a few sentences describing the overall goals for this Pull Request.
 
A list of issues is at https://github.com/qgis/QGIS-Documentation/issues.
Add "fix #issuenumber" for each issue the PR fixes. The ticket(s) will be closed automatically.
If your PR doesn't fix entirely the ticket, only add the ticket(s) reference preceded by # character.
-->
Goal:

Ticket(s): #
<!---
Indicate whether the fix should be backported to previous release.
Replace the space between square brackets by a `x` to make it checked.
-->
- [x] Backport to LTR documentation is requested

<!---
Reviewing is a process done by community members, mostly on a volunteer basis.
We try to keep the overhead as small as possible and appreciate if you help us.
Please read carefully and ensure you comply with our writing guidelines at
https://docs.qgis.org/testing/en/docs/documentation_guidelines/index.html.
Feel free to ask in a comment or the (qgis-community-team mailing list)
[https://lists.osgeo.org/mailman/listinfo/qgis-community-team] if you have troubles with any item.
--->
