### PR TITLE
Use actual link to pyqgis doc search page

### DIFF
--- a/docs/user_manual/appendices/qgis_desktop_network_connections.rst
+++ b/docs/user_manual/appendices/qgis_desktop_network_connections.rst
@@ -26,7 +26,7 @@ from the user before they take place, others happen automatically.
    * - Python API help
      - Browser PyQGIS documentation
      - User initiated
-     - https://qgis.org/pyqgis/%1/search.html?q=%2
+     - :pyqgis:`search`
      - IP, QGIS version, OS
      - IP in server log
    * - **version.qgis.org**


### PR DESCRIPTION
I don't know if this is actually what we wanted to show but in the [current docs](https://docs.qgis.org/testing/en/docs/user_manual/appendices/qgis_desktop_network_connections.html) it shows like this (and returns a 404 bad request)

![image](https://github.com/user-attachments/assets/5d9e99dc-f162-4ba3-8b78-c487a9cf58d6)

With the PR, it would show like this, leading to https://qgis.org/pyqgis/master/search

![image](https://github.com/user-attachments/assets/ce749a1f-c067-44bf-b776-2e495ad4a898)

@anitagraser @elpaso would that be OK for you?