### PR TITLE
[3.34] Make strings in the themes folder also translatable

### DIFF
--- a/.github/workflows/pofiles.yml
+++ b/.github/workflows/pofiles.yml
@@ -47,7 +47,7 @@ jobs:
           make gettext
           sphinx-intl update -p build/gettext -l en
           # Remove obsolete strings from the generated *.po files
-          find locale/en/LC_MESSAGES/docs/ -type f -name '*.po' -exec sed -i '/^#~ /,/^$/d' {} \;
+          find locale/en/LC_MESSAGES/ -type f -name '*.po' -exec sed -i '/^#~ /,/^$/d' {} \;
 
     - name: Commit the changes in the PO files      
       id: "auto-commit-action"

--- a/.tx/config
+++ b/.tx/config
@@ -1934,3 +1934,9 @@ source_file = locale/en/LC_MESSAGES/docs/user_manual/working_with_vector_tiles/v
 source_lang = en
 type        = PO
 
+[o:qgis:p:qgis-documentation:r:49461a22f7afeffa595077a47d45daeb]
+file_filter = locale/<lang>/LC_MESSAGES/sphinx.po
+source_file = locale/en/LC_MESSAGES/sphinx.po
+source_lang = en
+type        = PO
+

--- a/conf.py
+++ b/conf.py
@@ -63,7 +63,7 @@ extensions = [
 ]
 
 # Add any paths that contain templates here, relative to this directory.
-templates_path = ['_templates']
+templates_path = ['./themes']
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.

--- a/locale/en/LC_MESSAGES/sphinx.po
+++ b/locale/en/LC_MESSAGES/sphinx.po
@@ -1,0 +1,90 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2002-now, QGIS project
+# This file is distributed under the same license as the QGIS Documentation
+# package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2025.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: QGIS Documentation 3.34\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-02-06 21:09+0100\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: en\n"
+"Language-Team: en <LL@li.org>\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.14.0\n"
+
+#: ../../themes/rtd_qgis/breadcrumbs.html:14
+msgid "Learn how to contribute!"
+msgstr ""
+
+#: ../../themes/rtd_qgis/layout.html:15
+msgid ""
+"This documentation is a work in progress. For the Long Term Release and "
+"translations, please visit the "
+msgstr ""
+
+#: ../../themes/rtd_qgis/layout.html:15 ../../themes/rtd_qgis/layout.html:21
+msgid "latest version"
+msgstr ""
+
+#: ../../themes/rtd_qgis/layout.html:21
+msgid ""
+"This documentation is for a QGIS version which has reached end of life. "
+"Instead visit the "
+msgstr ""
+
+#: ../../themes/rtd_qgis/versions.html:19
+msgid "Languages"
+msgstr ""
+
+#: ../../themes/rtd_qgis/versions.html:26
+msgid "Versions"
+msgstr ""
+
+#: ../../themes/rtd_qgis/versions.html:34
+msgid "Downloads"
+msgstr ""
+
+#: ../../themes/rtd_qgis/versions.html:44
+msgid "Contribute to Docs"
+msgstr ""
+
+#: ../../themes/rtd_qgis/versions.html:46
+msgid "Edit on GitHub"
+msgstr ""
+
+#: ../../themes/rtd_qgis/versions.html:51
+msgid "Translate Page"
+msgstr ""
+
+#: ../../themes/rtd_qgis/versions.html:55
+msgid "Report Issue"
+msgstr ""
+
+#: ../../themes/rtd_qgis/versions.html:61
+msgid "On QGIS Project"
+msgstr ""
+
+#: ../../themes/rtd_qgis/versions.html:63
+msgid "Home"
+msgstr ""
+
+#: ../../themes/rtd_qgis/versions.html:66
+msgid "C++ API"
+msgstr ""
+
+#: ../../themes/rtd_qgis/versions.html:69
+msgid "PyQGIS API"
+msgstr ""
+
+#: ../../themes/rtd_qgis/versions.html:72
+msgid "Source"
+msgstr ""
+

--- a/scripts/create_transifex_resources.sh
+++ b/scripts/create_transifex_resources.sh
@@ -11,7 +11,7 @@
 # Update: Harrissou Sant-anna, December 2020
 
 TARGETBRANCH=`git branch --show-current`
-SOURCEPOFILES='locale/en/LC_MESSAGES/docs/'
+SOURCEPOFILES='locale/en/LC_MESSAGES/'
 PROJECT='qgis-documentation'
 CONFIGFILE='.tx/config'
 

--- a/themes/rtd_qgis/breadcrumbs.html
+++ b/themes/rtd_qgis/breadcrumbs.html
@@ -11,7 +11,7 @@
 	     <a class="qgis-edit-guidelines" href="https://docs.qgis.org/{{ version }}/{{ language }}/docs/documentation_guidelines/index.html">
 	-->
 	<a class="qgis-edit-guidelines" href="https://qgis.org/community/involve/">
-		Learn how to contribute!
+		{{ _( "Learn how to contribute!" ) }}
 	</a>
     </li>
 {% endif %}

--- a/themes/rtd_qgis/layout.html
+++ b/themes/rtd_qgis/layout.html
@@ -29,6 +29,6 @@
 
  {% block sidebartitle %}
    {{ super() }}
-   <a href= "{{pathto('genindex.html', 1)}}">Index</a>
+   <a href= "{{pathto('genindex.html', 1)}}">{{ _('Index') }}</a>
  {% endblock sidebartitle %}
 


### PR DESCRIPTION
making every user-facing strings in the docs really translatable.
This is a backport of #9624 with an additional commit that applies the changes and generates the new strings to translate (see sphinx.po file).

Any objections to merging this so close to 3.34 EOL? Afaict at worst it adds new strings to Transifex but these strings are already visible in English in the docs, regardless the locale. So no harm if not translated, other than lowering translation ratio 😄  On the contrary, if translated, the red banner for outdated docs would now display translated.