### PR TITLE
Corrected two typo's

### DIFF
--- a/docs/user_manual/working_with_vector_tiles/vector_tiles.rst
+++ b/docs/user_manual/working_with_vector_tiles/vector_tiles.rst
@@ -141,7 +141,7 @@ applied to the features, indicating:
 * a :guilabel:`Label`, a title for comprehensive identification of the rule
 * the name of a particular :guilabel:`Layer` the rule should apply to, if not applied to ``(all layers)``
 * a :guilabel:`Min. Zoom` and a :guilabel:`Max. Zoom`, for the range of display.
-  symbology and labelling can be dependent on the zoom level.
+  Symbology and labeling can be dependent on the zoom level.
 * a :guilabel:`Filter`, a QGIS expression to identify the features to apply the style to
 
 Each rule is added pressing the |symbologyAdd| :sup:`Add rule` button


### PR DESCRIPTION
Line 144: symbology and labelling == Symbology and labeling

<!---
Include a few sentences describing the overall goals for this Pull Request.
 
A list of issues is at https://github.com/qgis/QGIS-Documentation/issues.
Add "fix #issuenumber" for each issue the PR fixes. The ticket(s) will be closed automatically.
If your PR doesn't fix entirely the ticket, only add the ticket(s) reference preceded by # character.
-->
Goal: Display correct documentation

Ticket(s): #

- [x] Backport to LTR documentation is requested
