### PR TITLE
Backport some of the HTML and PDF build configuration from recent versions

### DIFF
--- a/REQUIREMENTS.txt
+++ b/REQUIREMENTS.txt
@@ -1,6 +1,6 @@
-Sphinx==2.4.4
-sphinx-intl==0.9.11
-sphinx_rtd_theme
-sphinx-intl[transifex]
-PyYAML
-pdflatex
+pyYAML
+Sphinx==7.4.6
+sphinx_copybutton
+sphinx-intl
+sphinx_rtd_theme==2.0.0
+sphinx_togglebutton

--- a/docs_conf.yml
+++ b/docs_conf.yml
@@ -1,4 +1,4 @@
 
-version_list: testing, latest, 3.22, 3.16, 3.10, 3.4, 2.18, 2.14, 2.8, 2.6, 2.2, 2.0, 1.8
+version_list: testing, latest, 3.40, 3.34, 3.28, 3.22, 3.16, 3.10, 3.4, 2.18
 # Fill this list based on languages that are actually pulled from transifex
 supported_languages: en, bg, cs, de, es, fi, fr, id, it, ja, ko, nl, pt_BR, pt_PT, ro, ru, tr, zh_Hant, zh_Hans


### PR DESCRIPTION
and adapt the changes to repo and tools contexts
Fixes #7619 
Actually, the issue is already fixed (I locally build and pushed to server). This PR is to align the branch with the necessary changes...
Because 3.10 is an old version, it wasn't possible to build it as it was (without setting a compatible environment). The fix here is to instead replace the old libraries and commands with the ones used in master and build 3.10 docs with them.  Focus was put mainly on the HTML build.