### PR TITLE
Restructure html label section and add word-spacing

### DIFF
--- a/docs/user_manual/style_library/label_settings.rst
+++ b/docs/user_manual/style_library/label_settings.rst
@@ -156,22 +156,38 @@ Use whitespaces instead of tabs for any kind of indentation.
 The expression is parsed and any supported HTML tag overrides its corresponding setting in the labels properties.
 An exhaustive list of the supported subset of HTML tags and CSS properties can be found `here <https://doc.qt.io/qt-5/richtext-html-subset.html>`_.
 
+Examples of supported HTML tags:
 
-Supported CSS properties include:
+* Text formatting, such as italic or bold, e.g.:
 
-* Font properties (``color``, ``font-family``, ``font-size``, ``font-weight``, ``font-style``, ``word-spacing``). 
-  Note that ``word-spacing`` will always use unit px.
-* Text decorations such as underline, strikethrough and overline (``text-decoration``)
+  .. code:: html
+
+    <i>QGIS</i> <b>rocks!</b>
+
+* Superscript and subscript, where the text will be vertically :sup:`super` or 
+  :sub:`sub` aligned and automatically sized to 2/3 of the parent font size.
+  You can also set a fixed font size for the superscript/subscript
+  by including css rules, e.g.:
+
+  .. code:: html
+
+    <sup style="font-size:33pt">my superscript text</sup>
+
+Examples of supported CSS properties:
+
+* Font properties (``color``, ``font-family``, ``font-size``, ``font-weight``, ``font-style``, ``word-spacing``).
+  Note that ``word-spacing`` will always use unit points.
+* Text decorations such as underline, overline and line-through (``text-decoration``)
 * Text alignment (``vertical-align``)
 
-Supported tags include superscript and subscript, where the text will be vertically :sup:`super` or 
-:sub:`sub` aligned and automatically sized to 2/3 of the parent font size.
-You can also set a fixed font size for the superscript/subscript
-by including css rules, e.g.:
+CSS properties can be set on HTML tags with the style attribute.
+The HTML tag span does not apply any formatting to text by itself and is ideal if you just want to apply CSS styling.
+A CSS property name and its value are separated by a colon (``:``). 
+Multiple CSS properties are separated by semicolon (``;``), e.g.:
 
 .. code:: html
 
-  <sup style="font-size:33pt">my superscript text</sup>
+  <span style="text-decoration:underline;color:blue;word-spacing:20">I will be displayed as blue underlined text with increased space between words</span>
 
 Below an example of a HTML-based expression and rendering
 (applies different colors and underline to the same label):

--- a/docs/user_manual/style_library/label_settings.rst
+++ b/docs/user_manual/style_library/label_settings.rst
@@ -157,9 +157,9 @@ They also combine well with other background, shadow, buffer... properties of la
 
 Several CSS properties are supported:
 
-* Font properties (color, font family, font size, word-spacing, bold and italic)
-* Text decorations (underline, strikethrough, and overline)
-* Some properties, such as ``vertical-align: super`` or ``vertical-align: sub``,
+* Font properties (``color``, ``font-family``, ``font-size``, ``font-weight``, ``font-style`` and ``word-spacing``)
+* Underline, strikethrough and overline through ``text-decoration``
+* Some properties such as ``vertical-align: super`` or ``vertical-align: sub``
   are also available in any other HTML element.
 
 Notable tags include superscript and subscript, where the text will be vertically :sup:`super` or 

--- a/docs/user_manual/style_library/label_settings.rst
+++ b/docs/user_manual/style_library/label_settings.rst
@@ -152,17 +152,19 @@ Allow HTML Formatting
 .....................
 
 With :guilabel:`Allow HTML Formatting` enabled, you need to provide the HTML code in the :guilabel:`Value` field.
+Use whitespaces instead of tabs for any kind of indentation.
 The expression is parsed and any supported HTML tag overrides its corresponding setting in the labels properties.
-They also combine well with other background, shadow, buffer... properties of labels.
+It is impossible to list every supported HTML tag and CSS property. 
+Be courageous and explore!
 
