### PR TITLE
Add precision to to_string function

### DIFF
--- a/docs/user_manual/expressions/expression_help/Conversions.rst
+++ b/docs/user_manual/expressions/expression_help/Conversions.rst
@@ -338,7 +338,7 @@ Converts a string to a real number. If a value cannot be converted to real the e
 to_string
 .........
 
-Converts a number to string.
+Converts a number to string. The conversion is not locale-aware, see 'format_number' for a locale-aware alternative.
 
 .. list-table::
    :widths: 15 85
@@ -348,7 +348,7 @@ Converts a number to string.
    * - Arguments
      - * **number** - Integer or real value. The number to convert to string.
    * - Examples
-     - * ``to_string(123)`` → '123'
+     - * ``to_string(1.23)`` → '1.23'
 
 
 .. end_to_string_section

--- a/docs/user_manual/expressions/expression_help/String.rst
+++ b/docs/user_manual/expressions/expression_help/String.rst
@@ -568,7 +568,7 @@ Converts all words of a string to title case (all words lower case with leading 
 to_string
 .........
 
-Converts a number to string.
+Converts a number to string. The conversion is not locale-aware, see 'format_number' for a locale-aware alternative.
 
 .. list-table::
    :widths: 15 85
@@ -578,7 +578,7 @@ Converts a number to string.
    * - Arguments
      - * **number** - Integer or real value. The number to convert to string.
    * - Examples
-     - * ``to_string(123)`` → '123'
+     - * ``to_string(1.23)`` → '1.23'
 
 
 .. end_to_string_section


### PR DESCRIPTION
refs https://github.com/qgis/QGIS/pull/60479
<!---
Include a few sentences describing the overall goals for this Pull Request.
 
A list of issues is at https://github.com/qgis/QGIS-Documentation/issues.
Add "fix #issuenumber" for each issue the PR fixes. The ticket(s) will be closed automatically.
If your PR doesn't fix entirely the ticket, only add the ticket(s) reference preceded by # character.
-->
Goal:

Ticket(s): #
<!---
Indicate whether the fix should be backported to previous release.
Replace the space between square brackets by a `x` to make it checked.
-->
- [ ] Backport to LTR documentation is requested

<!---
Reviewing is a process done by community members, mostly on a volunteer basis.
We try to keep the overhead as small as possible and appreciate if you help us.
Please read carefully and ensure you comply with our writing guidelines at
https://docs.qgis.org/testing/en/docs/documentation_guidelines/index.html.
Feel free to ask in a comment or the (qgis-community-team mailing list)
[https://lists.osgeo.org/mailman/listinfo/qgis-community-team] if you have troubles with any item.
--->
