### PR TITLE
Aerate the References cell of "layer properties" entry in Layer menu

### DIFF
--- a/docs/user_manual/introduction/general_tools.rst
+++ b/docs/user_manual/introduction/general_tools.rst
@@ -2104,8 +2104,8 @@ Clicking the |dataDefine| :sup:`Data defined override` icon shows the following 
 * :guilabel:`Description...` that indicates if the option is enabled, which input is
   expected, the valid input type and the current definition. Hovering over the
   widget also pops up this information.
-* :guilabel:`Store data in the project`: a button allowing  the property to be stored
-  using to the :ref:`vector_auxiliary_storage` mechanism.
+* :guilabel:`Store data in the project`: a button allowing the property to be stored
+  using the :ref:`vector_auxiliary_storage` mechanism.
 * :guilabel:`Field type`: an entry to select from the layer's fields that match the
   valid input type.
 * :guilabel:`Color`: when the widget is linked to a color property, this menu

--- a/docs/user_manual/introduction/qgis_gui.rst
+++ b/docs/user_manual/introduction/qgis_gui.rst
@@ -1174,11 +1174,11 @@ copy or paste layer properties (style, scale, CRS...).
    * - :guilabel:`Layer Properties...`
      -
      -
-     - :ref:`vector_properties_dialog`,
-       :ref:`raster_properties_dialog`,
-       :ref:`label_meshproperties`,
-       :ref:`point_clouds_properties`,
-       :ref:`vectortiles_properties`
+     - * :ref:`vector <vector_properties_dialog>`
+       * :ref:`raster <raster_properties_dialog>`
+       * :ref:`mesh <label_meshproperties>`
+       * :ref:`point cloud <point_clouds_properties>`
+       * :ref:`vector tiles <vectortiles_properties>`
    * - :guilabel:`Filter...`
      - :kbd:`Ctrl+F`
      -


### PR DESCRIPTION
The idea is to replace in [QGIS GUI](https://docs.qgis.org/3.34/en/docs/user_manual/introduction/qgis_gui.html#layer)

![image](https://github.com/qgis/QGIS-Documentation/assets/7983394/9919f71d-61ab-4920-89b8-9bf53da8e067)

by 

![image](https://github.com/qgis/QGIS-Documentation/assets/7983394/97452246-5eea-4939-8572-62ed7886ee25)
