### PR TITLE
Update label_settings.rst for some options' availability

### DIFF
--- a/docs/user_manual/style_library/label_settings.rst
+++ b/docs/user_manual/style_library/label_settings.rst
@@ -279,9 +279,8 @@ In the |labelformatting| :guilabel:`Formatting` tab, you can:
   * :guilabel:`All uppercase`
   * :guilabel:`All lowercase`
   * :guilabel:`Small Caps`: renders lowercase characters as small caps.
-    Only available on some systems.
   * :guilabel:`All Small Caps`: renders all characters as small caps
-    regardless of their original case. Only available on some systems.
+    regardless of their original case.
   * :guilabel:`Title case`: modifies the first letter of each word into capital,
     and turns the other letters into lower case if the original text is using
     a single type case. In case of mixed type cases in the text, the other
@@ -303,7 +302,7 @@ In the |labelformatting| :guilabel:`Formatting` tab, you can:
   based on the :kbd:`Tab` characters.
 * :guilabel:`Stretch` ratio: allows text to be horizontally stretched or
   condensed by a factor. Handy for tweaking the widths of fonts to fit a bit
-  of extra text into labels. Only available on some systems.
+  of extra text into labels.
 * |checkbox| :guilabel:`Enable kerning` of the text font
 * Set the :guilabel:`Text orientation` which can be :guilabel:`Horizontal`
   or :guilabel:`Vertical`. It can also be :guilabel:`Rotation-based` when

--- a/docs/user_manual/style_library/label_settings.rst
+++ b/docs/user_manual/style_library/label_settings.rst
@@ -278,6 +278,10 @@ In the |labelformatting| :guilabel:`Formatting` tab, you can:
   * :guilabel:`No change`
   * :guilabel:`All uppercase`
   * :guilabel:`All lowercase`
+  * :guilabel:`Small Caps`: renders lowercase characters as small caps.
+    Only available on some systems.
+  * :guilabel:`All Small Caps`: renders all characters as small caps
+    regardless of their original case. Only available on some systems.
   * :guilabel:`Title case`: modifies the first letter of each word into capital,
     and turns the other letters into lower case if the original text is using
     a single type case. In case of mixed type cases in the text, the other
@@ -299,7 +303,7 @@ In the |labelformatting| :guilabel:`Formatting` tab, you can:
   based on the :kbd:`Tab` characters.
 * :guilabel:`Stretch` ratio: allows text to be horizontally stretched or
   condensed by a factor. Handy for tweaking the widths of fonts to fit a bit
-  of extra text into labels.
+  of extra text into labels. Only available on some systems.
 * |checkbox| :guilabel:`Enable kerning` of the text font
 * Set the :guilabel:`Text orientation` which can be :guilabel:`Horizontal`
   or :guilabel:`Vertical`. It can also be :guilabel:`Rotation-based` when


### PR DESCRIPTION
<!---
Include a few sentences describing the overall goals for this Pull Request.
 
A list of issues is at https://github.com/qgis/QGIS-Documentation/issues.
Add "fix #issuenumber" for each issue the PR fixes. The ticket(s) will be closed automatically.
If your PR doesn't fix entirely the ticket, only add the ticket(s) reference preceded by # character.
-->
Goal:

See https://github.com/qgis/QGIS/pull/45887 and https://github.com/qgis/QGIS/pull/45946 and https://gis.stackexchange.com/questions/491719/stretch-ratio-option-missing-in-qgis-3-40-5-label-settings-windows-11/491723.

Not sure if "Only available on some systems." is enough or should it be "Requires Qt 6.3+, or Qt 5.15 using KDE's fork and the cmake HAS_KDE_QT5_SMALL_CAPS_FIX switch defined during build" and "Requires Qt 6.3+, or Qt 5.15 using KDE's fork and the cmake HAS_KDE_QT5_FONT_STRETCH_FIX switch defined during build".

Ticket(s): #
<!---
Indicate whether the fix should be backported to previous release.
Replace the space between square brackets by a `x` to make it checked.
-->
- [x] Backport to LTR documentation is requested

<!---
Reviewing is a process done by community members, mostly on a volunteer basis.
We try to keep the overhead as small as possible and appreciate if you help us.
Please read carefully and ensure you comply with our writing guidelines at
https://docs.qgis.org/testing/en/docs/documentation_guidelines/index.html.
Feel free to ask in a comment or the (qgis-community-team mailing list)
[https://lists.osgeo.org/mailman/listinfo/qgis-community-team] if you have troubles with any item.
--->
