### PR TITLE
Fixes typo in reference

### DIFF
--- a/docs/user_manual/working_with_vector/attribute_table.rst
+++ b/docs/user_manual/working_with_vector/attribute_table.rst
@@ -527,7 +527,7 @@ Putting the layer into edit mode will also allow you to
 |editPaste| :sup:`Paste features from clipboard` (:kbd:`Ctrl+V`)
 |editCut| :sup:`Cut selected rows to clipboard` (:kbd:`Ctrl+X`)
 or |deleteSelectedFeatures| :sup:`Delete selected features`.
-More details at :ref:`editing_vector`.
+More details at :ref:`editingvector`.
 
 .. _vector_field_calculator:
 


### PR DESCRIPTION
Weirdly, the badges are green in the readme file while both should be red. Fixing the docs build one.