### PR TITLE
Update geometry.rst

### DIFF
--- a/docs/training_manual/spatial_databases/geometry.rst
+++ b/docs/training_manual/spatial_databases/geometry.rst
@@ -147,15 +147,15 @@ Your updated people schema should look something like this:
                3,
                '072 812 31 28',
                1,
-               'SRID=4326;POINT(33 33)');
+               'SRID=4326;POINT(13 -15)');
 
     insert into people (name,house_no, street_id, phone_no, city_id, the_geom)
        values ('IP Knightly',
                32,
                1,
                '071 812 31 28',
-               1,F
-               'SRID=4326;POINT(32 -34)');
+               1,
+               'SRID=4326;POINT(18 -24)');
 
     insert into people (name,house_no, street_id, phone_no, city_id, the_geom)
        values ('Rusty Bedsprings',
@@ -163,7 +163,7 @@ Your updated people schema should look something like this:
                1,
                '071 822 31 28',
                1,
-               'SRID=4326;POINT(34 -34)');
+               'SRID=4326;POINT(22 -25)');
 
   If you're getting the following error message:
 


### PR DESCRIPTION
fixes qgis/QGIS-Documentation#9409

<!---
Include a few sentences describing the overall goals for this Pull Request.
 
A list of issues is at https://github.com/qgis/QGIS-Documentation/issues.
Add "fix #issuenumber" for each issue the PR fixes. The ticket(s) will be closed automatically.
If your PR doesn't fix entirely the ticket, only add the ticket(s) reference preceded by # character.
-->
Goal: give coherent data for point coordinates (people table) to be included in Tokyo geometry (cities table)
And also correct a typo error in the second SQL request (extra 'F' symbol)

[16.5.4. Exercise: Linking Cities to People](https://docs.qgis.org/3.34/en/docs/training_manual/spatial_databases/geometry.html#exercise-linking-cities-to-people)

Ticket(s): #9409
<!---
Indicate whether the fix should be backported to previous release.
Replace the space between square brackets by a `x` to make it checked.
-->
- [ ] Backport to LTR documentation is requested

<!---
Reviewing is a process done by community members, mostly on a volunteer basis.
We try to keep the overhead as small as possible and appreciate if you help us.
Please read carefully and ensure you comply with our writing guidelines at
https://docs.qgis.org/testing/en/docs/documentation_guidelines/index.html.
Feel free to ask in a comment or the (qgis-community-team mailing list)
[https://lists.osgeo.org/mailman/listinfo/qgis-community-team] if you have troubles with any item.
--->






