### PR TITLE
Upgrade Sphinx version v2

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -45,6 +45,7 @@ jobs:
 
     - name: Build English ${{ matrix.format }} documentation
       run: |
+          export LC_ALL=C.UTF-8
           make ${{ matrix.format }}
     - name: Upload ${{ matrix.format }} build artifact
       uses: actions/upload-artifact@c7d193f32edcb7bfad88892161225aeda64e9392 # v4.0.0

--- a/REQUIREMENTS.txt
+++ b/REQUIREMENTS.txt
@@ -1,4 +1,13 @@
 # Memo: Dependencies should be added to https://github.com/qgis/QGIS-Website/blob/master/REQUIREMENTS.txt
 # Used for docker image builds
 
--r https://raw.githubusercontent.com/qgis/QGIS-Website/master/REQUIREMENTS.txt
+# -r https://raw.githubusercontent.com/qgis/QGIS-Website/master/REQUIREMENTS.txt
+icalendar
+pdflatex
+pyYAML
+requests==2.25.1
+sphinx_copybutton
+sphinx-intl
+sphinx_rtd_theme==2.0.0
+sphinx_togglebutton
+sphinxext-rediraffe

--- a/doctest.dockerfile
+++ b/doctest.dockerfile
@@ -3,7 +3,8 @@ FROM qgis/qgis:latest
 # Install requirement first to use caching
 COPY REQUIREMENTS.txt /documentation/REQUIREMENTS.txt
 RUN pip3 install -r /documentation/REQUIREMENTS.txt
-
+# RUN apt-get install -y locales
+ENV LC_ALL C.UTF-8
 WORKDIR /documentation
 
 CMD make doctest


### PR DESCRIPTION
Well, same concerns as in #8782 
The difference is that I instead suggest here to pin sphinx-rtd-theme version to 2.0.0 (sphinx is one of its dependencies so we shouldn't have to care much about it, and we will be running its most recent version while rtd team consider it is safe to update). Also, watching the old github actions we ran, it seems that we were already running rtd 2.0.0 with our old sphinx version.

