### PR TITLE
Update label_settings.rst - definition for Data defined rotation

### DIFF
--- a/docs/user_manual/style_library/label_settings.rst
+++ b/docs/user_manual/style_library/label_settings.rst
@@ -903,8 +903,10 @@ or an expression to set:
   * :guilabel:`Horizontal`: it can be **Left**, **Center** or **Right**
   * the text :guilabel:`Vertical`: it can be **Bottom**, **Base**, **Half**,
     **Cap** or **Top**
-* the text :guilabel:`Rotation`. Different units can be defined for the
-  labeling rotation (e.g. ``degrees``, ``minutes of arc``, ``turns``).
+* the text :guilabel:`Rotation`. Rotation is defined as clockwise angle with 0°
+  pointing in the direction of East for ``Horizontal`` oriented text and with 0°
+  pointing in North direction for ``Vertical`` oriented text. Different units can
+  be defined for the labeling rotation (e.g. ``degrees``, ``minutes of arc``, ``turns``).
   Check the :guilabel:`Preserve data rotation values` entry if you want to keep
   the rotation value in the associated field and apply it to the label, whether
   the label is pinned or not. If unchecked, unpinning the label rotation is


### PR DESCRIPTION
Added explanation about 0° angle pointing direction and rotation direction definition for Data defined Rotation under Placement. This is not common between different software's so it should be documented.

<!---
Include a few sentences describing the overall goals for this Pull Request.
 
A list of issues is at https://github.com/qgis/QGIS-Documentation/issues.
Add "fix #issuenumber" for each issue the PR fixes. The ticket(s) will be closed automatically.
If your PR doesn't fix entirely the ticket, only add the ticket(s) reference preceded by # character.
-->
Goal:

Ticket(s): #
<!---
Indicate whether the fix should be backported to previous release.
Replace the space between square brackets by a `x` to make it checked.
-->
- [ ] Backport to LTR documentation is requested

<!---
Reviewing is a process done by community members, mostly on a volunteer basis.
We try to keep the overhead as small as possible and appreciate if you help us.
Please read carefully and ensure you comply with our writing guidelines at
https://docs.qgis.org/testing/en/docs/documentation_guidelines/index.html.
Feel free to ask in a comment or the (qgis-community-team mailing list)
[https://lists.osgeo.org/mailman/listinfo/qgis-community-team] if you have troubles with any item.
--->
