### PR TITLE
Add warning to algorithms that drop primary keys or FID values

### DIFF
--- a/docs/user_manual/processing_algs/qgis/cartography.rst
+++ b/docs/user_manual/processing_algs/qgis/cartography.rst
@@ -1174,6 +1174,9 @@ Extracted label information include: position (served as point geometries),
 the associated layer name and feature ID, label text, rotation (in degree,
 clockwise), multiline alignment, and font details.
 
+.. warning::
+ This algorithm drops existing primary keys or FID values and regenerates them in output layers.
+
 Parameters
 ..........
 

--- a/docs/user_manual/processing_algs/qgis/networkanalysis.rst
+++ b/docs/user_manual/processing_algs/qgis/networkanalysis.rst
@@ -455,6 +455,9 @@ Shortest path (point to layer)
 Computes the optimal (shortest or fastest) routes between a given
 start point and multiple end points defined by a point vector layer.
 
+.. warning::
+ This algorithm drops existing primary keys or FID values and regenerates them in output layers.
+
 Parameters
 ..........
 

--- a/docs/user_manual/processing_algs/qgis/vectoranalysis.rst
+++ b/docs/user_manual/processing_algs/qgis/vectoranalysis.rst
@@ -823,6 +823,8 @@ rendering of the lines.
 Additionally, the distance between vertices can be specified.
 A smaller distance results in a denser, more accurate line.
 
+.. warning::
+ This algorithm drops existing primary keys or FID values and regenerates them in output layers.
 
 .. figure:: img/join_lines.png
   :align: center

--- a/docs/user_manual/processing_algs/qgis/vectorcreation.rst
+++ b/docs/user_manual/processing_algs/qgis/vectorcreation.rst
@@ -28,6 +28,9 @@ distances will offset them to the right.
 |checkbox| Allows :ref:`features in-place modification <processing_inplace_edit>`
 of line features
 
+.. warning::
+ This algorithm drops existing primary keys or FID values and regenerates them in output layers.
+
 .. seealso:: :ref:`qgisoffsetline`, :ref:`qgisarraytranslatedfeatures`
 
 Parameters
@@ -171,6 +174,9 @@ M values present in the geometry can also be translated.
 |checkbox| Allows
 :ref:`features in-place modification <processing_inplace_edit>`
 of point, line, and polygon features
+
+.. warning::
+ This algorithm drops existing primary keys or FID values and regenerates them in output layers.
 
 .. seealso:: :ref:`qgistranslategeometry`, :ref:`qgisarrayoffsetlines`
 
@@ -401,6 +407,9 @@ coordinates fields.
 
 Besides X and Y coordinates you can also specify Z and M fields.
 
+.. warning::
+ This algorithm drops existing primary keys or FID values and regenerates them in output layers.
+
 Parameters
 ..........
 
@@ -561,6 +570,9 @@ Generates a point vector layer from an input raster and polygon layer.
 
 The points correspond to the pixel centroids that intersect the
 polygon layer.
+
+.. warning::
+ This algorithm drops existing primary keys or FID values and regenerates them in output layers.
 
 
 .. figure:: img/points_centroids_polygon.png
@@ -873,6 +885,9 @@ the lines).
 A minimum distance can be specified, to avoid points being too close
 to each other.
 
+.. warning::
+ This algorithm drops existing primary keys or FID values and regenerates them in output layers.
+
 .. seealso:: :ref:`qgisrandompointsonlines`
 
 Parameters
@@ -1061,6 +1076,9 @@ A minimum distance can be specified, to avoid points being too
 close to each other.
 
 **Default menu**: :menuselection:`Vector --> Research Tools`
+
+.. warning::
+ This algorithm drops existing primary keys or FID values and regenerates them in output layers.
 
 Parameters
 ..........
@@ -1324,6 +1342,9 @@ A minimum distance can be specified, to avoid points being too close
 to each other.
 
 **Default menu**: :menuselection:`Vector --> Research Tools`
