### PR TITLE
Fix geometry.rst

### DIFF
--- a/docs/pyqgis_developer_cookbook/geometry.rst
+++ b/docs/pyqgis_developer_cookbook/geometry.rst
@@ -372,7 +372,7 @@ The following code assumes ``layer`` is a :class:`QgsVectorLayer
     Area (m2): 389267821381.6008
     Area (km2): 389267.8213816008
 
-Alternatively, you may want to know the distance and bearing between two points.
+Alternatively, you may want to know the distance between two points.
 
 .. testcode:: geometry
 


### PR DESCRIPTION
After d3b7b6047c9156d4fe7138f06385f0a0bd76ca7f by @SrNetoChan and @arongergely, only the distance is calculated.

Another approach would be to add the bearing calculation.

https://docs.qgis.org/3.28/en/docs/pyqgis_developer_cookbook/geometry.html#:~:text=Alternatively%2C%20you%20may%20want%20to%20know%20the%20distance%20and%20bearing%20between%20two%20points.

<!---
Include a few sentences describing the overall goals for this Pull Request.
 
A list of issues is at https://github.com/qgis/QGIS-Documentation/issues.
Add "fix #issuenumber" for each issue the PR fixes. The ticket(s) will be closed automatically.
If your PR doesn't fix entirely the ticket, only add the ticket(s) reference preceded by # character.
-->
Goal:

Ticket(s): #
<!---
Indicate whether the fix should be backported to previous release.
Replace the space between square brackets by a `x` to make it checked.
-->
- [x] Backport to LTR documentation is requested

<!---
Reviewing is a process done by community members, mostly on a volunteer basis.
We try to keep the overhead as small as possible and appreciate if you help us.
Please read carefully and ensure you comply with our writing guidelines at
https://docs.qgis.org/testing/en/docs/documentation_guidelines/index.html.
Feel free to ask in a comment or the (qgis-community-team mailing list)
[https://lists.osgeo.org/mailman/listinfo/qgis-community-team] if you have troubles with any item.
--->
