### PR TITLE
export LC_ALL variable to C.UTF-8 in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,8 @@ BUILDDIR        = build
 SITEDIR         = /site
 VERSION         = testing
 
+# needed for Sphinx > 4.5?
+export LC_ALL=C.UTF-8
 
 # Put it first so that "make" without argument is like "make help".
 help:


### PR DESCRIPTION
Seems required by new Sphinx versions
Combined with https://github.com/qgis/QGIS-Website/pull/1135/, supersedes #8782 and #8783