### PR TITLE
Homogenize Python version in use across github workflows

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -34,10 +34,10 @@ jobs:
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       with:
         fetch-depth: 1
-    - name: Set up Python 3.9
+    - name: Set up Python 3.12
       uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0
       with:
-        python-version: 3.9
+        python-version: '3.12'
     - name: Install Requirements
       run: |
         if [[ ${{ matrix.format }} != "html" ]]; then

--- a/.github/workflows/doctest.yml
+++ b/.github/workflows/doctest.yml
@@ -34,10 +34,10 @@ jobs:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       with:
         fetch-depth: 1
-    - name: Set up Python 3.9
+    - name: Set up Python 3.12
       uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0
       with:
-        python-version: 3.9
+        python-version: '3.12'
     - name: Pip upgrade
       run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/pofiles.yml
+++ b/.github/workflows/pofiles.yml
@@ -31,10 +31,10 @@ jobs:
       with:
         ref: release_3.34
 
-    - name: Set up Python 3.11
+    - name: Set up Python 3.12
       uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0
       with:
-        python-version: '3.11'
+        python-version: '3.12'
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/translation_statistics.yml
+++ b/.github/workflows/translation_statistics.yml
@@ -36,10 +36,10 @@ jobs:
       with:
         fetch-depth: 1
 
-    - name: Set up Python 3.11
+    - name: Set up Python 3.12
       uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0
       with:
-        python-version: '3.11'
+        python-version: '3.12'
 
     - name: Install dependencies
       run: python3 -m pip install requests


### PR DESCRIPTION
Raised to 3.12. New sphinx versions (v8) dropped Python 3.9 (and very soon 3.10).