### PR TITLE
typo fix

### DIFF
--- a/docs/documentation_guidelines/writing.rst
+++ b/docs/documentation_guidelines/writing.rst
@@ -472,7 +472,7 @@ Special Comments
 
 Sometimes, you may want to emphasize some points of the description, either to
 warn, remind or give some hints to the user. In QGIS Documentation, we use reST
-special directives such as ``.. warning::``, ``.. seealso::`, ``.. note::`` and ``.. tip::``.
+special directives such as ``.. warning::``, ``.. seealso::``, ``.. note::`` and ``.. tip::``.
 These directives generate frames that highlight your comments. See `Paragraph Level markup
 <https://www.sphinx-doc.org/en/master/usage/restructuredtext/directives.html#paragraph-level-markup>`_
 for more information.


### PR DESCRIPTION
Before:
![before](https://github.com/user-attachments/assets/7058ea27-4924-4a75-a3b9-e2bba8857dc5)

After:
![after](https://github.com/user-attachments/assets/77c2a19c-86da-4e36-9afc-a6572b37c061)

