### PR TITLE
Update base image from Bullseye to Bookworm

### DIFF
--- a/docs/server_manual/containerized_deployment.rst
+++ b/docs/server_manual/containerized_deployment.rst
@@ -36,7 +36,7 @@ it. To do so create a directory :file:`qgis-server` and within its directory:
 
 .. code-block:: dockerfile
 
-  FROM debian:bullseye-slim
+  FROM debian:bookworm-slim
   
   ENV LANG=en_EN.UTF-8
   
@@ -54,7 +54,7 @@ it. To do so create a directory :file:`qgis-server` and within its directory:
       && wget -O /etc/apt/keyrings/qgis-archive-keyring.gpg https://download.qgis.org/downloads/qgis-archive-keyring.gpg \
       # Add repository for latest version of qgis-server
       # Please refer to QGIS repositories documentation if you want other version (https://qgis.org/en/site/forusers/alldownloads.html#repositories)
-      && echo "deb [signed-by=/etc/apt/keyrings/qgis-archive-keyring.gpg] https://qgis.org/debian bullseye main" | tee /etc/apt/sources.list.d/qgis.list \
+      && echo "deb [signed-by=/etc/apt/keyrings/qgis-archive-keyring.gpg] https://qgis.org/debian bookworm main" | tee /etc/apt/sources.list.d/qgis.list \
       && apt-get update \
       && apt-get install --no-install-recommends --no-install-suggests --allow-unauthenticated -y \
           qgis-server \


### PR DESCRIPTION
As per https://wiki.debian.org/DebianReleases Debian Bullseye will reach EOL in about 6 months, so it's time to move on to the newer shinier thing

This commit updates the suggested Dockerfile example to use Debian bookworm-slim instead of bullseye-slim

<!---
Reviewing is a process done by community members, mostly on a volunteer basis.
We try to keep the overhead as small as possible and appreciate if you help us.
Please read carefully and ensure you comply with our writing guidelines at
https://docs.qgis.org/testing/en/docs/documentation_guidelines/index.html.
Feel free to ask in a comment or the (qgis-community-team mailing list)
[https://lists.osgeo.org/mailman/listinfo/qgis-community-team] if you have troubles with any item.
--->
