### PR TITLE
setAutoRefreshEnabled(bool) is deprecated

### DIFF
--- a/docs/pyqgis_developer_cookbook/cheat_sheet.rst
+++ b/docs/pyqgis_developer_cookbook/cheat_sheet.rst
@@ -247,7 +247,7 @@ Otherwise
     # Set seconds (5 seconds)
     layer.setAutoRefreshInterval(5000)
     # Enable data reloading
-    layer.setAutoRefreshMode(Qgis.ReloadData)
+    layer.setAutoRefreshMode(Qgis.AutoRefreshMode.ReloadData)
 
 **Show methods**
 

--- a/docs/pyqgis_developer_cookbook/cheat_sheet.rst
+++ b/docs/pyqgis_developer_cookbook/cheat_sheet.rst
@@ -32,6 +32,7 @@ Cheat sheet for PyQGIS
     )
 
     from qgis.core import (
+        Qgis,
         QgsProject,
         QgsLayerTreeModel,
     )

--- a/docs/pyqgis_developer_cookbook/cheat_sheet.rst
+++ b/docs/pyqgis_developer_cookbook/cheat_sheet.rst
@@ -245,8 +245,8 @@ Otherwise
     layer = QgsProject.instance().mapLayersByName("layer name you like")[0]
     # Set seconds (5 seconds)
     layer.setAutoRefreshInterval(5000)
-    # Enable auto refresh
-    layer.setAutoRefreshEnabled(True)
+    # Enable data reloading
+    layer.setAutoRefreshMode(Qgis.ReloadData)
 
 **Show methods**
 


### PR DESCRIPTION
Fixes the deprecation warning at https://github.com/qgis/QGIS-Documentation/actions/runs/7612232660/job/20729401705#step:8:728
> Document: docs/pyqgis_developer_cookbook/cheat_sheet
> ----------------------------------------------------
> Logged warning: Duplicate provider native registered
> <doctest cheat_sheet[0]>:7: DeprecationWarning: QgsMapLayer.setAutoRefreshEnabled() is deprecated
>   layer.setAutoRefreshEnabled(True)
> QSortFilterProxyModel: index from wrong model passed to mapToSource