### PR TITLE
Fix "Circle by a center point and another point" tool name

### DIFF
--- a/docs/user_manual/working_with_vector/editing_geometry_attributes.rst
+++ b/docs/user_manual/working_with_vector/editing_geometry_attributes.rst
@@ -1614,7 +1614,7 @@ curved geometry, if not, QGIS will segmentize the circular arcs.
   and the orientation of  the circle. (Left-click, right-click)
 - |circle3Points| :sup:`Circle from 3 points`: Draws a circle from three
   known points on the circle. (Left-click, left-click, right-click)
-- |circleCenterPoint| :sup:`Circle from center and a point`: Draws a circle
+- |circleCenterPoint| :sup:`Circle by a center point and another point`: Draws a circle
   with a given center and a point on the circle (Left-click, right-click).
   When used with the :ref:`advanced_digitizing_panel` this tool can become a
   "Add circle from center and radius" tool by setting and locking the distance


### PR DESCRIPTION
<!---
Include a few sentences describing the overall goals for this Pull Request.
 
A list of issues is at https://github.com/qgis/QGIS-Documentation/issues.
Add "fix #issuenumber" for each issue the PR fixes. The ticket(s) will be closed automatically.
If your PR doesn't fix entirely the ticket, only add the ticket(s) reference preceded by # character.
-->
Goal:

Fixes the "Circle by a center point and another point" tool name.

https://github.com/qgis/QGIS/blob/5cde6a9349f4b2c6d431859cb9ec9755bcd172fb/src/app/maptools/qgsmaptoolshapecirclecenterpoint.cpp#L33

![image](https://github.com/qgis/QGIS-Documentation/assets/16253859/113b0e96-13bd-4efb-9bad-b2e8d29ef590)


Ticket(s): #
<!---
Indicate whether the fix should be backported to previous release.
Replace the space between square brackets by a `x` to make it checked.
-->
- [x] Backport to LTR documentation is requested

<!---
Reviewing is a process done by community members, mostly on a volunteer basis.
We try to keep the overhead as small as possible and appreciate if you help us.
Please read carefully and ensure you comply with our writing guidelines at
https://docs.qgis.org/testing/en/docs/documentation_guidelines/index.html.
Feel free to ask in a comment or the (qgis-community-team mailing list)
[https://lists.osgeo.org/mailman/listinfo/qgis-community-team] if you have troubles with any item.
--->