+
+.. warning::
+ This algorithm drops existing primary keys or FID values and regenerates them in output layers.
 
 .. seealso:: :ref:`qgisrandompointsinpolygons`
 

--- a/docs/user_manual/processing_algs/qgis/vectorgeneral.rst
+++ b/docs/user_manual/processing_algs/qgis/vectorgeneral.rst
@@ -496,7 +496,6 @@ geometries but different attributes, only one of them will be added to
 the result layer.
 
 .. note::
-
  This algorithm does not require valid geometries as input.
 
 .. seealso:: :ref:`qgisdropgeometries`,
@@ -1360,6 +1359,9 @@ related child feature. This master feature contains all the
 attributes for the related features.
 This allows to have the relation as a plain table that can be e.g. exported to CSV.
 
+.. warning::
+ This algorithm drops existing primary keys or FID values and regenerates them in output layers.
+
 .. figure:: img/flatten_relationship.png
   :align: center
   :width: 100%
@@ -1434,8 +1436,10 @@ The additional attributes and their values are taken from a second
 vector layer.
 An attribute is selected in each of them to define the join criteria.
 
-.. seealso:: :ref:`qgisjoinbynearest`,
-   :ref:`qgisjoinattributesbylocation`
+.. warning::
+ This algorithm drops existing primary keys or FID values and regenerates them in output layers.
+
+.. seealso:: :ref:`qgisjoinbynearest`, :ref:`qgisjoinattributesbylocation`
 
 Parameters
 ..........
@@ -1589,6 +1593,9 @@ A spatial criteria is applied to select the values from the second
 layer that are added to each feature from the first layer.
 
 **Default menu**: :menuselection:`Vector --> Data Management Tools`
+
+.. warning::
+ This algorithm drops existing primary keys or FID values and regenerates them in output layers.
 
 .. seealso:: :ref:`qgisjoinbynearest`,
    :ref:`qgisjoinattributestable`, :ref:`qgisjoinbylocationsummary`
@@ -1906,6 +1913,9 @@ join to the k-nearest neighboring features.
 If a maximum distance is specified, only features which are closer
 than this distance will be matched.
 
+.. warning::
+ This algorithm drops existing primary keys or FID values and regenerates them in output layers.
+
 .. seealso:: :ref:`qgisnearestneighbouranalysis`,
    :ref:`qgisjoinattributestable`,
    :ref:`qgisjoinattributesbylocation`, :ref:`qgisdistancematrix`
@@ -2051,6 +2061,9 @@ All layers will be reprojected to match this CRS.
 
 **Default menu**: :menuselection:`Vector --> Data Management Tools`
 
+.. warning::
+ This algorithm drops existing primary keys or FID values and regenerates them in output layers.
+
 .. seealso:: :ref:`qgissplitvectorlayer`
 
 Parameters
@@ -2125,6 +2138,9 @@ index according to an expression.
 
 Be careful, it might not work as expected with some providers, the
 order might not be kept every time.
+
+.. warning::
+ This algorithm drops existing primary keys or FID values and regenerates them in output layers.
 
 Parameters
 ..........
@@ -2542,6 +2558,9 @@ for added flexibility.
 |checkbox| Allows
 :ref:`features in-place modification <processing_inplace_edit>` 
 of point, line, and polygon features
+
+.. warning::
+ This algorithm drops existing primary keys or FID values and regenerates them in output layers.
 
 Parameters
 ..........

--- a/docs/user_manual/processing_algs/qgis/vectorgeometry.rst
+++ b/docs/user_manual/processing_algs/qgis/vectorgeometry.rst
@@ -570,6 +570,10 @@ of polygon features
 
 **Default menu**: :menuselection:`Vector --> Geoprocessing Tools`
 
+.. warning::
+ This algorithm may drop existing primary keys or FID values and regenerate them in output layers,
+ depending on the input parameters.
+
 .. seealso:: :ref:`qgisvariabledistancebuffer`,
    :ref:`qgismultiringconstantbuffer`, :ref:`qgisbufferbym`
 
