### PR TITLE
change level for tables section

### DIFF
--- a/docs/documentation_guidelines/writing.rst
+++ b/docs/documentation_guidelines/writing.rst
@@ -68,7 +68,7 @@ also possible to create block quotes with indentation. See the
 
 .. code-block::
 
-   #. In a numbered list, there should be 
+   #. In a numbered list, there should be
       three spaces when you break lines
    #. And next items directly follow
 
@@ -126,10 +126,10 @@ You can use tags to emphasize items.
      :kbd:`Ctrl+B`
 
   will show :kbd:`Ctrl+B`
-  
+
   When describing keyboard shortcuts, the following conventions
   should be used:
-  
+
   * Letter keys are displayed using uppercase: :kbd:`S`
   * Special keys are displayed with an uppercase first letter: :kbd:`Esc`
   * Key combinations are displayed with a ``+`` sign between keys,
@@ -331,7 +331,7 @@ see :ref:`figure_logo`
 
 
 Tables
-......
+------
 
 A simple table can be coded like this
 
@@ -560,9 +560,9 @@ is located in the same folder as the referencing :file:`.rst` file.
 
 .. tip:: If you are on Ubuntu, you can use the following command to remove the
   global menu function and create smaller application screens with menus:
-  
+
   .. code-block:: bash
-  
+
     sudo apt autoremove appmenu-gtk appmenu-gtk3 appmenu-qt
 
 
@@ -607,7 +607,7 @@ guidelines:
   the Processing toolbox.
 * Avoid using "This algorithm does this and that..." as the first sentence in the
   algorithm description. Try to use more general expressions like::
-  
+
     Takes a point layer and generates a polygon layer containing the...
 
 * Avoid describing what the algorithm does by replicating its name and please
@@ -670,7 +670,7 @@ guidelines:
   File                                      ``file``
   Matrix                                    ``matrix``
   Layer                                     ``layer``
-  Same output type as input type            ``same as input``  
+  Same output type as input type            ``same as input``
   Definition                                ``definition``
   Point                                     ``point``
   MultipleLayers                            ``multipleLayers``
@@ -767,14 +767,14 @@ to help you with the layout and the description::
        - Specification of the output layer type (temporary, file,
          GeoPackage or PostGIS table).
          Encoding can also be specified.
-  
+
   Outputs
   .......
-  
+
   .. list-table::
      :header-rows: 1
      :widths: 20 20 20 40
-  
+
      * - Label
        - Name
        - Type


### PR DESCRIPTION
<!---
Include a few sentences describing the overall goals for this Pull Request.
 
A list of issues is at https://github.com/qgis/QGIS-Documentation/issues.
Add "fix #issuenumber" for each issue the PR fixes. The ticket(s) will be closed automatically.
If your PR doesn't fix entirely the ticket, only add the ticket(s) reference preceded by # character.
-->
Goal:
- There was no `Tables` in TOC so I pushed it one level up...

- This is my proposal, other good option could be to rename [`Figures and Images`](https://docs.qgis.org/3.40/en/docs/documentation_guidelines/writing.html#figures-and-images) to `Figures, Images and Tables`

before:
![image](https://github.com/user-attachments/assets/5ea05eac-9eaf-4b26-96c8-3dada7336a44)

new:
![image](https://github.com/user-attachments/assets/063c79a4-6285-4c8c-88bc-8f1839d18821)


Ticket(s): #
<!---
Indicate whether the fix should be backported to previous release.
Replace the space between square brackets by a `x` to make it checked.
-->
- [x] Backport to LTR documentation is requested

<!---
Reviewing is a process done by community members, mostly on a volunteer basis.
We try to keep the overhead as small as possible and appreciate if you help us.
Please read carefully and ensure you comply with our writing guidelines at
https://docs.qgis.org/testing/en/docs/documentation_guidelines/index.html.
Feel free to ask in a comment or the (qgis-community-team mailing list)
[https://lists.osgeo.org/mailman/listinfo/qgis-community-team] if you have troubles with any item.
--->
