### PR TITLE
[TM] Adjust contributing instructions

### DIFF
--- a/docs/training_manual/appendix/contribute.rst
+++ b/docs/training_manual/appendix/contribute.rst
@@ -2,74 +2,73 @@
 Appendix: Contributing To This Manual
 *******************************************************************************
 
-To add materials to this course, you must follow the guidelines in this
-Appendix. You are not to alter the conditions in this Appendix except for
-clarification. This is to ensure that the quality and consistency of this
-manual can be maintained.
+To add materials to this course, you must follow the guidelines in this Appendix.
+You are not allowed to alter the conditions in this Appendix except for clarification.
+This is to ensure that the quality and consistency of this manual can be maintained.
 
 Downloading Resources
 ===============================================================================
 
 The source of this document is available at `GitHub
 <https://github.com/qgis/QGIS-Documentation>`_. Consult `GitHub.com
-<https://github.com/>`_ for instructions on how to use the git version control
-system.
+<https://github.com/>`_ for instructions on how to use the git version control system.
 
 Manual Format
 ===============================================================================
 
 This manual is written using `Sphinx <https://www.sphinx-doc.org/en/master/>`_,
 a Python document generator using the `reStructuredText
-<https://docutils.sourceforge.io/rst.html>`_ markup language. Instructions on
-how to use these tools are available on their respective sites.
+<https://docutils.sourceforge.io/rst.html>`_ markup language.
+Instructions on how to use these tools are available on their respective sites.
 
 Adding a Module
 ===============================================================================
 
-* To add a new module, first create a new directory (directly under the
-  top-level of the :kbd:`qgis-training-manual` directory) with the name of the
-  new module.
-* Under this new directory, create a file called :kbd:`index.rst`. Leave this
-  file blank for now.
-* Open the :kbd:`index.rst` file under the top-level directory. Its first lines
-  are::
+To add a new module:
+
+#. First create a new directory (directly under the  top-level
+   of the :file:`qgis-training-manual` directory) with the name of the new module.
+#. Under this new directory, create a file called :file:`index.rst`.
+   Leave this file blank for now.
+#. Open the :file:`index.rst` file under the top-level directory.
+   Its first lines are::
 
     .. toctree::
        :maxdepth: 2
-       
- 
+
        foreword/index
        introduction/index
 
-You will note that this is a list of directory names, followed by the name
-:kbd:`index`. This directs the top-level index file to the index files in each
-directory. The order in which they are listed determines the order they will
-have in the document.
+  You will note that this is a list of directory names, followed by the name ``index``.
+  This directs the top-level index file to the index files in each directory.
+  The order in which they are listed determines the order they will have in the document.
 
-* Add the name of your new module (i.e., the name you gave the new directory),
-  followed by :kbd:`/index`, to this list, wherever you want your module to
-  appear.
-* Remember to keep the order of the modules logical, such that later modules
-  build on the knowledge presented in earlier modules.
-* Open your new module's own index file (:kbd:`[module name]/index.rst`).
-* Along the top of the page, write a line of 80 asterisks (:kbd:`*`). This
-  represents a module heading.
-* Follow this with a line containing the markup phrase :kbd:`|MOD|` (which
-  stands for "module"), followed by the name of your module.
-* End this off with another line of 80 asterisks.
-* Leave a line open beneath this.
-* Write a short paragraph explaining the purpose and content of the module.
-* Leave one line open, then add the following text::
+#. Add the name of your new module (i.e., the name you gave the new directory),
+   followed by ``/index``, to this list, wherever you want your module to appear.
+#. Remember to keep the order of the modules logical, such that later modules build
+   on the knowledge presented in earlier modules.
+#. Open your new module's own index file (:file:`{module_name}/index.rst`).
+#. Along the top of the page, create the module heading:
+
+   #. write a first line of asterisks (``*``).
+   #. Follow this with a line containing the markup phrase ``Module:``,
+      followed by the name of your module.
+   #. End this off with another line of same number of asterisks.
+
+   .. note:: The underline and the overline should not be shorter than the
+    line containing the module title.
+
+#. Leave a line open beneath this.
+#. Write a short paragraph explaining the purpose and content of the module.
+#. Leave one line open, then add the following text::
 
     .. toctree::
        :maxdepth: 2
