### PR TITLE
Update plugin structure requirements for upload to directory

### DIFF
--- a/docs/pyqgis_developer_cookbook/plugins/plugins.rst
+++ b/docs/pyqgis_developer_cookbook/plugins/plugins.rst
@@ -69,6 +69,9 @@ A typical plugin directory includes the following files:
   relative paths to resources used in the GUI forms.
 * :file:`resources.py` - *compiled resources, optional* - The translation of the .qrc file 
   described above to Python.
+* :file:`LICENSE` - *required* if plugin is to be published or updated in the 
+  QGIS Plugins Directory, otherwise *optional*. File should be a plain text file 
+  with no file extension in the filename.
 
 .. warning::
     If you plan to upload the plugin to the :ref:`official_pyqgis_repository`

--- a/docs/pyqgis_developer_cookbook/plugins/releasing.rst
+++ b/docs/pyqgis_developer_cookbook/plugins/releasing.rst
@@ -102,6 +102,8 @@ a plugin on the official repository:
 #. all required metadata listed in :ref:`metadata table<plugin_metadata_table>`
    must be present
 #. the `version` metadata field must be unique
+#. a licence file must be included, saved as `LICENSE` with no extension (i.e. 
+   not `LICENSE.txt`)
 
 Plugin structure
 ................
@@ -110,10 +112,10 @@ Following the validation rules the compressed (.zip) package of your plugin
 must have a specific structure to validate as a functional plugin. As the
 plugin will be unzipped inside the users plugins folder it must have it's own
 directory inside the .zip file to not interfere with other plugins. Mandatory
-files are: :file:`metadata.txt` and :file:`__init__.py`. But it would be nice
-to have a :file:`README` and of course an icon to represent the plugin
-(:file:`resources.qrc`). Following is an example of how a plugin.zip should
-look like.
+files are: :file:`metadata.txt`,  :file:`__init__.py` and :file:`LICENSE`. 
+But it would be nice to have a :file:`README` and of course an icon to represent 
+the plugin (:file:`resources.qrc`). Following is an example of how a plugin.zip 
+should look like.
 
 ::
 
@@ -125,6 +127,7 @@ look like.
     |   |-- icon.png
     |   `-- iconsource.svg
     |-- __init__.py
+    |-- LICENSE
     |-- Makefile
     |-- metadata.txt
     |-- more_code.py

--- a/docs/pyqgis_developer_cookbook/plugins/releasing.rst
+++ b/docs/pyqgis_developer_cookbook/plugins/releasing.rst
@@ -102,7 +102,7 @@ a plugin on the official repository:
 #. all required metadata listed in :ref:`metadata table<plugin_metadata_table>`
    must be present
 #. the `version` metadata field must be unique
-#. a licence file must be included, saved as ``LICENSE`` with no extension (i.e. 
+#. a license file must be included, saved as ``LICENSE`` with no extension (i.e. 
    not ``LICENSE.txt`` for example)
 
 Plugin structure
@@ -125,7 +125,7 @@ should look like.
     |   |-- translation_file_de.ts
     |-- img
     |   |-- icon.png
-    |   `-- iconsource.svg
+    |   |-- iconsource.svg
     |-- __init__.py
     |-- LICENSE
     |-- Makefile

--- a/docs/pyqgis_developer_cookbook/plugins/releasing.rst
+++ b/docs/pyqgis_developer_cookbook/plugins/releasing.rst
@@ -102,8 +102,8 @@ a plugin on the official repository:
 #. all required metadata listed in :ref:`metadata table<plugin_metadata_table>`
    must be present
 #. the `version` metadata field must be unique
-#. a licence file must be included, saved as `LICENSE` with no extension (i.e. 
-   not `LICENSE.txt`)
+#. a licence file must be included, saved as ``LICENSE`` with no extension (i.e. 
+   not ``LICENSE.txt`` for example)
 
 Plugin structure
 ................

--- a/docs/pyqgis_developer_cookbook/plugins/releasing.rst
+++ b/docs/pyqgis_developer_cookbook/plugins/releasing.rst
@@ -115,7 +115,7 @@ directory inside the .zip file to not interfere with other plugins. Mandatory
 files are: :file:`metadata.txt`,  :file:`__init__.py` and :file:`LICENSE`. 
 But it would be nice to have a :file:`README` and of course an icon to represent 
 the plugin. Following is an example of how a :file:`plugin.zip` 
-should look like.
+could look like.
 
 ::
 
@@ -133,7 +133,5 @@ should look like.
     |-- more_code.py
     |-- main_code.py
     |-- README
-    |-- resources.qrc
-    |-- resources_rc.py
-    `-- ui_Qt_user_interface_file.ui
+    |-- ui_Qt_user_interface_file.ui
 

--- a/docs/pyqgis_developer_cookbook/plugins/releasing.rst
+++ b/docs/pyqgis_developer_cookbook/plugins/releasing.rst
@@ -114,7 +114,7 @@ plugin will be unzipped inside the users plugins folder it must have it's own
 directory inside the .zip file to not interfere with other plugins. Mandatory
 files are: :file:`metadata.txt`,  :file:`__init__.py` and :file:`LICENSE`. 
 But it would be nice to have a :file:`README` and of course an icon to represent 
-the plugin (:file:`resources.qrc`). Following is an example of how a plugin.zip 
+the plugin. Following is an example of how a :file:`plugin.zip` 
 should look like.
 
 ::


### PR DESCRIPTION
Fixes #9192 : 
* add reference to required LICENSE file

Goal: clarify required files for validation in the official plugin repository

Ticket(s): #9192 

- [x] Backport to LTR documentation is requested
