### PR TITLE
[attribute table] Clarify rows sorting

### DIFF
--- a/docs/user_manual/working_with_vector/attribute_table.rst
+++ b/docs/user_manual/working_with_vector/attribute_table.rst
@@ -218,10 +218,10 @@ In the new dialog, you can:
 
 .. _sort_columns:
 
-Sorting columns
+Sorting rows
 ...............
 
-The table can be sorted by any column, by clicking on the column header. A
+The rows can be sorted by any column, by clicking on the column header. A
 small arrow indicates the sort order (downward pointing means descending
 values from the top row down, upward pointing means ascending values from
 the top row down).
@@ -231,6 +231,9 @@ using multiple columns you can write ``concat(col0, col1)``.
 
 In form view, features identifier can be sorted using the |sort| :guilabel:`Sort
 by preview expression` option.
+
+Note that sorting the rows only affects the table rendering and does not alter
+the features order in the layer datasource.
 
 .. _tip_sortcolumns:
 


### PR DESCRIPTION
<!---
Include a few sentences describing the overall goals for this Pull Request.
 
A list of issues is at https://github.com/qgis/QGIS-Documentation/issues.
Add "fix #issuenumber" for each issue the PR fixes. The ticket(s) will be closed automatically.
If your PR doesn't fix entirely the ticket, only add the ticket(s) reference preceded by # character.
-->
Goal:

A proposal to clarify the sorting of the rows.

https://docs.qgis.org/3.34/en/docs/user_manual/working_with_vector/attribute_table.html#sorting-columns

Ticket(s): #
<!---
Indicate whether the fix should be backported to previous release.
Replace the space between square brackets by a `x` to make it checked.
-->
- [ ] Backport to LTR documentation is requested

<!---
Reviewing is a process done by community members, mostly on a volunteer basis.
We try to keep the overhead as small as possible and appreciate if you help us.
Please read carefully and ensure you comply with our writing guidelines at
https://docs.qgis.org/testing/en/docs/documentation_guidelines/index.html.
Feel free to ask in a comment or the (qgis-community-team mailing list)
[https://lists.osgeo.org/mailman/listinfo/qgis-community-team] if you have troubles with any item.
--->
