### PR TITLE
Replace "the_geom" with "geom" in PostGIS lessons

### DIFF
--- a/docs/training_manual/spatial_databases/geometry.rst
+++ b/docs/training_manual/spatial_databases/geometry.rst
@@ -310,7 +310,9 @@ tablespaces:
 
   CREATE TABLESPACE homespace LOCATION '/home/pg';
 
-When you create a database, you can then specify which tablespace to use e.g.::
+When you create a database, you can then specify which tablespace to use e.g.:
+
+.. code-block:: bash
 
   createdb --tablespace=homespace t4a
 

--- a/docs/training_manual/spatial_databases/geometry.rst
+++ b/docs/training_manual/spatial_databases/geometry.rst
@@ -34,15 +34,15 @@ Try Yourself: :abbr:`★★☆ (Moderate level)`
 
   ::
 
-    alter table streets add column the_geom geometry;
+    alter table streets add column geom geometry;
     alter table streets add constraint streets_geom_point_chk check
-         (st_geometrytype(the_geom) = 'ST_LineString'::text OR the_geom IS NULL);
-    insert into geometry_columns values ('','public','streets','the_geom',2,4326,
+         (st_geometrytype(geom) = 'ST_LineString'::text OR geom IS NULL);
+    insert into geometry_columns values ('','public','streets','geom',2,4326,
          'LINESTRING');
     create index streets_geo_idx
       on streets
       using gist
-      (the_geom);
+      (geom);
 
 
 Now let's insert a linestring into our streets table. In this case we will
@@ -51,7 +51,7 @@ update an existing street record:
 .. code-block:: sql
 
   update streets
-  set the_geom = 'SRID=4326;LINESTRING(20 -33, 21 -34, 24 -33)'
+  set geom = 'SRID=4326;LINESTRING(20 -33, 21 -34, 24 -33)'
   where streets.id=2;
 
 Take a look at the results in QGIS. (You may need to right-click on the streets
@@ -69,7 +69,7 @@ polygons have at least four vertices, with the last and first being co-located:
 
 .. code-block:: sql
 
-    insert into cities (name, the_geom)
+    insert into cities (name, geom)
     values ('Tokyo', 'SRID=4326;POLYGON((10 -10, 5 -32, 30 -27, 10 -10))');
 
 .. note::  A polygon requires double brackets around its coordinate list; this
@@ -78,7 +78,7 @@ polygons have at least four vertices, with the last and first being co-located:
 
 .. code-block:: sql
 
-    insert into cities (name, the_geom)
+    insert into cities (name, geom)
     values ('Tokyo Outer Wards',
             'SRID=4326;POLYGON((20 10, 20 20, 35 20, 20 10),
                                (-10 -30, -5 0, -15 -15, -10 -30))'
@@ -116,14 +116,14 @@ Your updated people schema should look something like this:
     house_no  | integer               | not null
     street_id | integer               | not null
     phone_no  | character varying     |
-    the_geom  | geometry              |
+    geom      | geometry              |
     city_id   | integer               | not null
   Indexes:
     "people_pkey" PRIMARY KEY, btree (id)
     "people_name_idx" btree (name)
   Check constraints:
-    "people_geom_point_chk" CHECK (st_geometrytype(the_geom) =
-                         'ST_Point'::text OR the_geom IS NULL)
+    "people_geom_point_chk" CHECK (st_geometrytype(geom) =
+                         'ST_Point'::text OR geom IS NULL)
   Foreign-key constraints:
     "people_city_id_fkey" FOREIGN KEY (city_id) REFERENCES cities(id)
     "people_street_id_fkey" FOREIGN KEY (street_id) REFERENCES streets(id)
@@ -141,7 +141,7 @@ Your updated people schema should look something like this:
 
   ::
 
-    insert into people (name,house_no, street_id, phone_no, city_id, the_geom)
+    insert into people (name,house_no, street_id, phone_no, city_id, geom)
        values ('Faulty Towers',
                34,
                3,
@@ -149,7 +149,7 @@ Your updated people schema should look something like this:
                1,
                'SRID=4326;POINT(13 -15)');
 
-    insert into people (name,house_no, street_id, phone_no, city_id, the_geom)
+    insert into people (name,house_no, street_id, phone_no, city_id, geom)
        values ('IP Knightly',
                32,
                1,
@@ -157,7 +157,7 @@ Your updated people schema should look something like this:
                1,
                'SRID=4326;POINT(18 -24)');
 
-    insert into people (name,house_no, street_id, phone_no, city_id, the_geom)
+    insert into people (name,house_no, street_id, phone_no, city_id, geom)
        values ('Rusty Bedsprings',
                39,
                1,
@@ -234,17 +234,17 @@ To avoid empty geometries, use:
 
 .. code-block:: sql
 
-  where not st_isempty(st_intersection(a.the_geom, b.the_geom))
+  where not st_isempty(st_intersection(a.geom, b.geom))
 
 .. figure:: img/qgis_001.png
    :align: center
 
 .. code-block:: sql
 
-  select st_intersection(a.the_geom, b.the_geom), b.*
+  select st_intersection(a.geom, b.geom), b.*
   from clip as a, road_lines as b
-  where not st_isempty(st_intersection(st_setsrid(a.the_geom,32734),
-    b.the_geom));
+  where not st_isempty(st_intersection(st_setsrid(a.geom,32734),
+    b.geom));
 
 .. figure:: img/qgis_002.png
    :align: center
@@ -265,9 +265,9 @@ following command:
 
 .. code-block:: sql
 
-  select ST_LineFromMultiPoint(st_collect(the_geom)), 1 as id
+  select ST_LineFromMultiPoint(st_collect(geom)), 1 as id
   from (
-    select the_geom
+    select geom
     from points
     order by id
   ) as foo;

--- a/docs/training_manual/spatial_databases/simple_feature_model.rst
+++ b/docs/training_manual/spatial_databases/simple_feature_model.rst
@@ -40,7 +40,7 @@ Let's add a point field to our people table:
 
 .. code-block:: sql
 
-  alter table people add column the_geom geometry;
+  alter table people add column geom geometry;
 
 
 Add a constraint based on geometry type
@@ -53,8 +53,8 @@ You will notice that the geometry field type does not implicitly specify what
 
   alter table people
   add constraint people_geom_point_chk
-      check(st_geometrytype(the_geom) = 'ST_Point'::text
-            OR the_geom IS NULL);
+      check(st_geometrytype(geom) = 'ST_Point'::text
+            OR geom IS NULL);
 
 This adds a constraint to the table so that it will only accept a point geometry
 or a null value.
@@ -73,10 +73,10 @@ sure it has a constraint enforcing geometries to be polygons.
 
      create table cities (id serial not null primary key,
                           name varchar(50),
-                          the_geom geometry not null);
+                          geom geometry not null);
       alter table cities
       add constraint cities_geom_point_chk
-      check (st_geometrytype(the_geom) = 'ST_Polygon'::text );
+      check (st_geometrytype(geom) = 'ST_Polygon'::text );
 
 
 
@@ -88,7 +88,7 @@ At this point you should also add an entry into the ``geometry_columns`` table:
 .. code-block:: sql
 
   insert into geometry_columns values
-    ('','public','people','the_geom',2,4326,'POINT');
+    ('','public','people','geom',2,4326,'POINT');
 
 Why? :kbd:`geometry_columns` is used by certain applications to be aware of
 which tables in the database contain geometry data.
@@ -124,7 +124,7 @@ Add an appropriate `geometry_columns` entry for your new cities layer
    ::
 
      insert into geometry_columns values
-           ('','public','cities','the_geom',2,4326,'POLYGON');
+           ('','public','cities','geom',2,4326,'POLYGON');
 
 
 
@@ -135,7 +135,7 @@ Now that our tables are geo-enabled, we can store geometries in them:
 
 .. code-block:: sql
 
-  insert into people (name,house_no, street_id, phone_no, the_geom)
+  insert into people (name,house_no, street_id, phone_no, geom)
           values ('Fault Towers',
                    34,
                    3,
@@ -195,7 +195,7 @@ and add layers to your project as usual.
 ...............................................................................
 
 Formulate a query that shows a person's name, street name and position (from the
-the_geom column) as plain text.
+geom column) as plain text.
 
 .. admonition:: Answer
    :class: dropdown
@@ -204,7 +204,7 @@ the_geom column) as plain text.
 
      select people.name,
             streets.name as street_name,
