### PR TITLE
"Split features" keeps original feature and assigns biggest geometry

### DIFF
--- a/docs/user_manual/working_with_vector/editing_geometry_attributes.rst
+++ b/docs/user_manual/working_with_vector/editing_geometry_attributes.rst
@@ -1365,7 +1365,10 @@ To split line or polygon features:
 #. Select the |splitFeatures| :sup:`Split Features` tool.
 #. Draw a line across the feature(s) you want to split.
    If a selection is active, only selected features are split.
-   Fields of resulting features are filled according to their :ref:`splitting policy <policies>`.
+   The original feature is then assigned the biggest geometry resulting from the splitting,
+   and new features are created for the remaining parts.
+   Fields of the features are filled/updated according to the datasource provider rules
+   or their :ref:`splitting policy <policies>`.
 #. You can then as usual modify any of the attributes of any resulting feature.
 
 .. tip:: **Split a polyline into new features in one-click**


### PR DESCRIPTION
<!---
Include a few sentences describing the overall goals for this Pull Request.
 
A list of issues is at https://github.com/qgis/QGIS-Documentation/issues.
Add "fix #issuenumber" for each issue the PR fixes. The ticket(s) will be closed automatically.
If your PR doesn't fix entirely the ticket, only add the ticket(s) reference preceded by # character.
-->
Goal: refs qgis/QGIS#59806

Ticket(s): #
<!---
Indicate whether the fix should be backported to previous release.
Replace the space between square brackets by a `x` to make it checked.
-->
- [ ] Backport to LTR documentation is requested

<!---
Reviewing is a process done by community members, mostly on a volunteer basis.
We try to keep the overhead as small as possible and appreciate if you help us.
Please read carefully and ensure you comply with our writing guidelines at
https://docs.qgis.org/testing/en/docs/documentation_guidelines/index.html.
Feel free to ask in a comment or the (qgis-community-team mailing list)
[https://lists.osgeo.org/mailman/listinfo/qgis-community-team] if you have troubles with any item.
--->
