### PR TITLE
Replace broken old-fashion URLs of QGIS website

### DIFF
--- a/docs/documentation_guidelines/do_translations.rst
+++ b/docs/documentation_guidelines/do_translations.rst
@@ -184,8 +184,8 @@ Translation in Transifex
 
 In order to translate using Transifex, you need to:
 
-#. `create an account on Transifex and join the QGIS project
-   <https://qgis.org/en/site/getinvolved/translate.html#join-a-project>`_.
+#. :ref:`create an account on Transifex and join the QGIS project
+   <becoming-translator>`.
 #. Once you are part of a language team, click on the corresponding project
    (in this case ``QGIS Documentation``). A list of available languages with
    their ratio of translation is displayed.

--- a/docs/documentation_guidelines/first_contribution.rst
+++ b/docs/documentation_guidelines/first_contribution.rst
@@ -19,8 +19,8 @@ follow, the tricks you can use and the traps you should be aware of.
 
 For any help, do not hesitate to either ask in a comment on the issue report you
 are trying to fix or write to the `QGIS-community-team list
-<https://lists.osgeo.org/mailman/listinfo/qgis-community-team>`_. More details at
-`Get involved in documentation <https://qgis.org/en/site/getinvolved/document.html>`_.
+<https://lists.osgeo.org/mailman/listinfo/qgis-community-team>`_.
+Read general information on `QGIS community support <https://qgis.org/resources/support/>`_.
 
 Let's now dive into the process.
 

--- a/docs/documentation_guidelines/index.rst
+++ b/docs/documentation_guidelines/index.rst
@@ -10,11 +10,11 @@ for all `supported versions <https://qgis.org/resources/roadmap/#release-schedul
 (testing, Long Term Release (LTR) and next-to-be LTR).
 
 QGIS Documentation source files are available at https://github.com/qgis/QGIS-Documentation.
-They are mainly written using the reStructuredText (reST) format syntax,
-coupled with some scripts from the Sphinx toolset to post-process the HTML output.
-For general information on these tools,
-see https://docutils.sourceforge.io/docs/ref/rst/restructuredtext.html
-or https://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html.
+They are mainly written using the `reStructuredText (reST) format
+<https://docutils.sourceforge.io/docs/ref/rst/restructuredtext.html>`_ syntax,
+coupled with some scripts from the `Sphinx toolset
+<https://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html>`_
+to post-process the HTML output.
 
 The following chapters will guide you through learning:
 

--- a/docs/documentation_guidelines/index.rst
+++ b/docs/documentation_guidelines/index.rst
@@ -6,7 +6,7 @@ Documentation Guidelines
 
 QGIS Documentation is available at https://docs.qgis.org.
 As the writing process is going on, a build is automatically run every day (see bottom of the page for exact time)
-for all `supported versions <https://qgis.org/en/site/getinvolved/development/roadmap.html#release-schedule>`_
+for all `supported versions <https://qgis.org/resources/roadmap/#release-schedule>`_
 (testing, Long Term Release (LTR) and next-to-be LTR).
 
 QGIS Documentation source files are available at https://github.com/qgis/QGIS-Documentation.
@@ -25,7 +25,7 @@ The following chapters will guide you through learning:
 
 If you are looking for general information about how to contribute to the QGIS
 project, you may find help at `Get Involved in the QGIS Community
-<https://qgis.org/en/site/getinvolved/index.html>`_.
+<https://qgis.org/community/involve/>`_.
 
 
 .. toctree::

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -65,8 +65,7 @@ you can download for offline reading. They are accessible from the
 
     * Submit an issue or pull request on the `GitHub repository
       <https://github.com/qgis/QGIS-Documentation/>`_,
-    * Help us `translate the documentation
-      <https://qgis.org/en/site/getinvolved/translate.html>`_ into your language
+    * Help us :ref:`translate the documentation <translation_guidelines>` into your language
     * Or talk to us on either the `qgis-community-team
       <https://lists.osgeo.org/mailman/listinfo/qgis-community-team>`_ mailing-list,
       the `#qgis <http://webchat.freenode.net/?channels=#qgis>`_ channel on IRC

--- a/docs/server_manual/containerized_deployment.rst
+++ b/docs/server_manual/containerized_deployment.rst
@@ -53,7 +53,7 @@ it. To do so create a directory :file:`qgis-server` and within its directory:
       && mkdir -m755 -p /etc/apt/keyrings \
       && wget -O /etc/apt/keyrings/qgis-archive-keyring.gpg https://download.qgis.org/downloads/qgis-archive-keyring.gpg \
       # Add repository for latest version of qgis-server
-      # Please refer to QGIS repositories documentation if you want other version (https://qgis.org/en/site/forusers/alldownloads.html#repositories)
+      # Please refer to QGIS repositories documentation if you want other version (https://qgis.org/resources/installation-guide/#repositories)
       && echo "deb [signed-by=/etc/apt/keyrings/qgis-archive-keyring.gpg] https://qgis.org/debian bookworm main" | tee /etc/apt/sources.list.d/qgis.list \
       && apt-get update \
       && apt-get install --no-install-recommends --no-install-suggests --allow-unauthenticated -y \

--- a/docs/server_manual/getting_started.rst
+++ b/docs/server_manual/getting_started.rst
@@ -22,7 +22,7 @@ distributions and OSs provide packages for QGIS Server.
   without using ``sudo``.
 
 Requirements and steps to add official QGIS repositories to install QGIS Server on a Debian based system are
