### PR TITLE
Addon flat-tables - for spanning rows and columns 

### DIFF
--- a/REQUIREMENTS.txt
+++ b/REQUIREMENTS.txt
@@ -5,3 +5,4 @@ sphinx-intl
 sphinx_rtd_theme==2.0.0
 sphinx_togglebutton
 sphinxext-rediraffe
+linuxdoc

--- a/conf.py
+++ b/conf.py
@@ -59,7 +59,8 @@ extensions = [
     'sphinx.ext.extlinks',
     'sphinxext.rediraffe',
     'sphinx_togglebutton',
-    'sphinx_copybutton'
+    'sphinx_copybutton',
+    'linuxdoc.rstFlatTable',
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/docs/documentation_guidelines/writing.rst
+++ b/docs/documentation_guidelines/writing.rst
@@ -333,6 +333,9 @@ see :ref:`figure_logo`
 Tables
 ------
 
+Simple Tables and Grid Tables
+.............................
+
 A simple table can be coded like this
 
 .. code-block:: rst
@@ -389,6 +392,9 @@ My drawn table, mind you this is unfortunately not regarded as a caption
 
 You can reference to it like this my_drawn_table_.
 
+List Tables
+...........
+
 For even more complex tables, it is easier to use ``list-table``:
 
 .. code-block:: rst
@@ -426,6 +432,131 @@ The result:
 
        * Point
        * Line
+
+List tables are better option than drawn tables because they are easier to work with
+in the long run and they are much better fit for following changes using ``DIFF``.
+
+
+Flat Tables
+...........
+
+Flat tables extend possibilities of List Tables, for cases when it's needed to span columns and rows you can use ``flat-table``:
+
+.. code-block:: rst
+
+    .. flat-table::
+      :header-rows: 3
+      :widths: 10 10 40 40
+
+      * - :cspan:`3` WKB examples
+
+      * - :cspan:`2` INPUT
+        - OUTPUT
+
+      * - DataType
+        - Variant
+        - SpatiaLite SQL
+        - WKB (Hex notation)
+
+      * - :rspan:`1` POINT
+        - POINT
+        - .. code-block:: sql
+
+           ST_AsBinary(
+             ST_GeomFromText('POINT(1 1)')
+           );
+        - | 01 01 00 00 00 00 00 00 00 00 00 F0 3F 00 00 00
+          | 00 00 00 F0 3F
+
+      * - POINTZ
+        - .. code-block:: sql
+
+           ST_AsBinary(
+             ST_GeomFromText('POINTZ (1 1 1)')
+           );
+        - | 01 E9 03 00 00 00 00 00 00 00 00 F0 3F 00 00 00
+          | 00 00 00 F0 3F 00 00 00 00 00 00 F0 3F
+
+      * - :rspan:`1` LINESTRING
+        - LINESTRING
+        - .. code-block:: sql
+
+           ST_AsBinary(
+             ST_GeomFromText('LINESTRING (1 1, 2 2)')
+           );
+        - | 01 02 00 00 00 02 00 00 00 00 00 00 00 00 00 F0
+          | 3F 00 00 00 00 00 00 F0 3F 00 00 00 00 00 00 00
+          | 40 00 00 00 00 00 00 00 40
+
+      * - LINESTRINGZ
+        - .. code-block:: sql
+
+           ST_AsBinary(
+             ST_GeomFromText('LINESTRINGZ (1 1 1, 2 2 2)')
+           );
+        - | 01 EA 03 00 00 02 00 00 00 00 00 00 00 00 00 F0
+          | 3F 00 00 00 00 00 00 F0 3F 00 00 00 00 00 00 F0
+          | 3F 00 00 00 00 00 00 00 40 00 00 00 00 00 00 00
+          | 40 00 00 00 00 00 00 00 40
+
+The result:
+
+.. flat-table::
+  :header-rows: 3
+  :widths: 10 10 40 40
+
+  * - :cspan:`3` WKB examples
+
+  * - :cspan:`2` INPUT
+    - OUTPUT
+
+  * - DataType
+    - Variant
+    - SpatiaLite SQL
+    - WKB (Hex notation)
+
+  * - :rspan:`1` POINT
+    - POINT
+    - .. code-block:: sql
+
+        ST_AsBinary(
+          ST_GeomFromText('POINT(1 1)')
+        );
+    - | 01 01 00 00 00 00 00 00 00 00 00 F0 3F 00 00 00
+      | 00 00 00 F0 3F
+
+  * - POINTZ
+    - .. code-block:: sql
+
+        ST_AsBinary(
+          ST_GeomFromText('POINTZ (1 1 1)')
+        );
+    - | 01 E9 03 00 00 00 00 00 00 00 00 F0 3F 00 00 00
+      | 00 00 00 F0 3F 00 00 00 00 00 00 F0 3F
+
+  * - :rspan:`1` LINESTRING
+    - LINESTRING
+    - .. code-block:: sql
+
+        ST_AsBinary(
+          ST_GeomFromText('LINESTRING (1 1, 2 2)')
+        );
+    - | 01 02 00 00 00 02 00 00 00 00 00 00 00 00 00 F0
+      | 3F 00 00 00 00 00 00 F0 3F 00 00 00 00 00 00 00
+      | 40 00 00 00 00 00 00 00 40
+
+  * - LINESTRINGZ
+    - .. code-block:: sql
+
+        ST_AsBinary(
+          ST_GeomFromText('LINESTRINGZ (1 1 1, 2 2 2)')
+        );
+    - | 01 EA 03 00 00 02 00 00 00 00 00 00 00 00 00 F0
+      | 3F 00 00 00 00 00 00 F0 3F 00 00 00 00 00 00 F0
+      | 3F 00 00 00 00 00 00 00 40 00 00 00 00 00 00 00
+      | 40 00 00 00 00 00 00 00 40
+
+For other possibilities please visit following link: `FlatTables <https://return42.github.io/linuxdoc/linuxdoc-howto/table-markup.html#flat-table>`_
 
 Index
 -----


### PR DESCRIPTION
<!---
Include a few sentences describing the overall goals for this Pull Request.
 
A list of issues is at https://github.com/qgis/QGIS-Documentation/issues.
Add "fix #issuenumber" for each issue the PR fixes. The ticket(s) will be closed automatically.
If your PR doesn't fix entirely the ticket, only add the ticket(s) reference preceded by # character.
-->
Goal:
For some examples in documentation I need possibility to span columns and rows.
Line-Tables don't support this so I found and additional extension [Flat-Tables](https://return42.github.io/linuxdoc/linuxdoc-howto/table-markup.html#flat-table) that extends Line-Tables and adds this functionality. I hope that you are OK with this proposal, I really didn't want to draw big tables just to get spanning of columns and grids.

I'm open to all comments and different suggestions to approach this problem if implementing additional extensions is not acceptable.

Feel free to change anything, or propose a change, I'll implement it.


Ticket(s): #
<!---
Indicate whether the fix should be backported to previous release.
Replace the space between square brackets by a `x` to make it checked.
-->
- [x] Backport to LTR documentation is requested

<!---
Reviewing is a process done by community members, mostly on a volunteer basis.
We try to keep the overhead as small as possible and appreciate if you help us.
Please read carefully and ensure you comply with our writing guidelines at
https://docs.qgis.org/testing/en/docs/documentation_guidelines/index.html.
Feel free to ask in a comment or the (qgis-community-team mailing list)
[https://lists.osgeo.org/mailman/listinfo/qgis-community-team] if you have troubles with any item.
--->
