### PR TITLE
sphinx Add support for markdown files

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -59,8 +59,14 @@ extensions = [
     'sphinx.ext.extlinks',
     'sphinxext.rediraffe',
     'sphinx_togglebutton',
-    'sphinx_copybutton'
+    'sphinx_copybutton',
+    'myst_parser'
 ]
+
+source_suffix = {
+    '.rst': 'restructuredtext',
+    '.md': 'markdown'
+}
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
@@ -71,7 +77,10 @@ templates_path = ['_templates']
 exclude_patterns = [
     'venv',
     '.github',
-    'docs/user_manual/expressions/expression_help/*'
+    'docs/user_manual/expressions/expression_help/*',
+    'README.md',
+    'release_process.md',
+    'qgis-projects/user_manual/readme.md'
 ]
 
 # -- Internationalisation ----------------------------------------------------

--- a/conf.py
+++ b/conf.py
@@ -70,6 +70,7 @@ templates_path = ['_templates']
 # This pattern also affects html_static_path and html_extra_path.
 exclude_patterns = [
     'venv',
+    '.github',
     'docs/user_manual/expressions/expression_help/*'
 ]
 


### PR DESCRIPTION
Goal:

This adds support to use markdown files to generate the
documentation. The existing `rst` files still work and this allows to
mix them with markdown files. Both formats coexist without any
friction.

This way, a contributor can use its favorite format. Besides, markdown
syntax is considered easier to write than the rst one. This might
attract new contributors to the project.

This also introduces a new dependency for markdown parsing:
`myst-parser`.

See: https://www.sphinx-doc.org/en/master/usage/markdown.html

Related: https://github.com/qgis/QGIS-Website/pull/1255