-provided in `QGIS installers page <https://qgis.org/en/site/forusers/alldownloads.html>`_.
+provided in `QGIS installers page <https://qgis.org/resources/installation-guide/#linux>`_.
 You may want to install at least the latest Long Term Release.
 
 Once the target version repository is configured and QGIS Server installed,
@@ -621,8 +621,8 @@ Installation on Windows
 
 .. index:: Windows
 
-QGIS Server can also be installed on Windows systems using the 64 bit version
-of the OSGeo4W network installer (https://qgis.org/en/site/forusers/download.html).
+QGIS Server can also be installed on Windows systems using
+the OSGeo4W network installer (https://qgis.org/resources/installation-guide/#windows).
 
 A simple procedure is the following:
 

--- a/docs/training_manual/qgis_server/install.rst
+++ b/docs/training_manual/qgis_server/install.rst
@@ -17,7 +17,7 @@ any Debian based distribution like Ubuntu and its derivatives.
 -------------------------------------------------------------------------------
 
 In this lesson we're going to do only the install from packages as shown
-`here <https://qgis.org/en/site/forusers/alldownloads.html#linux>`_ .
+`here <https://qgis.org/resources/installation-guide/#linux>`_ .
 
 Install QGIS Server with:
 

--- a/docs/user_manual/grass_integration/grass_integration.rst
+++ b/docs/user_manual/grass_integration/grass_integration.rst
@@ -879,9 +879,7 @@ like this:
 
 
 The parser reads this definition and creates a new tab inside the Toolbox when
-you select the module. A more detailed description for adding new modules, changing
-a module's group, etc., can be found at 
-https://qgis.org/en/site/getinvolved/development/addinggrasstools.html.
+you select the module.
 
 
 .. Substitutions definitions - AVOID EDITING PAST THIS LINE

--- a/docs/user_manual/preamble/contributors.rst
+++ b/docs/user_manual/preamble/contributors.rst
@@ -12,7 +12,7 @@
 QGIS is an open source project developed by a team of dedicated volunteers and
 organisations. We strive to be a welcoming community for people of all race, creed,
 gender and walks of life.
-At any moment, you can `get involved <https://qgis.org/en/site/getinvolved/index.html>`_.
+At any moment, you can `get involved <https://qgis.org/community/involve/>`_.
 
 .. index::
    single: Contributors; Authors
@@ -71,7 +71,7 @@ QGIS is a multi-language application and as is, also publishes a documentation
 translated into several languages. Many other languages are being translated
 and would be released as soon as they reach a reasonable percentage of
 translation. If you wish to help improving a language or request a new one,
-please see https://qgis.org/en/site/getinvolved/index.html.
+please see :ref:`translation_guidelines`.
 
 The current translations are made possible thanks to:
 

--- a/docs/user_manual/preamble/help_and_support.rst
+++ b/docs/user_manual/preamble/help_and_support.rst
@@ -69,7 +69,7 @@ some QGIS communities are organized into QGIS User Groups.
 These groups are places to discuss local topics, organize regional
 or national user meetings, organize sponsoring of features...
 The list of current user groups is available at
-https://qgis.org/en/site/forusers/usergroups.html
+https://qgis.org/community/groups/
 
 You are welcome to subscribe to any of the lists. Please remember to
 contribute to the list by answering questions and sharing your
@@ -96,7 +96,7 @@ Commercial support
 ==================
 
 Commercial support for QGIS is also available. Check the website
-https://qgis.org/en/site/forusers/commercial_support.html for more information.
+https://qgis.org/resources/support/commercial-support/ for more information.
 
 BugTracker
 ==========
@@ -119,7 +119,7 @@ If you have found a bug and fixed it yourself, you can submit a
 Pull Request on the `Github QGIS Project <https://github.com/qgis/QGIS/pulls>`_.
 
 Read
-`Bugs, Features and Issues <https://qgis.org/en/site/getinvolved/development/bugreporting.html#bugs-features-and-issues>`_
+`Bugs, Features and Issues <https://qgis.org/resources/support/bug-reporting/>`_
 and :ref:`submit_patch` for more details.
 
 Blog

--- a/docs/user_manual/preamble/preamble.rst
+++ b/docs/user_manual/preamble/preamble.rst
@@ -27,8 +27,7 @@ Translated versions of this document can be browsed and downloaded
 via the documentation area of the QGIS project as well.
 
 For more information about contributing to this document and about
-translation, please visit
-https://qgis.org/en/site/getinvolved/index.html.
+translation, please read :ref:`QGIS-documentation-guidelines`.
 
 **Links in this Document**
 
@@ -61,8 +60,8 @@ What is new in QGIS |version|
 
 This release of QGIS includes hundreds of bug fixes and many new
 features and enhancements, compared to |QGIS_CURRENT|_.
-For a list of new features, visit the visual changelogs at
-https://qgis.org/en/site/forusers/visualchangelogs.html.
+For a list of new features, visit the `visual changelogs
+<https://qgis.org/project/visual-changelogs/>`_.
 
 .. only:: not testing and not outdated
 


### PR DESCRIPTION
The QGIS website refactoring replaces and deletes some information we were linking to in the docs. This PR tries to fix the issues