### PR TITLE
Add antialias setting to raster tile processing plugin

### DIFF
--- a/docs/user_manual/processing_algs/qgis/rastertools.rst
+++ b/docs/user_manual/processing_algs/qgis/rastertools.rst
@@ -257,6 +257,12 @@ Basic parameters
 
        Default: QColor(0, 0, 0, 0)
      - Choose the background color for the tiles
+   * - **Enable antialiasing**
+     - ``ANTIALIAS``
+     - [boolean]
+
+       Default: True
+     - Determines if antialiasing should be enabled
    * - **Tile format**
      - ``TILE_FORMAT``
      - [enumeration]
@@ -464,6 +470,12 @@ Parameters
 
        Default: QColor(0, 0, 0, 0)
      - Choose the background color for the tiles
+   * - **Enable antialiasing**
+     - ``ANTIALIAS``
+     - [boolean]
+
+       Default: True
+     - Determines if antialiasing should be enabled
    * - **Tile format**
      - ``TILE_FORMAT``
      - [enumeration]


### PR DESCRIPTION
Goal: Add documentation for qgis/QGIS/pull/53674 (fixes #8370)

![image](https://github.com/qgis/QGIS-Documentation/assets/446308/c648bf99-3b13-4550-859c-06e59dfc5ded)

(retake of #8365 )