### PR TITLE
Move tip on attachment widget close to the widget description

### DIFF
--- a/docs/user_manual/working_with_vector/vector_properties.rst
+++ b/docs/user_manual/working_with_vector/vector_properties.rst
@@ -2451,6 +2451,14 @@ with the field type. The available widgets are:
   relative or absolute mode. It can be used to display a hyperlink (to
   document path), a picture or a web page. User can also configure an
   :ref:`external storage system <external_storage>` to fetch/store resources.
+
+  .. tip:: **Relative Path in Attachment widget**
+
+   If the path which is selected with the file browser is located in the same
+   directory as the :file:`.qgs` project file or below, paths are converted to
+   relative paths. This increases portability of a :file:`.qgs` project with
+   multimedia information attached.
+
 * **Hidden**: A hidden attribute column is invisible. The user is not able
   to see its contents.
 * **Key/Value**: Displays a two-columns table to store sets of key/value
@@ -2496,14 +2504,6 @@ with the field type. The available widgets are:
   configured to use a value relation widget, but the required layer is
   not already loaded into the project, QGIS will automatically search for
   the layer in the same database/connection.
-
-
-.. tip:: **Relative Path in Attachment widget**
-
-   If the path which is selected with the file browser is located in the same
-   directory as the :file:`.qgs` project file or below, paths are converted to
-   relative paths. This increases portability of a :file:`.qgs` project with
-   multimedia information attached.
 
 
 .. index:: Jointure, Join layers


### PR DESCRIPTION
It looks weird to have those information appear far away, next to quite different widgets

<!---
Include a few sentences describing the overall goals for this Pull Request.
 
A list of issues is at https://github.com/qgis/QGIS-Documentation/issues.
Add "fix #issuenumber" for each issue the PR fixes. The ticket(s) will be closed automatically.
If your PR doesn't fix entirely the ticket, only add the ticket(s) reference preceded by # character.
-->
Goal:

Ticket(s): #
<!---
Indicate whether the fix should be backported to previous release.
Replace the space between square brackets by a `x` to make it checked.
-->
- [ ] Backport to LTR documentation is requested

<!---
Reviewing is a process done by community members, mostly on a volunteer basis.
We try to keep the overhead as small as possible and appreciate if you help us.
Please read carefully and ensure you comply with our writing guidelines at
https://docs.qgis.org/testing/en/docs/documentation_guidelines/index.html.
Feel free to ask in a comment or the (qgis-community-team mailing list)
[https://lists.osgeo.org/mailman/listinfo/qgis-community-team] if you have troubles with any item.
--->
