### PR TITLE
Added one period at end sentence. Update symbol_selector.rst

### DIFF
--- a/docs/user_manual/style_library/symbol_selector.rst
+++ b/docs/user_manual/style_library/symbol_selector.rst
@@ -486,7 +486,7 @@ layer types:
     one set to label every 100m in a small font, skipping multiples of 1000,
     and a second set to label every 1000m in a big bold font.
   * :guilabel:`Average angle over`: Labels are rendered using an angle calculated by averaging the linestring,
-    so sharp tiny jaggies don't result in unslightly label rotation
+    so sharp tiny jaggies don't result in unslightly label rotation.
   * :guilabel:`Show marker symbols`, at referenced points in the line feature, using a full QGIS marker symbol.
     This allows e.g. showing a cross-hatch at the labeled point, for a "ruler" style line.
 


### PR DESCRIPTION
Sentence is not translated in the lokalised Dutch version. Only difference I see with other sentences in the same paragraph was a missing period at the end of the sentence.
Maybe this will fix it

Goal: Delivering good documentation

- [x] Backport to LTR documentation is requested