@@ -759,6 +763,10 @@ as for the original features.
 of point features
 
 **Default menu**: :menuselection:`Vector --> Geometry Tools`
+
+.. warning::
+ This algorithm may drop existing primary keys or FID values and regenerate them in output layers,
+ depending on the input parameters.
 
 .. seealso:: :ref:`qgispointonsurface`
 
@@ -1133,6 +1141,9 @@ See the 'Promote to multipart' or 'Aggregate' algorithms for
 alternative options.
 
 **Default menu**: :menuselection:`Vector --> Geometry Tools`
+
+.. warning::
+ This algorithm drops existing primary keys or FID values and regenerates them in output layers.
 
 .. seealso:: :ref:`qgisaggregate`, :ref:`qgispromotetomulti`,
    :ref:`qgisdissolve`
@@ -2146,6 +2157,9 @@ input feature that happens to be processed.
 
 **Default menu**: :menuselection:`Vector --> Geoprocessing Tools`
 
+.. warning::
+ This algorithm drops existing primary keys or FID values and regenerates them in output layers.
+
 .. seealso:: :ref:`qgiscoverageunion`, :ref:`qgisaggregate`, :ref:`qgiscollect`
 
 Parameters
@@ -2808,6 +2822,9 @@ vertex for the original geometry.
 :ref:`features in-place modification <processing_inplace_edit>`
 of point features
 
+.. warning::
+ This algorithm drops existing primary keys or FID values and regenerates them in output layers.
+
 .. seealso:: :ref:`qgisextractvertices`, :ref:`qgisfilterverticesbym`,
    :ref:`qgisfilterverticesbyz`
 
@@ -2896,6 +2913,9 @@ geometry and bisector angle of vertex for original geometry.
 of point features
 
 **Default menu**: :menuselection:`Vector --> Geometry Tools`
+
+.. warning::
+ This algorithm drops existing primary keys or FID values and regenerates them in output layers.
 
 .. seealso:: :ref:`qgisextractspecificvertices`,
    :ref:`qgisfilterverticesbym`, :ref:`qgisfilterverticesbyz`
@@ -3076,9 +3096,8 @@ the minimum value is tested.
 :ref:`features in-place modification <processing_inplace_edit>`
 of point, line and polygon features with M enabled
 
-.. note:: Depending on the input geometry attributes and the filters
-   used, the resultant geometries created by this algorithm may no
-   longer be valid.
+.. warning:: Depending on the input geometry attributes and the filters used,
+   the geometries created by this algorithm may no longer be valid.
 
 .. seealso:: :ref:`qgisfilterverticesbyz`, :ref:`qgisextractvertices`,
  :ref:`qgisextractspecificvertices`
@@ -3176,9 +3195,8 @@ the minimum value is tested.
 :ref:`features in-place modification <processing_inplace_edit>`
 of point, line and polygon features with Z enabled
 
-.. note:: Depending on the input geometry attributes and the filters
-   used, the resultant geometries created by this algorithm may no
-   longer be valid.
+.. warning:: Depending on the input geometry attributes and the filters used,
+   the geometries created by this algorithm may no longer be valid.
    You may need to run the :ref:`qgisfixgeometries` algorithm to
    ensure their validity.
 
@@ -3268,7 +3286,7 @@ Always outputs multi-geometry layer.
 :ref:`features in-place modification <processing_inplace_edit>`
 of point, line, and polygon features without M enabled
 
-.. note:: M values will be dropped from the output.
+.. warning:: M values will be dropped from the output.
 
 .. seealso:: :ref:`qgischeckvalidity`
 
@@ -4152,10 +4170,11 @@ input layer, using a fixed or dynamic distance and number of rings.
 :ref:`features in-place modification <processing_inplace_edit>`
 of polygon features
 
