### PR TITLE
Add additional Offset Curve Documentation

### DIFF
--- a/docs/user_manual/working_with_vector/editing_geometry_attributes.rst
+++ b/docs/user_manual/working_with_vector/editing_geometry_attributes.rst
@@ -1327,12 +1327,12 @@ Your changes may then be saved with the |saveEdits|
 For geometries on background layers make sure that snapping is on and hold :kbd:`Ctrl`
 to select the geometry from the background. Also hold :kbd:`Ctrl` when doing the second click
 or when pressing enter after entering the desired distance.
-Geometries will be converted to line or polygon depending on the layer types. 
+Geometries will be converted to the target layer geometry type. 
 
 QGIS options dialog (Digitizing tab then **Curve offset tools** section) or
-the gear icon in the :guilabel:`User Input` dialog allows
-you to configure some parameters like **Join style**, **Quadrant segments**,
-**Miter limit**.
+the |settings| icon in the :guilabel:`User Input` dialog allows
+you to configure :ref:`some parameters <curve_offset_tool>` like **Join style**,
+**Quadrant segments**, **Miter limit** and **End cap style**.
 
 .. index::
    single: Digitizing tools; Reverse Line

--- a/docs/user_manual/working_with_vector/editing_geometry_attributes.rst
+++ b/docs/user_manual/working_with_vector/editing_geometry_attributes.rst
@@ -1313,9 +1313,10 @@ The tool can be applied to the edited layer (the geometries are modified)
 or also to background layers (in which case it creates copies of the lines /
 rings and adds them to the edited layer).
 It is thus ideally suited for the creation of distance line layers.
-The :guilabel:`User Input` dialog pops-up, showing the displacement distance.
+The :guilabel:`User Input` dialog pops-up, showing the displacement distance
+and other settings.
 
-To create a shift of a line layer, you must first go into editing mode
+To create a shift of a line or polygon layer, you must first go into editing mode
 and activate the |offsetCurve| :sup:`Offset Curve` tool.
 Then click on a feature to shift it.
 Move the mouse and click where wanted or enter the desired distance in
@@ -1323,8 +1324,13 @@ the user input widget. Holding :kbd:`Ctrl` during the 2nd click will make an off
 Your changes may then be saved with the |saveEdits|
 :sup:`Save Layer Edits` tool.
 
+For geometries on background layers make sure that snapping is on and hold :kbd:`Ctrl`
+to select the geometry from the background. Also hold :kbd:`Ctrl` when doing the second click
+or when pressing enter after entering the desired distance.
+Geometries will be converted to line or polygon depending on the layer types. 
 
-QGIS options dialog (Digitizing tab then **Curve offset tools** section) allows
+QGIS options dialog (Digitizing tab then **Curve offset tools** section) or
+the gear icon in the :guilabel:`User Input` dialog allows
 you to configure some parameters like **Join style**, **Quadrant segments**,
 **Miter limit**.
 

--- a/docs/user_manual/working_with_vector/editing_geometry_attributes.rst
+++ b/docs/user_manual/working_with_vector/editing_geometry_attributes.rst
@@ -1325,8 +1325,7 @@ Your changes may then be saved with the |saveEdits|
 :sup:`Save Layer Edits` tool.
 
 For geometries on background layers make sure that snapping is on and hold :kbd:`Ctrl`
-to select the geometry from the background. Also hold :kbd:`Ctrl` when doing the second click
-or when pressing enter after entering the desired distance.
+to select the geometry from the background. Also hold :kbd:`Ctrl` when doing the second click.
 Geometries will be converted to the target layer geometry type. 
 
 QGIS options dialog (Digitizing tab then **Curve offset tools** section) or


### PR DESCRIPTION
Adds additional Offset Curve Documentation including from background layers.
This is in conjunction with https://github.com/qgis/QGIS/pull/59438 

<!---
Include a few sentences describing the overall goals for this Pull Request.
 
A list of issues is at https://github.com/qgis/QGIS-Documentation/issues.
Add "fix #issuenumber" for each issue the PR fixes. The ticket(s) will be closed automatically.
If your PR doesn't fix entirely the ticket, only add the ticket(s) reference preceded by # character.
-->
Goal:

Ticket(s): #
<!---
Indicate whether the fix should be backported to previous release.
Replace the space between square brackets by a `x` to make it checked.
-->
- [ ] Backport to LTR documentation is requested

<!---
Reviewing is a process done by community members, mostly on a volunteer basis.
We try to keep the overhead as small as possible and appreciate if you help us.
Please read carefully and ensure you comply with our writing guidelines at
https://docs.qgis.org/testing/en/docs/documentation_guidelines/index.html.
Feel free to ask in a comment or the (qgis-community-team mailing list)
[https://lists.osgeo.org/mailman/listinfo/qgis-community-team] if you have troubles with any item.
--->
