### PR TITLE
Base docker build commands on their target docs version

### DIFF
--- a/cronjob.sh
+++ b/cronjob.sh
@@ -21,11 +21,19 @@ git stash drop
 # get latest version from github
 git pull
 
+# Return release number from branch name e.g. master, 3.34
+TARGETBRANCH=`git branch --show-current | sed 's,release_,,g'`
+TARGETREPO="QGIS-Documentation"
+
+if [[ "$TARGETBRANCH" != "master" ]]; then \
+    TARGETREPO=$TARGETREPO-$TARGETBRANCH
+fi;
+
 # NOTE: docker builds and rsync's the build/zip/pdf to the local mounted /site dir
 # AFTER the build, we are going to rsync everything to www2.qgis.org
-docker run -v $PWD:/build -v /var/www/qgisdata/QGIS-Documentation/live/html:/site -w="/build" --rm=true --name="qgis_docs_master_build" qgis/sphinx_pdf_3 make all
+docker run -v $PWD:/build -v /var/www/qgisdata/$TARGETREPO/live/html:/site -w="/build" --rm=true --name="qgis_docs_"$TARGETBRANCH"_build" qgis/sphinx_pdf_3 make all
 # in one go: ALL languages, the zip's AND the pdf's:
-rsync -hrzc --delete --progress  /var/www/qgisdata/QGIS-Documentation/live/html www2.qgis.org:/var/www/qgisdata/QGIS-Documentation/live/;
+rsync -hrzc --delete --progress  /var/www/qgisdata/$TARGETREPO/live/html www2.qgis.org:/var/www/qgisdata/$TARGETREPO/live/;
 
 now=`date`
 echo "Finished: $now"

--- a/docker-run.sh
+++ b/docker-run.sh
@@ -6,5 +6,9 @@
 
 cp ~/.transifexrc .
 pwd=$(pwd)
-docker run -v $pwd:/build -w="/build" --rm=true --name="qgis_docs_master_build" qgis/sphinx_pdf_3 make $@
+
+# Return release number from branch name e.g. master, 3.34
+TARGETBRANCH=`git branch --show-current | sed 's,release_,,g'`
+
+docker run -v $pwd:/build -w="/build" --rm=true --name="qgis_docs_"$TARGETBRANCH"_build" qgis/sphinx_pdf_3 make $@
 rm -rf .transifexrc

--- a/docker-world.sh
+++ b/docker-world.sh
@@ -23,6 +23,14 @@ git stash drop
 # get latest version
 git pull
 
+# Return release number from branch name e.g. master, 3.34
+TARGETBRANCH=`git branch --show-current | sed 's,release_,,g'`
+TARGETREPO="QGIS-Documentation"
+
+if [[ "$TARGETBRANCH" != "master" ]]; then \
+    TARGETREPO=$TARGETREPO-$TARGETBRANCH
+fi;
+
 # only languages which have translations in transifex
 #: ${langs:=en ca da de es fa fi fr gl hu id it ja km_KH ko lt nl pl pt_BR pt_PT ro tr ru uk zh-Hans zh-Hant}
 : ${langs:=en}
@@ -42,9 +50,9 @@ for l in $langs
       #time rsync -hvrzc --delete --progress build/pdf /var/www/qgisdata/QGIS-Documentation/live/html
       #time rsync -hvrzc --delete --progress build/zip /var/www/qgisdata/QGIS-Documentation/live/html
       # 20220317: local sync to new www2
-      time rsync -hvrzc --delete --progress build/html/$l root@195.201.96.242:/var/www/qgisdata/QGIS-Documentation/live/html
-      time rsync -hvrzc --delete --progress build/pdf root@195.201.96.242:/var/www/qgisdata/QGIS-Documentation/live/html
-      time rsync -hvrzc --delete --progress build/zip root@195.201.96.242:/var/www/qgisdata/QGIS-Documentation/live/html
+      time rsync -hvrzc --delete --progress build/html/$l root@195.201.96.242:/var/www/qgisdata/$TARGETREPO/live/html
+      time rsync -hvrzc --delete --progress build/pdf root@195.201.96.242:/var/www/qgisdata/$TARGETREPO/live/html
+      time rsync -hvrzc --delete --progress build/zip root@195.201.96.242:/var/www/qgisdata/$TARGETREPO/live/html
     else
       echo "Build FAILED: not syncing to web";
     fi

--- a/release_process.md
+++ b/release_process.md
@@ -70,10 +70,6 @@ New releases are branched off the `master` branch and thus require a set of chan
   - [ ] In [README.MD](README.MD) file, update the badges to point to the current branch instead of `master`,
     and current version instead of `testing`
   - [ ] In [Makefile](Makefile) file, set the `VERSION` number as in the conf.py file
-  - [ ] In [docker-world.sh](docker-world.sh) file: replace `QGIS-Documentation` with `QGIS-Documentation-x.y`
-  - [ ] In [cronjob.sh](cronjob.sh) file:
-    - [ ] replace `QGIS-Documentation` with `QGIS-Documentation-x.y`
-    - [ ] replace `qgis_docs_master_build` with `qgis_docs_x.y_build`
   - [ ] In [doctest.dockerfile](doctest.dockerfile): set the project container to pull QGIS sources from (i.e. `release-x_y`)
   - [ ] In main [index.rst](docs/index.rst) file: replace `testing` with `x.y` in the Table Of Contents
 </details>
@@ -174,5 +170,5 @@ Automating the process as much as possible would lower the risk and make it less
 
 * Some values are somehow copy-pasted across places while they could likely be put in a variable: 
 
-  * languages list: they are defined in docs_conf.yml, Makefile, docker-world.sh
-  * version number: it is defined in conf.py, Makefile, docker-world.sh, cronjob.sh, doctest.dockerfile
+  * languages list: they are defined in docs_conf.yml, Makefile
+  * version number: it is defined in conf.py, Makefile, doctest.dockerfile


### PR DESCRIPTION
These commands are meant to be run on our servers to build the different releases (master and release_x.y branches). Instead of manually adjusting them at every new release (at the risk of forgetting one or making a mistake), let's automatize using the target release as variable.
@rduivenvoorde opinions?