### PR TITLE
fix: Mention the default URL to open user manual pages from QGIS Desktop

### DIFF
--- a/docs/user_manual/introduction/qgis_configuration.rst
+++ b/docs/user_manual/introduction/qgis_configuration.rst
@@ -176,7 +176,8 @@ plugin libraries`.
 
 Add or Remove :guilabel:`Documentation Path(s)` to use for QGIS help. By default,
 a link to the official online User Manual corresponding to the version being used
-is added. You can however add other links and prioritize them from top to bottom:
+is added (i.e. ``https://docs.qgis.org/§qgis_short_version/$qgis_locale/docs/user_manual/``).
+You can however add other links and prioritize them from top to bottom:
 each time you click on a :guilabel:`Help` button in a dialog, the topmost link
 is checked and if no corresponding page is found, the next one is tried,
 and so on.


### PR DESCRIPTION
 refs https://github.com/qgis/QGIS/issues/58586
This may be helpful when you inadvertently remove the entry and don't remember how it was constructed