### PR TITLE
Remove `make -jX`  step in qtcreator instructions

### DIFF
--- a/docs/developers_guide/qtcreator.rst
+++ b/docs/developers_guide/qtcreator.rst
@@ -104,30 +104,6 @@ you may want to enable more features such as:
 
 Press :guilabel:`Apply Configuration Changes`.
 
-By default, Qt Creator uses all the CPU cores available to speed the build with
-maximum parallelization. To avoid that your computer freezes, you should specify a
-smaller number of cores. Under the :guilabel:`Build Steps` section:
-
-#. Press the :menuselection:`Add build step -->` menu and select
-   :guilabel:`Custom Process Step`
-#. Fill the new form as follows:
-
-   * :guilabel:`Command`: ``make``
-   * :guilabel:`Arguments`: ``-j4`` to use 4 cores (setting depends on your device)
-   * :guilabel:`Working directory`: ``%{buildDir}``
-
-.. image:: img/customProcess.png
-
-.. note::
-
-  Also, if you want to reduce your build times, you can do it with ``ninja``, an
-  alternative to ``make`` with similar build options. You'd need to set it as
-  the :guilabel:`CMake generator`:
-  
-  #. Open :menuselection:`Tools --> Options --> Build & Run --> Kits`
-  #. Select the :guilabel:`Desktop (default)` kit entry, displaying its properties
-  #. Press :guilabel:`Change...` next to :guilabel:`CMake generator`
-
 You are now ready to build. Press the |build| :sup:`Build` button at the left
 bottom of the dialog (or :kbd:`Ctrl+B`) to launch the project build! Qt Creator
 will begin compiling and this may take some time the first time, depending on your


### PR DESCRIPTION
This step is no longer necessary.

<!---
Include a few sentences describing the overall goals for this Pull Request.
 
A list of issues is at https://github.com/qgis/QGIS-Documentation/issues.
Add "fix #issuenumber" for each issue the PR fixes. The ticket(s) will be closed automatically.
If your PR doesn't fix entirely the ticket, only add the ticket(s) reference preceded by # character.
-->
Goal: Improve instructions for building QGIS with QtCreator

Ticket(s): #
<!---
Indicate whether the fix should be backported to previous release.
Replace the space between square brackets by a `x` to make it checked.
-->
- [ ] Backport to LTR documentation is requested

<!---
Reviewing is a process done by community members, mostly on a volunteer basis.
We try to keep the overhead as small as possible and appreciate if you help us.
Please read carefully and ensure you comply with our writing guidelines at
https://docs.qgis.org/testing/en/docs/documentation_guidelines/index.html.
Feel free to ask in a comment or the (qgis-community-team mailing list)
[https://lists.osgeo.org/mailman/listinfo/qgis-community-team] if you have troubles with any item.
--->
