### PR TITLE
Add scrollbar to left menu and ensure the search top frame is always visible

### DIFF
--- a/themes/rtd_qgis/static/css/qgis_docs.css
+++ b/themes/rtd_qgis/static/css/qgis_docs.css
@@ -5,6 +5,21 @@
 .rst-content .guilabel {
  background:#7fbbe3
 }
+
+/* adds scrollbar to side navigator and keep showing the top title block */
+.wy-side-nav-search {
+   margin-bottom: 0;
+}
+.wy-side-scroll {
+   width: auto;
+   overflow-y: hidden;
+   display: flex;
+   flex-direction: column;
+}
+.wy-menu.wy-menu-vertical {
+   overflow-y: auto;
+}
+
 /*rtd theme does not render menuselection, so let's apply guilabel settings to it*/
 .rst-content .menuselection {
  background:#7fbbe3;


### PR DESCRIPTION
can be convenient when you don't have a mouse and need to go to a section that is not visible in the side bar.
The fix also ensures the clicked item in the side bar is kept visible and identifiable instead of being hidden under the testing banner
before and after (with scrollbar while hovering over the side bar)
![image](https://github.com/qgis/QGIS-Documentation/assets/7983394/33179944-2a48-4c99-b37b-9478c695f3b7)
