### PR TITLE
Field types

### DIFF
--- a/docs/user_manual/processing_algs/algs_include.rst
+++ b/docs/user_manual/processing_algs/algs_include.rst
@@ -335,3 +335,28 @@ Resampling methods
 * 11 --- Third quartile (Q3)
 
 .. **end_raster_resampling_methods**
+
+
+Vector field types
+==================
+
+.. **vector_field_types**
+
+.. The following section is included in vector based algorithms such as
+  qgisaggregate, qgisrefactorfields
+
+* 1 --- Boolean
+* 2 --- Integer (32bit)
+* 4 --- Integer (64bit)
+* 6 --- Decimal (double)
+* 9 --- Integer list --- ``sub_type: 2``
+* 9 --- Integer (64bit) list --- ``sub_type: 4``
+* 9 --- Decimal (double) list --- ``sub_type: 6``
+* 10 --- Text (string)
+* 11 --- String list
+* 12 --- Binary Object (BLOB)
+* 14 --- Date
+* 15 --- Time
+* 16 --- Date & Time
+
+.. **end_vector_field_types**

--- a/docs/user_manual/processing_algs/algs_include.rst
+++ b/docs/user_manual/processing_algs/algs_include.rst
@@ -349,9 +349,9 @@ Vector field types
 * 2 --- Integer (32bit)
 * 4 --- Integer (64bit)
 * 6 --- Decimal (double)
-* 9 --- Integer list --- ``sub_type: 2``
-* 9 --- Integer (64bit) list --- ``sub_type: 4``
-* 9 --- Decimal (double) list --- ``sub_type: 6``
+* 9 --- Integer list
+* 9 --- Integer (64bit) list
+* 9 --- Decimal (double) list
 * 10 --- Text (string)
 * 11 --- String list
 * 12 --- Binary Object (BLOB)
@@ -360,3 +360,17 @@ Vector field types
 * 16 --- Date & Time
 
 .. **end_vector_field_types**
+
+
+.. **vector_field_subtypes**
+
+.. The following section is included in vector based algorithms such as
+  qgisaggregate, qgisrefactorfields
+
+* 2 --- Integer list
+* 4 --- Integer (64bit) list
+* 6 --- Decimal (double) list
+* 10 --- String list
+* 0 --- Any other types
+
+.. **end_vector_field_subtypes**

--- a/docs/user_manual/processing_algs/qgis/vectorgeometry.rst
+++ b/docs/user_manual/processing_algs/qgis/vectorgeometry.rst
@@ -303,27 +303,27 @@ Parameters
        For each of the fields you'd like to retrieve information from,
        you need to define the following:
 
-       ``Input expression`` [expression] (``input``)
+       :guilabel:`Input expression` (``input``) [expression]
          Field or expression from the input layer.
 
-       ``Aggregate function`` [enumeration] (``aggregate``)
+       :guilabel:`Aggregate function` (``aggregate``) [enumeration]
          :ref:`Function <aggregates_function>` to use on the input
          expression to return the aggregated value.
 
          Default: *concatenate* (for string data type), *sum* (for
          numeric data type)
 
-       ``Delimiter`` [string] (``delimiter``)
+       :guilabel:`Delimiter` (``delimiter``) [string]
          Text string to separate aggregated values, for example in
          case of concatenation.
 
          Default: *,*
 
-       ``Output field name`` [string] (``name``)
+       :guilabel:`Output field name` (``name``) [string]
          Name of the aggregated field in the output layer.
          By default input field name is kept.
 
-       ``Type`` [enumeration] (``type``)
+       :guilabel:`Type` (``type``) [enumeration]
          Data type of the output field.
          Available types may not be compatible with the output layer provider.
          One of:
@@ -347,10 +347,10 @@ Parameters
             :start-after: **vector_field_subtypes**
             :end-before: **end_vector_field_subtypes**
 
-       ``Length`` [number] (``length``)
+       :guilabel:`Length` (``length``) [number]
          Length of the output field.
 
-       ``Precision`` [number] (``precision``)
+       :guilabel:`Precision` (``precision``) [number]
          Precision of the output field.
 
    * - **Load fields from layer**

--- a/docs/user_manual/processing_algs/qgis/vectorgeometry.rst
+++ b/docs/user_manual/processing_algs/qgis/vectorgeometry.rst
@@ -324,15 +324,24 @@ Parameters
          By default input field name is kept.
 
        ``Type`` [enumeration] (``type``)
