### PR TITLE
Update authentication.rst

### DIFF
--- a/docs/pyqgis_developer_cookbook/authentication.rst
+++ b/docs/pyqgis_developer_cookbook/authentication.rst
@@ -210,7 +210,7 @@ Available Authentication methods
 authentication manager init. Available authentication methods are:
 
 #. ``Basic`` User and password authentication
-#. ``Esri-Token`` ESRI token based authentication
+#. ``EsriToken`` ESRI token based authentication
 #. ``Identity-Cert`` Identity certificate authentication
 #. ``OAuth2`` OAuth2 authentication
 #. ``PKI-Paths`` PKI paths authentication


### PR DESCRIPTION
I tried it today on QGIS 3.28.12. It's mentioned in this post https://gis.stackexchange.com/questions/438856/create-esri-token-authentication-in-pyqgis. "Esri-Token" is not recognized by the authentication manager in QGIS and the token is not stored.

<!---
Include a few sentences describing the overall goals for this Pull Request.
 
A list of issues is at https://github.com/qgis/QGIS-Documentation/issues.
Add "fix #issuenumber" for each issue the PR fixes. The ticket(s) will be closed automatically.
If your PR doesn't fix entirely the ticket, only add the ticket(s) reference preceded by # character.
-->
Goal:

Ticket(s): #
<!---
Indicate whether the fix should be backported to previous release.
Replace the space between square brackets by a `x` to make it checked.
-->
- [ ] Backport to LTR documentation is requested

<!---
Reviewing is a process done by community members, mostly on a volunteer basis.
We try to keep the overhead as small as possible and appreciate if you help us.
Please read carefully and ensure you comply with our writing guidelines at
https://docs.qgis.org/testing/en/docs/documentation_guidelines/index.html.
Feel free to ask in a comment or the (qgis-community-team mailing list)
[https://lists.osgeo.org/mailman/listinfo/qgis-community-team] if you have troubles with any item.
--->