-       
 
        lesson1
        lesson2
 
-  ... where :kbd:`lesson1`, :kbd:`lesson2`, etc., are the names of your planned
-  lessons.
+   ... where ``lesson1``, ``lesson2``, etc., are the names of your planned lessons.
 
 The module-level index file will look like this:
 
@@ -83,7 +82,6 @@ The module-level index file will look like this:
 
   .. toctree::
      :maxdepth: 2
-     
 
      lesson1
      lesson2
@@ -93,34 +91,33 @@ Adding a Lesson
 
 To add a lesson to a new or existing module:
 
-* Open the module directory.
-* Open the :kbd:`index.rst` file (created above in the case of new modules).
-* Ensure that the name of the planned lesson is listed underneath the
-  :kbd:`toctree` directive, as shown above.
-* Create a new file under the module directory.
-* Name this file exactly the same as the name you provided in the module's
-  :kbd:`index.rst` file, and add the extension :kbd:`.rst`.
+#. Open the module directory.
+#. Open the :file:`index.rst` file (created above in the case of new modules).
+#. Ensure that the name of the planned lesson is listed underneath the
+   :file:`toctree` directive, as shown above.
+#. Create a new file under the module directory.
+#. Name this file exactly the same as the name you provided in the module's
+   :file:`index.rst` file, and add the extension :file:`.rst`.
 
-.. note:: For editing purposes, a :kbd:`.rst` file works exactly like a normal
-   text file (:kbd:`.txt`).
+  .. note:: For editing purposes, a :file:`.rst` file works exactly like a normal
+    text file (:file:`.txt`).
 
-* To begin writing the lesson, write the markup phrase ``Lesson:``, followed by
-  the lesson name.
-* In the next line, write a line of 80 equal signs (:kbd:`=`).
-* Leave a line open after this.
-* Write a short description of the lesson's intended purpose.
-* Include a general introduction to the subject matter. See the existing
-  lessons in this manual for examples.
-* Beneath this, start a new paragraph, beginning with this phrase::
+#. To begin writing the lesson, write the markup phrase ``Lesson``,
+   followed by the lesson name.
+#. In the next line, write a line of equal signs (``=``), not shorter than the lesson title.
+#. Leave a line open after this.
+#. Write a short description of the lesson's intended purpose.
+#. Include a general introduction to the subject matter.
+   See the existing lessons in this manual for examples.
+#. Beneath this, start a new paragraph, beginning with this phrase::
 
     **The goal for this lesson:**
 
-* Briefly explain the intended outcome of completing this lesson.
-* If you can't describe the goal of the lesson in one or two sentences,
-  consider breaking the subject matter up into multiple lessons.
+#. Briefly explain the intended outcome of completing this lesson.
+#. If you can't describe the goal of the lesson in one or two sentences,
+   consider breaking the subject matter up into multiple lessons.
 
-Each lesson will be subdivided into multiple sections, which will be addressed
-next.
+Each lesson will be subdivided into multiple sections, which will be addressed next.
 
 Adding a Section
 ===============================================================================
@@ -132,9 +129,9 @@ There are two types of sections: "follow along" and "try yourself".
   giving click-by-click directions as clearly as possible, interspersed with
   screenshots.
 * A "try yourself" section gives the reader a short assignment to try by
-  themselves. It is usually associated with an entry in the answer sheet at the
-  end of the documentation, which will show or explain how to complete the
-  assignment, and will show the expected outcome if possible.
+  themselves. It is usually associated with an entry in the answer box beneath,
+  which will show or explain how to complete the assignment,
+  and will show the expected outcome if possible.
 
 Every section comes with a difficulty level. An easy section is denoted by
 ``★☆☆``, moderate by ``★★☆``, and advanced by ``★★★``.
@@ -142,98 +139,70 @@ Every section comes with a difficulty level. An easy section is denoted by
 Adding a "follow along" section
 -------------------------------------------------------------------------------
 
