### PR TITLE
Fix typo in WMS GetMap parameter

### DIFF
--- a/docs/server_manual/services/wms.rst
+++ b/docs/server_manual/services/wms.rst
@@ -543,7 +543,7 @@ and **Romania** they're highlighted in yellow.
 
 .. _wms_formatoptions:
 
-FORMAT-OPTIONS
+FORMAT_OPTIONS
 ^^^^^^^^^^^^^^
 
 This parameter can be used to specify options for the selected format.


### PR DESCRIPTION
It is FORMAT_OPTIONS not FORMAT-OPTIONS

<!---
Include a few sentences describing the overall goals for this Pull Request.
 
A list of issues is at https://github.com/qgis/QGIS-Documentation/issues.
Add "fix #issuenumber" for each issue the PR fixes. The ticket(s) will be closed automatically.
If your PR doesn't fix entirely the ticket, only add the ticket(s) reference preceded by # character.
-->
Goal:

Ticket(s): #
<!---
Indicate whether the fix should be backported to previous release.
Replace the space between square brackets by a `x` to make it checked.
-->
- [ ] Backport to LTR documentation is requested

<!---
Reviewing is a process done by community members, mostly on a volunteer basis.
We try to keep the overhead as small as possible and appreciate if you help us.
Please read carefully and ensure you comply with our writing guidelines at
https://docs.qgis.org/testing/en/docs/documentation_guidelines/index.html.
Feel free to ask in a comment or the (qgis-community-team mailing list)
[https://lists.osgeo.org/mailman/listinfo/qgis-community-team] if you have troubles with any item.
--->