-Several CSS properties are supported:
+Supported CSS properties include:
 
-* Font properties (``color``, ``font-family``, ``font-size``, ``font-weight``, ``font-style`` and ``word-spacing``)
-* Underline, strikethrough and overline through ``text-decoration``
-* Some properties such as ``vertical-align: super`` or ``vertical-align: sub``
-  are also available in any other HTML element
+* Font properties (``color``, ``font-family``, ``font-size``, ``font-weight``, ``font-style``, ``word-spacing``). 
+  Note that ``word-spacing`` will always use unit px.
+* Text decorations such as underline, strikethrough and overline (``text-decoration``)
+* Text alignment (``vertical-align``)
 
-Notable tags include superscript and subscript, where the text will be vertically :sup:`super` or 
+Supported tags include superscript and subscript, where the text will be vertically :sup:`super` or 
 :sub:`sub` aligned and automatically sized to 2/3 of the parent font size.
 You can also set a fixed font size for the superscript/subscript
 by including css rules, e.g.:
@@ -188,12 +190,6 @@ Below an example of a HTML-based expression and rendering
     :align: center
 
     Labeling with HTML formatting enabled
- 
-Note:
-
-* It is impossible to list every supported HTML tag and CSS property. Be courageous and explore!
-* Use whitespaces instead of tabs for any kind of indentation
-* CSS property ``word-spacing`` will always use unit px
 
 .. _labels_formatting:
 

--- a/docs/user_manual/style_library/label_settings.rst
+++ b/docs/user_manual/style_library/label_settings.rst
@@ -130,47 +130,7 @@ In the |text| :guilabel:`Text` tab, you can set:
 * the :guilabel:`Size` in any :ref:`supported unit <unit_selector>`
 * the :guilabel:`Color`
 * the :guilabel:`Opacity`
-* and :guilabel:`Allow HTML Formatting`:
-  The HTML formatting option enables the proper rendering of some HTML tags to customize the label.
-  The supported HTML tags are:
-
-  * Color, applicable to text, underline, strikethrough, and overline
-  * Font properties (font family, font size, bold and italic)
-  * Superscript and subscript components in text,
-    where the text will be vertically :sup:`super` or :sub:`sub` aligned
-    and automatically sized to 2/3 of the parent font size.
-    You can also set a fixed font size for the superscript/subscript
-    by including css rules, e.g.:
-
-    .. code:: html
-
-      <sup style="font-size:33pt">my superscript text</sup>
-
-    The CSS formatting rules ``vertical-align: super`` or ``vertical-align: sub``
-    are also available in any other HTML element (annotation, layout label or HTML items, ...).
-
-  In order to use the HTML formatting, you need to provide the HTML code in the :guilabel:`Value` field.
-  The expression is parsed and any supported HTML tag overrides its corresponding setting in the labels properties.
-  They also combine well with other background, shadow, buffer... properties of labels.
-
-  Below an example of a HTML-based expression and rendering
-  (applies different colors and underline to the same label):
-
-  .. code:: html
-
-    format(
-      '<span style="color:blue">%1</span> ( <span style="color:red"><u>%2 ft</u></span> )',
-      title( lower( "Name" ) ),
-      round($length)
-    )
-
-  .. _figure_label_html_formatting:
-
-  .. figure:: img/label_HTML_formatting.png
-     :align: center
-
-     Labeling with HTML formatting enabled
-
+* and :guilabel:`Allow HTML Formatting` enables the use of a subset of HTML tags and CSS rules to customize the label.
 
 At the bottom of the tab, a widget shows a filterable list of compatible items
 stored in your :ref:`style manager database <vector_style_manager>`.
@@ -183,6 +143,57 @@ and provide a name and tag(s).
  are also available in this widget. Select one to quickly overwrite the current
  :ref:`textual properties <text_format>` of the label.
  Likewise, you can create/overwrite a text format from there.
