### PR TITLE
Fix broken links in PostGIS documentation

### DIFF
--- a/docs/training_manual/spatial_databases/index.rst
+++ b/docs/training_manual/spatial_databases/index.rst
@@ -15,11 +15,11 @@ Another useful resource is the `online <https://postgis.net/docs/>`_ PostGIS
 documentation.
 
 There are also some more extensive tutorials on PostGIS and Spatial Databases
-available from Boundless Geo:
+created by Boundless Geo that are now hosted on the PostGIS's website:
 
-* `Introduction to PostGIS <https://web.archive.org/web/20171221050136/http://workshops.boundlessgeo.com/postgis-intro/>`_
-* `Spatial Database Tips and Tricks
-  <https://web.archive.org/web/20180921013715/http://workshops.boundlessgeo.com/postgis-spatialdbtips/>`_
+* `Introduction to PostGIS <https://postgis.net/workshops/postgis-intro/>`_
+* `PostGIS Database Tips and Tricks
+  <https://postgis.net/documentation/tips/>`_
 
 See also `PostGIS In Action <https://www.postgis.us>`_.
 

--- a/docs/training_manual/spatial_databases/index.rst
+++ b/docs/training_manual/spatial_databases/index.rst
@@ -11,7 +11,7 @@ into the database and make use of the geographic functions that PostGIS offers.
 While working through this section, you may want to keep a copy of the **PostGIS
 cheat sheet**  available
 from `Boston GIS user group <https://www.bostongis.com/postgis_quickguide.bqg>`_.
-Another useful resource is the `online <https://postgis.net/docs/>`_ PostGIS
+Another useful resource is the `online <https://postgis.net/documentation/>`_ PostGIS
 documentation.
 
 There are also some more extensive tutorials on PostGIS and Spatial Databases

--- a/docs/training_manual/spatial_databases/index.rst
+++ b/docs/training_manual/spatial_databases/index.rst
@@ -15,7 +15,7 @@ Another useful resource is the `online <https://postgis.net/docs/>`_ PostGIS
 documentation.
 
 There are also some more extensive tutorials on PostGIS and Spatial Databases
-created by Boundless Geo that are now hosted on the PostGIS's website:
+created by Boundless that are now hosted on the PostGIS's website:
 
 * `Introduction to PostGIS <https://postgis.net/workshops/postgis-intro/>`_
 * `PostGIS Database Tips and Tricks

--- a/docs/training_manual/spatial_databases/index.rst
+++ b/docs/training_manual/spatial_databases/index.rst
@@ -17,9 +17,9 @@ documentation.
 There are also some more extensive tutorials on PostGIS and Spatial Databases
 available from Boundless Geo:
 
-* `Introduction to PostGIS <http://workshops.boundlessgeo.com/postgis-intro/>`_
+* `Introduction to PostGIS <https://web.archive.org/web/20171221050136/http://workshops.boundlessgeo.com/postgis-intro/>`_
 * `Spatial Database Tips and Tricks
-  <http://workshops.boundlessgeo.com/postgis-spatialdbtips/>`_
+  <https://web.archive.org/web/20180921013715/http://workshops.boundlessgeo.com/postgis-spatialdbtips/>`_
 
 See also `PostGIS In Action <https://www.postgis.us>`_.
 


### PR DESCRIPTION
Perhaps these links just need to be removed? I can rewrite this to adjust for that change.

- May need to just remove them since the links are broken
- Boundless Spatial, Inc. was acquired in 2019 by Planet Labs PBC to become Planet Federal
- Soon thereafter these websites were shutdown

Fixes #8235