-* To start this section, write the markup phrase of the intended difficulty
-  level (as shown above).
-* Leave a space and then write ``Follow Along:``.
-* Leave another space and write the name of the section (use only an initial
-  capital letter, as well as capitals for proper nouns).
-* In the next line, write a line of 80 minuses/dashes (:kbd:`-`). Ensure that
-  your text editor does not replace the default minus/dash character with a
-  long dash or other character.
-* Write a short introduction to the section, explaining its purpose. Then give
-  detailed (click-by-click) instructions on the procedure to be demonstrated.
-* In each section, include internal links, external links and screenshots as
-  needed.
-* Try to end each section with a short paragraph that concludes it and leads
-  naturally to the next section, if possible.
+#. To start this section, write the markup phrase of the intended difficulty
+   level (as shown above).
+#. Leave a space and then write ``Follow Along:``.
+#. Leave another space and write the name of the section (use only an initial
+   capital letter, as well as capitals for proper nouns).
+#. In the next line, write a line of minuses/dashes (``-``), not shorter than the section title.
+#. Write a short introduction to the section, explaining its purpose.
+   Then give detailed (click-by-click) instructions on the procedure to be demonstrated.
+#. In each section, include internal links, external links and screenshots as needed.
+#. Try to end each section with a short paragraph that concludes it
+   and leads naturally to the next section, if possible.
 
 Adding a "try yourself" section
 -------------------------------------------------------------------------------
 
-* To start this section, write the markup phrase of the intended difficulty
-  level (as shown above).
-* Leave a space and then write ``Try Yourself:``.
-* In the next line, write a line of 80 minuses/dashes (``-``). Ensure that
-  your text editor does not replace the default minus/dash character with a
-  long dash or other character.
-* Explain the exercise that you want the reader to complete. Refer to previous
-  sections, lessons or modules if necessary.
-* Include screenshots to clarify the requirements if a plain textual
-  description is not clear.
+
+#. To start this section, write the markup phrase of the intended difficulty
+   level (as shown above).
+#. Leave a space and then write ``Try Yourself:``.
+#. In the next line, write a line of minuses/dashes (``-``), not shorter than the section title.
+#. Explain the exercise that you want the reader to complete.
+   Refer to previous sections, lessons or modules if necessary.
+#. Include screenshots to clarify the requirements if a plain textual
+   description is not clear.
 
 In most cases, you will want to provide an answer regarding how to complete the
-assignment given in this section. To do so, you will need to add an entry in
-the answer sheet.
+assignment given in this section.
+To do so, you will need to create and feed an answer block beneath the instructions.
 
-* First, decide on a unique name for the answer. Ideally, this name will
-  include the name of the lesson and an incrementing number.
-* Create a link for this answer:
-
-  ::
-
-    :ref:`Check your results <answer-name>`
-
-* Open the answer sheet (:kbd:`answers/answers.rst`).
-* Create a link to the "try yourself" section by writing this line:
-
-  ::
+#. First, create the custom collapsible widget that contains the answer::
   
-    .. _answer-name:
+    .. admonition:: Answer
+       :class: dropdown
 
-* Write the instructions on how to complete the assignment, using links and
-  images where needed.
-* To end it off, include a link back to the "try yourself" section by writing
-  this line:
+#. Keeping an indentation with regard to the above block, write the instructions
+   on how to complete the assignment, using links and images where needed.
 
-  ::
-  
-    :ref:`Back to text <backlink-answer-name>`
-
-* To make this link work, add the following line above the heading to the "try
-  yourself" section:
-
-  ::
-  
-    .. _backlink-answer-name:
-
-Remember that each of these lines shown above must have a blank line above and
-below it, otherwise it could cause errors while creating the document.
 
 Add a Conclusion
 ===============================================================================
 
-* To end a lesson, write the phrase ``In Conclusion``, followed
-  by a new line of 80 minuses/dashes (``-``). Write a conclusion for the
-  lesson, explaining which concepts have been covered in the lesson.
+To end a lesson:
+
+#. Write the phrase ``In Conclusion``, followed by a new line of minuses/dashes (``-``).
+#. Write a conclusion for the lesson, explaining which concepts have been covered in the lesson.
 
 Add a Further Reading Section
 ===============================================================================
 
