### PR TITLE
Revert custom formatting for guilabel and menuselection

### DIFF
--- a/themes/rtd_qgis/static/css/qgis_docs.css
+++ b/themes/rtd_qgis/static/css/qgis_docs.css
@@ -2,19 +2,6 @@
 @import url(theme.css);
 
 /* Customize for QGIS Documentation*/
-.rst-content .guilabel {
- background:#7fbbe3
-}
-/*rtd theme does not render menuselection, so let's apply guilabel settings to it*/
-.rst-content .menuselection {
- background:#7fbbe3;
- font-size: 80%;
- border:1px solid #7fbbe3;
- font-weight:700;
- border-radius:4px;
- padding:2.4px 6px;
- margin:auto 2px
-}
 /*keyboard text are by default rendered bigger*/
 .rst-content .kbd {
  font-size: 90%


### PR DESCRIPTION
Afair :menuselection: didn't have a special formatting in readthedocs theme so we made these changes to have both look alike, as in our pre-readthedocs theme time. They both look alike now in the theme (https://github.com/readthedocs/sphinx_rtd_theme/pull/1426) so let's remove our customization. Opinions?

BEFORE
![image](https://github.com/qgis/QGIS-Documentation/assets/7983394/79fd2967-a442-498b-a85d-39c70e144046)

AFTER
![image](https://github.com/qgis/QGIS-Documentation/assets/7983394/47e441af-74e1-4688-9538-964a8a8b9cb5)
