### PR TITLE
Preparing github actions for 3.40 LTR

### DIFF
--- a/.github/workflows/pofiles.yml
+++ b/.github/workflows/pofiles.yml
@@ -3,7 +3,7 @@ name: Update English PO files for translation
 on:
   push:
     branches:
-      - release_3.34
+      - release_3.40
     paths:
       - 'docs/**'
       - 'themes/**/*.html'
@@ -36,7 +36,7 @@ jobs:
     - name: checkout
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       with:
-        ref: release_3.34
+        ref: release_3.40
 
     - name: Set up Python 3.12
       uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5.4.0

--- a/.github/workflows/pull_minimized_translations.yml
+++ b/.github/workflows/pull_minimized_translations.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       # only pull to the branch we translate
-      TARGET_BRANCH: "release_3.34"
+      TARGET_BRANCH: "release_3.40"
 
     steps:
     - name: Harden Runner

--- a/.github/workflows/translation_statistics.yml
+++ b/.github/workflows/translation_statistics.yml
@@ -23,7 +23,7 @@ jobs:
     env:
       TRANSIFEX_PASSWORD: ${{ secrets.TRANSIFEX_PASSWORD }}
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      LABELS: "Translation, backport release_3.34"
+      LABELS: "Translation, backport release_3.40"
 
     steps:
     - name: Harden Runner

--- a/scripts/fix_versions.sh
+++ b/scripts/fix_versions.sh
@@ -9,9 +9,9 @@ set -e
 
 # The target deprecated versions to update, folders in site directory
 # List to complete
-DEPRECATED=(3.28 3.22 3.16 3.10 3.4)
+DEPRECATED=(3.34 3.28 3.22 3.16 3.10 3.4)
 # The versions to reference. List to complete
-DOCVERSIONS=(testing latest 3.34 3.28 3.22 3.16 3.10 3.4 2.18)
+DOCVERSIONS=(testing latest 3.40 3.34 3.28 3.22 3.16 3.10 3.4 2.18)
 # The main parent folder as a parameter, or use current folder (default value)
 SPATH=${1:-$PWD}
 


### PR DESCRIPTION
(cherry picked from commit c29dc74b1d9f5973d0547efb8bc7a26f8602108c)
Backport #9683
I thought actions files in the master branch were the ones that have priority, but ... Should fix the actions not running for 3.40

<!---
Include a few sentences describing the overall goals for this Pull Request.
 
A list of issues is at https://github.com/qgis/QGIS-Documentation/issues.
Add "fix #issuenumber" for each issue the PR fixes. The ticket(s) will be closed automatically.
If your PR doesn't fix entirely the ticket, only add the ticket(s) reference preceded by # character.
-->
Goal:

Ticket(s): #
<!---
Indicate whether the fix should be backported to previous release.
Replace the space between square brackets by a `x` to make it checked.
-->
- [ ] Backport to LTR documentation is requested

<!---
Reviewing is a process done by community members, mostly on a volunteer basis.
We try to keep the overhead as small as possible and appreciate if you help us.
Please read carefully and ensure you comply with our writing guidelines at
https://docs.qgis.org/testing/en/docs/documentation_guidelines/index.html.
Feel free to ask in a comment or the (qgis-community-team mailing list)
[https://lists.osgeo.org/mailman/listinfo/qgis-community-team] if you have troubles with any item.
--->
