### PR TITLE
[3.34] Detail how to be able to fill options for input layers in the "raster aligns" algorithm

### DIFF
--- a/docs/user_manual/processing_algs/qgis/rastertools.rst
+++ b/docs/user_manual/processing_algs/qgis/rastertools.rst
@@ -8,7 +8,7 @@ Raster tools
       :depth: 1
 
 
-.. _qgisalignraster:
+.. _qgisalignsingleraster:
 
 Align raster
 ------------
@@ -17,7 +17,8 @@ Align raster
 Aligns raster by resampling it to the same cell size
 and reprojecting to the same CRS as a reference raster.
 
-.. warning:: This algorithm is ONLY available in the :ref:`Model Designer <processing.modeler>` context.
+.. warning:: **This algorithm is ONLY available in the** :ref:`Model Designer <processing.modeler>` context.
+ For other contexts, use instead :ref:`qgisalignrasters`.
 
 Parameters
 ..........
@@ -123,7 +124,7 @@ Outputs
 Python code
 ...........
 
-**Algorithm ID**: ``native:alignraster``
+**Algorithm ID**: ``native:alignsingleraster``
 
 .. include:: ../algs_include.rst
   :start-after: **algorithm_code_section**
@@ -139,7 +140,8 @@ Align rasters
 Aligns rasters by resampling them to the same cell size
 and reprojecting to the same CRS as a reference raster.
 
-.. warning:: This algorithm is NOT available in the :ref:`Model Designer <processing.modeler>` context.
+.. warning:: **This algorithm is NOT available in the** :ref:`Model Designer <processing.modeler>` context.
+ Use instead :ref:`qgisalignsingleraster`.
 
 Parameters
 ..........
@@ -158,7 +160,10 @@ Parameters
      - [raster] [list]
      - List of input raster layers with resampling options associated
        (filled as a :class:`QgsProcessingParameterAlignRasterLayers
-       <qgis.core.QgsProcessingParameterAlignRasterLayers>` item):
+       <qgis.core.QgsProcessingParameterAlignRasterLayers>` item ---
+       done in GUI by pressing :guilabel:`Configure Raster...` button
+       for each selected layer):
+
 
        **Input layer** [string] (``inputFile``)
          Full path of the input layer to align


### PR DESCRIPTION
backports #9005

and fix algorithm reference

<!---
Include a few sentences describing the overall goals for this Pull Request.
 
A list of issues is at https://github.com/qgis/QGIS-Documentation/issues.
Add "fix #issuenumber" for each issue the PR fixes. The ticket(s) will be closed automatically.
If your PR doesn't fix entirely the ticket, only add the ticket(s) reference preceded by # character.
-->
Goal:

Ticket(s): #
<!---
Indicate whether the fix should be backported to previous release.
Replace the space between square brackets by a `x` to make it checked.
-->
- [ ] Backport to LTR documentation is requested

<!---
Reviewing is a process done by community members, mostly on a volunteer basis.
We try to keep the overhead as small as possible and appreciate if you help us.
Please read carefully and ensure you comply with our writing guidelines at
https://docs.qgis.org/testing/en/docs/documentation_guidelines/index.html.
Feel free to ask in a comment or the (qgis-community-team mailing list)
[https://lists.osgeo.org/mailman/listinfo/qgis-community-team] if you have troubles with any item.
--->
