### PR TITLE
Split long local list of algorithms into columns

### DIFF
--- a/docs/user_manual/processing_algs/gdal/rasteranalysis.rst
+++ b/docs/user_manual/processing_algs/gdal/rasteranalysis.rst
@@ -6,6 +6,7 @@ Raster analysis
    .. contents::
       :local:
       :depth: 1
+      :class: toc-columns
 
 
 .. _gdalaspect:

--- a/docs/user_manual/processing_algs/qgis/cartography.rst
+++ b/docs/user_manual/processing_algs/qgis/cartography.rst
@@ -6,6 +6,7 @@ Cartography
    .. contents::
       :local:
       :depth: 1
+      :class: toc_columns
 
 .. _qgisangletonearest:
 

--- a/docs/user_manual/processing_algs/qgis/modelertools.rst
+++ b/docs/user_manual/processing_algs/qgis/modelertools.rst
@@ -11,6 +11,7 @@ Modeler tools
    .. contents::
       :local:
       :depth: 1
+      :class: toc_columns
 
 
 .. _qgiscondition:

--- a/docs/user_manual/processing_algs/qgis/rasteranalysis.rst
+++ b/docs/user_manual/processing_algs/qgis/rasteranalysis.rst
@@ -6,6 +6,7 @@ Raster analysis
    .. contents::
       :local:
       :depth: 1
+      :class: toc_columns
 
 
 .. _qgiscellstackpercentrankfromvalue:

--- a/docs/user_manual/processing_algs/qgis/vectoranalysis.rst
+++ b/docs/user_manual/processing_algs/qgis/vectoranalysis.rst
@@ -6,6 +6,7 @@ Vector analysis
    .. contents::
       :local:
       :depth: 1
+      :class: toc-columns
 
 
 .. _qgisbasicstatisticsforfields:

--- a/docs/user_manual/processing_algs/qgis/vectorcreation.rst
+++ b/docs/user_manual/processing_algs/qgis/vectorcreation.rst
@@ -6,6 +6,7 @@ Vector creation
    .. contents::
       :local:
       :depth: 1
+      :class: toc-columns
 
 
 .. _qgisarrayoffsetlines:

--- a/docs/user_manual/processing_algs/qgis/vectorgeneral.rst
+++ b/docs/user_manual/processing_algs/qgis/vectorgeneral.rst
@@ -6,6 +6,7 @@ Vector general
    .. contents::
       :local:
       :depth: 1
+      :class: toc-columns
 
 
 .. _qgisassignprojection:

--- a/docs/user_manual/processing_algs/qgis/vectorgeometry.rst
+++ b/docs/user_manual/processing_algs/qgis/vectorgeometry.rst
@@ -6,6 +6,8 @@ Vector geometry
    .. contents::
       :local:
       :depth: 1
+      :class: toc-columns
+
 
 .. _qgisexportaddgeometrycolumns:
 


### PR DESCRIPTION
The idea is to move from left to right (as done for expression functions), hopefully leading to a more usable/readable TOC and less scrolling
![image](https://github.com/qgis/QGIS-Documentation/assets/7983394/4d638c7a-2652-415c-9d58-4754208d25b7)

Groups that have more than 10 algorithms available have their algs list split