-            st_astext(people.the_geom) as geometry
+            st_astext(people.geom) as geometry
      from   streets, people
      where  people.street_id=streets.id;
 

--- a/docs/training_manual/spatial_databases/simple_feature_model.rst
+++ b/docs/training_manual/spatial_databases/simple_feature_model.rst
@@ -69,7 +69,7 @@ sure it has a constraint enforcing geometries to be polygons.
 .. admonition:: Answer
    :class: dropdown
 
-   ::
+   .. code-block: sql
 
      create table cities (id serial not null primary key,
                           name varchar(50),

--- a/docs/training_manual/spatial_databases/spatial_queries.rst
+++ b/docs/training_manual/spatial_databases/spatial_queries.rst
@@ -96,7 +96,7 @@ Modify the cities table so its geometry column is spatially indexed.
 .. admonition:: Answer
   :class: dropdown
 
-  ::
+   .. code-block:: psql
 
     CREATE INDEX cities_geo_idx
       ON cities

--- a/docs/training_manual/spatial_databases/spatial_queries.rst
+++ b/docs/training_manual/spatial_databases/spatial_queries.rst
@@ -19,18 +19,18 @@ point(X,Y) you can do this with:
 
   select *
   from people
-  where st_distance(the_geom,'SRID=4326;POINT(33 -34)') < 2;
+  where st_distance(geom,'SRID=4326;POINT(33 -34)') < 2;
 
 Result:
 
 .. code-block:: sql
 
-   id |     name     | house_no | street_id |   phone_no    |   the_geom
+   id |     name     | house_no | street_id |   phone_no    |   geom
   ----+--------------+----------+-----------+---------------+---------------
     6 | Fault Towers |       34 |         3 | 072 812 31 28 | 01010008040C0
   (1 row)
 
-.. note::  the_geom value above was truncated for space on this page. If you
+.. note::  geom value above was truncated for space on this page. If you
    want to see the point in human-readable coordinates, try something similar
    to what you did in the section "View a point as WKT", above.
 
@@ -60,7 +60,7 @@ much faster. To create a spatial index on the geometry column use:
   CREATE INDEX people_geo_idx
     ON people
     USING gist
-    (the_geom);
+    (geom);
 
   \d people
 
@@ -77,14 +77,14 @@ Result:
     house_no  | integer               | not null
     street_id | integer               | not null
     phone_no  | character varying     |
-    the_geom  | geometry              |
+    geom      | geometry              |
   Indexes:
     "people_pkey" PRIMARY KEY, btree (id)
-    "people_geo_idx" gist (the_geom)  <-- new spatial key added
+    "people_geo_idx" gist (geom)  <-- new spatial key added
     "people_name_idx" btree (name)
   Check constraints:
-    "people_geom_point_chk" CHECK (st_geometrytype(the_geom) = 'ST_Point'::text
-    OR the_geom IS NULL)
+    "people_geom_point_chk" CHECK (st_geometrytype(geom) = 'ST_Point'::text
+    OR geom IS NULL)
   Foreign-key constraints:
     "people_street_id_fkey" FOREIGN KEY (street_id) REFERENCES streets(id)
 
@@ -100,7 +100,7 @@ Modify the cities table so its geometry column is spatially indexed.
 
     CREATE INDEX cities_geo_idx
       ON cities
-      USING gist (the_geom);
+      USING gist (geom);
 
 
 

--- a/docs/user_manual/managing_data_source/supported_data.rst
+++ b/docs/user_manual/managing_data_source/supported_data.rst
@@ -517,7 +517,7 @@ The following example creates a GiST index::
          \q to quit
 
   gis_data=# CREATE INDEX sidx_alaska_lakes ON alaska_lakes
-  gis_data-# USING GIST (the_geom GIST_GEOMETRY_OPS);
+  gis_data-# USING GIST (geom GIST_GEOMETRY_OPS);
   CREATE INDEX
   gis_data=# VACUUM ANALYZE alaska_lakes;
   VACUUM


### PR DESCRIPTION
the_geom is not used for years, let's abandon it also. This si simply a search and replace; we should consider investigating the geometry_columns calls also.

<!---
Include a few sentences describing the overall goals for this Pull Request.
 
A list of issues is at https://github.com/qgis/QGIS-Documentation/issues.
Add "fix #issuenumber" for each issue the PR fixes. The ticket(s) will be closed automatically.
If your PR doesn't fix entirely the ticket, only add the ticket(s) reference preceded by # character.
-->
Goal:

Ticket(s): #
<!---
Indicate whether the fix should be backported to previous release.
Replace the space between square brackets by a `x` to make it checked.
-->
- [X] Backport to LTR documentation is requested

<!---
Reviewing is a process done by community members, mostly on a volunteer basis.
We try to keep the overhead as small as possible and appreciate if you help us.
Please read carefully and ensure you comply with our writing guidelines at
https://docs.qgis.org/testing/en/docs/documentation_guidelines/index.html.
Feel free to ask in a comment or the (qgis-community-team mailing list)
[https://lists.osgeo.org/mailman/listinfo/qgis-community-team] if you have troubles with any item.
--->
