### PR TITLE
Delete exercice levels in the preparing data chapter

### DIFF
--- a/docs/training_manual/appendix/preparing_data.rst
+++ b/docs/training_manual/appendix/preparing_data.rst
@@ -3,7 +3,7 @@
 Preparing Exercise Data
 =======================
 
-.. note:: This process is intended for course conveners, or more experienced
+.. important:: This process is intended for course conveners, or more experienced
   QGIS users who wish to create localised sample data sets for their course.
   Default data sets are provided with the Training Manual, but you may follow
   these instructions if you wish to replace the default data sets.
@@ -21,7 +21,7 @@ more complex data sources which may or may not be available for your region.
 .. note:: These instructions assume you have a good knowledge of QGIS and are
   not intended to be used as teaching material.
 
-:abbr:`★★★ (Advanced level)` Try Yourself:  Create OSM based vector files
+Create OSM based vector files
 --------------------------------------------------------------------------------
 
 If you wish to replace the default data set with localised data for your course,
@@ -59,8 +59,7 @@ tools.
    .. figure:: img/quickosm_plugin_download.png
       :align: center
 
-#. Execute the new plugin from :menuselection:`Vector --> QuickOSM -->
-   QuickOSM...` menu
+#. Execute the new plugin from :menuselection:`Vector --> QuickOSM --> QuickOSM...` menu
 #. In the :guilabel:`Quick query` tab, select ``building`` in the :guilabel:`Key`
    drop-down menu
 #. Leave the :guilabel:`Value` field empty, meaning that you are querying all
@@ -175,7 +174,7 @@ are added to the map):
 The important thing is that you have 7 vector layers matching those
 shown above and that all those layers have some data.
 
-:abbr:`★★★ (Advanced level)` Try Yourself: Create SRTM DEM tiff files
+Create SRTM DEM tiff files
 --------------------------------------------------------------------------------
 
 For modules :ref:`tm_create_vector_data` and :ref:`tm_rasters`, you'll also need
@@ -195,7 +194,7 @@ Keep the :file:`GeoTiff` format. Once the form is filled, click on the
 Once you have downloaded the required file(s), they should be saved in the
 :file:`exercise_data` directory, under :file:`raster/SRTM` subfolders.
 
-:abbr:`★★★ (Advanced level)` Try Yourself: Create imagery tiff files
+Create imagery tiff files
 --------------------------------------------------------------------------------
 
 
@@ -212,7 +211,7 @@ For reference, the image in the example data is:
    :align: center
 
 
-:abbr:`★☆☆ (Basic level)` Try Yourself: Replace tokens
+Replace tokens
 --------------------------------------------------------------------------------
 
 Having created your localized dataset, the final step is to replace the tokens


### PR DESCRIPTION
That chapter targets people willing to adapt the lessons and teach QGIS to others so I hope they are good enough to cover all the levels of difficulties in the manual (or not worry about)

Moreover, I think we shouldn't go into details that way in the chapter. They are assumed to know how to do it (btw, QuickOSM we rely on no longer has that interface), we should instead mention the main points they should pay attention to.

Last but not least, we would avoid, in the training manual top page 👇🏿 
![image](https://github.com/qgis/QGIS-Documentation/assets/7983394/72e91912-6143-4851-b8dd-44afec0b9bcc)