-.. seealso:: :ref:`qgisbuffer`,
-   :ref:`qgisvariabledistancebuffer`,
-   :ref:`qgisrectanglesovalsdiamonds`,
-   :ref:`qgissinglesidedbuffer`
+.. warning::
+ This algorithm drops existing primary keys or FID values and regenerates them in output layers.
+
+.. seealso:: :ref:`qgisbuffer`, :ref:`qgisvariabledistancebuffer`,
+   :ref:`qgisrectanglesovalsdiamonds`, :ref:`qgissinglesidedbuffer`
 
 Parameters
 ..........
@@ -4249,6 +4268,9 @@ but divided into single features.
 of point, line, and polygon features
 
 **Default menu**: :menuselection:`Vector --> Geometry Tools`
+
+.. warning::
+ This algorithm drops existing primary keys or FID values and regenerates them in output layers.
 
 .. seealso:: :ref:`qgiscollect`, :ref:`qgispromotetomulti`
 
@@ -4600,6 +4622,10 @@ guaranteed to lie on the surface of the feature geometry.
 :ref:`features in-place modification <processing_inplace_edit>`
 of point features
 
+.. warning::
+ This algorithm may drop existing primary keys or FID values and regenerate them in output layers,
+ depending on the input parameters.
+
 .. seealso:: :ref:`qgiscentroids`
 
 Parameters
@@ -4675,6 +4701,9 @@ created.
    :align: center
 
    Points created along the source line layer
+
+.. warning::
+ This algorithm drops existing primary keys or FID values and regenerates them in output layers.
 
 .. seealso:: :ref:`qgisinterpolatepoint`
 
@@ -6637,7 +6666,7 @@ Snapping can be performed on the X, Y, Z or M axis. A grid spacing of
 :ref:`features in-place modification <processing_inplace_edit>`
 of point, line, and polygon features
 
-.. note:: Snapping to grid may generate an invalid geometry in some
+.. warning:: Snapping to grid may generate an invalid geometry in some
    corner cases.
 
 .. seealso:: :ref:`qgissnapgeometries`
@@ -6732,6 +6761,9 @@ linearly interpolated from existing values.
 |checkbox| Allows
 :ref:`features in-place modification <processing_inplace_edit>`
 of line features
+
+.. warning::
+ This algorithm drops existing primary keys or FID values and regenerates them in output layers.
 
 Parameters
 ..........
@@ -7138,6 +7170,9 @@ new fields:
 * TR_LENGTH: Total length of the transect returned
 * TR_ORIENT: Side of the transect (only on the left or right of
   the line, or both side)
+
+.. warning::
+ This algorithm drops existing primary keys or FID values and regenerates them in output layers.
 
 .. figure:: img/transect.png
    :align: center

--- a/docs/user_manual/processing_algs/qgis/vectoroverlay.rst
+++ b/docs/user_manual/processing_algs/qgis/vectoroverlay.rst
@@ -428,6 +428,9 @@ overlapping features from both the input and overlay layers.
 
 **Default menu**: :menuselection:`Vector --> Geoprocessing Tools`
 
+.. warning::
+ This algorithm drops existing primary keys or FID values and regenerates them in output layers.
+
 .. seealso:: :ref:`qgismultiintersection`, :ref:`qgisclip`, :ref:`qgisdifference`
 
 Parameters
@@ -567,6 +570,9 @@ features from both the input and overlay layers.
   feature overlay layers 'b' and 'c' (left) - overlapping areas become a new two-feature layer 
   with all layers' attributes (right)
 
+.. warning::
+ This algorithm drops existing primary keys or FID values and regenerate them in output layers.
+
 .. seealso:: :ref:`qgisintersection`, :ref:`qgisclip`, :ref:`qgisdifference`
 
 Parameters
@@ -656,6 +662,9 @@ Creates point features where the lines from the two layers intersect.
   Points of intersection
 
 **Default menu**: :menuselection:`Vector --> Analysis Tools`
