### PR TITLE
Typo corrected

### DIFF
--- a/docs/training_manual/complete_analysis/analysis_exercise.rst
+++ b/docs/training_manual/complete_analysis/analysis_exercise.rst
@@ -277,7 +277,7 @@ First we change the resolution of our rainfall data to 30 meters
    .. figure:: img/wrap_rainfall.png
       :align: center
 
-      Wrap (Reproject) Rainfall_clipped
+      Warp (Reproject) Rainfall_clipped
 
 
 Then we align the DEM:


### PR DESCRIPTION
line 280 
      Wrap (Reproject) Rainfall_clipped

 should be:
      Warp (Reproject) Rainfall_clipped

<!---
Include a few sentences describing the overall goals for this Pull Request.
 
A list of issues is at https://github.com/qgis/QGIS-Documentation/issues.
Add "fix #issuenumber" for each issue the PR fixes. The ticket(s) will be closed automatically.
If your PR doesn't fix entirely the ticket, only add the ticket(s) reference preceded by # character.
-->
Goal: Display correct documentation

Ticket(s): #

- [x] Backport to LTR documentation is requested