-* This section is optional.
-* Write the phrase ``Further Reading``, followed by a new line of
-  80 minuses/dashes (``-``).
+This section is optional.
+
+* Write the phrase ``Further Reading``, followed by a new line
+  of minuses/dashes (``-``).
 * Include links to appropriate external websites.
 
 Add a What's Next Section
 ===============================================================================
 
-* Write the phrase ``What's Next?`` for "what's next", followed by a new line of 80
-  minuses/dashes (``-``).
-* Explain how this lesson has prepared students for the next lesson or module.
-* Remember to change the "what's next" section of the previous lesson if
-  necessary, so that it refers to your new lesson. This will be necessary if
-  you have inserted a new lesson among existing lessons, or after an existing
-  lesson.
+#. Write the phrase ``What's Next?``, followed by a new line of minuses/dashes (``-``).
+#. Explain how this lesson has prepared students for the next lesson or module.
+#. Remember to change the "what's next" section of the previous lesson if necessary,
+   so that it refers to your new lesson.
+   This will be necessary if you have inserted a new lesson among existing lessons,
+   or after an existing lesson.
 
 Using Markup
 ===============================================================================
@@ -244,18 +213,18 @@ markup to your text.
 New concepts
 -------------------------------------------------------------------------------
 
-* If you are explaining a new concept, you will need to write the new concept's
-  name in italics by enclosing it in asterisks (:kbd:`*`).
+If you are explaining a new concept, you will need to write the new concept's
+name in italics by enclosing it in asterisks (``*``).
 
-  ::
+::
   
-    This sample text shows how to introduce a *new concept*.
+  This sample text shows how to introduce a *new concept*.
 
 Emphasis
 -------------------------------------------------------------------------------
 
 * To emphasize a crucial term which is not a new concept, write the term in
-  bold by enclosing it in double asterisks (:kbd:`**`).
+  bold by enclosing it in double asterisks (``**``).
 * Use this sparingly! If used too much, it can seem to the reader that you are
   shouting or being condescending.
 
@@ -268,7 +237,7 @@ Emphasis
 Images
 -------------------------------------------------------------------------------
 
-* When adding an image, save it to the folder :kbd:`_static/lesson_name/`.
+* When adding an image, save it to an :file:`img` folder next to the lesson file.
 * Include it in the document like this::
   
     .. figure:: img/image_file.extension
@@ -284,11 +253,10 @@ Internal links
 
     .. _link-name:
 
-* To create a link, add this line::
+* Remember to leave a line open above and below this line.
+* To create a link, refer to it as below::
 
     :ref:`Descriptive link text <link-name>`
-  
-* Remember to leave a line open above and below this line.
 
 External links
 -------------------------------------------------------------------------------
@@ -297,16 +265,14 @@ External links
 
     `Descriptive link text <link-url>`_
 
-* Remember to leave a line open above and below this line.
-
 Using monospaced text
 -------------------------------------------------------------------------------
 
 * When you are writing text that the user needs to enter, a path name, or the
   name of a database element such as a table or column name, you must write it
-  in :kbd:`monospaced text`. For example::
+  in ``monospaced text``. For example::
 
-    Enter the following path in the text box: :kbd:`path/to/file`.
+    Enter the following path in the text box: ``path/to/file``.
 
 Labeling GUI items
 -------------------------------------------------------------------------------
@@ -331,15 +297,15 @@ Menu selections
 Adding notes
 -------------------------------------------------------------------------------
 
-* You might need to a note in the text, which explains extra details that can't
+* You might need to add a note in the text, which explains extra details that can't
   easily be made part of the flow of the lesson. This is the markup::
 
     [Normal paragraph.]
   
     .. note:: Note text.
-       New line within note.
+      New line within note.
   
-       New paragraph within note.
+      New paragraph within note.
   
     [Unindented text resumes normal paragraph.]
 
@@ -355,7 +321,7 @@ advertisement for their company.
 If you have volunteered to write a module, lesson or section in your own
 capacity, and not on behalf of a sponsor, you may include an authorship note
 below the heading of the module, lesson or section that you authored. This must
