### PR TITLE
Keep the string as a whole to not mislead readers and translators

### DIFF
--- a/docs/user_manual/working_with_mesh/mesh.rst
+++ b/docs/user_manual/working_with_mesh/mesh.rst
@@ -12,7 +12,7 @@
 What's a mesh?
 ==============
 
-A mesh is an unstructured grid usually with temporal and other components.
+A mesh is an unstructured grid usually with temporal and other components.
 The spatial component contains a collection of vertices, edges and/or faces,
 in 2D or 3D space:
 
@@ -778,8 +778,9 @@ The following table displays the various combinations.
  |                                       | vertices in mesh layer? |                               |                                          |
  +=======================================+=========================+===============================+==========================================+
  | "Free" vertex, not connected to any   | No                      | :guilabel:`Vertex Z value`    | Default or user defined                  |
+ | face or edge of a face                |                         |                               |                                          |
  +                                       +                         +-------------------------------+------------------------------------------+
- | face or edge of a face                |                         | :guilabel:`Advanced           | :guilabel:`z` widget if in               |
+ |                                       |                         | :guilabel:`Advanced           | :guilabel:`z` widget if in               |
  |                                       |                         | Digitizing Panel` (if         | |locked| :sup:`Locked` state             |
  |                                       |                         | :guilabel:`z` widget is in    |                                          |
  |                                       |                         | |locked| :sup:`Locked` state) |                                          |


### PR DESCRIPTION
Previously
![image](https://github.com/qgis/QGIS-Documentation/assets/7983394/2e0afb54-8dbb-4a53-9784-dbd5bd74c4f6)

With the PR
![image](https://github.com/qgis/QGIS-Documentation/assets/7983394/fd58c763-93d3-4bd0-bfbf-7643573f5a03)
