### PR TITLE
Also display reference videos inside a frame

### DIFF
--- a/docs/user_manual/map_views/elevation_profile.rst
+++ b/docs/user_manual/map_views/elevation_profile.rst
@@ -222,6 +222,10 @@ It is also possible to interact with the elements displayed in the plot canvas:
 For more details, give a look to `QGIS elevation profile/cross section tool -- a deep dive!
 <https://www.youtube.com/watch?v=AknJjNPystU>`_, a presentation done by Nyall Dawson.
 
+.. raw:: html
+
+  <p align="center"><iframe width="560" height="315" src="https://www.youtube.com/embed/AknJjNPystU" title="QGIS elevation profile/cross section tool -- a deep dive!" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen="true"></iframe></p>
+
 
 .. Substitutions definitions - AVOID EDITING PAST THIS LINE
    This will be automatically updated by the find_set_subst.py script.

--- a/docs/user_manual/map_views/map_view.rst
+++ b/docs/user_manual/map_views/map_view.rst
@@ -910,6 +910,11 @@ menu or from the :guilabel:`Annotations Toolbar`:
   but displayed in an annotation item. Also see this video
   https://www.youtube.com/watch?v=0pDBuSbQ02o&feature=youtu.be&t=2m25s
   from Tim Sutton for more information.
+
+.. raw:: html
+
+  <iframe width="560" height="315" src="https://www.youtube.com/embed/0pDBuSbQ02o?start=145" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+
 * |annotation| :sup:`Move Annotation` to adjust annotation element size or position
   (using click and drag)
 


### PR DESCRIPTION
I think it will make these videos more visible in the docs (only rendered in HTML version). Example for the elevation profile

![image](https://github.com/qgis/QGIS-Documentation/assets/7983394/988785f9-c948-4f4c-9e8a-c51cbd87dde7)

Opinions welcome...