-take the form :kbd:`This [module/lesson/section] contributed by [author name].`
+take the form ``This [module/lesson/section] contributed by [author name].``
 Do not add further text, contact details, etc. Such details are to be added in
 the "Contributors" section of the Foreword, along with the name(s) of the
 part(s) you added. If you only made enhancements, corrections and/or additions,

--- a/docs/training_manual/basic_map/mapviewnavigation.rst
+++ b/docs/training_manual/basic_map/mapviewnavigation.rst
@@ -83,7 +83,7 @@ the real world.
 
 You can also use this field to set the Map Scale manually.
 
-#. In the Status Bar, click on the :guilabel:`Scale` textfield.
+#. In the Status Bar, click on the :guilabel:`Scale` text field.
 #. Type in ``50000`` and press :kbd:`Enter`.  This will redraw the features in the 
    Map Canvas to reflect the scale you typed in.
 #. Alternatively, click on the options arrow of the :guilabel:`Scale` field to see
@@ -95,7 +95,7 @@ You can also use this field to set the Map Scale manually.
 #. Select :guilabel:`1:5000`.  This will also update the map scale in the Map Canvas.
 
 Now you know the basics of navigating the Map Canvas. Check out the User Manual on 
-:ref:`Zooming and Panning<zoom_pan>` to learn about alternative ways of navigating 
+:ref:`Zooming and Panning <zoom_pan>` to learn about alternative ways of navigating
 the Map Canvas.
 
 In Conclusion

--- a/docs/training_manual/databases/db_manager.rst
+++ b/docs/training_manual/databases/db_manager.rst
@@ -14,10 +14,8 @@ databases using the QGIS DB Manager.
 ------------------------------------------------------------------------------------
 
 You should first open the DB Manager interface by selecting
-:guilabel:`Database --> DB Manager --> DB Manager` on the menu or by
-selecting the DB Manager icon on the toolbar.
-
-    |dbManager|
+:menuselection:`Database --> DB Manager --> DB Manager` on the menu
+or by selecting the |dbManager| :sup:`DB Manager` icon on the toolbar.
 
 You should already see the previous connections we have configured
 and be able to expand the ``myPG`` section and its ``public`` schema
@@ -30,8 +28,7 @@ about the Schemas contained in your database.
    :align: center
 
 Schemas are a way of grouping data tables and other objects in a
