### PR TITLE
s/Unkown/Unknown/

### DIFF
--- a/docs/developers_guide/codingstandards.rst
+++ b/docs/developers_guide/codingstandards.rst
@@ -284,7 +284,7 @@ Enumerated types should be named in CamelCase with a leading capital e.g.:
   };
 
 Do not use generic type names that will conflict with other types. e.g. use
-``UnkownUnit`` rather than ``Unknown``
+``UnknownUnit`` rather than ``Unknown``
 
 Global Constants & Macros
 ==========================


### PR DESCRIPTION
Fix typo in coding standards that distracts from explanation of enum naming standard.