### PR TITLE
Put more generic build instructions first

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,34 +32,6 @@ The latest documentation is available at <https://docs.qgis.org/latest>
 
 The best way to build the documentation is within a Python Virtual Environment (venv).
 
-## Build on Linux
-
-To check/create the venv and use it in the build:
-
-```
-make -f venv.mk html
-```
-
-The venv.mk will create/update a virtual env (if not available) in current dir/venv AND run the html build in it.
-
-You can also use that virtual environment later doing:
-
-```
-source venv/bin/activate
-```
-
-to activate the venv and then run the build from within that venv:
-
-```
-make html
-```
-
-If, for some reason, you want to start from scratch:
-
-```
-make -f venv.mk cleanall
-```
-
 ## Build on macOS or Linux
 
 You can also use your own virtual env by creating it first:
@@ -128,6 +100,34 @@ Want to build your own language? Note that you will use the translations from th
 ```
 set SPHINXOPTS=-D language=nl
 make.bat html
+```
+
+## Build on Linux (alternative)
+
+To check/create the venv and use it in the build:
+
+```
+make -f venv.mk html
+```
+
+The venv.mk will create/update a virtual env (if not available) in current dir/venv AND run the html build in it.
+
+You can also use that virtual environment later doing:
+
+```
+source venv/bin/activate
+```
+
+to activate the venv and then run the build from within that venv:
+
+```
+make html
+```
+
+If, for some reason, you want to start from scratch:
+
+```
+make -f venv.mk cleanall
 ```
 
 ## Build PDFs

--- a/README.md
+++ b/README.md
@@ -32,9 +32,9 @@ The latest documentation is available at <https://docs.qgis.org/latest>
 
 The best way to build the documentation is within a Python Virtual Environment (venv).
 
-## Build on macOS or Linux
+## Build on Linux or macOS
 
-You can also use your own virtual env by creating it first:
+You can use your own virtual env by creating it first:
 
 ```
 # you NEED python >3.6. Depending on distro either use `python3` or `python`
@@ -65,6 +65,23 @@ Want to build your own language? Note that you will use the translations from th
 
 ```
 make LANG=nl html
+```
+
+<details>
+  <summary>Tip: One-line command to create the venv and run the build in a row</summary>
+
+  The `venv.mk` file will create/update a virtual env (if not available) in current dir/venv
+  AND run the html build in it.
+
+  ```
+  make -f venv.mk html
+  ```
+</details>
+
+If, for some reason, you want to (re)start from scratch:
+
+```
+make -f venv.mk cleanall
 ```
 
 ## Build on Windows
@@ -100,34 +117,6 @@ Want to build your own language? Note that you will use the translations from th
 ```
 set SPHINXOPTS=-D language=nl
 make.bat html
-```
-
-## Build on Linux (alternative)
-
-To check/create the venv and use it in the build:
-
-```
-make -f venv.mk html
-```
-
-The venv.mk will create/update a virtual env (if not available) in current dir/venv AND run the html build in it.
-
-You can also use that virtual environment later doing:
-
-```
-source venv/bin/activate
-```
-
-to activate the venv and then run the build from within that venv:
-
-```
-make html
-```
-
-If, for some reason, you want to start from scratch:
-
-```
-make -f venv.mk cleanall
 ```
 
 ## Build PDFs


### PR DESCRIPTION
For me the instructions `## Build on Linux` are not working. I didn't searched why but I noticed that the `Linux & MacOs` instruction are working.
So I thought it makes sense to put them first in the README as they are more generic.

Maybe the "Linux only" way of building can be completely removed as it is redundant? Or it bring some more value?