-PostgreSQL database and a container for permissions and other
-constraints.
+PostgreSQL database and a container for permissions and other constraints.
 Managing PostgreSQL schemas is beyond the scope of this manual, but
 you can find more information about them in the
 `PostgreSQL documentation on Schemas

--- a/docs/training_manual/processing/log.rst
+++ b/docs/training_manual/processing/log.rst
@@ -3,26 +3,65 @@ The processing log
 
 .. note:: This lesson describes the processing log.
 
-All the analysis performed with the processing framework is logged in QGIS logging system. This allows you to know more about what has been done with the processing tools, to solve problems when they happen, and also to re--run previous operations, since the logging system also implements some interactivity.
+All the analysis performed with the processing framework is logged in QGIS logging system.
+This allows you to know more about what has been done with the processing tools,
+to solve problems when they happen, and also to re--run previous operations,
+since the logging system also implements some interactivity.
 
-To open the log, click on the balloon at the bottom right, on the QGIS status bar. Some algorithms might leave here information about their execution. For instance, those algorithms that call an external application usually log the console output of that application to this entry. If you have a look at it, you will see that the output of the SAGA algorithm that we just run (and that fail to execute because input data was not correct) is stored here.
+To open the log, click on the balloon at the bottom right, on the QGIS status bar.
+Some algorithms might leave here information about their execution.
+For instance, those algorithms that call an external application
+usually log the console output of that application to this entry.
+If you have a look at it, you will see that the output of the SAGA algorithm that we just run
+(and that fails to execute because input data was not correct) is stored here.
 
-This is helpful to understand what is going on. Advanced users will be able to analyze that output to find out why the algorithm failed. If you are not an advanced user, this will be useful for others to help you diagnose the problem you are having, which might be a problem in the installation of the external software or an issue with the data you provided.
+This is helpful to understand what is going on.
+Advanced users will be able to analyze that output to find out why the algorithm failed.
+If you are not an advanced user, this will be useful for others to help you diagnose the problem you are having,
+which might be a problem in the installation of the external software or an issue with the data you provided.
 
-Even if the algorithm could be executed, some algorithms might leave warnings in case the result might not be right. For instance, when executing an interpolation algorithm with a very small amount of points, the algorithm can run and will produce a result, but it is likely that it will not be correct, since more points should be used. It's a good idea to regularly check for this type of warnings if you are not sure about some aspect of a given algorithm.
+Even if the algorithm could be executed, some algorithms might leave warnings in case the result might not be right.
+For instance, when executing an interpolation algorithm with a very small amount of points,
+the algorithm can run and will produce a result, but it is likely that it will not be correct, since more points should be used.
+It's a good idea to regularly check for this type of warnings if you are not sure about some aspect of a given algorithm.
 
-From the *Processing* menu, under the *History* section, you'll find *Algorithms*. All algorithms that are executed, even if they are executed from the GUI and not from the console (which will be explained later in this manual) are stored in this section as a console call. That means that everytime you run an algorithm, a console command is added to the log, and you have the full history of your working session. Here is how that history looks like:
+From the :menuselection:`Processing --> History...` menu, you'll find *algorithms* that are executed,
+regardless of they are executed from the GUI or from the console (which will be explained later in this manual).
+The execution is stored in this dialog as a console call.
+That means that everytime you run an algorithm, a console command is added to the log,
+and you have the full history of your working session.
+Here is how that history looks like:
 
 .. figure:: img/log/history.png
 
-This can be very useful when starting working with the console, to learn about the syntax of algorithms. We will use it when we discuss how to run analysis commands from the console.
+This can be very useful when starting working with the console, to learn about the syntax of algorithms.
+We will use it when we discuss how to run analysis commands from the console.
 
-The history is also interactive, and you can re--run any previous algorithm just by double--clicking on its entry. This is an easy way of replicating the work we already did before.
+:abbr:`★☆☆ (Basic level)` Follow Along
+---------------------------------------
 
-For instance, try the following. Open the data corresponding to the first chapter of this manual and run the algorithm explained there. Now go to the log dialog and locate the last algorithm in the list, which corresponds to the algorithm you have just run. Double--click on it an a new result should be produced, just like when you run it using the normal dialog and calling it from the toolbox.
+The history is also interactive, and you can run any previous algorithm just by double-clicking on its entry.
+This is an easy way of replicating the work we already did before.
 
+For instance, try the following:
+
+#. Open the data corresponding to the first chapter of this manual and run the algorithm explained there.
+#. Now go to the log dialog and locate the last algorithm in the list, which corresponds to the algorithm you have just run.
+#. Double-click on it and a new result should be produced, just like when you run it using the normal dialog and calling it from the toolbox.
 
 :abbr:`★★★ (Advanced level)` Advanced
+-------------------------------------
 
-You can also modify the algorithm. Just copy it, open the :menuselection:`Plugins --> Python console`, click on :menuselection:`Import class --> Import Processing class`, then paste it to re-run the analysis; change the text at will. To display the resulting file, type :kbd:`iface.addVectorLayer('/path/filename.shp', 'Layer name in legend', 'ogr')`. Otherwise, you can use :kbd:`processing.runandload`.
+You can also modify the algorithm.
+
+#. Copy the algorithm call
+#. Open the :menuselection:`Plugins --> Python console`
+#. Paste your copy to run the analysis; change the text at will.
+#. To display the resulting file, type::
+
+    iface.addVectorLayer('/path/filename.shp', 'Layer name in legend', 'ogr')
+
+   Otherwise, you can use::
+
+    processing.runAndloadResults
 


### PR DESCRIPTION
Let's adjust the training manual contributing instructions after #8916, clarifying instructions formatting, removing the 80 chars limitation, killing some :kbd: misuse, fixing typos
