### PR TITLE
Processing scripts: Improve distinction between alg.INT and alg.NUMBER

### DIFF
--- a/docs/user_manual/processing/scripts.rst
+++ b/docs/user_manual/processing/scripts.rst
@@ -479,7 +479,7 @@ Input types
    * - :class:`QgsProcessingParameterGeometry <qgis.core.QgsProcessingParameterGeometry>`
      - ``alg.GEOMETRY``
      - A geometry
-   * - :class:`QgsProcessingParameterNumber <qgis.core.QgsProcessingParameterNumber>`
+   * - :attr:`QgsProcessingParameterNumber.Integer <qgis.core.QgsProcessingParameterNumber.Integer>`
      - ``alg.INT``
      - An integer
    * - :class:`QgsProcessingParameterLayout <qgis.core.QgsProcessingParameterLayout>`
@@ -503,7 +503,7 @@ Input types
    * - :class:`QgsProcessingParameterMultipleLayers <qgis.core.QgsProcessingParameterMultipleLayers>`
      - ``alg.MULTILAYER``
      - A set of layers
-   * - :class:`QgsProcessingParameterNumber <qgis.core.QgsProcessingParameterNumber>`
+   * - :attr:`QgsProcessingParameterNumber.Double <qgis.core.QgsProcessingParameterNumber.Double>`
      - ``alg.NUMBER``
      - A numerical value
    * - :class:`QgsProcessingParameterPoint <qgis.core.QgsProcessingParameterPoint>`


### PR DESCRIPTION
Cherry-picks d910f61e0d7ba410ec60f54bedeeb370ad1d4fb7

<!---
Include a few sentences describing the overall goals for this Pull Request.
 
A list of issues is at https://github.com/qgis/QGIS-Documentation/issues.
Add "fix #issuenumber" for each issue the PR fixes. The ticket(s) will be closed automatically.
If your PR doesn't fix entirely the ticket, only add the ticket(s) reference preceded by # character.
-->
Goal:

Ticket(s): #
<!---
Indicate whether the fix should be backported to previous release.
Replace the space between square brackets by a `x` to make it checked.
-->
- [ ] Backport to LTR documentation is requested

<!---
Reviewing is a process done by community members, mostly on a volunteer basis.
We try to keep the overhead as small as possible and appreciate if you help us.
Please read carefully and ensure you comply with our writing guidelines at
https://docs.qgis.org/testing/en/docs/documentation_guidelines/index.html.
Feel free to ask in a comment or the (qgis-community-team mailing list)
[https://lists.osgeo.org/mailman/listinfo/qgis-community-team] if you have troubles with any item.
--->
