### PR TITLE
QGIS server containerized deployment

### DIFF
--- a/docs/server_manual/containerized_deployment.rst
+++ b/docs/server_manual/containerized_deployment.rst
@@ -368,7 +368,7 @@ Create a file :file:`deployments.yaml` with this content:
   kind: Deployment
   metadata:
     name: qgis-server
-    namespace: qgis-server
+    namespace: default
   spec:
     replicas: 1
     selector:
@@ -407,7 +407,7 @@ Create a file :file:`deployments.yaml` with this content:
   kind: Deployment
   metadata:
     name: qgis-nginx
-    namespace: qgis-server
+    namespace: default
   spec:
     replicas: 1
     selector:
@@ -543,7 +543,7 @@ To clean up, type:
 
 .. code-block:: bash
 
-  kubectl delete -n default service/qgis-server service/qgis-nginx deployment/qgis-nginx deployment/qgis-server
+  kubectl delete service/qgis-server service/qgis-nginx deployment/qgis-nginx deployment/qgis-server configmap/nginx-configuration
 
 Cloud deployment
 ================

--- a/docs/server_manual/containerized_deployment.rst
+++ b/docs/server_manual/containerized_deployment.rst
@@ -247,21 +247,21 @@ Now that you have Swarm working, create the service file (see
       # Should use version with utf-8 locale support:
       image: qgis-server:latest
       volumes:
-      - REPLACE_WITH_FULL_PATH/data:/data:ro
+        - REPLACE_WITH_FULL_PATH/data:/data:ro
       environment:
-      - LANG=en_EN.UTF-8
-      - QGIS_PROJECT_FILE=/data/osm.qgs
-      - QGIS_SERVER_LOG_LEVEL=0  # INFO (log all requests)
-      - DEBUG=1                  # display env before spawning QGIS Server
+        - LANG=en_EN.UTF-8
+        - QGIS_PROJECT_FILE=/data/osm.qgs
+        - QGIS_SERVER_LOG_LEVEL=0  # INFO (log all requests)
+        - DEBUG=1                  # display env before spawning QGIS Server
   
     nginx:
       image: nginx:1.13
       ports:
-      - 8080:80
+        - 8080:80
       volumes:
-      - REPLACE_WITH_FULL_PATH/nginx.conf:/etc/nginx/conf.d/default.conf:ro
+        - REPLACE_WITH_FULL_PATH/nginx.conf:/etc/nginx/conf.d/default.conf:ro
       depends_on:
-      - qgis-server
+        - qgis-server
   
 
 To deploy (or update) the stack, type:

--- a/docs/server_manual/containerized_deployment.rst
+++ b/docs/server_manual/containerized_deployment.rst
@@ -479,7 +479,7 @@ To deploy or update your manifests:
 
 .. code-block:: bash
 
-  kubectl apply -k ./
+  kubectl apply -f ./
 
 To check what is currently deployed:
 

--- a/docs/server_manual/containerized_deployment.rst
+++ b/docs/server_manual/containerized_deployment.rst
@@ -364,95 +364,95 @@ Create a file :file:`deployments.yaml` with this content:
 
 .. code-block:: yaml
 
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: qgis-server
-  namespace: qgis-server
-spec:
-  replicas: 1
-  selector:
-    matchLabels:
-      myLabel: qgis-server
-  template:
-    metadata:
-      labels:
+  apiVersion: apps/v1
+  kind: Deployment
+  metadata:
+    name: qgis-server
+    namespace: qgis-server
+  spec:
+    replicas: 1
+    selector:
+      matchLabels:
         myLabel: qgis-server
-    spec:
-      containers:
-        - name: qgis-server
-          image: localhost:32000/qgis-server:latest
-          imagePullPolicy: Always
-          env:
-            - name: LANG
-              value: en_EN.UTF-8
-            - name: QGIS_PROJECT_FILE
-              value: /data/osm.qgs
-            - name: QGIS_SERVER_LOG_LEVEL
-              value: "0"
-            - name: DEBUG
-              value: "1"
-          ports:
-            - containerPort: 5555
-          volumeMounts:
-            - name: qgis-data
-              mountPath: /data/
-      volumes:
-        - name: qgis-data
-          hostPath:
-            path: REPLACE_WITH_FULL_PATH/data
-
----
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: qgis-nginx
-  namespace: qgis-server
-spec:
-  replicas: 1
-  selector:
-    matchLabels:
-      myLabel: qgis-nginx
-  template:
-    metadata:
-      labels:
+    template:
+      metadata:
+        labels:
+          myLabel: qgis-server
+      spec:
+        containers:
+          - name: qgis-server
+            image: localhost:32000/qgis-server:latest
+            imagePullPolicy: Always
+            env:
+              - name: LANG
+                value: en_EN.UTF-8
+              - name: QGIS_PROJECT_FILE
+                value: /data/osm.qgs
+              - name: QGIS_SERVER_LOG_LEVEL
+                value: "0"
+              - name: DEBUG
+                value: "1"
+            ports:
+              - containerPort: 5555
+            volumeMounts:
+              - name: qgis-data
+                mountPath: /data/
+        volumes:
+          - name: qgis-data
+            hostPath:
+              path: REPLACE_WITH_FULL_PATH/data
+  
+  ---
+  apiVersion: apps/v1
+  kind: Deployment
+  metadata:
+    name: qgis-nginx
+    namespace: qgis-server
+  spec:
+    replicas: 1
+    selector:
+      matchLabels:
         myLabel: qgis-nginx
-    spec:
-      containers:
-        - name: qgis-nginx
-          image: nginx:1.13
-          ports:
-            - containerPort: 80
-          volumeMounts:
-            - name: nginx-conf
-              mountPath: /etc/nginx/conf.d/
-      volumes:
-        - name: nginx-conf
-          configMap:
-            name: nginx-configuration
-
----
-kind: ConfigMap 
-apiVersion: v1 
-metadata: 
-  name: nginx-configuration
-data: 
-  nginx.conf: |
-    server {
-      listen 80;
-      server_name _;
-      location / {
-        root  /usr/share/nginx/html;
-        index index.html index.htm;
-      }
-      location /qgis-server {
-        proxy_buffers 16 16k;
-        proxy_buffer_size 16k;
-        gzip off;
-        include fastcgi_params;
-        fastcgi_pass qgis-server:5555;
+    template:
+      metadata:
+        labels:
+          myLabel: qgis-nginx
+      spec:
+        containers:
+          - name: qgis-nginx
+            image: nginx:1.13
+            ports:
+              - containerPort: 80
+            volumeMounts:
+              - name: nginx-conf
+                mountPath: /etc/nginx/conf.d/
+        volumes:
+          - name: nginx-conf
+            configMap:
+              name: nginx-configuration
+  
+  ---
+  kind: ConfigMap 
+  apiVersion: v1 
+  metadata: 
+    name: nginx-configuration
+  data: 
+    nginx.conf: |
+      server {
+        listen 80;
+        server_name _;
+        location / {
+          root  /usr/share/nginx/html;
+          index index.html index.htm;
         }
-      }
+        location /qgis-server {
+          proxy_buffers 16 16k;
+          proxy_buffer_size 16k;
+          gzip off;
+          include fastcgi_params;
+          fastcgi_pass qgis-server:5555;
+          }
+        }
 
 
 Service manifests

--- a/docs/server_manual/containerized_deployment.rst
+++ b/docs/server_manual/containerized_deployment.rst
@@ -364,72 +364,96 @@ Create a file :file:`deployments.yaml` with this content:
 
 .. code-block:: yaml
 
-  apiVersion: apps/v1
-  kind: Deployment
-  metadata:
-    name: qgis-server
-    namespace: default
-  spec:
-    replicas: 1
-    selector:
-      matchLabels:
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: qgis-server
+  namespace: qgis-server
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      myLabel: qgis-server
+  template:
+    metadata:
+      labels:
         myLabel: qgis-server
-    template:
-      metadata:
-        labels:
-          myLabel: qgis-server
-      spec:
-        containers:
-          - name: qgis-server
-            image: localhost:32000/qgis-server:latest
-            imagePullPolicy: IfNotPresent
-            env:
-              - name: LANG
-                value: en_EN.UTF-8
-              - name: QGIS_PROJECT_FILE
-                value: /data/osm.qgs
-              - name: QGIS_SERVER_LOG_LEVEL
-                value: "0"
-              - name: DEBUG
-                value: "1"
-            ports:
-              - containerPort: 5555
-            volumeMounts:
-              - name: qgis-data
-                mountPath: /data/
-        volumes:
-          - name: qgis-data
-            hostPath:
-              path: REPLACE_WITH_FULL_PATH/data
-  
-  ---
-  apiVersion: apps/v1
-  kind: Deployment
-  metadata:
-    name: qgis-nginx
-    namespace: default
-  spec:
-    replicas: 1
-    selector:
-      matchLabels:
+    spec:
+      containers:
+        - name: qgis-server
+          image: localhost:32000/qgis-server:latest
+          imagePullPolicy: Always
+          env:
+            - name: LANG
+              value: en_EN.UTF-8
+            - name: QGIS_PROJECT_FILE
+              value: /data/osm.qgs
+            - name: QGIS_SERVER_LOG_LEVEL
+              value: "0"
+            - name: DEBUG
+              value: "1"
+          ports:
+            - containerPort: 5555
+          volumeMounts:
+            - name: qgis-data
+              mountPath: /data/
+      volumes:
+        - name: qgis-data
+          hostPath:
+            path: REPLACE_WITH_FULL_PATH/data
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: qgis-nginx
+  namespace: qgis-server
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      myLabel: qgis-nginx
+  template:
+    metadata:
+      labels:
         myLabel: qgis-nginx
-    template:
-      metadata:
-        labels:
-          myLabel: qgis-nginx
-      spec:
-        containers:
-          - name: qgis-nginx
-            image: nginx:1.13
-            ports:
-              - containerPort: 80
-            volumeMounts:
-              - name: nginx-conf
-                mountPath: /etc/nginx/conf.d/default.conf
-        volumes:
-          - name: nginx-conf
-            hostPath:
-              path: REPLACE_WITH_FULL_PATH/nginx.conf
+    spec:
+      containers:
+        - name: qgis-nginx
+          image: nginx:1.13
+          ports:
+            - containerPort: 80
+          volumeMounts:
+            - name: nginx-conf
+              mountPath: /etc/nginx/conf.d/
+      volumes:
+        - name: nginx-conf
+          configMap:
+            name: nginx-configuration
+
+---
+kind: ConfigMap 
+apiVersion: v1 
+metadata: 
+  name: nginx-configuration
+data: 
+  nginx.conf: |
+    server {
+      listen 80;
+      server_name _;
+      location / {
+        root  /usr/share/nginx/html;
+        index index.html index.htm;
+      }
+      location /qgis-server {
+        proxy_buffers 16 16k;
+        proxy_buffer_size 16k;
+        gzip off;
+        include fastcgi_params;
+        fastcgi_pass qgis-server:5555;
+        }
+      }
+
 
 Service manifests
 """""""""""""""""


### PR DESCRIPTION
Goal: Fix non-working examples for containerized deployment of QGIS Server.

The current documentation on containerized deployment includes some steps that if followed, will not work. Such as:

- `kubectl apply -k` will expect to have a kustomization.yaml file that is nowhere present in the documentation. The way of applying the deployments in this case would be `kubectl apply -f`.

- I have also added a ConfigMap for the NGINX configuration. In the current version, the nginx.conf file would not be accessible if the deployment is done outside of a local cluster.