+
+.. warning::
+ This algorithm drops existing primary keys or FID values and regenerate them in output layers.
 
 Parameters
 ..........
@@ -777,6 +786,9 @@ Output will contain multi geometries for split features.
 |checkbox| Allows :ref:`features in-place modification <processing_inplace_edit>`
 of line and polygon features
 
+.. warning::
+ This algorithm drops existing primary keys or FID values and regenerate them in output layers.
+
 Parameters
 ..........
 
@@ -859,6 +871,9 @@ attributes and fields from both the input and overlay layers.
   resulting three-feature layer with both layers' attributes (right)
 
 **Default menu**: :menuselection:`Vector --> Geoprocessing Tools`
+
+.. warning::
+ This algorithm drops existing primary keys or FID values and regenerate them in output layers.
 
 .. seealso:: :ref:`qgisdifference`, :ref:`qgisclip`,
    :ref:`qgisintersection`
@@ -994,6 +1009,9 @@ attribute values from both layers for overlapping features.
 
 **Default menu**: :menuselection:`Vector --> Geoprocessing Tools`
 
+.. warning::
+ This algorithm drops existing primary keys or FID values and regenerate them in output layers.
+
 .. seealso:: :ref:`qgismultiunion`, :ref:`qgisclip`, :ref:`qgisdifference`,
    :ref:`qgisintersection`
 
@@ -1127,6 +1145,9 @@ attribute values from overlay layers for overlapping features.
    If you want to split overlaps on the same layer as well as other layers,
    first run the algorithm with multiple layers then run the algorithm
    again with only the previous output.
+
+.. warning::
+ This algorithm drops existing primary keys or FID values and regenerate them in output layers.
 
 .. seealso:: :ref:`qgisunion`, :ref:`qgisclip`, :ref:`qgisdifference`,
    :ref:`qgisintersection`

--- a/docs/user_manual/processing_algs/qgis/vectorselection.rst
+++ b/docs/user_manual/processing_algs/qgis/vectorselection.rst
@@ -486,6 +486,9 @@ The subset is defined randomly, based on feature IDs, using a
 percentage or count value to define the total number of features in
 the subset.
 
+.. warning::
+ This algorithm drops existing primary keys or FID values and regenerate them in output layers.
+
 .. seealso:: :ref:`qgisrandomselection`
 
 Parameters

--- a/docs/user_manual/processing_algs/qgis/vectortable.rst
+++ b/docs/user_manual/processing_algs/qgis/vectortable.rst
@@ -436,6 +436,10 @@ applying an expression to each feature.
 
 The expression is defined as a Python function.
 
+.. warning::
+ This algorithm is a potential security risk if executed with unchecked inputs,
+ and may result in system damage or data leaks.
+
 Parameters
 ..........
 


### PR DESCRIPTION
(cherry picked from commit f361fdf789c570817f3fea77553b17ace31803d1)
Backports #9743

<!---
Include a few sentences describing the overall goals for this Pull Request.
 
A list of issues is at https://github.com/qgis/QGIS-Documentation/issues.
Add "fix #issuenumber" for each issue the PR fixes. The ticket(s) will be closed automatically.
If your PR doesn't fix entirely the ticket, only add the ticket(s) reference preceded by # character.
-->
Goal:

Ticket(s): #
<!---
Indicate whether the fix should be backported to previous release.
Replace the space between square brackets by a `x` to make it checked.
-->
- [ ] Backport to LTR documentation is requested

<!---
Reviewing is a process done by community members, mostly on a volunteer basis.
We try to keep the overhead as small as possible and appreciate if you help us.
Please read carefully and ensure you comply with our writing guidelines at
https://docs.qgis.org/testing/en/docs/documentation_guidelines/index.html.
Feel free to ask in a comment or the (qgis-community-team mailing list)
[https://lists.osgeo.org/mailman/listinfo/qgis-community-team] if you have troubles with any item.
--->
