### PR TITLE
[GH-Action] Remove the automerge PR operation

### DIFF
--- a/.github/workflows/translation_statistics.yml
+++ b/.github/workflows/translation_statistics.yml
@@ -23,7 +23,7 @@ jobs:
     env:
       TRANSIFEX_PASSWORD: ${{ secrets.TRANSIFEX_PASSWORD }}
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      BACKPORT_BRANCH: "release_3.28"
+      LABELS: "Translation, backport release_3.28, backport release_3.34"
 
     steps:
     - name: Harden Runner
@@ -56,13 +56,4 @@ jobs:
         commit-message: Update statistics of translation
         title: Update statistics of translation
         delete-branch: true
-        labels: |
-          Translation
-          backport ${{ env.BACKPORT_BRANCH }}
-
-    - name: Enable Pull Request Automerge
-      uses: peter-evans/enable-pull-request-automerge@v3
-      with:
-        token: ${{ secrets.GITHUB_TOKEN }}
-        pull-request-number: ${{ steps.create_pr.outputs.pull-request-number }}
-        merge-method: rebase
+        labels: ${{ env.LABELS }}


### PR DESCRIPTION
as it can not trigger the backport actions after merge. Let's then manually merge the generated PR and control the workflow.
Also update list of labels

@m-kuhn you OK? I had to manually remove and add back the labels to have their backport PR created.
<!---
Include a few sentences describing the overall goals for this Pull Request.
 
A list of issues is at https://github.com/qgis/QGIS-Documentation/issues.
Add "fix #issuenumber" for each issue the PR fixes. The ticket(s) will be closed automatically.
If your PR doesn't fix entirely the ticket, only add the ticket(s) reference preceded by # character.
-->
Goal:

Ticket(s): #
<!---
Indicate whether the fix should be backported to previous release.
Replace the space between square brackets by a `x` to make it checked.
-->
- [ ] Backport to LTR documentation is requested

<!---
Reviewing is a process done by community members, mostly on a volunteer basis.
We try to keep the overhead as small as possible and appreciate if you help us.
Please read carefully and ensure you comply with our writing guidelines at
https://docs.qgis.org/testing/en/docs/documentation_guidelines/index.html.
Feel free to ask in a comment or the (qgis-community-team mailing list)
[https://lists.osgeo.org/mailman/listinfo/qgis-community-team] if you have troubles with any item.
--->
