### PR TITLE
Rename processing menu to model designer

### DIFF
--- a/docs/user_manual/introduction/qgis_gui.rst
+++ b/docs/user_manual/introduction/qgis_gui.rst
@@ -1776,7 +1776,7 @@ Processing
      - :kbd:`Ctrl+Alt+T`
      -
      - :ref:`processing.toolbox`
-   * - |processingModel| :guilabel:`Graphical Modeler...`
+   * - |processingModel| :guilabel:`Model Designer...`
      - :kbd:`Ctrl+Alt+G`
      -
      - :ref:`processing.modeler`

--- a/docs/user_manual/processing/modeler.rst
+++ b/docs/user_manual/processing/modeler.rst
@@ -19,7 +19,7 @@ No matter how many steps and different algorithms it involves, a
 model is executed as a single algorithm, saving time and effort.
 
 The model designer can be opened from the Processing menu
-(:menuselection:`Processing --> Graphical Modeler`).
+(:menuselection:`Processing --> Model Designer`).
 
 The model designer interface
 -------------------------------
@@ -193,7 +193,7 @@ View menu
    * - |checkbox| :guilabel:`Show Comments`
      -
      -
-     - Displays comments associated to every algorithm or input in the graphical designer
+     - Displays comments associated to every algorithm or input in the model designer
    * - |unchecked| :guilabel:`Enable Snapping`
      -
      -


### PR DESCRIPTION
<!---
Include a few sentences describing the overall goals for this Pull Request.
 
A list of issues is at https://github.com/qgis/QGIS-Documentation/issues.
Add "fix #issuenumber" for each issue the PR fixes. The ticket(s) will be closed automatically.
If your PR doesn't fix entirely the ticket, only add the ticket(s) reference preceded by # character.
-->
Goal:

Continuation of #8418 now that the processing menu entry called "Graphical Modeler..." has been changed to "Model Designer..." in https://github.com/qgis/QGIS/pull/54015

NO BACKPORTING to 3.28 branch

Ticket(s): #
<!---
Indicate whether the fix should be backported to previous release.
Replace the space between square brackets by a `x` to make it checked.
-->
- [ ] Backport to LTR documentation is requested

<!---
Reviewing is a process done by community members, mostly on a volunteer basis.
We try to keep the overhead as small as possible and appreciate if you help us.
Please read carefully and ensure you comply with our writing guidelines at
https://docs.qgis.org/testing/en/docs/documentation_guidelines/index.html.
Feel free to ask in a comment or the (qgis-community-team mailing list)
[https://lists.osgeo.org/mailman/listinfo/qgis-community-team] if you have troubles with any item.
--->
