### PR TITLE
Remove features from selection with Cmd-drag on Mac. Also typo fixes.

### DIFF
--- a/docs/user_manual/introduction/general_tools.rst
+++ b/docs/user_manual/introduction/general_tools.rst
@@ -896,14 +896,14 @@ tools:
    somewhere else accidentally and clear your selection.
 
 While using the |selectRectangle| :guilabel:`Select Feature(s)` tool,
-holding :kbd:`Shift` or :kbd:`Ctrl` (:kbd:`Cmd` on Mac) toggles whether a feature is selected
-(i.e. either adds to the current selection or removes from it).
+holding :kbd:`Shift` or :kbd:`Ctrl` (:kbd:`Cmd` on macOS) toggles whether a feature is selected
+(i.e., either adds to the current selection or removes from it).
 
 For the other tools, different behaviors can be performed by holding down:
 
 * :kbd:`Shift`: add features to the current selection
 * :kbd:`Ctrl`/:kbd:`Cmd`: subtract features from the current selection
-* :kbd:`Ctrl+Shift`/:kbd:`Cmd+Shift`: intersect with the current selection, i.e. only keep
+* :kbd:`Ctrl+Shift`/:kbd:`Cmd+Shift`: intersect with the current selection, i.e., only keep
   overlapping features from the current selection
 * :kbd:`Alt`: select features that are totally within the selection shape.
   Combined with :kbd:`Shift` or :kbd:`Ctrl`/:kbd:`Cmd` keys, you can add or subtract

--- a/docs/user_manual/introduction/general_tools.rst
+++ b/docs/user_manual/introduction/general_tools.rst
@@ -896,17 +896,17 @@ tools:
    somewhere else accidentally and clear your selection.
 
 While using the |selectRectangle| :guilabel:`Select Feature(s)` tool,
-holding :kbd:`Shift` or :kbd:`Ctrl` toggles whether a feature is selected
-(ie either adds to the current selection or remove from it).
+holding :kbd:`Shift` or :kbd:`Ctrl` (:kbd:`Cmd` on Mac) toggles whether a feature is selected
+(i.e. either adds to the current selection or removes from it).
 
 For the other tools, different behaviors can be performed by holding down:
 
 * :kbd:`Shift`: add features to the current selection
-* :kbd:`Ctrl`: substract features from the current selection
-* :kbd:`Ctrl+Shift`: intersect with current selection, ie only keep
+* :kbd:`Ctrl`/:kbd:`Cmd`: subtract features from the current selection
+* :kbd:`Ctrl+Shift`/:kbd:`Cmd+Shift`: intersect with the current selection, i.e. only keep
   overlapping features from the current selection
 * :kbd:`Alt`: select features that are totally within the selection shape.
-  Combined with :kbd:`Shift` or :kbd:`Ctrl` keys, you can add or substract
+  Combined with :kbd:`Shift` or :kbd:`Ctrl`/:kbd:`Cmd` keys, you can add or subtract
   features to/from the current selection.
 
 .. _automatic_selection:


### PR DESCRIPTION
<!---
Include a few sentences describing the overall goals for this Pull Request.
 
A list of issues is at https://github.com/qgis/QGIS-Documentation/issues.
Add "fix #issuenumber" for each issue the PR fixes. The ticket(s) will be closed automatically.
If your PR doesn't fix entirely the ticket, only add the ticket(s) reference preceded by # character.
-->
Goal: Add info to the docs to inform Mac users of how to remove features from a selection using the Select Feature(s) tool.

Ticket(s): #
<!---
Indicate whether the fix should be backported to previous release.
Replace the space between square brackets by a `x` to make it checked.
-->
- [ ] Backport to LTR documentation is requested

<!---
Reviewing is a process done by community members, mostly on a volunteer basis.
We try to keep the overhead as small as possible and appreciate if you help us.
Please read carefully and ensure you comply with our writing guidelines at
https://docs.qgis.org/testing/en/docs/documentation_guidelines/index.html.
Feel free to ask in a comment or the (qgis-community-team mailing list)
[https://lists.osgeo.org/mailman/listinfo/qgis-community-team] if you have troubles with any item.
--->
