### PR TITLE
Fix actions badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <img src="https://github.com/qgis/QGIS/blob/master/images/README-md/main_logo.png" width="300" alt="Our full logo">
 
-[![Docs Builds](https://github.com/qgis/QGIS-Documentation/workflows/Docs%20builds/badge.svg?branch=master)](https://github.com/qgis/QGIS-Documentation/actions/workflows/builds.yml?query=branch%3Amaster+event%3Apush)
-[![Doctest Build](https://github.com/qgis/QGIS-Documentation/workflows/Doctest%20build/badge.svg?branch=master)](https://github.com/qgis/QGIS-Documentation/actions/workflows/doctest.yml?query=branch%3Amaster+event%3Apush)
+[![Docs Builds](https://github.com/qgis/QGIS-Documentation/actions/workflows/builds.yml/badge.svg?branch=master&event=push)](https://github.com/qgis/QGIS-Documentation/actions/workflows/builds.yml)
+[![Doctest Build](https://github.com/qgis/QGIS-Documentation/actions/workflows/doctest.yml/badge.svg?branch=master&event=push)](https://github.com/qgis/QGIS-Documentation/actions/workflows/doctest.yml)
 [![Read the documentation](https://img.shields.io/badge/Read-the%20docs-green.svg)](https://docs.qgis.org/testing/)
 
 


### PR DESCRIPTION
These should currently show as
![image](https://github.com/user-attachments/assets/2a19e05b-cb06-4dab-ac05-3d463424e4e5)

Fixes #9179