### PR TITLE
Add a message on translation progress at the top of the pages

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -234,6 +234,14 @@ StandaloneHTMLBuilder.supported_image_types = [
     'image/jpeg'
 ]
 
+rst_prolog = r"""
+    .. only:: html and i18n
+
+      .. warning::
+        Translation is a community effort `you can join <https://qgis.org/en/site/getinvolved/translate.html#becoming-a-translator>`_.
+        This page is currently translated at |translation progress|.
+    """
+
 # -- Options for LaTeX output --------------------------------------------------
 
 latex_engine = 'xelatex'

--- a/conf.py
+++ b/conf.py
@@ -237,7 +237,7 @@ StandaloneHTMLBuilder.supported_image_types = [
 rst_prolog = r"""
     .. only:: html and i18n
 
-      .. warning::
+      .. important::
         Translation is a community effort `you can join <https://qgis.org/en/site/getinvolved/translate.html#becoming-a-translator>`_.
         This page is currently translated at |translation progress|.
     """


### PR DESCRIPTION
One nice thing added in recent versions of sphinx is a substitution evaluating [percentage of the active page](https://www.sphinx-doc.org/en/master/usage/restructuredtext/roles.html#substitutions). Let's then use it to show readers (and potential translators) how much English remains in the page they are about to read.
Only display the warning when using a language other than English, with html builds. Test on 3.28 branch below

https://github.com/qgis/QGIS-Documentation/assets/7983394/074ffa2f-b888-4390-82eb-0383b934939a

I don't think it is worth a backport to 3.28 as it will require some tweaks on Transifex, and we are one week left. Better invest those efforts on 3.34.
Do you agree with showing this info? as a warning or an info? Suggestions of wording? 
@rduivenvoorde @agiudiceandrea @selmaVH1 