### PR TITLE
Add a script to easily replace strings in rst or po files

### DIFF
--- a/scripts/strings_fixer.sh
+++ b/scripts/strings_fixer.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This script is used to batch replace strings in the repo, either rst or po files
 # It can be used to fix e.g. broken or redirected URLs (spotted using linkcheck),

--- a/scripts/strings_fixer.sh
+++ b/scripts/strings_fixer.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+
+# This script is used to batch replace strings in the repo, either rst or po files
+# It can be used to fix e.g. broken or redirected URLs (spotted using linkcheck),
+# malformed Sphinx roles.
+# With po files, the idea is to replace the strings in the repo at once
+# and avoid pushing strings translators would have to fix in their languages.
+
+# **Todo: Make folder and format parameters callable**
+
+# Harrissou Sant-anna, february 2025
+
+# target file format to update, default to po (or rst?)
+TARGETFORMAT="po"
+
+#echo $TARGETFORMAT
+declare -A MATCHING_STRINGS
+
+MATCHING_STRINGS=(
+       [">\` _"]=">\`_"
+       ["> \`_"]=">\`_"
+       [":ref: "]=":ref:"
+       [": ref: "]=":ref:"
+       [":ref : "]=":ref:"
+       [": ref :"]=":ref:"
+       [":guilabel: "]=":guilabel:"
+       [": guilabel: "]=":guilabel:"
+       [":guilabel : "]=":guilabel:"
+       [": guilabel :"]=":guilabel:"
+       [":sup: "]=":sup:"
+       [": sup: "]=":sup:"
+       [":sup : "]=":sup:"
+       [": sup :"]=":sup:"
+       [":menuselection: "]=":menuselection:"
+       [": menuselection: "]=":menuselection:"
+       [":menuselection : "]=":menuselection:"
+       [": menuselection :"]=":menuselection:"
+       # complete specific strings to update, e.g., urls from make linkcheck output
+       #["oldstringtoreplace"]="newstringforreplacement"
+       )
+
+SOURCEFILES='locale'
+
+for FILE in `find $SOURCEFILES -type f -name "*.$TARGETFORMAT"`
+do
+  echo $FILE;
+
+  for string in "${!MATCHING_STRINGS[@]}"
+  do
+    #echo "$string - ${MATCHING_STRINGS[$string]}"
+    sed -i -e "s@$string@${MATCHING_STRINGS[$string]}@g" "$FILE"
+  done
+done

--- a/scripts/strings_fixer.sh
+++ b/scripts/strings_fixer.sh
@@ -6,14 +6,17 @@
 # With po files, the idea is to replace the strings in the repo at once
 # and avoid pushing strings translators would have to fix in their languages.
 
-# **Todo: Make folder and format parameters callable**
+# Usage: Run from the repository main folder
+#   scripts/strings_fixer.sh -- will replace strings in po files in the "locale" folder
+#   scripts/strings_fixer.sh docs/about rst -- will replace strings in rst files in the "docs/about" folder
 
 # Harrissou Sant-anna, february 2025
 
-# target file format to update, default to po (or rst?)
-TARGETFORMAT="po"
+# Folder to browse for text replacement, defaults to locale
+SOURCEFILES=${1:-"locale"}
+# target file format to update, defaults to po
+TARGETFORMAT=${2:-"po"}
 
-#echo $TARGETFORMAT
 declare -A MATCHING_STRINGS
 
 MATCHING_STRINGS=(
@@ -36,18 +39,16 @@ MATCHING_STRINGS=(
        [":menuselection : "]=":menuselection:"
        [": menuselection :"]=":menuselection:"
        # complete specific strings to update, e.g., urls from make linkcheck output
-       #["oldstringtoreplace"]="newstringforreplacement"
-       )
+       # ["oldstringtoreplace"]="newstringforreplacement"
+)
 
-SOURCEFILES='locale'
-
-for FILE in `find $SOURCEFILES -type f -name "*.$TARGETFORMAT"`
+for FILE in `find ${SOURCEFILES} -type f -name "*.${TARGETFORMAT}"`
 do
-  echo $FILE;
+  echo "${FILE}";
 
   for string in "${!MATCHING_STRINGS[@]}"
   do
     #echo "$string - ${MATCHING_STRINGS[$string]}"
-    sed -i -e "s@$string@${MATCHING_STRINGS[$string]}@g" "$FILE"
+    sed -i -e "s@${string}@${MATCHING_STRINGS[${string}]}@g" "${FILE}"
   done
 done


### PR DESCRIPTION
A probably ugly, but working, script that helps replace broken or redirected urls found by Linkcheck (used to fill #9676).
It will also be called on translated po files to avoid broken translated strings due to modified urls. Morever, it is designed for fixing a number of common translation errors related to Sphinx text formatting.

<!---
Include a few sentences describing the overall goals for this Pull Request.
 
A list of issues is at https://github.com/qgis/QGIS-Documentation/issues.
Add "fix #issuenumber" for each issue the PR fixes. The ticket(s) will be closed automatically.
If your PR doesn't fix entirely the ticket, only add the ticket(s) reference preceded by # character.
-->
Goal:

Ticket(s): #
<!---
Indicate whether the fix should be backported to previous release.
Replace the space between square brackets by a `x` to make it checked.
-->
- [ ] Backport to LTR documentation is requested

<!---
Reviewing is a process done by community members, mostly on a volunteer basis.
We try to keep the overhead as small as possible and appreciate if you help us.
Please read carefully and ensure you comply with our writing guidelines at
https://docs.qgis.org/testing/en/docs/documentation_guidelines/index.html.
Feel free to ask in a comment or the (qgis-community-team mailing list)
[https://lists.osgeo.org/mailman/listinfo/qgis-community-team] if you have troubles with any item.
--->
