### PR TITLE
Move down the Identify features section in vector attribute table page

### DIFF
--- a/docs/user_manual/working_with_vector/attribute_table.rst
+++ b/docs/user_manual/working_with_vector/attribute_table.rst
@@ -34,57 +34,6 @@ values, or a range of values that are allowed, to be added to a specific vector
 layer during digitizing. Have a closer look at the edit widget in section
 :ref:`vector_attributes_menu` to find out more.
 
-.. _identify_features_vector:
-
-Using the Identify Tool with Attribute Table
-============================================
-
-The |identify| :guilabel:`Identify features` tool can be used to display all attributes
-of a feature in the map canvas. It is a quick way to view and verify all data without
-having to search for it in the attribute table.
-
-To use the :guilabel:`Identify features` tool for vector layers, follow these steps:
-
-#. Select the vector layer in the Layers panel.
-#. Click on the :guilabel:`Identify features` tool in the toolbar or press :kbd:`Ctrl+Shift+I`.
-#. Click on a feature in the map view.
-
-The :guilabel:`Identify results` panel will display different features information
-depending on the layer type. There are two columns in the panel, on the left side
-you can see :guilabel:`Feature` and on the right side :guilabel:`Value`.
-Under the :guilabel:`Feature` column, panel will display following information:
-
-* **Derived** section - those are the information calculated or derived from other
-  information in the layer. For example, the area of a polygon or the length of a line.
-  General information that can be found in this section:
-
-  * Depending on the geometry type, cartesian measurements of length, perimeter, or area
-    in the layer's CRS units. For 3D line vectors, the cartesian line length is available.
-  * Depending on the geometry type and if an ellipsoid is set in the :guilabel:`Project Properties`
-    dialog (:guilabel:`General` --> :guilabel:`Measurements`), ellipsoidal values
-    of length, perimeter, or area using the specified units.
-  * The count of geometry parts in the feature and the number of the part clicked.
-  * The count of vertices in the feature.
-
-  Coordinate information that can be found in this section:
-  
-  * X and Y coordinate values of the clicked point.
-  * The number of the closest vertex to the clicked point.
-  * X and Y coordinate values of the closest vertex.
-  * If you click on a curved segment, the radius of that section is also displayed.
-
-* **Data attributes**: This is the list of attribute fields and values for the
-  feature that has been clicked.
-* information about the related child feature if you defined a :ref:`relation <vector_relations>`:
-
-  * the name of the relation
-  * the entry in reference field, e.g. the name of the related child feature
-  * **Actions**: lists actions defined in the layer's properties dialog (see :ref:`actions_menu`)
-    and the default action is ``View feature form``.
-  * **Data attributes**: This is the list of attributes fields and values of the
-    related child feature.
-
-
 .. _attribute_table_overview:
 
 Introducing the attribute table interface
@@ -740,6 +689,57 @@ changes for all selected features at once.
 
   Multi edit mode is only available for auto generated and drag and drop forms
   (see :ref:`customize_form`); it is not supported by custom ui forms.
+
+
+.. _identify_features_vector:
+
+Exploring features attributes through the Identify Tool
+=======================================================
+
+The |identify| :ref:`Identify features <identify>` tool can be used to display all attributes
+of a feature in the map canvas. It is a quick way to view and verify all data without
+having to search for it in the attribute table.
+
+To use the :guilabel:`Identify features` tool for vector layers, follow these steps:
+
+#. Select the vector layer in the Layers panel.
+#. Click on the :guilabel:`Identify features` tool in the toolbar or press :kbd:`Ctrl+Shift+I`.
+#. Click on a feature in the map view.
+
+The :guilabel:`Identify results` panel will display different features information
+depending on the layer type. There are two columns in the panel, on the left side
+you can see :guilabel:`Feature` and on the right side :guilabel:`Value`.
+Under the :guilabel:`Feature` column, panel will display following information:
+
+* **Derived** section - those are the information calculated or derived from other
+  information in the layer. For example, the area of a polygon or the length of a line.
+  General information that can be found in this section:
+
+  * Depending on the geometry type, cartesian measurements of length, perimeter, or area
+    in the layer's CRS units. For 3D line vectors, the cartesian line length is available.
+  * Depending on the geometry type and if an ellipsoid is set in the :guilabel:`Project Properties`
+    dialog (:guilabel:`General` --> :guilabel:`Measurements`), ellipsoidal values
+    of length, perimeter, or area using the specified units.
+  * The count of geometry parts in the feature and the number of the part clicked.
+  * The count of vertices in the feature.
+
+  Coordinate information that can be found in this section:
+  
+  * X and Y coordinate values of the clicked point.
+  * The number of the closest vertex to the clicked point.
+  * X and Y coordinate values of the closest vertex.
+  * If you click on a curved segment, the radius of that section is also displayed.
+
+* **Data attributes**: This is the list of attribute fields and values for the
+  feature that has been clicked.
+* information about the related child feature if you defined a :ref:`relation <vector_relations>`:
+
+  * the name of the relation
+  * the entry in reference field, e.g. the name of the related child feature
+  * **Actions**: lists actions defined in the layer's properties dialog (see :ref:`actions_menu`)
+    and the default action is ``View feature form``.
+  * **Data attributes**: This is the list of attributes fields and values of the
+    related child feature.
 
 
 .. index:: External Storage, WebDAV


### PR DESCRIPTION
This tool is not in the attribute table itself so it may look weird to start with it. It is an accompanying tool for viewing attribute data, so let's expose it as such. Also add a ref to the tool.
follow-up #8864
