### PR TITLE
Remove language from QGIS Website url

### DIFF
--- a/themes/rtd_qgis/versions.html
+++ b/themes/rtd_qgis/versions.html
@@ -60,7 +60,7 @@ with the md5 value of "github#qgis/QGIS-Documentation#release_3.28#locale/en/LC_
       <dl>
         <dt>{{ _('On QGIS Project') }}</dt>
           <dd>
-            <a href="https://qgis.org/{{ language }}" target="_blank" rel="noopener noreferrer">{{ _('Home') }}</a>
+            <a href="https://qgis.org" target="_blank" rel="noopener noreferrer">{{ _('Home') }}</a>
           </dd>
           <dd>
             <a href="https://qgis.org/api/{{ api_version }}" target="_blank" rel="noopener noreferrer">{{ _('C++ API') }}</a>


### PR DESCRIPTION
The new website is language agnostic so let's not use that variable in constructing the URL