### PR TITLE
Upgrade sphinx version

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -45,6 +45,7 @@ jobs:
 
     - name: Build English ${{ matrix.format }} documentation
       run: |
+          export LC_ALL=C.UTF-8
           make ${{ matrix.format }}
     - name: Upload ${{ matrix.format }} build artifact
       uses: actions/upload-artifact@c7d193f32edcb7bfad88892161225aeda64e9392 # v4.0.0

--- a/REQUIREMENTS.txt
+++ b/REQUIREMENTS.txt
@@ -1,4 +1,14 @@
 # Memo: Dependencies should be added to https://github.com/qgis/QGIS-Website/blob/master/REQUIREMENTS.txt
 # Used for docker image builds
 
--r https://raw.githubusercontent.com/qgis/QGIS-Website/master/REQUIREMENTS.txt
+# -r https://raw.githubusercontent.com/qgis/QGIS-Website/master/REQUIREMENTS.txt
+icalendar
+pdflatex
+pyYAML
+requests==2.25.1
+Sphinx==7.2.6
+sphinx_copybutton
+sphinx-intl
+sphinx_rtd_theme
+sphinx_togglebutton
+sphinxext-rediraffe

--- a/doctest.dockerfile
+++ b/doctest.dockerfile
@@ -3,7 +3,8 @@ FROM qgis/qgis:latest
 # Install requirement first to use caching
 COPY REQUIREMENTS.txt /documentation/REQUIREMENTS.txt
 RUN pip3 install -r /documentation/REQUIREMENTS.txt
-
+# RUN apt-get install -y locales
+ENV LC_ALL C.UTF-8
 WORKDIR /documentation
 
 CMD make doctest


### PR DESCRIPTION
With Sphinx 4.x being more and more deprecated, we need to either pin our dependencies or upgrade (see https://github.com/qgis/QGIS-Website/pull/1135#issuecomment-1890916531). This PR proposes to upgrade to a more recent Sphinx version (pinned at 7.2.6) with a unpinned sphinx-rtd-theme.
While upgrading, I faced some other issues with setting the locale (see https://github.com/sphinx-doc/sphinx/issues/11739) and this PR tries to fix them (at least for the github actions). Basically from what I could find, you need to locally set the LC_ALL locale env to C.UTF-8 but I'm not comfortable with this kind of things and:
* it looks to me like a workaround
* on a local build, people have to set that variable: what is its scope actually? Would that "break" anything on their system? Is it possible to set that env only in the venv they are running? <-- I'm asking this because we need to instruct people that new requirement.
* I can't find how to do the same on macOS and I didn't test Windows. **So if you know a better way to solve that locale issue on all platforms, ...**