### PR TITLE
Adding nix-shell dev workflow for Selma

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,3 @@
+use nix
+layout python
+

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 testdata
+.vscode-extensions
 sphinx-env
 *.pyc
 *.mo

--- a/README.md
+++ b/README.md
@@ -34,6 +34,20 @@ The latest documentation of QGIS is available at <https://docs.qgis.org/latest>
 
 The best way to build the documentation is within a Python Virtual Environment (venv).
 
+## Build on Linux (NixOS)
+
+If you are using NixOS or the nix package manager, setting up a development
+environment is very easy:
+
+```
+cd QGIS-Documentation
+nix-shell
+./vscode.sh
+```
+
+Will provide you with a fully working, repeatable environment for building the
+HTML documentation.
+ 
 ## Build on Linux or macOS
 
 You can use your own virtual env by creating it first:

--- a/clean.sh
+++ b/clean.sh
@@ -1,0 +1,9 @@
+#! /usr/bin/env bash
+
+rm -rf .direnv
+rm -rf .venv
+rm -rf .vscode-extensions
+rm -rf __pycache__
+cd ..
+cd -
+

--- a/list-vscode-extensions.sh
+++ b/list-vscode-extensions.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+code --extensions-dir=".vscode-extensions" --list-extensions | xargs -L 1 echo code --extensions-dir=".vscode-extensions" --install-extension

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,44 @@
+let
+  pinnedHash = "933d7dc155096e7575d207be6fb7792bc9f34f6d"; 
+  pkgs = import (fetchTarball "https://github.com/NixOS/nixpkgs/archive/${pinnedHash}.tar.gz") { };
+  pythonPackages = pkgs.python3Packages;
+in pkgs.mkShell rec {
+  name = "impurePythonEnv";
+  venvDir = "./.venv";
+  buildInputs = [
+    # A Python interpreter including the 'venv' module is required to bootstrap
+    # the environment.
+    pythonPackages.python
+
+    # This executes some shell code to initialize a venv in $venvDir before
+    # dropping into the shell
+    pythonPackages.venvShellHook
+    pkgs.vscode
+
+    # Those are dependencies that we would like to use from nixpkgs, which will
+    # add them to PYTHONPATH and thus make them accessible from within the venv.
+  ];
+
+  # Run this command, only after creating the virtual environment
+  postVenvCreation = ''
+     export DIRENV_LOG_FORMAT=
+     unset SOURCE_DATE_EPOCH
+     pip install -r REQUIREMENTS.txt
+     echo "-----------------------"
+     echo "🌈 Your Dev Environment is prepared."
+     echo "📒 Note:"
+     echo "-----------------------"
+     echo "start vscode like this:"
+     echo ""
+     echo "./vscode.sh"
+     echo "-----------------------"
+  '';
+
+  # Now we can execute any commands within the virtual environment.
+  # This is optional and can be left out to run pip manually.
+  postShellHook = ''
+    # allow pip to install wheels
+    unset SOURCE_DATE_EPOCH
+  '';
+
+}

--- a/vscode.sh
+++ b/vscode.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+echo "🪛 Installing VSCode Extensions:"
+echo "--------------------------------"
+code --extensions-dir=".vscode-extensions" --install-extension github.copilot
+code --extensions-dir=".vscode-extensions" --install-extension github.copilot-chat
+code --extensions-dir=".vscode-extensions" --install-extension github.vscode-pull-request-github
+code --extensions-dir=".vscode-extensions" .


### PR DESCRIPTION
This PR adds supports for working on the docs on NixOS or other operating systems where the nix package manager is available (this includes Windows on WSL2, macOS and most Linux distros), specifically with direnv and nix-shell.

After entering the directory in your terminal, simply typing nix-shell````, you will get all the dependencies installed for building. I will add PDF generation support in the future, right now it just installs the python deps.
