### PR TITLE
fix: grammar and punctuation in localization.rst

### DIFF
--- a/docs/developers_guide/localization.rst
+++ b/docs/developers_guide/localization.rst
@@ -65,7 +65,7 @@ methods available in QT classes because these methods ignore locale settings.
 The same consideration applies to integral types and ``::toInt()`` or
 ``::toLongLong()`` methods.
 
-``QLocale().toDouble()`` or ``QLocale().toInt()`` and the others ``QLocale()``
+``QLocale().toDouble()`` or ``QLocale().toInt()`` and the other ``QLocale()``
 conversion methods can be used in this situation.
 
 As a better alternative, QGIS API provides a few classes that
@@ -87,7 +87,7 @@ The general recommendation is to use :class:`QgsDoubleSpinBox <qgis.gui.QgsDoubl
 for all floating point types I/O whenever it is possible because it is very well tested and
 it validates the input correctly. As an alternative it is possible
 to use the :class:`QgsDoubleValidator <qgis.gui.QgsDoubleValidator>` class
-independently on a string obtained from another widget (e.g. a simple
+independently on a string obtained from another widget (e.g., a simple
 ``QLineEdit`` widget).
 
 


### PR DESCRIPTION
- the other~s~ ...
- e.**g.,**

<!---
Include a few sentences describing the overall goals for this Pull Request.
 
A list of issues is at https://github.com/qgis/QGIS-Documentation/issues.
Add "fix #issuenumber" for each issue the PR fixes. The ticket(s) will be closed automatically.
If your PR doesn't fix entirely the ticket, only add the ticket(s) reference preceded by # character.
-->
Goal:

Ticket(s): #
<!---
Indicate whether the fix should be backported to previous release.
Replace the space between square brackets by a `x` to make it checked.
-->
- [ ] Backport to LTR documentation is requested

<!---
Reviewing is a process done by community members, mostly on a volunteer basis.
We try to keep the overhead as small as possible and appreciate if you help us.
Please read carefully and ensure you comply with our writing guidelines at
https://docs.qgis.org/testing/en/docs/documentation_guidelines/index.html.
Feel free to ask in a comment or the (qgis-community-team mailing list)
[https://lists.osgeo.org/mailman/listinfo/qgis-community-team] if you have troubles with any item.
--->
