### PR TITLE
Mention array_to_string as alternative for string concatenation functions

### DIFF
--- a/docs/user_manual/expressions/functions_list.rst
+++ b/docs/user_manual/expressions/functions_list.rst
@@ -1118,14 +1118,15 @@ operators, with some special characteristics:
 
 * When any of the arguments is a NULL value, either ``||`` or ``+`` will
   return a NULL value. To return the other arguments regardless the NULL value,
-  you may want to use the ``concat`` function::
+  you may want to use the ``concat`` or ``array_to_string`` function::
 
     'My feature id is: ' + NULL ==> NULL 
     'My feature id is: ' || NULL => NULL 
     concat('My feature id is: ', NULL) => 'My feature id is: '
+    array_to_string( array('My feature id is:', NULL), ' ,') => 'My feature id is:'
 
-further reading: :ref:`expression_function_Operators_concat`,
-:ref:`expression_function_Operators_plus`
+further reading: :ref:`expression_function_Arrays_array_to_string`,
+:ref:`expression_function_Operators_concat`, :ref:`expression_function_Operators_plus`
 
 .. include:: expression_help/String.rst
    :start-after: .. end_concat_section
@@ -1177,7 +1178,8 @@ Further reading: :ref:`expression_function_String_substr`,
    :start-after: .. end_regexp_substr_section
    :end-before: .. end_replace_section
 
-Further reading: :ref:`expression_function_String_regexp_replace`
+Further reading: :ref:`expression_function_String_regexp_replace`,
+:ref:`expression_function_Arrays_array_replace`
 
 .. include:: expression_help/String.rst
    :start-after: .. end_replace_section

--- a/docs/user_manual/expressions/functions_list.rst
+++ b/docs/user_manual/expressions/functions_list.rst
@@ -1123,7 +1123,7 @@ operators, with some special characteristics:
     'My feature id is: ' + NULL ==> NULL 
     'My feature id is: ' || NULL => NULL 
     concat('My feature id is: ', NULL) => 'My feature id is: '
-    array_to_string( array('My feature id is:', NULL), ' ,') => 'My feature id is:'
+    array_to_string( array('My feature id is: ', NULL) ) => 'My feature id is: '
 
 further reading: :ref:`expression_function_Arrays_array_to_string`,
 :ref:`expression_function_Operators_concat`, :ref:`expression_function_Operators_plus`


### PR DESCRIPTION
Also connect replace and array_replace functions

<!---
Include a few sentences describing the overall goals for this Pull Request.
 
A list of issues is at https://github.com/qgis/QGIS-Documentation/issues.
Add "fix #issuenumber" for each issue the PR fixes. The ticket(s) will be closed automatically.
If your PR doesn't fix entirely the ticket, only add the ticket(s) reference preceded by # character.
-->
Goal:

Ticket(s): #
<!---
Indicate whether the fix should be backported to previous release.
Replace the space between square brackets by a `x` to make it checked.
-->
- [ ] Backport to LTR documentation is requested

<!---
Reviewing is a process done by community members, mostly on a volunteer basis.
We try to keep the overhead as small as possible and appreciate if you help us.
Please read carefully and ensure you comply with our writing guidelines at
https://docs.qgis.org/testing/en/docs/documentation_guidelines/index.html.
Feel free to ask in a comment or the (qgis-community-team mailing list)
[https://lists.osgeo.org/mailman/listinfo/qgis-community-team] if you have troubles with any item.
--->