+
+
+.. _labels_text_html:
+
+
+Allow HTML Formatting
+.....................
+
+With :guilabel:`Allow HTML Formatting` enabled, you need to provide the HTML code in the :guilabel:`Value` field.
+The expression is parsed and any supported HTML tag overrides its corresponding setting in the labels properties.
+They also combine well with other background, shadow, buffer... properties of labels.
+
+Several CSS properties are supported:
+
+* Font properties (color, font family, font size, word-spacing, bold and italic)
+* Text decorations (underline, strikethrough, and overline)
+* Some properties, such as ``vertical-align: super`` or ``vertical-align: sub``,
+  are also available in any other HTML element.
+
+Notable tags include superscript and subscript, where the text will be vertically :sup:`super` or 
+:sub:`sub` aligned and automatically sized to 2/3 of the parent font size.
+You can also set a fixed font size for the superscript/subscript
+by including css rules, e.g.:
+
+.. code:: html
+
+  <sup style="font-size:33pt">my superscript text</sup>
+
+Below an example of a HTML-based expression and rendering
+(applies different colors and underline to the same label):
+
+.. code:: html
+
+  format(
+    '<span style="color:blue">%1</span> ( <span style="color:red"><u>%2 ft</u></span> )',
+    title( lower( "Name" ) ),
+    round($length)
+  )
+
+.. _figure_label_html_formatting:
+
+.. figure:: img/label_HTML_formatting.png
+    :align: center
+
+    Labeling with HTML formatting enabled
+ 
+Note:
+
+* It is impossible to list every supported HTML tag and CSS propery. Be courageous and explore!
+* Use whitespaces instead of tabs for any kind of indentation
+* CSS property ``word-spacing`` will always use unit px
 
 .. _labels_formatting:
 

--- a/docs/user_manual/style_library/label_settings.rst
+++ b/docs/user_manual/style_library/label_settings.rst
@@ -191,7 +191,7 @@ Below an example of a HTML-based expression and rendering
  
 Note:
 
-* It is impossible to list every supported HTML tag and CSS propery. Be courageous and explore!
+* It is impossible to list every supported HTML tag and CSS property. Be courageous and explore!
 * Use whitespaces instead of tabs for any kind of indentation
 * CSS property ``word-spacing`` will always use unit px
 

--- a/docs/user_manual/style_library/label_settings.rst
+++ b/docs/user_manual/style_library/label_settings.rst
@@ -160,7 +160,7 @@ Several CSS properties are supported:
 * Font properties (``color``, ``font-family``, ``font-size``, ``font-weight``, ``font-style`` and ``word-spacing``)
 * Underline, strikethrough and overline through ``text-decoration``
 * Some properties such as ``vertical-align: super`` or ``vertical-align: sub``
-  are also available in any other HTML element.
+  are also available in any other HTML element
 
 Notable tags include superscript and subscript, where the text will be vertically :sup:`super` or 
 :sub:`sub` aligned and automatically sized to 2/3 of the parent font size.

--- a/docs/user_manual/style_library/label_settings.rst
+++ b/docs/user_manual/style_library/label_settings.rst
@@ -154,8 +154,8 @@ Allow HTML Formatting
 With :guilabel:`Allow HTML Formatting` enabled, you need to provide the HTML code in the :guilabel:`Value` field.
 Use whitespaces instead of tabs for any kind of indentation.
 The expression is parsed and any supported HTML tag overrides its corresponding setting in the labels properties.
-It is impossible to list every supported HTML tag and CSS property. 
-Be courageous and explore!
+An exhaustive list of the supported subset of HTML tags and CSS properties can be found `here <https://doc.qt.io/qt-5/richtext-html-subset.html>`_.
+
 
 Supported CSS properties include:
 


### PR DESCRIPTION
Fixes #9245

This PR proposes the following changes:
- Document the word-spacing CSS property.
- Refactor the "Allow HTML Formatting" into its own subsection to de-clutter the text tab bullet point list. 
- Change some of the wording to be more precise, i.e. distinguish between CSS properties and HTML tags. 
 
Discussed with @selmaVH1 at Hackfest, thanks Selma!