-         Data type of the output field. One of:
+         Data type of the output field.
+         Available types may not be compatible with the output layer provider.
+         Depending on the field type, an additional ``sub_type`` parameter may be required.
+         One of:
 
          * 1 --- Boolean
-         * 2 --- Integer
-         * 4 --- Integer64
-         * 6 --- Double
-         * 10 --- String
+         * 2 --- Integer (32bit)
+         * 4 --- Integer (64bit)
+         * 6 --- Decimal (double)
+         * 9 --- Integer list --- ``sub_type: 2``
+         * 9 --- Integer (64bit) list --- ``sub_type: 4``
+         * 9 --- Decimal (double) list --- ``sub_type: 6``
+         * 10 --- Text (string)
+         * 11 --- String list
+         * 12 --- Binary Object (BLOB)
          * 14 --- Date
-         * 16 --- DateTime
+         * 15 --- Time
+         * 16 --- Date & Time
 
        ``Length`` [number] (``length``)
          Length of the output field.

--- a/docs/user_manual/processing_algs/qgis/vectorgeometry.rst
+++ b/docs/user_manual/processing_algs/qgis/vectorgeometry.rst
@@ -326,22 +326,13 @@ Parameters
        ``Type`` [enumeration] (``type``)
          Data type of the output field.
          Available types may not be compatible with the output layer provider.
-         Depending on the field type, an additional ``sub_type`` parameter may be required.
+         Depending on the field type, an additional ``sub_type`` parameter may be required
+         when running the algorithm in Python code or command line.
          One of:
 
-         * 1 --- Boolean
-         * 2 --- Integer (32bit)
-         * 4 --- Integer (64bit)
-         * 6 --- Decimal (double)
-         * 9 --- Integer list --- ``sub_type: 2``
-         * 9 --- Integer (64bit) list --- ``sub_type: 4``
-         * 9 --- Decimal (double) list --- ``sub_type: 6``
-         * 10 --- Text (string)
-         * 11 --- String list
-         * 12 --- Binary Object (BLOB)
-         * 14 --- Date
-         * 15 --- Time
-         * 16 --- Date & Time
+         .. include:: ../algs_include.rst
+            :start-after: **vector_field_types**
+            :end-before: **end_vector_field_types**
 
        ``Length`` [number] (``length``)
          Length of the output field.
@@ -365,7 +356,6 @@ Parameters
        .. include:: ../algs_include.rst
           :start-after: **layer_output_types**
           :end-before: **end_layer_output_types**
-
 
 Outputs
 .......

--- a/docs/user_manual/processing_algs/qgis/vectorgeometry.rst
+++ b/docs/user_manual/processing_algs/qgis/vectorgeometry.rst
@@ -326,15 +326,26 @@ Parameters
        ``Type`` [enumeration] (``type``)
          Data type of the output field.
          Available types may not be compatible with the output layer provider.
-         For certain field types, e.g. lists, an extra ``sub_type`` parameter helps refine the
-         the specific type of the data. 
-         This parameter is automatically set in the GUI but may be needed
-         if you're running the algorithm in Python or from the command line.
          One of:
+
+         .. attention:: For certain field types, e.g. lists,
+          an extra ``sub_type`` parameter helps refine the specific type of the data.
+          It is automatically set in the GUI but may be needed
+          if you're running the algorithm in Python or from the command line.
 
          .. include:: ../algs_include.rst
             :start-after: **vector_field_types**
             :end-before: **end_vector_field_types**
+
+       :guilabel:`Sub-type` (``sub_type``) [enumeration]
+         For certain field types, e.g. lists, this parameter helps refine the specific ``type`` of the data.
+         It is automatically set in the GUI but may be needed
+         if you're running the algorithm in Python or from the command line.
+         One of:
+
+         .. include:: ../algs_include.rst
+            :start-after: **vector_field_subtypes**
+            :end-before: **end_vector_field_subtypes**
 
        ``Length`` [number] (``length``)
          Length of the output field.

--- a/docs/user_manual/processing_algs/qgis/vectorgeometry.rst
+++ b/docs/user_manual/processing_algs/qgis/vectorgeometry.rst
@@ -326,8 +326,10 @@ Parameters
        ``Type`` [enumeration] (``type``)
          Data type of the output field.
          Available types may not be compatible with the output layer provider.
-         Depending on the field type, an additional ``sub_type`` parameter may be required
-         when running the algorithm in Python code or command line.
+         For certain field types, e.g. lists, an extra ``sub_type`` parameter helps refine the
+         the specific type of the data. 
+         This parameter is automatically set in the GUI but may be needed
+         if you're running the algorithm in Python or from the command line.
          One of:
 
          .. include:: ../algs_include.rst

