### PR TITLE
Add Python annotations and remove args kwargs from Python methods

### DIFF
--- a/docs/pyqgis_developer_cookbook/processing.rst
+++ b/docs/pyqgis_developer_cookbook/processing.rst
@@ -91,18 +91,22 @@ If you want to add your existing plugin to Processing, you need to add some code
       :skipif: True
 
       from qgis.core import QgsProcessingProvider
+      from qgis.PyQt.QtGui import QIcon
 
       from .example_processing_algorithm import ExampleProcessingAlgorithm
 
 
       class Provider(QgsProcessingProvider):
 
-          def loadAlgorithms(self, *args, **kwargs):
+          """ The provider of our plugin. """
+
+          def loadAlgorithms(self):
+              """ Load each algorithm into the current provider. """
               self.addAlgorithm(ExampleProcessingAlgorithm())
               # add additional algorithms here
               # self.addAlgorithm(MyOtherAlgorithm())
 
-          def id(self, *args, **kwargs):
+          def id(self) -> str:
               """The ID of your plugin, used for identifying the provider.
 
               This string should be a unique, short, character only string,
@@ -110,7 +114,7 @@ If you want to add your existing plugin to Processing, you need to add some code
               """
               return 'yourplugin'
 
-          def name(self, *args, **kwargs):
+          def name(self) -> str:
               """The human friendly name of your plugin in Processing.
 
               This string should be as short as possible (e.g. "Lastools", not
@@ -118,7 +122,7 @@ If you want to add your existing plugin to Processing, you need to add some code
               """
               return self.tr('Your plugin')
 
-          def icon(self):
+          def icon(self) -> QIcon:
               """Should return a QIcon which is used for your provider inside
               the Processing toolbox.
               """


### PR DESCRIPTION
Follow up from my previous PR #9465. Sorry, I'm giving a PyQGIS training these days... ;-)

* Remove `args` and `kwargs` from the example, we do not need them, it makes the function signature easier
* Adding Python annotations, similar as in QGIS recently https://github.com/qgis/QGIS/pull/59811 and https://github.com/qgis/QGIS/pull/59812

- [x] Backport to LTR documentation is requested

