### PR TITLE
Fix field type list for "Field calculator", "Advanced Python field calculator" and "Add field to attributes table" algs

### DIFF
--- a/docs/user_manual/processing_algs/qgis/vectortable.rst
+++ b/docs/user_manual/processing_algs/qgis/vectortable.rst
@@ -172,9 +172,17 @@ Parameters
        Default: 0
      - Type of the new field. You can choose between:
        
-       * 0 --- Integer
-       * 1 --- Float
-       * 2 --- String
+       * 0 --- Integer (32 bit)
+       * 1 --- Decimal (double)
+       * 2 --- Text (string)
+       * 3 --- Boolean
+       * 4 --- Date
+       * 5 --- Time
+       * 6 --- Date & Time
+       * 7 --- Binary Object (BLOB)
+       * 8 --- String List
+       * 9 --- Integer List
+       * 10 --- Decimal (double) List
        
    * - **Field length**
      - ``FIELD_LENGTH``
@@ -457,9 +465,17 @@ Parameters
        Default: 0
      - Type of the new field. One of:
        
-       * 0 --- Integer
-       * 1 --- Float
-       * 2 --- String
+       * 0 --- Integer (32 bit)
+       * 1 --- Decimal (double)
+       * 2 --- Text (string)
+       * 3 --- Boolean
+       * 4 --- Date
+       * 5 --- Time
+       * 6 --- Date & Time
+       * 7 --- Binary Object (BLOB)
+       * 8 --- String List
+       * 9 --- Integer List
+       * 10 --- Decimal (double) List
        
    * - **Field length**
      - ``FIELD_LENGTH``
@@ -790,10 +806,17 @@ Parameters
        Default: 0
      - The type of the field.  One of:
        
-       * 0 --- Float
-       * 1 --- Integer
-       * 2 --- String
+       * 0 --- Decimal (double)
+       * 1 --- Integer (32 bit)
+       * 2 --- Text (string)
        * 3 --- Date
+       * 4 --- Time
+       * 5 --- Date & Time
+       * 6 --- Boolean
+       * 7 --- Binary Object (BLOB)
+       * 8 --- String List
+       * 9 --- Integer List
+       * 10 --- Decimal (double) List
        
    * - **Output field width**
      - ``FIELD_LENGTH``


### PR DESCRIPTION
- "Field calculator" native:fieldcalculator
- "Advanced Python field calculator" qgis:advancedpythonfieldcalculator
- "Add field to attributes table" `native:addfieldtoattributestable`

Unfortunately the order of the field types' list is different in "Field calculator" form "Advanced Python field calculator" and "Add field to attributes table"

![image](https://github.com/user-attachments/assets/8d20a9f1-eee2-40b9-aae7-a5c3543c9dd5)

Fixes https://github.com/qgis/QGIS-Documentation/issues/9261.
Fixes https://github.com/qgis/QGIS-Documentation/issues/9260.

<!---
Include a few sentences describing the overall goals for this Pull Request.
 
A list of issues is at https://github.com/qgis/QGIS-Documentation/issues.
Add "fix #issuenumber" for each issue the PR fixes. The ticket(s) will be closed automatically.
If your PR doesn't fix entirely the ticket, only add the ticket(s) reference preceded by # character.
-->
Goal:

Ticket(s): #
<!---
Indicate whether the fix should be backported to previous release.
Replace the space between square brackets by a `x` to make it checked.
-->
- [x] Backport to LTR documentation is requested

<!---
Reviewing is a process done by community members, mostly on a volunteer basis.
We try to keep the overhead as small as possible and appreciate if you help us.
Please read carefully and ensure you comply with our writing guidelines at
https://docs.qgis.org/testing/en/docs/documentation_guidelines/index.html.
Feel free to ask in a comment or the (qgis-community-team mailing list)
[https://lists.osgeo.org/mailman/listinfo/qgis-community-team] if you have troubles with any item.
--->