--- a/docs/user_manual/processing_algs/qgis/vectortable.rst
+++ b/docs/user_manual/processing_algs/qgis/vectortable.rst
@@ -950,13 +950,26 @@ Parameters
        :guilabel:`Type` (``type``) [enumeration]
          Data type of the output field.
          Available types may not be compatible with the output layer provider.
-         Depending on the field type, an additional ``sub_type`` parameter may be required
-         when running the algorithm in Python code or command line.
          One of:
+
+         .. attention:: For certain field types, e.g. lists,
+          an extra ``sub_type`` parameter helps refine the the specific type of the data.
+          It is automatically set in the GUI but may be needed
+          if you're running the algorithm in Python or from the command line.
 
          .. include:: ../algs_include.rst
             :start-after: **vector_field_types**
             :end-before: **end_vector_field_types**
+
+       :guilabel:`Sub-type` (``sub_type``) [enumeration]
+         For certain field types, e.g. lists, this parameter helps refine the specific ``type`` of the data.
+         It is automatically set in the GUI but may be needed
+         if you're running the algorithm in Python or from the command line.
+         One of:
+
+         .. include:: ../algs_include.rst
+            :start-after: **vector_field_subtypes**
+            :end-before: **end_vector_field_subtypes**
 
        :guilabel:`Length` (``length``) [number]
          Length of the output field.

--- a/docs/user_manual/processing_algs/qgis/vectortable.rst
+++ b/docs/user_manual/processing_algs/qgis/vectortable.rst
@@ -950,22 +950,13 @@ Parameters
        :guilabel:`Type` (``type``) [enumeration]
          Data type of the output field.
          Available types may not be compatible with the output layer provider.
-         Depending on the field type, an additional ``sub_type`` parameter may be required.
+         Depending on the field type, an additional ``sub_type`` parameter may be required
+         when running the algorithm in Python code or command line.
          One of:
 
-         * 1 --- Boolean
-         * 2 --- Integer (32bit)
-         * 4 --- Integer (64bit)
-         * 6 --- Decimal (double)
-         * 9 --- Integer list --- ``sub_type: 2``
-         * 9 --- Integer (64bit) list --- ``sub_type: 4``
-         * 9 --- Decimal (double) list --- ``sub_type: 6``
-         * 10 --- Text (string)
-         * 11 --- String list
-         * 12 --- Binary Object (BLOB)
-         * 14 --- Date
-         * 15 --- Time
-         * 16 --- Date & Time
+         .. include:: ../algs_include.rst
+            :start-after: **vector_field_types**
+            :end-before: **end_vector_field_types**
 
        :guilabel:`Length` (``length``) [number]
          Length of the output field.

--- a/docs/user_manual/processing_algs/qgis/vectortable.rst
+++ b/docs/user_manual/processing_algs/qgis/vectortable.rst
@@ -949,7 +949,23 @@ Parameters
 
        :guilabel:`Type` (``type``) [enumeration]
          Data type of the output field.
-         Available types depend on the output layer provider.
+         Available types may not be compatible with the output layer provider.
+         Depending on the field type, an additional ``sub_type`` parameter may be required.
+         One of:
+
+         * 1 --- Boolean
+         * 2 --- Integer (32bit)
+         * 4 --- Integer (64bit)
+         * 6 --- Decimal (double)
+         * 9 --- Integer list --- ``sub_type: 2``
+         * 9 --- Integer (64bit) list --- ``sub_type: 4``
+         * 9 --- Decimal (double) list --- ``sub_type: 6``
+         * 10 --- Text (string)
+         * 11 --- String list
+         * 12 --- Binary Object (BLOB)
+         * 14 --- Date
+         * 15 --- Time
+         * 16 --- Date & Time
 
        :guilabel:`Length` (``length``) [number]
          Length of the output field.


### PR DESCRIPTION
in Aggregate and Refactor fields algorithms
Fixes #3666

@selmaVH1 @nyalldawson @agiudiceandrea may I request your feedback, please? I found from the log panel that Int/Int64/Double lists share the same `type` enum and there is an additional sub_type parameter to differentiate them (which of course is not exposed in the GUI). I'm not sure of how to clearly explain this to the users. this is what I came to (I also don't keep the order in which the types are displayed in the drop-down widget). Any ideas? Thanks
 
![image](https://github.com/user-attachments/assets/b3a6705c-1e1b-478e-9be2-f74094d710f5)
