### PR TITLE
Update "Filter vertices by M value" and "Filter vertices by Z value" algs docs

### DIFF
--- a/docs/user_manual/processing_algs/qgis/vectorgeometry.rst
+++ b/docs/user_manual/processing_algs/qgis/vectorgeometry.rst
@@ -3055,7 +3055,7 @@ the minimum value is tested.
    
 |checkbox| Allows
 :ref:`features in-place modification <processing_inplace_edit>`
-of line and polygon features with M enabled
+of point, line and polygon features with M enabled
 
 .. note:: Depending on the input geometry attributes and the filters
    used, the resultant geometries created by this algorithm may no
@@ -3155,7 +3155,7 @@ the minimum value is tested.
    
 |checkbox| Allows
 :ref:`features in-place modification <processing_inplace_edit>`
-of line and polygon features with Z enabled
+of point, line and polygon features with Z enabled
 
 .. note:: Depending on the input geometry attributes and the filters
    used, the resultant geometries created by this algorithm may no

--- a/docs/user_manual/processing_algs/qgis/vectorgeometry.rst
+++ b/docs/user_manual/processing_algs/qgis/vectorgeometry.rst
@@ -3077,7 +3077,7 @@ Parameters
      - Description
    * - **Input layer**
      - ``INPUT``
-     - [vector: line, polygon]
+     - [vector: any]
      - Input line or polygon vector layer
        to remove vertices from
    * - **Minimum**
@@ -3179,7 +3179,7 @@ Parameters
      - Description
    * - **Input layer**
      - ``INPUT``
-     - [vector: line, polygon]
+     - [vector: any]
      - Input line or polygon vector layer
        to remove vertices from
    * - **Minimum**

--- a/docs/user_manual/processing_algs/qgis/vectorgeometry.rst
+++ b/docs/user_manual/processing_algs/qgis/vectorgeometry.rst
@@ -3078,7 +3078,7 @@ Parameters
    * - **Input layer**
      - ``INPUT``
      - [vector: any]
-     - Input line or polygon vector layer
+     - Input vector layer
        to remove vertices from
    * - **Minimum**
 
@@ -3180,7 +3180,7 @@ Parameters
    * - **Input layer**
      - ``INPUT``
      - [vector: any]
-     - Input line or polygon vector layer
+     - Input vector layer
        to remove vertices from
    * - **Minimum**
 


### PR DESCRIPTION
<!---
Include a few sentences describing the overall goals for this Pull Request.
 
A list of issues is at https://github.com/qgis/QGIS-Documentation/issues.
Add "fix #issuenumber" for each issue the PR fixes. The ticket(s) will be closed automatically.
If your PR doesn't fix entirely the ticket, only add the ticket(s) reference preceded by # character.
-->
Goal:

Both "Filter vertices by M value" and "Filter vertices by Z value" algs will accept any spatial vector layer as input since QGIS 3.36

Fixes https://github.com/qgis/QGIS-Documentation/issues/8884.

Ticket(s): #
<!---
Indicate whether the fix should be backported to previous release.
Replace the space between square brackets by a `x` to make it checked.
-->
- [ ] Backport to LTR documentation is requested

<!---
Reviewing is a process done by community members, mostly on a volunteer basis.
We try to keep the overhead as small as possible and appreciate if you help us.
Please read carefully and ensure you comply with our writing guidelines at
https://docs.qgis.org/testing/en/docs/documentation_guidelines/index.html.
Feel free to ask in a comment or the (qgis-community-team mailing list)
[https://lists.osgeo.org/mailman/listinfo/qgis-community-team] if you have troubles with any item.
--->
