### PR TITLE
Update and make translatable the warning on outdated info in IDE debugging chapter

### DIFF
--- a/docs/pyqgis_developer_cookbook/plugins/ide_debugging.rst
+++ b/docs/pyqgis_developer_cookbook/plugins/ide_debugging.rst
@@ -25,6 +25,7 @@ From :menuselection:`Plugins --> Manage and Install plugins…`, install:
 * *First Aid*: This will add a Python console and local debugger
   to inspect variables when an exception is raised from a plugin.
 
+.. warning:: Despite our constant efforts, information beyond this line may not be updated for QGIS 3.
 
 A note on configuring your IDE on Linux and Windows
 ====================================================

--- a/docs/pyqgis_developer_cookbook/plugins/ide_debugging.rst
+++ b/docs/pyqgis_developer_cookbook/plugins/ide_debugging.rst
@@ -26,8 +26,6 @@ From :menuselection:`Plugins --> Manage and Install plugins…`, install:
   to inspect variables when an exception is raised from a plugin.
 
 
-.. warning:: |outofdate|
-
 A note on configuring your IDE on Linux and Windows
 ====================================================
 
@@ -337,4 +335,3 @@ following these steps.
 
 .. |checkbox| image:: /static/common/checkbox.png
    :width: 1.3em
-.. |outofdate| replace:: `Despite our constant efforts, information beyond this line may not be updated for QGIS 3. Refer to https://qgis.org/pyqgis/master for the python API documentation or, give a hand to update the chapters you know about. Thanks.`

--- a/substitutions.txt
+++ b/substitutions.txt
@@ -861,7 +861,6 @@
 .. |otb| image:: /static/common/otb.png
    :width: 1.5em
 .. |otto| image:: img/otto_dassau.png
-.. |outofdate| replace:: `Despite our constant efforts, information beyond this line may not be updated for QGIS 3. Refer to https://qgis.org/pyqgis/master for the python API documentation or, give a hand to update the chapters you know about. Thanks.`
 .. |overlay| image:: /static/common/overlay.png
    :width: 1.5em
 .. |paintEffects| image:: /static/common/mIconPaintEffects.png


### PR DESCRIPTION
Fixes #8851
It is the only page in which that message is shown (other occurrences were removed during the cookbook update), it has been there for years with almost nobody caring about, and the text is not inline with that specific chapter.
@agiudiceandrea ?