### PR TITLE
Fix "Raster layer unique values report" area unit of measure

### DIFF
--- a/docs/user_manual/processing_algs/qgis/rasteranalysis.rst
+++ b/docs/user_manual/processing_algs/qgis/rasteranalysis.rst
@@ -2511,7 +2511,8 @@ Python code
 
 Raster layer unique values report
 ---------------------------------
-Returns the count and area of each unique value in a given raster layer.
+Returns the count and the area, expressed in the area unit of the layer's CRS, of
+each unique value in a given raster layer.
 
 Parameters
 ..........
@@ -2609,8 +2610,8 @@ Outputs
 
        * *value*: pixel value
        * *count*: count of pixels with this value
-       * *m*\ :sup:`2`: total area in square meters of pixels with
-         this value.
+       * *m2* or *deg2* or *ft2* or ... : total area of pixels with this value.
+         The column name depends on the area unit of the layer's CRS.
 
    * - **Width in pixels**
      - ``WIDTH_IN_PIXELS``


### PR DESCRIPTION
<!---
Include a few sentences describing the overall goals for this Pull Request.
 
A list of issues is at https://github.com/qgis/QGIS-Documentation/issues.
Add "fix #issuenumber" for each issue the PR fixes. The ticket(s) will be closed automatically.
If your PR doesn't fix entirely the ticket, only add the ticket(s) reference preceded by # character.
-->
Goal:

The unit of measure of the total area of pixels with a certain value and the corresponding column name is not always the square meters and "m²", but they depends on the unit of measure of the layer's CRS.

Not sure if the wording is the best one...

Ticket(s): https://github.com/qgis/QGIS/issues/58685

<!---
Indicate whether the fix should be backported to previous release.
Replace the space between square brackets by a `x` to make it checked.
-->
- [ ] Backport to LTR documentation is requested

<!---
Reviewing is a process done by community members, mostly on a volunteer basis.
We try to keep the overhead as small as possible and appreciate if you help us.
Please read carefully and ensure you comply with our writing guidelines at
https://docs.qgis.org/testing/en/docs/documentation_guidelines/index.html.
Feel free to ask in a comment or the (qgis-community-team mailing list)
[https://lists.osgeo.org/mailman/listinfo/qgis-community-team] if you have troubles with any item.
--->
