### PR TITLE
Add precision to algorithms' geometry and number parameter types

### DIFF
--- a/docs/documentation_guidelines/writing.rst
+++ b/docs/documentation_guidelines/writing.rst
@@ -635,7 +635,7 @@ guidelines:
 
     * - **Number of points**
       - ``NUMBER_OF_POINTS``
-      - [number]
+      - [numeric: integer]
 
         Default: 1
       - Number of points to create
@@ -649,6 +649,8 @@ guidelines:
   Point vector layer                        ``vector: point``          |pointLayer|
   Line vector layer                         ``vector: line``           |lineLayer|
   Polygon vector layer                      ``vector: polygon``        |polygonLayer|
+  All spatial vector layers                 ``vector: geometry``
+  Geometryless vector layer                 ``vector: table``          |tableLayer|
   Generic vector layer                      ``vector: any``
   Vector field numeric                      ``tablefield: numeric``    |fieldFloat|
   Vector field string                       ``tablefield: string``     |fieldText|
@@ -656,14 +658,14 @@ guidelines:
   Raster layer                              ``raster``                 |rasterLayer|
   Raster band                               ``raster band``
   HTML file                                 ``html``
-  Table layer                               ``table``                  |tableLayer|
   Expression                                ``expression``             |expression|
   Point geometry                            ``coordinates``
   Extent                                    ``extent``
   CRS                                       ``crs``                    |setProjection|
   Enumeration                               ``enumeration``            |selectString|
   List                                      ``list``
-  Number                                    ``number``                 |selectNumber|
+  Integer value                             ``numeric: integer``       |selectNumber|
+  Decimal value                             ``numeric: double``        |selectNumber|
   String                                    ``string``                 |inputText|
   Boolean                                   ``boolean``                |checkbox|
   Folder path                               ``folder``

--- a/docs/user_manual/processing_algs/gdal/rasteranalysis.rst
+++ b/docs/user_manual/processing_algs/gdal/rasteranalysis.rst
@@ -320,14 +320,14 @@ Basic parameters
        represented by the value 0.
    * - **Maximum distance (in pixels) to search out for values to interpolate**
      - ``DISTANCE``
-     - [number]
+     - [numeric: integer]
 
        Default: 10
      - The number of pixels to search in all directions to find values
        to interpolate from
    * - **Number of smoothing iterations to run after the interpolation**
      - ``ITERATIONS``
-     - [number]
+     - [numeric: integer]
 
        Default: 0
      - The number of 3x3 filter passes to run (0 or more) to smoothen
@@ -468,28 +468,28 @@ Basic parameters
 
    * - **The first radius of search ellipse**
      - ``RADIUS_1``
-     - [number]
+     - [numeric: double]
 
        Default: 0.0
      - The first radius (X axis if rotation angle is 0) of
        the search ellipse
    * - **The second radius of search ellipse**
      - ``RADIUS_2``
-     - [number]
+     - [numeric: double]
 
        Default: 0.0
      - The second radius (Y axis if rotation angle is 0)
        of the search ellipse
    * - **Angle of search ellipse rotation in degrees (counter clockwise)**
      - ``ANGLE``
-     - [number]
+     - [numeric: double]
 
        Default: 0.0
      - Angle of ellipse rotation in degrees.
        Ellipse rotated counter clockwise.
    * - **Minimum number of data points to use**
      - ``MIN_POINTS``
-     - [number]
+     - [numeric: double]
 
        Default: 0.0
      - Minimum number of data points to average.
@@ -498,7 +498,7 @@ Basic parameters
        NoData marker.
    * - **NoData**
      - ``NODATA``
-     - [number]
+     - [numeric: double]
 
        Default: 0.0
      - NoData marker to fill empty points
@@ -625,31 +625,31 @@ Parameters
      - Input point vector layer
    * - **Weighting power**
      - ``POWER``
-     - [number]
+     - [numeric: double]
 
        Default: 2.0
      - Weighting power
    * - **Smoothing**
      - ``SMOOTHING``
-     - [number]
+     - [numeric: double]
 
        Default: 0.0
      - Smoothing parameter
    * - **The radius of the search circle**
      - ``RADIUS``
-     - [number]
+     - [numeric: double]
 
        Default: 1.0
      - The radius of the search circle
    * - **Maximum number of data points to use**
      - ``MAX_POINTS``
-     - [number]
+     - [numeric: integer]
 
        Default: 12
      - Do not search for more points than this number.
    * - **Minimum number of data points to use**
      - ``MIN_POINTS``
-     - [number]
+     - [numeric: integer]
 
        Default: 0
      - Minimum number of data points to average.
@@ -658,7 +658,7 @@ Parameters
        NoData marker.
    * - **NoData**
      - ``NODATA``
-     - [number]
+     - [numeric: double]
 
        Default: 0.0
      - NoData marker to fill empty points
@@ -793,46 +793,46 @@ Basic parameters
      - Input point vector layer
    * - **Weighting power**
      - ``POWER``
-     - [number]
+     - [numeric: double]
 
        Default: 2.0
      - Weighting power
    * - **Smothing**
      - ``SMOOTHING``
-     - [number]
+     - [numeric: double]
 
        Default: 0.0
      - Smoothing parameter
    * - **The first radius of search ellipse**
      - ``RADIUS_1``
-     - [number]
+     - [numeric: double]
 
        Default: 0.0
      - The first radius (X axis if rotation angle is 0) of
        the search ellipse
    * - **The second radius of search ellipse**
      - ``RADIUS_2``
-     - [number]
+     - [numeric: double]
 
        Default: 0.0
      - The second radius (Y axis if rotation angle is 0)
        of the search ellipse
    * - **Angle of search ellipse rotation in degrees (counter clockwise)**
      - ``ANGLE``
-     - [number]
+     - [numeric: double]
 
        Default: 0.0
      - Angle of ellipse rotation in degrees.
        Ellipse rotated counter clockwise.
    * - **Maximum number of data points to use**
      - ``MAX_POINTS``
-     - [number]
+     - [numeric: integer]
 
        Default: 0
      - Do not search for more points than this number.
    * - **Minimum number of data points to use**
      - ``MIN_POINTS``
-     - [number]
+     - [numeric: integer]
 
        Default: 0
      - Minimum number of data points to average.
@@ -841,7 +841,7 @@ Basic parameters
        NoData marker.
    * - **NoData**
      - ``NODATA``
-     - [number]
+     - [numeric: double]
 
        Default: 0.0
      - NoData marker to fill empty points
@@ -971,7 +971,7 @@ Basic parameters
      - Input point vector layer
    * - **Search distance**
      - ``RADIUS``
-     - [number]
+     - [numeric: double]
 
        Default: -1.0
      - In case the point to be interpolated does not fit into a 
@@ -982,7 +982,7 @@ Basic parameters
        If set to ``0``, NoData value will be used.
    * - **NoData**
      - ``NODATA``
-     - [number]
+     - [numeric: double]
 
        Default: 0.0
      - NoData marker to fill empty points
@@ -1118,37 +1118,37 @@ Basic parameters
      - Input point vector layer
    * - **The first radius of search ellipse**
      - ``RADIUS_1``
-     - [number]
+     - [numeric: double]
 
        Default: 0.0
      - The first radius (X axis if rotation angle is 0) of
        the search ellipse
    * - **The second radius of search ellipse**
      - ``RADIUS_2``
-     - [number]
+     - [numeric: double]
 
        Default: 0.0
      - The second radius (Y axis if rotation angle is 0)
        of the search ellipse
    * - **Angle of search ellipse rotation in degrees (counter clockwise)**
      - ``ANGLE``
-     - [number]
+     - [numeric: double]
 
        Default: 0.0
      - Angle of ellipse rotation in degrees.
        Ellipse rotated counter clockwise.
    * - **Minimum number of data points to use**
      - ``MIN_POINTS``
-     - [number]
+     - [numeric: integer]
 
-       Default: 0.0
+       Default: 0
      - Minimum number of data points to average.
        If less amount of points found the grid node
        considered empty and will be filled with
        NoData marker.
    * - **NoData**
      - ``NODATA``
-     - [number]
+     - [numeric: double]
 
        Default: 0.0
      - NoData marker to fill empty points
@@ -1280,28 +1280,28 @@ Basic parameters
      - Input point vector layer
    * - **The first radius of search ellipse**
      - ``RADIUS_1``
-     - [number]
+     - [numeric: double]
 
        Default: 0.0
      - The first radius (X axis if rotation angle is 0) of
        the search ellipse
    * - **The second radius of search ellipse**
      - ``RADIUS_2``
-     - [number]
+     - [numeric: double]
 
        Default: 0.0
      - The second radius (Y axis if rotation angle is 0)
        of the search ellipse
    * - **Angle of search ellipse rotation in degrees (counter clockwise)**
      - ``ANGLE``
-     - [number]
+     - [numeric: double]
 
        Default: 0.0
      - Angle of ellipse rotation in degrees.
        Ellipse rotated counter clockwise.
    * - **NoData**
      - ``NODATA``
-     - [number]
+     - [numeric: double]
 
        Default: 0.0
      - NoData marker to fill empty points
@@ -1438,20 +1438,20 @@ Basic parameters
      - Band containing the elevation information
    * - **Z factor (vertical exaggeration)**
      - ``Z_FACTOR``
-     - [number]
+     - [numeric: double]
 
        Default: 1.0
      - The factor exaggerates the height of the output elevation
        raster
-   * - **Scale (ratio of vert. units to horiz.)**
+   * - **Scale (ratio of vertical units to horizontal)**
      - ``SCALE``
-     - [number]
+     - [numeric: double]
 
        Default: 1.0
      - The ratio of vertical units to horizontal units
    * - **Azimuth of the light**
      - ``AZIMUTH``
-     - [number]
+     - [numeric: double]
 
        Default: 315.0
      - Defines the azimuth of the light shining on the elevation
@@ -1460,7 +1460,7 @@ Basic parameters
        comes from the east it is 90 a.s.o.
    * - **Altitude of the light**
      - ``ALTITUDE``
-     - [number]
+     - [numeric: double]
 
        Default: 45.0
      - Defines the altitude of the light, in degrees.
@@ -1602,7 +1602,7 @@ Basic parameters
      - Input Elevation raster layer
    * - **How far from black (white)**
      - ``NEAR``
-     - [number]
+     - [numeric: integer]
 
        Default: 15
      - Select how far from black, white or custom colors the pixel
@@ -1752,7 +1752,7 @@ Basic parameters
 
        Optional
      - ``MAX_DISTANCE``
-     - [number]
+     - [numeric: double]
 
        Default: 0.0
      - The maximum distance to be generated.
@@ -1762,7 +1762,7 @@ Basic parameters
 
        Optional
      - ``REPLACE``
-     - [number]
+     - [numeric: double]
 
        Default: 0.0
      - Specify a value to apply to all pixels that are within the maximum distance
@@ -1771,7 +1771,7 @@ Basic parameters
 
        Optional
      - ``NODATA``
-     - [number]
+     - [numeric: double]
 
        Default: 0.0
      - Specify the NoData value to use for the pixels beyond the maximum distance.
@@ -2011,7 +2011,7 @@ Basic parameters
      - Input elevation raster layer
    * - **Threshold**
      - ``THRESHOLD``
-     - [number]
+     - [numeric: integer]
 
        Default: 10
      - Only raster polygons smaller than this size
@@ -2133,7 +2133,7 @@ Basic parameters
      - Band containing the elevation information
    * - **Ratio of vertical units to horizontal**
      - ``SCALE``
-     - [number]
+     - [numeric: double]
 
        Default: 1.0
      - The ratio of vertical units to horizontal units

--- a/docs/user_manual/processing_algs/gdal/rasterconversion.rst
+++ b/docs/user_manual/processing_algs/gdal/rasterconversion.rst
@@ -38,11 +38,11 @@ Parameters
        Default: The first band of the input layer
      - If the raster is multiband, choose the band you want to
        convert
-   * - **Source NoData**
+   * - **Input pixel value to treat as NoData**
 
        Optional
      - ``NODATA_INPUT``
-     - [number]
+     - [numeric: integer]
 
        Default: None
      - Input pixel value to treat as "NoData" (GDAL >= 3.7).
@@ -50,7 +50,7 @@ Parameters
 
        Optional
      - ``NODATA_OUTPUT``
-     - [number]
+     - [numeric: integer]
 
        Default: None
      - Assign specified "NoData" value to output (GDAL >= 3.7).
@@ -446,7 +446,7 @@ Parameters
      - Input (RGB) raster layer
    * - **Number of colors**
      - ``NCOLORS``
-     - [number]
+     - [numeric: integer]
 
        Default: 2
      - The number of colors the resulting image will contain.
@@ -529,7 +529,7 @@ Basic parameters
 
        Optional
      - ``NODATA``
-     - [number]
+     - [numeric: double]
 
        Default: Not set
      - Defines the value to use for NoData in the output raster

--- a/docs/user_manual/processing_algs/gdal/rasterextraction.rst
+++ b/docs/user_manual/processing_algs/gdal/rasterextraction.rst
@@ -59,7 +59,7 @@ Basic parameters
 
        Optional
      - ``NODATA``
-     - [number]
+     - [numeric: double]
 
        Default: None
      - Defines a value that should be inserted for the NoData
@@ -207,7 +207,7 @@ Basic parameters
 
        Optional
      - ``NODATA``
-     - [number]
+     - [numeric: double]
 
        Default: None
      - Defines a value that should be inserted for the NoData
@@ -241,7 +241,7 @@ Basic parameters
 
        Optional
      - ``X_RESOLUTION``
-     - [number]
+     - [numeric: double]
 
        Default: None
      - The width of the cells in the output raster
@@ -249,7 +249,7 @@ Basic parameters
 
        Optional
      - ``Y_RESOLUTION``
-     - [number]
+     - [numeric: double]
 
        Default: None
      - The height of the cells in the output raster
@@ -386,7 +386,7 @@ Basic parameters
      - Raster band to create the contours from
    * - **Interval between contour lines**
      - ``INTERVAL``
-     - [number]
+     - [numeric: double]
 
        Default: 10.0
      - Defines the interval between the contour lines in the given
@@ -403,7 +403,7 @@ Basic parameters
 
        Optional
      - ``OFFSET``
-     - [number]
+     - [numeric: double]
 
        Default: 0.0
      -
@@ -447,7 +447,7 @@ Advanced parameters
 
        Optional
      - ``NODATA``
-     - [number]
+     - [numeric: double]
 
        Default: None
      - Defines a value that should be inserted for the NoData
@@ -525,7 +525,7 @@ Basic parameters
      - Raster band to create the contours from
    * - **Interval between contour lines**
      - ``INTERVAL``
-     - [number]
+     - [numeric: double]
 
        Default: 10.0
      - Defines the interval between the contour lines in the given
@@ -534,7 +534,7 @@ Basic parameters
 
        Optional
      - ``OFFSET``
-     - [number]
+     - [numeric: double]
 
        Default: 0.0
      -
@@ -598,7 +598,7 @@ Advanced parameters
 
        Optional
      - ``NODATA``
-     - [number]
+     - [numeric: double]
 
        Default: None
      - Defines a value that should be inserted for the NoData

--- a/docs/user_manual/processing_algs/gdal/rastermiscellaneous.rst
+++ b/docs/user_manual/processing_algs/gdal/rastermiscellaneous.rst
@@ -434,7 +434,7 @@ Advanced parameters
 
        Optional
      - ``NODATA``
-     - [number]
+     - [numeric: double]
 
        Default: 0.0
      -
@@ -591,7 +591,7 @@ Advanced parameters
 
        Optional
      - ``NODATA_INPUT``
-     - [number]
+     - [number: double]
 
        Default: None
      - Ignores pixels from files being merged in with this pixel value
@@ -599,7 +599,7 @@ Advanced parameters
 
        Optional
      - ``NODATA_OUTPUT``
-     - [number]
+     - [number: double]
 
        Default: None
      - Assigns the specified NoData value to output bands.
@@ -904,7 +904,7 @@ Basic parameters
 
        Optional
      - ``NO_DATA``
-     - [number]
+     - [number: double]
 
        Default: None
      - Value to use for NoData
@@ -1170,25 +1170,25 @@ Basic parameters
      - The input raster files
    * - **Tile width**
      - ``TILE_SIZE_X``
-     - [number]
+     - [number: integer]
 
        Default: 256
      - Width of the tiles in pixels (minimum 0)
    * - **Tile height**
      - ``TILE_SIZE_Y``
-     - [number]
+     - [number: integer]
 
        Default: 256
      - Height of the tiles in pixels (minimum 0)
    * - **Overlap in pixels between consecutive tiles**
      - ``OVERLAP``
-     - [number]
+     - [number: integer]
 
        Default: 0
      -
    * - **Number of pyramid levels to build**
      - ``LEVELS``
-     - [number]
+     - [number: integer]
 
        Default: 1
      - Minimum: 0
@@ -1512,19 +1512,19 @@ Basic parameters
      - The location of the observer
    * - **Observer height**
      - ``OBSERVER_HEIGHT``
-     - [number]
+     - [number: double]
 
        Default: 1.0
      - The altitude of the observer, in the DEM units
    * - **Target height**
      - ``TARGET_HEIGHT``
-     - [number]
+     - [number: double]
 
        Default: 1.0
      - The altitude of the target element, in the DEM units
    * - **Maximum distance from observer to compute visibility**
      - ``MAX_DISTANCE``
-     - [number]
+     - [number: double]
 
        Default: 100.0
      - Maximum distance from observer to compute visibility,

--- a/docs/user_manual/processing_algs/gdal/rasterprojections.rst
+++ b/docs/user_manual/processing_algs/gdal/rasterprojections.rst
@@ -199,7 +199,7 @@ Basic parameters
 
        Optional
      - ``NODATA``
-     - [number]
+     - [number: double]
 
        Default: None
      - Sets NoData value for output bands.
@@ -209,7 +209,7 @@ Basic parameters
 
        Optional
      - ``TARGET_RESOLUTION``
-     - [number]
+     - [number: double]
 
        Default: None
      - Defines the output file resolution of reprojection result

--- a/docs/user_manual/processing_algs/gdal/vectorconversion.rst
+++ b/docs/user_manual/processing_algs/gdal/vectorconversion.rst
@@ -12,8 +12,7 @@ Vector conversion
 
 Convert format
 --------------
-Converts any OGR-supported vector layer into another OGR-supported
-format.
+Converts any OGR-supported vector layer into another OGR-supported format.
 
 This algorithm is derived from the
 `ogr2ogr utility <https://gdal.org/en/latest/programs/ogr2ogr.html>`_.
@@ -132,7 +131,7 @@ Basic parameters
       - Description
    *  - **Input layer**
       - ``INPUT``
-      - [vector: any]
+      - [vector: geometry]
       - Input vector layer
    *  - **Input raster layer**
       - ``INPUT_RASTER``
@@ -227,7 +226,7 @@ Basic parameters
       - Description
    *  - **Input layer**
       - ``INPUT``
-      - [vector: any]
+      - [vector: geometry]
       - Input vector layer
    *  - **Input raster layer**
       - ``INPUT_RASTER``
@@ -235,7 +234,7 @@ Basic parameters
       - Input raster layer
    *  - **A fixed value to burn**
       - ``BURN``
-      - [number]
+      - [number: double]
 
         Default: 0.0
       - The value to burn
@@ -298,8 +297,7 @@ Python code
 
 Rasterize (vector to raster)
 ----------------------------
-Converts vector geometries (points, lines and polygons) into a raster
-image.
+Converts vector geometries (points, lines and polygons) into a raster image.
 
 This algorithm is derived from the
 `GDAL rasterize utility <https://gdal.org/en/latest/programs/gdal_rasterize.html>`_.
@@ -323,7 +321,7 @@ Basic parameters
      - Description
    * - **Input layer**
      - ``INPUT``
-     - [vector: any]
+     - [vector: geometry]
      - Input vector layer
    * - **Field to use for a burn-in value**
 
@@ -336,7 +334,7 @@ Basic parameters
 
        Optional
      - ``BURN``
-     - [number]
+     - [number: double]
 
        Default: 0.0
      - A fixed value to burn into a band for all features.
@@ -361,7 +359,7 @@ Basic parameters
 
    * - **Width/Horizontal resolution**
      - ``WIDTH``
-     - [number]
+     - [number: double]
 
        Default: 0.0
      - Sets the width (if size units is "Pixels") or horizontal
@@ -369,7 +367,7 @@ Basic parameters
        output raster. Minimum value: 0.0.
    * - **Height/Vertical resolution**
      - ``HEIGHT``
-     - [number]
+     - [number: double]
 
        Default: 0.0
      - Sets the height (if size units is "Pixels") or vertical
@@ -392,7 +390,7 @@ Basic parameters
 
        Optional
      - ``NODATA``
-     - [number]
+     - [number: double]
 
        Default: 0.0
      - Assigns a specified NoData value to output bands
@@ -456,7 +454,7 @@ Advanced parameters
 
        Optional
      - ``INIT``
-     - [number]
+     - [number: double]
      - Pre-initializes the output image bands with this value.
        Not marked as the NoData value in the output file.
        The same value is used in all the bands.

--- a/docs/user_manual/processing_algs/gdal/vectorgeoprocessing.rst
+++ b/docs/user_manual/processing_algs/gdal/vectorgeoprocessing.rst
@@ -31,7 +31,7 @@ Basic parameters
      - Description
    * - **Input layer**
      - ``INPUT``
-     - [vector: any]
+     - [vector: geometry]
      - The input vector layer
    * - **Geometry column name**
      - ``GEOMETRY``
@@ -41,7 +41,7 @@ Basic parameters
      - The name of the input layer geometry column to use
    * - **Buffer distance**
      - ``DISTANCE``
-     - [number]
+     - [number: double]
 
        Default: 10.0
      - Minimum: 0.0
@@ -152,7 +152,7 @@ Basic parameters
      - Description
    * - **Input layer**
      - ``INPUT``
-     - [vector: any]
+     - [vector: geometry]
      - The input vector layer
    * - **Clip extent**
      - ``EXTENT``
@@ -248,7 +248,7 @@ Basic parameters
      - Description
    * - **Input layer**
      - ``INPUT``
-     - [vector: any]
+     - [vector: geometry]
      - The input vector layer
    * - **Mask layer**
      - ``MASK``
@@ -338,7 +338,7 @@ Basic parameters
      - Description
    * - **Input layer**
      - ``INPUT``
-     - [vector: any]
+     - [vector: geometry]
      - The input layer to dissolve
    * - **Dissolve field**
 
@@ -487,7 +487,7 @@ Basic parameters
      - The name of the input layer geometry column to use
    * - **Offset distance (left-sided: positive, right-sided: negative)**
      - ``DISTANCE``
-     - [number]
+     - [number: double]
 
        Default: 10.0
      -
@@ -582,7 +582,7 @@ Basic parameters
      - The name of the input layer geometry column to use
    * - **Buffer distance**
      - ``DISTANCE``
-     - [number]
+     - [number: double]
 
        Default: 10.0
      -
@@ -709,9 +709,9 @@ Basic parameters
      - The name of the input layer geometry column to use
    * - **Distance from line start represented as a fraction of line length**
      - ``DISTANCE``
-     - [number]
+     - [number: double]
 
-       Default: 0.5 (middle of the line)
+       Default: 0.5
      -
    * - **Points along lines**
      - ``OUTPUT``

--- a/docs/user_manual/processing_algs/gdal/vectormiscellaneous.rst
+++ b/docs/user_manual/processing_algs/gdal/vectormiscellaneous.rst
@@ -868,7 +868,7 @@ Basic parameters
      - Description
    * - **Input layer**
      - ``INPUT``
-     - [vector: any]
+     - [vector: geometry]
      - Input vector layer
    * - **Enable listing of all layers in the dataset**
      - ``ALL_LAYERS``
@@ -987,7 +987,7 @@ Basic parameters
      - Description
    * - **Input layer**
      - ``INPUT``
-     - [vector: any]
+     - [vector: geometry]
      - Input vector layer
    * - **Enable listing of all layers in the dataset**
      - ``ALL_LAYERS``

--- a/docs/user_manual/processing_algs/qgis/cartography.rst
+++ b/docs/user_manual/processing_algs/qgis/cartography.rst
@@ -46,13 +46,13 @@ Parameters
      - Point features to calculate the rotation for
    * - **Reference layer**
      - ``REFERENCE_LAYER``
-     - [vector: any]
+     - [vector: geometry]
      - Layer to find the closest feature from for rotation calculation
    * - **Maximum distance to consider**
 
        Optional
      - ``MAX_DISTANCE``
-     - [number]
+     - [numeric: double]
 
        Default: Not set
      - If no reference feature is found within this distance, no rotation
@@ -169,11 +169,11 @@ Outputs
      - Description
    * - **Color ramp count**
      - ``COLORRAMPS``
-     - [number]
+     - [numeric: integer]
      - 
    * - **Label settings count**
      - ``LABELSETTINGS``
-     - [number]
+     - [numeric: integer]
      - 
    * - **Output style database**
      - ``OUTPUT``
@@ -181,11 +181,11 @@ Outputs
      - Output :file:`.XML` file combining the selected style items
    * - **Symbol count**
      - ``SYMBOLS``
-     - [number]
+     - [numeric: integer]
      - 
    * - **Text format count**
      - ``TEXTFORMATS``
-     - [number]
+     - [numeric: integer]
      - 
 
 Python code
@@ -262,7 +262,7 @@ Parameters
 
        Optional
      - ``NON_MATCHING_CATEGORIES``
-     - [table]
+     - [vector: table]
 
        Default: ``[Skip output]``
      - Output table for categories which do not match any symbol in
@@ -276,7 +276,7 @@ Parameters
 
        Optional
      - ``NON_MATCHING_SYMBOLS``
-     - [table]
+     - [vector: table]
 
        Default: ``[Skip output]``
      - Output table for symbols from the provided style database which
@@ -299,12 +299,12 @@ Outputs
      - Description
    * - **Non-matching categories**
      - ``NON_MATCHING_CATEGORIES``
-     - [table]
+     - [vector: table]
      - Lists categories which could not be matched to any symbol in
        the provided style database
    * - **Non-matching symbol names**
      - ``NON_MATCHING_SYMBOLS``
-     - [table]
+     - [vector: table]
      - Lists symbols from the provided style database which could
        not match any category
    * - **Categorized layer**
@@ -389,11 +389,11 @@ Outputs
      - Description
    * - **Color ramp count**
      - ``COLORRAMPS``
-     - [number]
+     - [numeric: integer]
      - Number of color ramps
    * - **Label settings count**
      - ``LABELSETTINGS``
-     - [number]
+     - [numeric: integer]
      - Number of label settings
    * - **Output style database**
      - ``OUTPUT``
@@ -401,11 +401,11 @@ Outputs
      - Output :file:`.XML` file for the selected style items
    * - **Symbol count**
      - ``SYMBOLS``
-     - [number]
+     - [numeric: integer]
      - Number of symbols
    * - **Text format count**
      - ``TEXTFORMATS``
-     - [number]
+     - [numeric: integer]
      - Number of text formats
 
 Python code
@@ -450,7 +450,7 @@ Basic parameters
 
        Optional
      - ``COVERAGE_LAYER``
-     - [vector: any]
+     - [vector: geometry]
      - Layer to use to generate the atlas
    * - **Filter expression**
      - ``FILTER_EXPRESSION``
@@ -510,7 +510,7 @@ Advanced parameters
      - ``DPI``
 
        Default: Not set
-     - [number]
+     - [numeric: double]
      - DPI of the output file(s). If not set, the value in the print layout settings will be used.
    * - **Generate world file**
      - ``GEOREFERENCE``
@@ -590,7 +590,7 @@ Basic parameters
 
        Optional
      - ``COVERAGE_LAYER``
-     - [vector: any]
+     - [vector: geometry]
      - Layer to use to generate the atlas
    * - **Filter expression**
      - ``FILTER_EXPRESSION``
@@ -643,7 +643,7 @@ Advanced parameters
      - ``DPI``
 
        Default: Not set
-     - [number]
+     - [numeric: double]
      - DPI of the output file(s). If not set, the value in the print layout settings will be used.
    * - **Always export as vectors**
      - ``FORCE_VECTOR``
@@ -763,7 +763,7 @@ Basic parameters
 
        Optional
      - ``COVERAGE_LAYER``
-     - [vector: any]
+     - [vector: geometry]
      - Layer to use to generate the atlas
    * - **Filter expression**
      - ``FILTER_EXPRESSION``
@@ -816,7 +816,7 @@ Advanced parameters
      - ``DPI``
 
        Default: Not set
-     - [number]
+     - [numeric: double]
      - DPI of the output file(s). If not set, the value in the print layout settings will be used.
    * - **Always export as vectors**
      - ``FORCE_VECTOR``
@@ -962,7 +962,7 @@ Advanced parameters
      - ``DPI``
 
        Default: Not set
-     - [number]
+     - [numeric: double]
      - DPI of the output file(s). If not set, the value in the print layout settings will be used.
    * - **Generate world file**
      - ``GEOREFERENCE``
@@ -1067,7 +1067,7 @@ Advanced parameters
      - ``DPI``
 
        Default: Not set
-     - [number]
+     - [numeric: double]
      - DPI of the output file(s). If not set, the value in the print layout settings will be used.
    * - **Always export as vectors**
      - ``FORCE_VECTOR``
@@ -1249,7 +1249,7 @@ Advanced parameters
      - ``DPI``
 
        Default: 96.0
-     - [number]
+     - [numeric: double]
      -
 
 Outputs
@@ -1374,7 +1374,7 @@ Outputs
      - Description
    * - **Map height**
      - ``HEIGHT``
-     - [number]
+     - [numeric: double]
      - 
    * - **Extent**
      - ``OUTPUT``
@@ -1383,15 +1383,15 @@ Outputs
        the input layout map item(s)
    * - **Map rotation**
      - ``ROTATION``
-     - [number]
+     - [numeric: double]
      - 
    * - **Map scale**
      - ``SCALE``
-     - [number]
+     - [numeric: double]
      - 
    * - **Map width**
      - ``WIDTH``
-     - [number]
+     - [numeric: double]
      - 
 
 Python code
@@ -1498,14 +1498,14 @@ Parameters
      - The input polygon layer
    * - **Minimum number of colors**
      - ``MIN_COLORS``
-     - [number]
+     - [numeric: integer]
 
        Default: 4
      - The minimum number of colors to assign.
        Minimum 1, maximum 1000.
    * - **Minimum distance between features**
      - ``MIN_DISTANCE``
-     - [number]
+     - [numeric: double]
 
        Default: 0.0
      - Prevent nearby (but non-touching) features from

--- a/docs/user_manual/processing_algs/qgis/interpolation.rst
+++ b/docs/user_manual/processing_algs/qgis/interpolation.rst
@@ -38,7 +38,7 @@ Parameters
      - Point vector layer to use for the heatmap
    * - **Radius**
      - ``RADIUS``
-     - [number]
+     - [numeric: double]
 
        Default: 100.0
      - Heatmap search radius (or kernel bandwidth) in map units.
@@ -48,7 +48,7 @@ Parameters
        may show finer details and variation in point density.
    * - **Output raster size**
      - ``PIXEL_SIZE``
-     - [number]
+     - [numeric: double]
 
        Default: 0.1
      - Pixel size of the output raster layer in layer units.
@@ -106,7 +106,7 @@ Parameters
 
        Optional
      - ``DECAY``
-     - [number]
+     - [numeric: double]
 
        Default: *0.0*
      - Can be used with Triangular kernels to further control
@@ -283,8 +283,7 @@ Parameters
      - ``INTERPOLATION_DATA``
      - [string]
      - Vector layer(s) and field(s) to use for the interpolation,
-       coded
-       in a string (see the ``ParameterInterpolationData`` class in
+       coded in a string (see the ``ParameterInterpolationData`` class in
        :source:`InterpolationWidgets <python/plugins/processing/algs/qgis/ui/InterpolationWidgets.py>`
        for more details).
 
@@ -310,7 +309,7 @@ Parameters
        ``'::~::'``.
    * - **Distance coefficient P**
      - ``DISTANCE_COEFFICIENT``
-     - [number]
+     - [numeric: double]
 
        Default: 2.0
      - Sets the distance coefficient for the interpolation.
@@ -326,7 +325,7 @@ Parameters
 
    * - **Output raster size**
      - ``PIXEL_SIZE``
-     - [number]
+     - [numeric: double]
 
        Default: 0.1
      - Pixel size of the output raster layer in layer units.
@@ -416,25 +415,25 @@ Basic parameters
      - Description
    * - **Input line layer**
      - ``INPUT``
-     - [vector: any]
+     - [vector: line]
      - Input vector layer containing line features
    * - **Weight field**
      - ``WEIGHT``
-     - [number]
-     - Field of the layer containing the weight factor to use during
-       the calculation
+     - [tablefield: numeric]
+     - Field of the layer containing the weight factor to use
+       during the calculation
    * - **Search Radius**
      - ``RADIUS``
-     - [number]
+     - [numeric: double]
 
-       Default: 10
+       Default: 10.0
      - Radius of the circular neighbourhood. Units can be specified
        here.
    * - **Pixel size**
      - ``PIXEL_SIZE``
-     - [number]
+     - [numeric: double]
 
-       Default: 10
+       Default: 10.0
      - Pixel size of the output raster layer in layer units.
        The raster has square pixels.
    * - **Line density raster**
@@ -537,8 +536,7 @@ Parameters
      - ``INTERPOLATION_DATA``
      - [string]
      - Vector layer(s) and field(s) to use for the interpolation,
-       coded in a string (see the ``ParameterInterpolationData``
-       class in
+       coded in a string (see the ``ParameterInterpolationData`` class in
        :source:`InterpolationWidgets <python/plugins/processing/algs/qgis/ui/InterpolationWidgets.py>`
        for more details).
 
@@ -583,7 +581,7 @@ Parameters
 
    * - **Output raster size**
      - ``PIXEL_SIZE``
-     - [number]
+     - [numeric: double]
 
        Default: 0.1
      - Pixel size of the output raster layer in layer units.
@@ -597,8 +595,7 @@ Parameters
        ``Pixel Size Y`` will be updated simultaneously - doubling the
        number of rows will double the number of columns, and the cell
        size will be halved.
-       The extent of the output raster will remain the same
-       (approximately).       
+       The extent of the output raster will remain the same (approximately).
    * - **Interpolated**
      - ``OUTPUT``
      - [raster]

--- a/docs/user_manual/processing_algs/qgis/layertools.rst
+++ b/docs/user_manual/processing_algs/qgis/layertools.rst
@@ -31,8 +31,8 @@ Parameters
      - Description
    * - **Input layers**
      - ``LAYERS``
-     - [vector: any] [list]
-     - Input vector layers to get information on.
+     - [layer] [list]
+     - Input layers to get information on.
    * - **Output**
      - ``OUTPUT``
      - [vector: polygon]
@@ -165,8 +165,7 @@ Extract layer extent
 Generates a vector layer with the minimum bounding box (rectangle with
 N-S orientation) that covers all the input features.
 
-The output layer contains a single bounding box for the whole input
-layer.
+The output layer contains a single bounding box for the whole input layer.
 
 .. figure:: img/extract_layer_extent.png
    :align: center
@@ -204,6 +203,7 @@ Parameters
 
 Outputs
 .......
+
 .. list-table::
    :header-rows: 1
    :widths: 20 20 20 40

--- a/docs/user_manual/processing_algs/qgis/mesh.rst
+++ b/docs/user_manual/processing_algs/qgis/mesh.rst
@@ -47,7 +47,7 @@ Parameters
 
        Optional
      - ``INCREMENT``
-     - [number]
+     - [numeric: double]
 
        Default: *Not set*
      - Interval between generated levels.
@@ -55,15 +55,16 @@ Parameters
 
        Optional
      - ``MINIMUM``
-     - [number]
+     - [numeric: double]
 
        Default: *Not set*
      - Starting level values of contours.
+       No generated levels will be lower than this value.
    * - **Maximum contour level**
 
        Optional
      - ``MAXIMUM``
-     - [number]
+     - [numeric: double]
 
        Default: *Not set*
      - Maximum values of contours, i.e. no generated levels will be greater than this value.
@@ -71,10 +72,10 @@ Parameters
 
        Optional
      - ``CONTOUR_LEVEL_LIST``
-     - [number]
+     - [string]
 
        Default: *Not set*
-     - List of wanted levels of contours (separated by commas).
+     - List of desired levels of contours (separated by commas).
        If filled, the increment, minimum, and maximum fields will not be considered.
    * - **Output coordinate system**
 
@@ -181,17 +182,24 @@ Parameters
      - Lines where the data will be extracted from the dataset mesh
    * - **Line segmentation resolution**
      - ``RESOLUTION``
-     - [number]
+     - [numeric: double]
 
        Default: 10.0
      - The distance between points on the lines where the data
        will be extracted from the dataset mesh.
-   * - **Digits count for dataset value**
-     - ``DATASET_DIGITS``
-     - [number]
+       Units can be selected.
+   * - **Digits count for coordinates**
+     - ``COORDINATES_DIGITS``
+     - [numeric: integer]
 
        Default: 2
-     - Number of digits to round dataset values
+     - Number of digits for rounding the coordinate values
+   * - **Digits count for dataset value**
+     - ``DATASET_DIGITS``
+     - [numeric: integer]
+
+       Default: 2
+     - Number of digits for rounding the dataset values
    * - **Exported data CSV file**
      - ``OUTPUT``
      - [file]
@@ -461,7 +469,7 @@ Parameters
 
        Optional
      - ``GRID_SPACING``
-     - [number]
+     - [numeric: double]
 
        Default: 10.0
      - Spacing between the sample points to use
@@ -655,7 +663,7 @@ Parameters
 
        Optional
      - ``TIME_STEP``
-     - [number]
+     - [numeric: double]
 
        Default: 0
      - Time between two consecutive steps to extract.
@@ -667,16 +675,16 @@ Parameters
      - Vector layer containing points where the data will be extracted from the dataset mesh
    * - **Digits count for coordinates**
      - ``COORDINATES_DIGITS``
-     - [number]
-     - Number of digits to round coordinate values
+     - [numeric: integer]
+     - Number of digits for rounding coordinate values
 
        Default: 2
    * - **Digits count for dataset value**
      - ``DATASET_DIGITS``
-     - [number]
+     - [numeric: integer]
 
        Default: 2
-     - Number of digits to round dataset values
+     - Number of digits for rounding dataset values
    * - **Exported data CSV file**
      - ``OUTPUT``
      - [file]
@@ -771,7 +779,7 @@ Basic parameters
 
    * - **Pixel size**
      - ``PIXEL_SIZE``
-     - [number]
+     - [numeric: double]
 
        Default: 1.0
      - Pixel size of the output raster layer.
@@ -812,10 +820,9 @@ Advanced parameters
 
        Default: ''
      - For adding one or more creation options that control the
-       raster to be created (colors, block size, file
-       compression...).
-       For convenience, you can rely on predefined profiles (see
-       :ref:`GDAL driver options section <gdal_createoptions>`).
+       raster to be created (colors, block size, file compression...).
+       For convenience, you can rely on predefined profiles
+       (see :ref:`GDAL driver options section <gdal_createoptions>`).
 
        Batch Process and Model Designer: separate multiple options with a pipe
        character (``|``).
@@ -845,7 +852,6 @@ Python code
 .. include:: ../algs_include.rst
   :start-after: **algorithm_code_section**
   :end-before: **end_algorithm_code_section**
-
 
 
 .. _qgissurfacetopolygon:
@@ -968,6 +974,7 @@ Parameters
        * 1 --- SELAFIN
        * 2 --- PLY
        * 3 --- Ugrid
+       * 4 --- Mike21
    * - **Output coordinate system**
 
        Optional

--- a/docs/user_manual/processing_algs/qgis/metadatatools.rst
+++ b/docs/user_manual/processing_algs/qgis/metadatatools.rst
@@ -33,7 +33,8 @@ Parameters
    * - **History entry**
      - ``HISTORY``
      - [string]
-     - The text to be appended as a new entry in the layer's history metadata. This will be added to any existing history entries.
+     - The text to be appended as a new entry in the layer's history metadata.
+       This will be added to any existing history entries.
 
 Outputs
 .......
@@ -50,7 +51,6 @@ Outputs
      - ``OUTPUT``
      - [same as input]
      - The resulting layer with the updated history in its **Metadata properties**. 
-
 
 Python code
 ...........
@@ -96,7 +96,7 @@ Parameters
 
        Default: False
      - If checked, the metadata information will be saved with the layer,
-        hence available in subsequent projects.
+       hence available by default in subsequent projects.
 
 Outputs
 .......
@@ -114,7 +114,6 @@ Outputs
      - [layer]
      - The target layer with the metadata replaced by the metadata from the source layer.
        This includes all metadata fields, such as history, abstract, and other properties.
-
 
 Python code
 ...........
@@ -173,8 +172,8 @@ Outputs
    * - **Output file**
      - ``OUTPUT``
      - [file]
-     - The QMD file containing the exported metadata. This file can be used to import metadata into another layer.
-
+     - The :file:`.qmd` file containing the exported metadata.
+       This file can be used to import metadata into another layer.
 
 Python code
 ...........
@@ -191,7 +190,7 @@ Python code
 Set Layer Metadata
 ------------------
 
-Applies metadata to a layer from a QMD file.
+Applies metadata to a layer from a :file:`.qmd` file.
 
 Parameters
 ..........
@@ -211,14 +210,14 @@ Parameters
    * - **Metadata file**
      - ``METADATA``
      - [file]
-     - The QMD file containing the metadata to be applied.
+     - The :file:`.qmd` file containing the metadata to be applied.
    * - **Save metadata as default**
      - ``DEFAULT``
      - [boolean]
 
        Default: False
      - If checked, the metadata information will be saved with the layer,
-        hence available in subsequent projects.
+       hence available by default in subsequent projects.
 
 Outputs
 .......
@@ -234,8 +233,7 @@ Outputs
    * - **Output layer**
      - ``OUTPUT``
      - [same as input]
-     - The input layer with the metadata replaced by the metadata from the QMD file.
-
+     - The input layer with the metadata replaced by the metadata from the :file:`.qmd` file.
 
 Python code
 ...........

--- a/docs/user_manual/processing_algs/qgis/modelertools.rst
+++ b/docs/user_manual/processing_algs/qgis/modelertools.rst
@@ -714,7 +714,7 @@ Parameters
      - Attribute for the distance radius of the buffer
    * - **Segments**
      - ``SEGMENTS``
-     - [number]
+     - [numeric: integer]
 
        Default: *5*
      - Controls the number of line segments to use to approximate a
@@ -751,7 +751,7 @@ Parameters
        when offsetting corners in a line.
    * - **Miter limit**
      - ``MITER_LIMIT``
-     - [number]
+     - [numeric: double]
 
        Default: 2.0
      - Only applicable for mitered join styles, and controls the

--- a/docs/user_manual/processing_algs/qgis/networkanalysis.rst
+++ b/docs/user_manual/processing_algs/qgis/networkanalysis.rst
@@ -14,8 +14,8 @@ Service area (from layer)
 -------------------------
 Returns all the edges or parts of edges of a network that can be
 reached within a distance or a time, starting from a point layer.
-This allows evaluation of accessibility within a network, e.g. what
-are the places I can navigate to on a road network without spending
+This allows evaluation of accessibility within a network,
+e.g., what are the places I can navigate to on a road network without spending
 cost greater than a given value (the cost can be distance or time).
 
 Parameters
@@ -53,9 +53,9 @@ Basic parameters
        * 1 --- Fastest
    * - **Travel cost (distance for "Shortest", time for "Fastest")**
      - ``TRAVEL_COST``
-     - [number]
+     - [numeric: double]
 
-       Default: 0
+       Default: 0.0
      - The value is estimated as a distance (in the network
        layer units) when looking for the *Shortest* path and
        as time (in hours) for the *Fastest* path.
@@ -118,19 +118,16 @@ Advanced parameters
 
        Optional
      - ``DIRECTION_FIELD``
-     - [tablefield: string]
-
-       Default: 0.0
+     - [tablefield: any]
      - The field used to specify directions for the network edges.
        
-       The values used in this field are specified with the three
-       parameters ``Value for forward direction``,
-       ``Value for backward direction`` and ``Value for both directions``.
+       The values used in this field are specified with the three parameters
+       ``Value for forward direction``, ``Value for backward direction``
+       and ``Value for both directions``.
        Forward and reverse directions correspond to a one-way edge,
        "both directions" indicates a two-way edge.
-       If a feature does not have a value in this field, or no field
-       is set then the   default direction setting (provided with
-       the ``Default direction`` parameter) is used.
+       If a feature does not have a value in this field, or no field is set
+       then the default direction setting (provided with the ``Default direction`` parameter) is used.
    * - **Value for forward direction**
 
        Optional
@@ -156,16 +153,15 @@ Advanced parameters
      - [string]
 
        Default: '' (empty string)
-     - Value set in the direction field to identify
-       bidirectional edges
+     - Value set in the direction field to identify bidirectional edges
    * - **Default direction**
      - ``DEFAULT_DIRECTION``
      - [enumeration]
 
        Default: 2
      - If a feature has no value set in the direction field or
-       if no direction field is set, then this direction value
-       is used. One of:
+       if no direction field is set, then this direction value is used.
+       One of:
 
        * 0 --- Forward direction
        * 1 --- Backward direction
@@ -174,7 +170,7 @@ Advanced parameters
 
        Optional
      - ``SPEED_FIELD``
-     - [tablefield: string]
+     - [tablefield: numeric]
      - Field providing the speed value (in ``km/h``) for the
        edges of the network when looking for the fastest path.
        
@@ -183,14 +179,14 @@ Advanced parameters
        with the ``Default speed`` parameter) is used.
    * - **Default speed (km/h)**
      - ``DEFAULT_SPEED``
-     - [number]
+     - [numeric: double]
 
        Default: 50.0
      - Value to use to calculate the travel time if no speed
-       field is provided for an edge
+       value is provided for an edge in the specified field
    * - **Topology tolerance**
      - ``TOLERANCE``
-     - [number]
+     - [numeric: double]
 
        Default: 0.0
      - Two lines with nodes closer than the specified
@@ -210,8 +206,10 @@ Advanced parameters
        edge at the boundaries of the service area.
        One point is the start of that edge, the other is the end.
    * - **Maximum point distance from network**
+
+       Optional
      - ``POINT_TOLERANCE``
-     - [number]
+     - [numeric: double]
 
        Default: Not set
      - Specifies an optional limit on the distance from the points to the network layer.
@@ -233,8 +231,7 @@ Outputs
    * - **Service area (boundary nodes)**
      - ``OUTPUT``
      - [vector: point]
-     - The output point layer with the service area boundary
-       nodes.
+     - The output point layer with the service area boundary nodes.
    * - **Service area (lines)**
      - ``OUTPUT_LINES``
      - [vector: line]
@@ -260,13 +257,11 @@ Python code
 
 Service area (from point)
 -------------------------
-Returns all the edges or parts of edges of a network that can be
-reached within a given distance or time, starting from a point
-feature.
-This allows the evaluation of accessibility within a network, e.g.
-what are the places I can navigate to on a road network without
-spending a cost greater than a given value (the cost can be distance
-or time).
+Returns all the edges or parts of edges of a network that can be reached
+within a given distance or time, starting from a point feature.
+This allows the evaluation of accessibility within a network,
+e.g., what are the places I can navigate to on a road network without spending a cost
+greater than a given value (the cost can be distance or time).
 
 Parameters
 ..........
@@ -287,11 +282,6 @@ Basic parameters
      - ``INPUT``
      - [vector: line]
      - Line vector layer representing the network to be covered
-   * - **Start point (x, y)**
-     - ``START_POINT``
-     - [coordinates]
-     - Coordinate of the point to calculate the service
-       area around.
    * - **Path type to calculate**
      - ``STRATEGY``
      - [enumeration]
@@ -301,15 +291,24 @@ Basic parameters
 
        * 0 --- Shortest
        * 1 --- Fastest
+   * - **Start point**
+     - ``START_POINT``
+     - [coordinates]
+     - Coordinate of the point to calculate the service area around.
+
+       Press the :guilabel:`...` button next to the option
+       and click on the canvas to fill the parameter with the clicked point coordinate.
    * - **Travel cost (distance for "Shortest", time for "Fastest")**
      - ``TRAVEL_COST``
-     - [number]
+     - [numeric: double]
 
-       Default: 0
+       Default: 0.O
      - The value is estimated as a distance (in the network
        layer units) when looking for the *Shortest* path and
        as time (in hours) for the *Fastest* path.
    * - **Service area (lines)**
+
+       Optional
      - ``OUTPUT_LINES``
      - [vector: line]
 
@@ -322,6 +321,8 @@ Basic parameters
           :end-before: **end_layer_output_types_skip**
 
    * - **Service area (boundary nodes)**
+
+       Optional
      - ``OUTPUT``
      - [vector: point]
 
@@ -344,10 +345,12 @@ Advanced parameters
    :widths: 20 20 20 40
 
    * - **Maximum point distance from network**
-     - ``POINT_TOLERANCE``
-     - [number]
 
-       Default: Not set
+       Optional
+     - ``POINT_TOLERANCE``
+     - [numeric: double]
+
+       Default: 0.0
      - Specifies an optional limit on the distance from the start point to the network layer.
        If the point is further from the network than this distance an error will be raised.
        If not set, the point will be snapped to the nearest point on the network layer,
@@ -375,14 +378,12 @@ Outputs
    * - **Service area (boundary nodes)**
      - ``OUTPUT``
      - [vector: point]
-     - The output point layer with the service area boundary
-       nodes.
+     - The output point layer with the service area boundary nodes.
    * - **Service area (lines)**
      - ``OUTPUT_LINES``
      - [vector: line]
      - Line layer representing the parts of the network
-       that can be serviced by the start point, for the
-       given cost.
+       that can be serviced by the start point, for the given cost.
 
 Python code
 ...........
@@ -438,6 +439,9 @@ Basic parameters
      - ``END_POINT``
      - [coordinates]
      - Point feature representing the end point of the routes
+
+       Press the :guilabel:`...` button next to the option
+       and click on the canvas to fill the parameter with the clicked point coordinate.
    * - **Shortest path**
      - ``OUTPUT``
      - [vector: line]
@@ -451,6 +455,8 @@ Basic parameters
           :end-before: **end_layer_output_types**
 
    * - **Non-routable features**
+
+       Optional
      - ``OUTPUT_NON_ROUTABLE``
      - [vector: point]
 
@@ -463,7 +469,6 @@ Basic parameters
           :start-after: **layer_output_types_skip**
           :end-before: **end_layer_output_types_skip**
 
-
 Advanced parameters
 ^^^^^^^^^^^^^^^^^^^
 
@@ -471,13 +476,14 @@ Advanced parameters
   :start-after: .. **network_advanced_parameters**
   :end-before: .. **end_network_advanced_parameters**
 
-
 .. list-table::
    :widths: 20 20 20 40
 
    * - **Maximum point distance from network**
+
+       Optional
      - ``POINT_TOLERANCE``
-     - [number]
+     - [numeric: double]
 
        Default: Not set
      - Specifies an optional limit on the distance from the start and end points to the network layer.
@@ -556,15 +562,17 @@ Basic parameters
 
        * 0 --- Shortest
        * 1 --- Fastest
-   * - **Start point (x, y)**
+   * - **Start point**
      - ``START_POINT``
      - [coordinates]
      - Point feature representing the start point of the routes
+
+       Press the :guilabel:`...` button next to the option
+       and click on the canvas to fill the parameter with the clicked point coordinate.
    * - **Vector layer with end points**
      - ``END_POINTS``
      - [vector: point]
-     - Point vector layer whose features are used as end
-       points of the routes
+     - Point vector layer whose features are used as end points of the routes
    * - **Shortest path**
      - ``OUTPUT``
      - [vector: line]
@@ -579,6 +587,8 @@ Basic parameters
 
    * - **Non-routable features**
      - ``OUTPUT_NON_ROUTABLE``
+
+       Optional
      - [vector: point]
 
        Default: ``[Skip output]``
@@ -602,8 +612,10 @@ Advanced parameters
    :widths: 20 20 20 40
 
    * - **Maximum point distance from network**
+
+       Optional
      - ``POINT_TOLERANCE``
-     - [number]
+     - [numeric: double]
 
        Default: Not set
      - Specifies an optional limit on the distance from the start and end points to the network layer.
@@ -682,11 +694,17 @@ Basic parameters
    * - **Start point (x, y)**
      - ``START_POINT``
      - [coordinates]
-     - Point feature representing the start point of the routes
+     - Point feature representing the start point of the routes.
+
+       Press the :guilabel:`...` button next to the option
+       and click on the canvas to fill the parameter with the clicked point coordinate.
    * - **End point (x, y)**
      - ``END_POINT``
      - [coordinates]
-     - Point feature representing the end point of the routes
+     - Point feature representing the end point of the routes.
+
+       Press the :guilabel:`...` button next to the option
+       and click on the canvas to fill the parameter with the clicked point coordinate.
    * - **Shortest path**
      - ``OUTPUT``
      - [vector: line]
@@ -708,8 +726,10 @@ Advanced parameters
    :widths: 20 20 20 40
 
    * - **Maximum point distance from network**
+
+       Optional
      - ``POINT_TOLERANCE``
-     - [number]
+     - [numeric: double]
 
        Default: Not set
      - Specifies an optional limit on the distance from the start and end points to the network layer.

--- a/docs/user_manual/processing_algs/qgis/plots.rst
+++ b/docs/user_manual/processing_algs/qgis/plots.rst
@@ -14,7 +14,6 @@ Bar plot
 --------
 Creates a bar plot from a category and a layer field.
 
-
 Parameters
 ..........
 
@@ -28,7 +27,7 @@ Parameters
      - Description
    * - **Input layer**
      - ``INPUT``
-     - [vector: any]
+     - [vector: geometry]
      - Input vector layer
    * - **Category field name**
      - ``NAME_FIELD``
@@ -122,7 +121,7 @@ Parameters
      - Description
    * - **Input layer**
      - ``INPUT``
-     - [vector: any]
+     - [vector: geometry]
      - Input vector layer
    * - **Category name field**
      - ``NAME_FIELD``
@@ -238,7 +237,7 @@ Basic parameters
      - The list of map layers to include in the elevation profile
    * - **Chart width (in pixels)**
      - ``WIDTH``
-     - [number]
+     - [numeric: integer]
 
        Default: 400
 
@@ -246,7 +245,7 @@ Basic parameters
      - The width of the output chart in pixels.
    * - **Chart height (in pixels)**
      - ``HEIGHT``
-     - [number]
+     - [numeric: integer]
 
        Default: 300
 
@@ -274,25 +273,25 @@ Advanced parameters
 
        Optional
      - ``MINIMUM_DISTANCE``
-     - [number]
+     - [numeric: double]
      - The minimum distance (X axis) to display on the chart. If not specified, the chart will auto-scale.
    * - **Chart maximum distance (X axis)**
 
        Optional
      - ``MAXIMUM_DISTANCE``
-     - [number]
+     - [numeric: double]
      - The maximum distance (X axis) to display on the chart. If not specified, the chart will auto-scale.
    * - **Chart minimum elevation (Y axis)**
 
        Optional
      - ``MINIMUM_ELEVATION``
-     - [number]
+     - [numeric: double]
      - The minimum elevation (Y axis) to display on the chart. If not specified, the chart will auto-scale.
    * - **Chart maximum elevation (Y axis)**
 
        Optional
      - ``MAXIMUM_ELEVATION``
-     - [number]
+     - [numeric: double]
      - The maximum elevation (Y axis) to display on the chart. If not specified, the chart will auto-scale.
    * - **Chart text color**
 
@@ -314,9 +313,9 @@ Advanced parameters
      - The color of the chart border.
    * - **Profile tolerance**
      - ``TOLERANCE``
-     - [number]
+     - [numeric: double]
 
-       Default: 5
+       Default: 5.0
 
        Minimum value: 0
      - Defines how far a feature (vector point, line, polygon, or point cloud)
@@ -324,7 +323,7 @@ Advanced parameters
        and does not affect other layer types.
    * - **Chart DPI**
      - ``DPI``
-     - [number]
+     - [numeric: integer]
 
        Default: 96
 
@@ -373,7 +372,6 @@ Mean and standard deviation plot
 --------------------------------
 Creates a box plot with mean and standard deviation values.
 
-
 Parameters
 ..........
 
@@ -387,7 +385,7 @@ Parameters
      - Description
    * - **Input table**
      - ``INPUT``
-     - [vector: any]
+     - [vector: geometry]
      - Input vector layer
    * - **Category name field**
      - ``NAME_FIELD``
@@ -395,7 +393,7 @@ Parameters
      - Categorical field to use for grouping the boxes (X axis)
    * - **Value field**
      - ``VALUE_FIELD``
-     - [tablefield: any]
+     - [tablefield: numeric]
      - Value to use for the plot (Y axis).
    * - **Plot**
      - ``OUTPUT``
@@ -458,7 +456,7 @@ Parameters
      - Description
    * - **Input layer**
      - ``INPUT``
-     - [vector: any]
+     - [vector: geometry]
      - Input vector layer
    * - **Category name field**
      - ``NAME_FIELD``
@@ -466,7 +464,7 @@ Parameters
      - Categorical field to use for grouping the features (X axis)
    * - **Value field**
      - ``VALUE_FIELD``
-     - [tablefield: any]
+     - [tablefield: numeric]
      - Value to use for the plot (Y axis).
    * - **Polar plot**
      - ``OUTPUT``
@@ -533,7 +531,7 @@ Parameters
      - Raster band to use for the histogram
    * - **number of bins**
      - ``BINS``
-     - [number]
+     - [numeric: integer]
 
        Default: 10
      - The number of bins to use in the histogram (X axis).
@@ -601,11 +599,11 @@ Parameters
      - Input vector layer
    * - **Attribute**
      - ``FIELD``
-     - [tablefield: any]
+     - [tablefield: numeric]
      - Value to use for the plot (Y axis).
    * - **number of bins**
      - ``BINS``
-     - [number]
+     - [numeric: integer]
 
        Default: 10
      - The number of bins to use in the histogram (X axis).
@@ -668,7 +666,7 @@ Parameters
      - Description
    * - **Input layer**
      - ``INPUT``
-     - [vector: any]
+     - [vector: geometry]
      - Input vector layer
    * - **X attribute**
      - ``XFIELD``
@@ -714,14 +712,12 @@ Parameters
      - If empty, the field name of the y attribute is used.
        With a single space, the axis title is not shown.
    * - **Use logarithmic scale for x-axis**
-
      - ``XAXIS_LOG``
      - [boolean]
 
        Default: False
      - When enabled, uses logarithmic scale for the x-axis
    * - **Use logarithmic scale for y-axis**
-
      - ``YAXIS_LOG``
      - [boolean]
 
@@ -784,7 +780,7 @@ Parameters
      - Description
    * - **Input layer**
      - ``INPUT``
-     - [vector: any]
+     - [vector: geometry]
      - Input vector layer
    * - **X attribute**
      - ``XFIELD``

--- a/docs/user_manual/processing_algs/qgis/pointcloudconversion.rst
+++ b/docs/user_manual/processing_algs/qgis/pointcloudconversion.rst
@@ -106,13 +106,13 @@ Basic parameters
      - A Field of the point cloud layer to extract the values from
    * - **Resolution of the density raster**
      - ``RESOLUTION``
-     - [number]
+     - [numeric: double]
 
        Default: 1.0
      - Cell size of the output raster
    * - **Tile size for parallel runs**
      - ``TILE_SIZE``
-     - [number]
+     - [numeric: integer]
 
        Default: 1000
      -
@@ -159,13 +159,13 @@ Advanced parameters
 
        Optional
      - ``ORIGIN_X``
-     - [number]
+     - [numeric: double]
      -
    * - **Y origin of a tile for parallel runs**
 
        Optional
      - ``ORIGIN_Y``
-     - [number]
+     - [numeric: double]
      -
 
 Outputs
@@ -230,13 +230,13 @@ Basic parameters
      - Input point cloud layer to export
    * - **Resolution of the density raster**
      - ``RESOLUTION``
-     - [number]
+     - [numeric: double]
 
        Default: 1.0
      - Cell size of the output raster
    * - **Tile size for parallel runs**
      - ``TILE_SIZE``
-     - [number]
+     - [numeric: integer]
 
        Default: 1000
      -
@@ -283,13 +283,13 @@ Advanced parameters
 
        Optional
      - ``ORIGIN_X``
-     - [number]
+     - [numeric: double]
      -
    * - **Y origin of a tile for parallel runs**
 
        Optional
      - ``ORIGIN_Y``
-     - [number]
+     - [numeric: double]
      -
 
 Outputs

--- a/docs/user_manual/processing_algs/qgis/pointclouddatamanagement.rst
+++ b/docs/user_manual/processing_algs/qgis/pointclouddatamanagement.rst
@@ -629,7 +629,7 @@ Basic parameters
      - Input point cloud layer to create a thinned version from
    * - **Sampling radius (in map units)**
      - ``SAMPLING_RADIUS``
-     - [number]
+     - [numeric: double]
 
        Default: 1.0
      - Distance within which points are sampled to a unique point
@@ -728,7 +728,7 @@ Basic parameters
      - Input point cloud layer to create a thinned version from
    * - **Number of points to skip**
      - ``POINTS_NUMBER``
-     - [number]
+     - [numeric: integer]
 
        Default: 1
      - Keep only every N-th point in the input layer
@@ -827,7 +827,7 @@ Basic parameters
      - Input point cloud layers to create tiles from
    * - **Tile length**
      - ``LENGTH``
-     - [number]
+     - [numeric: double]
 
        Default: 1000.0
      - Size of the edge of each generated tile

--- a/docs/user_manual/processing_algs/qgis/pointcloudextraction.rst
+++ b/docs/user_manual/processing_algs/qgis/pointcloudextraction.rst
@@ -44,13 +44,13 @@ Basic parameters
 
        Optional
      - ``RESOLUTION``
-     - [number]
+     - [numeric: double]
      - Resolution of cells used to calculate boundary
    * - **Minimal number of points in a cell to consider cell occupied**
 
        Optional
      - ``THRESHOLD``
-     - [number]
+     - [numeric: integer]
      - Minimal number of points in a cell to consider cell occupied
    * - **Boundary**
      - ``OUTPUT``
@@ -151,13 +151,13 @@ Basic parameters
      - Input point cloud layer to export
    * - **Resolution of the density raster**
      - ``RESOLUTION``
-     - [number]
+     - [numeric: double]
 
        Default: 1.0
      - Cell size of the output raster
    * - **Tile size for parallel runs**
      - ``TILE_SIZE``
-     - [number]
+     - [numeric: integer]
 
        Default: 1000
      - Size of the tiles to split the data into for parallel runs
@@ -204,13 +204,13 @@ Advanced parameters
 
        Optional
      - ``ORIGIN_X``
-     - [number]
+     - [numeric: double]
      -
    * - **Y origin of a tile for parallel runs**
 
        Optional
      - ``ORIGIN_Y``
-     - [number]
+     - [numeric: double]
      -
 
 Outputs

--- a/docs/user_manual/processing_algs/qgis/rasteranalysis.rst
+++ b/docs/user_manual/processing_algs/qgis/rasteranalysis.rst
@@ -78,7 +78,7 @@ Basic parameters
        * 1 --- Exclusive linear interpolation (PERCENTRANK.EXC)
    * - **Value**
      - ``VALUE``
-     - [number]
+     - [numeric: double]
 
        Default: 10.0
      - Value to rank among the respective values in the stack of all overlaid
@@ -120,7 +120,7 @@ Advanced parameters
      - Description
    * - **Output NoData value**
      - ``OUTPUT_NODATA_VALUE``
-     - [number]
+     - [numeric: double]
 
        Default: -9999.0
      - Value to use for NoData in the output layer
@@ -165,15 +165,15 @@ Outputs
      - The spatial extent of the output raster layer
    * - **Width in pixels**
      - ``WIDTH_IN_PIXELS``
-     - [integer]
+     - [numeric: integer]
      - The number of columns in the output raster layer
    * - **Height in pixels**
      - ``HEIGHT_IN_PIXELS``
-     - [integer]
+     - [numeric: integer]
      - The number of rows in the output raster layer
    * - **Total pixel count**
      - ``TOTAL_PIXEL_COUNT``
-     - [integer]
+     - [numeric: integer]
      - The count of pixels in the output raster layer
 
 Python code
@@ -256,7 +256,7 @@ Basic parameters
        * 2 --- Exclusive linear interpolation (PERCENTILE.EXC)
    * - **Percentile**
      - ``VALUE``
-     - [number]
+     - [numeric: double]
 
        Default: 0.25
      - Value to rank among the respective values in the stack of all overlaid
@@ -298,7 +298,7 @@ Advanced parameters
      - Description
    * - **Output NoData value**
      - ``OUTPUT_NODATA_VALUE``
-     - [number]
+     - [numeric: double]
 
        Default: -9999.0
      - Value to use for NoData in the output layer
@@ -343,15 +343,15 @@ Outputs
      - The spatial extent of the output raster layer
    * - **Width in pixels**
      - ``WIDTH_IN_PIXELS``
-     - [integer]
+     - [numeric: integer]
      - The number of columns in the output raster layer
    * - **Height in pixels**
      - ``HEIGHT_IN_PIXELS``
-     - [integer]
+     - [numeric: integer]
      - The number of rows in the output raster layer
    * - **Total pixel count**
      - ``TOTAL_PIXEL_COUNT``
-     - [integer]
+     - [numeric: integer]
      - The count of pixels in the output raster layer
 
 Python code
@@ -428,7 +428,7 @@ Basic parameters
      - The layer to rank the values among the stack of all overlaid layers
    * - **Value raster band**
      - ``VALUE_RASTER_BAND``
-     - [integer]
+     - [numeric: integer]
 
        Default: 1
      - Band of the "value raster layer" to compare to
@@ -478,7 +478,7 @@ Advanced parameters
      - Description
    * - **Output NoData value**
      - ``OUTPUT_NODATA_VALUE``
-     - [number]
+     - [numeric: double]
 
        Default: -9999.0
      - Value to use for NoData in the output layer
@@ -523,15 +523,15 @@ Outputs
      - The spatial extent of the output raster layer
    * - **Width in pixels**
      - ``WIDTH_IN_PIXELS``
-     - [integer]
+     - [numeric: integer]
      - The number of columns in the output raster layer
    * - **Height in pixels**
      - ``HEIGHT_IN_PIXELS``
-     - [integer]
+     - [numeric: integer]
      - The number of rows in the output raster layer
    * - **Total pixel count**
      - ``TOTAL_PIXEL_COUNT``
-     - [integer]
+     - [numeric: integer]
      - The count of pixels in the output raster layer
 
 Python code
@@ -664,7 +664,7 @@ Advanced parameters
 
        Optional
      - ``OUTPUT_NO_DATA_VALUE``
-     - [number]
+     - [numeric: double]
 
        Default: -9999.0
      - Value to use for NoData in the output layer
@@ -705,7 +705,7 @@ Outputs
     - The spatial extent of the output raster layer
   * - **Height in pixels**
     - ``HEIGHT_IN_PIXELS``
-    - [integer]
+    - [numeric: integer]
     - The number of rows in the output raster layer
   * - **Output raster**
     - ``OUTPUT``
@@ -713,11 +713,11 @@ Outputs
     - Output raster layer containing the result
   * - **Total pixel count**
     - ``TOTAL_PIXEL_COUNT``
-    - [integer]
+    - [numeric: integer]
     - The count of pixels in the output raster layer
   * - **Width in pixels**
     - ``WIDTH_IN_PIXELS``
-    - [integer]
+    - [numeric: integer]
     - The number of columns in the output raster layer
 
 Python code
@@ -822,7 +822,7 @@ Advanced parameters
 
        Optional
      - ``OUTPUT_NO_DATA_VALUE``
-     - [number]
+     - [numeric: double]
 
        Default: -9999.0
      - Value to use for NoData in the output layer
@@ -867,27 +867,27 @@ Outputs
      - The spatial extent of the output raster layer
    * - **Count of cells with equal value occurrences**
      - ``FOUND_LOCATIONS_COUNT``
-     - [number]
+     - [numeric: integer]
      -
    * - **Height in pixels**
      - ``HEIGHT_IN_PIXELS``
-     - [number]
+     - [numeric: integer]
      - The number of rows in the output raster layer
    * - **Total pixel count**
      - ``TOTAL_PIXEL_COUNT``
-     - [integer]
+     - [numeric: integer]
      - The count of pixels in the output raster layer
    * - **Mean frequency at valid cell locations**
      - ``MEAN_FREQUENCY_PER_LOCATION``
-     - [number]
+     - [numeric: double]
      -
    * - **Count of value occurrences**
      - ``OCCURRENCE_COUNT``
-     - [number]
+     - [numeric: integer]
      -
    * - **Width in pixels**
      - ``WIDTH_IN_PIXELS``
-     - [integer]
+     - [numeric: integer]
      - The number of columns in the output raster layer
 
 .. **endfrequencyparams**
@@ -955,13 +955,13 @@ Basic parameters
        you want to fuzzify.
    * - **Function midpoint**
      - ``FUZZYMIDPOINT``
-     - [number]
+     - [numeric: double]
 
-       Default: 10
+       Default: 10.0
      - Midpoint of the gaussian function
    * - **Function spread**
      - ``FUZZYSPREAD``
-     - [number]
+     - [numeric: double]
 
        Default: 0.01
      - Spread of the gaussian function
@@ -1029,15 +1029,15 @@ Outputs
      - The spatial extent of the output raster layer
    * - **Width in pixels**
      - ``WIDTH_IN_PIXELS``
-     - [integer]
+     - [numeric: integer]
      - The number of columns in the output raster layer
    * - **Height in pixels**
      - ``HEIGHT_IN_PIXELS``
-     - [integer]
+     - [numeric: integer]
      - The number of rows in the output raster layer
    * - **Total pixel count**
      - ``TOTAL_PIXEL_COUNT``
-     - [integer]
+     - [numeric: integer]
      - The count of pixels in the output raster layer
 
 Python code
@@ -1096,15 +1096,15 @@ Basic parameters
        fuzzify.
    * - **Function midpoint**
      - ``FUZZYMIDPOINT``
-     - [number]
+     - [numeric: double]
 
-       Default: 50
+       Default: 50.0
      - Midpoint of the large function
    * - **Function spread**
      - ``FUZZYSPREAD``
-     - [number]
+     - [numeric: double]
 
-       Default: 5
+       Default: 5.0
      - Spread of the large function
    * - **Fuzzified raster**
      - ``OUTPUT``
@@ -1171,15 +1171,15 @@ Outputs
      - The spatial extent of the output raster layer
    * - **Width in pixels**
      - ``WIDTH_IN_PIXELS``
-     - [integer]
+     - [numeric: integer]
      - The number of columns in the output raster layer
    * - **Height in pixels**
      - ``HEIGHT_IN_PIXELS``
-     - [integer]
+     - [numeric: integer]
      - The number of rows in the output raster layer
    * - **Total pixel count**
      - ``TOTAL_PIXEL_COUNT``
-     - [integer]
+     - [numeric: integer]
      - The count of pixels in the output raster layer
 
 Python code
@@ -1243,15 +1243,15 @@ Basic parameters
        fuzzify.
    * - **Low fuzzy membership bound**
      - ``FUZZYLOWBOUND``
-     - [number]
+     - [numeric: double]
 
-       Default: 0
+       Default: 0.0
      - Low bound of the linear function
    * - **High fuzzy membership bound**
      - ``FUZZYHIGHBOUND``
-     - [number]
+     - [numeric: double]
 
-       Default: 1
+       Default: 1.0
      - High bound of the linear function
    * - **Fuzzified raster**
      - ``OUTPUT``
@@ -1317,15 +1317,15 @@ Outputs
      - The spatial extent of the output raster layer
    * - **Width in pixels**
      - ``WIDTH_IN_PIXELS``
-     - [integer]
+     - [numeric: integer]
      - The number of columns in the output raster layer
    * - **Height in pixels**
      - ``HEIGHT_IN_PIXELS``
-     - [integer]
+     - [numeric: integer]
      - The number of rows in the output raster layer
    * - **Total pixel count**
      - ``TOTAL_PIXEL_COUNT``
-     - [integer]
+     - [numeric: integer]
      - The count of pixels in the output raster layer
 
 Python code
@@ -1384,13 +1384,13 @@ Basic parameters
        fuzzify.
    * - **Function midpoint**
      - ``FUZZYMIDPOINT``
-     - [number]
+     - [numeric: double]
 
-       Default: 50
+       Default: 50.0
      - Midpoint of the near function
    * - **Function spread**
      - ``FUZZYSPREAD``
-     - [number]
+     - [numeric: double]
 
        Default: 0.01
      - Spread of the near function
@@ -1458,15 +1458,15 @@ Outputs
      - The spatial extent of the output raster layer
    * - **Width in pixels**
      - ``WIDTH_IN_PIXELS``
-     - [integer]
+     - [numeric: integer]
      - The number of columns in the output raster layer
    * - **Height in pixels**
      - ``HEIGHT_IN_PIXELS``
-     - [integer]
+     - [numeric: integer]
      - The number of rows in the output raster layer
    * - **Total pixel count**
      - ``TOTAL_PIXEL_COUNT``
-     - [integer]
+     - [numeric: integer]
      - The count of pixels in the output raster layer
 
 Python code
@@ -1528,21 +1528,21 @@ Basic parameters
        fuzzify.
    * - **Low fuzzy membership bound**
      - ``FUZZYLOWBOUND``
-     - [number]
+     - [numeric: double]
 
-       Default: 0
+       Default: 0.0
      - Low bound of the power function
    * - **High fuzzy membership bound**
      - ``FUZZYHIGHBOUND``
-     - [number]
+     - [numeric: double]
 
-       Default: 1
+       Default: 1.0
      - High bound of the power function
    * - **High fuzzy membership bound**
      - ``FUZZYEXPONENT``
-     - [number]
+     - [numeric: double]
 
-       Default: 2
+       Default: 2.0
      - Exponent of the power function
    * - **Fuzzified raster**
      - ``OUTPUT``
@@ -1608,15 +1608,15 @@ Outputs
      - The spatial extent of the output raster layer
    * - **Width in pixels**
      - ``WIDTH_IN_PIXELS``
-     - [integer]
+     - [numeric: integer]
      - The number of columns in the output raster layer
    * - **Height in pixels**
      - ``HEIGHT_IN_PIXELS``
-     - [integer]
+     - [numeric: integer]
      - The number of rows in the output raster layer
    * - **Total pixel count**
      - ``TOTAL_PIXEL_COUNT``
-     - [integer]
+     - [numeric: integer]
      - The count of pixels in the output raster layer
 
 Python code
@@ -1671,19 +1671,18 @@ Basic parameters
      - [raster band]
 
        Default: The first band of the raster layer
-     - If the raster is multiband, choose the band that you want to
-       fuzzify.
+     - If the raster is multiband, choose the band that you want to fuzzify.
    * - **Function midpoint**
      - ``FUZZYMIDPOINT``
-     - [number]
+     - [numeric: double]
 
-       Default: 50
+       Default: 50.0
      - Midpoint of the small function
    * - **Function spread**
      - ``FUZZYSPREAD``
-     - [number]
+     - [numeric: double]
 
-       Default: 5
+       Default: 5.0
      - Spread of the small function
    * - **Fuzzified raster**
      - ``OUTPUT``
@@ -1749,15 +1748,15 @@ Outputs
      - The spatial extent of the output raster layer
    * - **Width in pixels**
      - ``WIDTH_IN_PIXELS``
-     - [integer]
+     - [numeric: integer]
      - The number of columns in the output raster layer
    * - **Height in pixels**
      - ``HEIGHT_IN_PIXELS``
-     - [integer]
+     - [numeric: integer]
      - The number of rows in the output raster layer
    * - **Total pixel count**
      - ``TOTAL_PIXEL_COUNT``
-     - [integer]
+     - [numeric: integer]
      - The count of pixels in the output raster layer
 
 Python code
@@ -1893,7 +1892,7 @@ Advanced parameters
      - Description
    * - **Output NoData value**
      - ``OUTPUT_NODATA_VALUE``
-     - [number]
+     - [numeric: double]
 
        Default: -9999.0
      - Value to use for NoData in the output layer
@@ -1938,15 +1937,15 @@ Outputs
      - The spatial extent of the output raster layer
    * - **Width in pixels**
      - ``WIDTH_IN_PIXELS``
-     - [integer]
+     - [numeric: integer]
      - The number of columns in the output raster layer
    * - **Height in pixels**
      - ``HEIGHT_IN_PIXELS``
-     - [integer]
+     - [numeric: integer]
      - The number of rows in the output raster layer
    * - **Total pixel count**
      - ``TOTAL_PIXEL_COUNT``
-     - [integer]
+     - [numeric: integer]
      - The count of pixels in the output raster layer
 
 .. **endpositionparams**
@@ -2120,7 +2119,7 @@ Advanced parameters
      - Description
    * - **Output NoData value**
      - ``NO_DATA``
-     - [number]
+     - [numeric: double]
 
        Default: -9999.0
      - Value to use for NoData in the output layer
@@ -2173,27 +2172,27 @@ Outputs
      - The coordinate reference system of the output raster layer
    * - **Width in pixels**
      - ``WIDTH_IN_PIXELS``
-     - [integer]
+     - [numeric: integer]
      - The number of columns in the output raster layer
    * - **Height in pixels**
      - ``HEIGHT_IN_PIXELS``
-     - [integer]
+     - [numeric: integer]
      - The number of rows in the output raster layer
    * - **Total pixel count**
      - ``TOTAL_PIXEL_COUNT``
-     - [integer]
+     - [numeric: integer]
      - The count of pixels in the output raster layer
    * - **NoData pixel count**
      - ``NODATA_PIXEL_COUNT``
-     - [integer]
+     - [numeric: integer]
      - The count of NoData pixels in the output raster layer
    * - **True pixel count**
      - ``TRUE_PIXEL_COUNT``
-     - [integer]
+     - [numeric: integer]
      - The count of True pixels (value = 1) in the output raster layer
    * - **False pixel count**
      - ``FALSE_PIXEL_COUNT``
-     - [integer]
+     - [numeric: integer]
      - The count of False pixels (value = 0) in the output raster
        layer
    * - **Output layer**
@@ -2290,7 +2289,7 @@ Advanced parameters
      - Description
    * - **Output NoData value**
      - ``NO_DATA``
-     - [number]
+     - [numeric: double]
 
        Default: -9999.0
      - Value to use for NoData in the output layer
@@ -2343,27 +2342,27 @@ Outputs
      - The coordinate reference system of the output raster layer
    * - **Width in pixels**
      - ``WIDTH_IN_PIXELS``
-     - [integer]
+     - [numeric: integer]
      - The number of columns in the output raster layer
    * - **Height in pixels**
      - ``HEIGHT_IN_PIXELS``
-     - [integer]
+     - [numeric: integer]
      - The number of rows in the output raster layer
    * - **Total pixel count**
      - ``TOTAL_PIXEL_COUNT``
-     - [integer]
+     - [numeric: integer]
      - The count of pixels in the output raster layer
    * - **NoData pixel count**
      - ``NODATA_PIXEL_COUNT``
-     - [integer]
+     - [numeric: integer]
      - The count of NoData pixels in the output raster layer
    * - **True pixel count**
      - ``TRUE_PIXEL_COUNT``
-     - [integer]
+     - [numeric: integer]
      - The count of True pixels (value = 1) in the output raster layer
    * - **False pixel count**
      - ``FALSE_PIXEL_COUNT``
-     - [integer]
+     - [numeric: integer]
      - The count of False pixels (value = 0) in the output raster layer
    * - **Output layer**
      - ``OUTPUT``
@@ -2440,7 +2439,7 @@ Parameters
 
        Optional
      - ``CELLSIZE``
-     - [number]
+     - [numeric: double]
      - Cell size of the output raster layer.
        If the cell size is not specified, the minimum cell size of
        the selected reference layer(s) will be used.
@@ -2547,7 +2546,7 @@ Parameters
 
        Optional
      - ``CELLSIZE``
-     - [number]
+     - [numeric: double]
      - Cell size of the output raster layer.
        If the cell size is not specified, the minimum cell size of
        the selected reference layer(s) will be used.
@@ -2645,7 +2644,7 @@ Outputs
      - Description
    * - **Number of bands in raster**
      - ``BAND_COUNT``
-     - [number]
+     - [numeric: integer]
      - The number of bands in the raster
    * - **CRS authority identifier**
      - ``CRS_AUTHID``
@@ -2662,39 +2661,39 @@ Outputs
        in the selected band
    * - **Height in pixels**
      - ``HEIGHT_IN_PIXELS``
-     - [integer]
+     - [numeric: integer]
      - The number of columns in the raster layer
    * - **Band NoData value**
      - ``NODATA_VALUE``
-     - [number]
+     - [numeric: double]
      - The value (if set) of the NoData pixels in the selected band
    * - **Pixel size (height) in map units**
      - ``PIXEL_HEIGHT``
-     - [integer]
+     - [numeric: integer]
      - Vertical size in map units of the pixel
    * - **Pixel size (width) in map units**
      - ``PIXEL_WIDTH``
-     - [integer]
+     - [numeric: integer]
      - Horizontal size in map units of the pixel
    * - **Width in pixels**
      - ``WIDTH_IN_PIXELS``
-     - [integer]
+     - [numeric: integer]
      - The number of rows in the raster layer
    * - **Maximum x-coordinate**
      - ``X_MAX``
-     - [number]
+     - [numeric: double]
      -
    * - **Minimum x-coordinate**
      - ``X_MIN``
-     - [number]
+     - [numeric: double]
      -
    * - **Maximum y-coordinate**
      - ``Y_MAX``
-     - [number]
+     - [numeric: double]
      -
    * - **Minimum y-coordinate**
      - ``Y_MIN``
-     - [number]
+     - [numeric: double]
      -
 
 Python code
@@ -2763,15 +2762,15 @@ Outputs
      - Description
    * - **Maximum value**
      - ``MAX``
-     - [number]
+     - [numeric: double]
      -
    * - **Mean value**
      - ``MEAN``
-     - [number]
+     - [numeric: double]
      -
    * - **Minimum value**
      - ``MIN``
-     - [number]
+     - [numeric: double]
      -
    * - **Statistics**
      - ``OUTPUT_HTML_FILE``
@@ -2790,19 +2789,19 @@ Outputs
 
    * - **Range**
      - ``RANGE``
-     - [number]
+     - [numeric: double]
      -
    * - **Standard deviation**
      - ``STD_DEV``
-     - [number]
+     - [numeric: double]
      -
    * - **Sum**
      - ``SUM``
-     - [number]
+     - [numeric: double]
      -
    * - **Sum of the squares**
      - ``SUM_OF_SQUARES``
-     - [number]
+     - [numeric: double]
      -
 
 Python code
@@ -2858,7 +2857,7 @@ Parameters
 
    * - **Unique values table**
      - ``OUTPUT_TABLE``
-     - [table]
+     - [vector: table]
 
        Default: ``[Skip output]``
      - Specification of the table for unique values:
@@ -2889,15 +2888,15 @@ Outputs
      - The spatial extent of the output raster layer
    * - **Height in pixels**
      - ``HEIGHT_IN_PIXELS``
-     - [integer]
+     - [numeric: integer]
      - The number of rows in the output raster layer
    * - **NoData pixel count**
      - ``NODATA_PIXEL_COUNT``
-     - [number]
+     - [numeric: integer]
      - The number of NoData pixels in the output raster layer
    * - **Total pixel count**
      - ``TOTAL_PIXEL_COUNT``
-     - [integer]
+     - [numeric: integer]
      - The count of pixels in the output raster layer
    * - **Unique values report**
      - ``OUTPUT_HTML_FILE``
@@ -2913,7 +2912,7 @@ Outputs
        * NoData pixel count: count of pixels with NoData value
    * - **Unique values table**
      - ``OUTPUT_TABLE``
-     - [table]
+     - [vector: table]
      - A table with three columns:
 
        * *value*: pixel value
@@ -2924,7 +2923,7 @@ Outputs
 
    * - **Width in pixels**
      - ``WIDTH_IN_PIXELS``
-     - [integer]
+     - [numeric: integer]
      - The number of columns in the output raster layer
 
 Python code
@@ -2987,7 +2986,7 @@ Basic parameters
        the zones
    * - **Statistics**
      - ``OUTPUT_TABLE``
-     - [table]
+     - [vector: table]
 
        Default: ``[Create temporary layer]``
      - Specification of the output report. One of:
@@ -3046,15 +3045,15 @@ Outputs
      - The spatial extent of the output raster layer
    * - **Height in pixels**
      - ``HEIGHT_IN_PIXELS``
-     - [integer]
+     - [numeric: integer]
      - The number of rows in the output raster layer
    * - **NoData pixel count**
      - ``NODATA_PIXEL_COUNT``
-     - [number]
+     - [numeric: integer]
      - The number of NoData pixels in the output raster layer
    * - **Statistics**
      - ``OUTPUT_TABLE``
-     - [table]
+     - [vector: table]
      - The output layer contains the following information
        **for each zone**:
 
@@ -3066,11 +3065,11 @@ Outputs
        * Mean: the mean of the pixel values in the zone;
    * - **Total pixel count**
      - ``TOTAL_PIXEL_COUNT``
-     - [number]
+     - [numeric: integer]
      - The count of pixels in the output raster layer
    * - **Width in pixels**
      - ``WIDTH_IN_PIXELS``
-     - [number]
+     - [numeric: integer]
      - The number of columns in the output raster layer
 
 Python code
@@ -3191,7 +3190,7 @@ Parameters
        the surface.
    * - **Base level**
      - ``LEVEL``
-     - [number]
+     - [numeric: double]
 
        Default: 0.0
      - Define a base or reference value.
@@ -3232,7 +3231,7 @@ Parameters
 
    * - **Surface volume table**
      - ``OUTPUT_TABLE``
-     - [table]
+     - [vector: table]
 
        Default: ``[Skip output]``
      - Specification of the output table. One of:
@@ -3254,15 +3253,15 @@ Outputs
      - Description
    * - **Volume**
      - ``VOLUME``
-     - [number]
+     - [numeric: double]
      - The calculated volume
    * - **Area**
      - ``AREA``
-     - [number]
+     - [numeric: double]
      - The area in square map units
    * - **Pixel_count**
      - ``PIXEL_COUNT``
-     - [number]
+     - [numeric: integer]
      - The total number of pixels that have been analyzed
    * - **Surface volume report**
      - ``OUTPUT_HTML_FILE``
@@ -3271,7 +3270,7 @@ Outputs
        pixel count) in HTML format
    * - **Surface volume table**
      - ``OUTPUT_TABLE``
-     - [table]
+     - [vector: table]
      - The output table (containing volume, area and
        pixel count)
 
@@ -3336,8 +3335,8 @@ Basic parameters
      - ``VALUE_FIELD``
      - [tablefield: numeric]
      - Field with the value that will be assigned to the pixels that
-       fall in the class (between the corresponding min and max
-       values). Use ``nan`` to set the value of the range to NoData. 
+       fall in the class (between the corresponding min and max values).
+       Use ``nan`` to set the value of the range to NoData.
    * - **Reclassified raster**
      - ``OUTPUT``
      - [raster]
@@ -3363,7 +3362,7 @@ Advanced parameters
      - Description
    * - **Output NoData value**
      - ``NO_DATA``
-     - [number]
+     - [numeric: double]
 
        Default: -9999.0
      - Value to apply to NoData values.
@@ -3384,8 +3383,7 @@ Advanced parameters
      - [boolean]
 
        Default: False
-     - Applies the NoData value to band values that do not fall in
-       any class.
+     - Applies the NoData value to band values that do not fall in any class.
        If False, the original value is kept.
    * - **Output data type**
      - ``DATA_TYPE``
@@ -3475,7 +3473,7 @@ Basic parameters
      - Raster band for which you want to recalculate values.
    * - **Reclassification table**
      - ``TABLE``
-     - [table]
+     - [vector: table]
      - A 3-columns table to fill with the values to set the boundaries
        of each class (``Minimum`` and ``Maximum``) and the new
        ``Value`` to assign to the band values that fall in the class.
@@ -3507,7 +3505,7 @@ Advanced parameters
      - Description
    * - **Output NoData value**
      - ``NO_DATA``
-     - [number]
+     - [numeric: double]
 
        Default: -9999.0
      - Value to apply to NoData values.
@@ -3629,13 +3627,13 @@ Basic parameters
      - If the raster is multiband, choose a band.
    * - **New minimum value**
      - ``MINIMUM``
-     - [number]
+     - [numeric: double]
 
        Default value: 0.0
      - Minimum pixel value to use in the rescaled layer
    * - **New maximum value**
      - ``MAXIMUM``
-     - [number]
+     - [numeric: double]
 
        Default value: 255.0
      - Maximum pixel value to use in the rescaled layer
@@ -3643,7 +3641,7 @@ Basic parameters
    
        Optional
      - ``NODATA``
-     - [number]
+     - [numeric: double]
      
        Default value: Not set
      - Value to assign to the NoData pixels.
@@ -3759,7 +3757,7 @@ Basic parameters
      - The raster to process.
    * - **Band number**
      - ``BAND``
-     - [number]
+     - [raster band]
 
        Default: 1
      - The band of the raster
@@ -3775,7 +3773,7 @@ Basic parameters
        * 2 --- Round down
    * - **Number of decimals places**
      - ``DECIMAL_PLACES``
-     - [number]
+     - [numeric: integer]
 
        Default: 2
      - Number of decimals places to round to.
@@ -3805,7 +3803,7 @@ Advanced parameters
      - Description
    * - **Base n for rounding to multiples of n**
      - ``BASE_N``
-     - [number]
+     - [numeric: integer]
 
        Default: 10
      - When the ``DECIMAL_PLACES`` parameter is negative,
@@ -3876,7 +3874,7 @@ Parameters
    * - **Input Layer**
      - ``INPUT``
      - [vector: point]
-     - Point vector layer to use for  sampling
+     - Point vector layer to use for sampling
    * - **Raster Layer**
      - ``RASTERCOPY``
      - [raster]

--- a/docs/user_manual/processing_algs/qgis/rastercreation.rst
+++ b/docs/user_manual/processing_algs/qgis/rastercreation.rst
@@ -52,15 +52,15 @@ Basic parameters
      - CRS for the output raster layer
    * - **Pixel size**
      - ``PIXEL_SIZE``
-     - [number]
+     - [numeric: double]]
 
        Default: 1.0
      - Pixel size (X=Y) in map units.
    * - **Constant value**
      - ``NUMBER``
-     - [number]
+     - [numeric: double]]
 
-       Default: 1
+       Default: 1.0
      - Constant pixel value for the output raster layer.
    * - **Constant**
      - ``OUTPUT``
@@ -187,7 +187,7 @@ Basic parameters
      - CRS for the output raster layer
    * - **Pixel size**
      - ``PIXEL_SIZE``
-     - [number]
+     - [numeric: double]]
 
        Default: 1.0
      - Pixel size (X=Y) in map units.
@@ -228,13 +228,13 @@ Advanced parameters
        * 5 --- Float64
    * - **N**
      - ``N``
-     - [number]
+     - [numeric: integer]
 
        Default: 10
      -
    * - **Probability**
      - ``PROBABILITY``
-     - [number]
+     - [numeric: double]]
 
        Default: 0.5
      -
@@ -326,7 +326,7 @@ Basic parameters
      - CRS for the output raster layer
    * - **Pixel size**
      - ``PIXEL_SIZE``
-     - [number]
+     - [numeric: double]]
 
        Default: 1.0
      - Pixel size (X=Y) in map units.
@@ -363,7 +363,7 @@ Advanced parameters
        * 1 --- Float64
    * - **Lambda**
      - ``LAMBDA``
-     - [number]
+     - [numeric: double]]
 
        Default: 1.0
      -
@@ -455,7 +455,7 @@ Basic parameters
      - CRS for the output raster layer
    * - **Pixel size**
      - ``PIXEL_SIZE``
-     - [number]
+     - [numeric: double]]
 
        Default: 1.0
      - Pixel size (X=Y) in map units.
@@ -492,13 +492,13 @@ Advanced parameters
        * 1 --- Float64
    * - **Alpha**
      - ``ALPHA``
-     - [number]
+     - [numeric: double]]
 
        Default: 1.0
      -
    * - **Beta**
      - ``BETA``
-     - [number]
+     - [numeric: double]]
 
        Default: 1.0
      -
@@ -591,7 +591,7 @@ Basic parameters
      - CRS for the output raster layer
    * - **Pixel size**
      - ``PIXEL_SIZE``
-     - [number]
+     - [numeric: double]]
 
        Default: 1.0
      - Pixel size (X=Y) in map units.
@@ -632,7 +632,7 @@ Advanced parameters
        * 5 --- Float64
    * - **Probability**
      - ``PROBABILITY``
-     - [number]
+     - [numeric: double]]
 
        Default: 0.5
      -
@@ -725,7 +725,7 @@ Basic parameters
      - CRS for the output raster layer
    * - **Pixel size**
      - ``PIXEL_SIZE``
-     - [number]
+     - [numeric: double]]
 
        Default: 1.0
      - Pixel size (X=Y) in map units.
@@ -766,13 +766,13 @@ Advanced parameters
        * 5 --- Float64
    * - **Distribution parameter k**
      - ``K_PARAMETER``
-     - [number]
+     - [numeric: integer]
 
        Default: 10
      -
    * - **Probability**
      - ``PROBABILITY``
-     - [number]
+     - [numeric: double]]
 
        Default: 0.5
      -
@@ -864,7 +864,7 @@ Basic parameters
      - CRS for the output raster layer
    * - **Pixel size**
      - ``PIXEL_SIZE``
-     - [number]
+     - [numeric: double]]
 
        Default: 1.0
      - Pixel size (X=Y) in map units.
@@ -901,13 +901,13 @@ Advanced parameters
        * 1 --- Float64
    * - **Mean of normal distribution**
      - ``MEAN``
-     - [number]
+     - [numeric: double]]
 
        Default: 0.0
      -
    * - **Standard deviation of normal distribution**
      - ``STDDEV``
-     - [number]
+     - [numeric: double]]
 
        Default: 1.0
      -
@@ -1000,7 +1000,7 @@ Basic parameters
      - CRS for the output raster layer
    * - **Pixel size**
      - ``PIXEL_SIZE``
-     - [number]
+     - [numeric: double]]
 
        Default: 1.0
      - Pixel size (X=Y) in map units.
@@ -1041,7 +1041,7 @@ Advanced parameters
        * 5 --- Float64
    * - **Mean**
      - ``MEAN``
-     - [number]
+     - [numeric: double]]
 
        Default: 1.0
      -
@@ -1135,7 +1135,7 @@ Basic parameters
      - CRS for the output raster layer
    * - **Pixel size**
      - ``PIXEL_SIZE``
-     - [number]
+     - [numeric: double]]
 
        Default: 1.0
      - Pixel size (X=Y) in map units.
@@ -1177,13 +1177,13 @@ Advanced parameters
        * 6 --- Float64
    * - **Lower bound for random number range**
      - ``LOWER_BOUND``
-     - [number]
+     - [numeric: double]]
 
        Default: 0.0
      -
    * - **Upper bound for random number range**
      - ``UPPER_BOUND``
-     - [number]
+     - [numeric: double]]
 
        Default: 0.0
      -

--- a/docs/user_manual/processing_algs/qgis/rasterterrainanalysis.rst
+++ b/docs/user_manual/processing_algs/qgis/rasterterrainanalysis.rst
@@ -48,7 +48,7 @@ Parameters
      - Digital Terrain Model raster layer
    * - **Z factor**
      - ``Z_FACTOR``
-     - [number]
+     - [numeric: double]
 
        Default: 1.0
      - Vertical exaggeration.       
@@ -137,20 +137,20 @@ Basic parameters
      - Digital Terrain Model raster layer
    * - **Band number**
      - ``BAND``
-     - [number] [list]
+     - [raster band]
      - The band of the DEM to consider
    * - **Kernel radius (pixels)**
      - ``RADIUS``
-     - [number]
+     - [numeric: integer]
 
        Default: 5
      - The radius of the filter kernel (in pixels).
        Must be large enough to reach ground cells next to non-ground objects.
    * - **Terrain slope (%, pixel size/vertical units)**
      - ``TERRAIN_SLOPE``
-     - [number]
+     - [numeric: double]
 
-       Default: 30
+       Default: 30.0
      - The approximate terrain slope in ``%``.
        The terrain slope must be adjusted to account for the ratio of height units vs raster pixel dimensions.
        Used to relax the filter criterium in steeper terrain.
@@ -167,7 +167,7 @@ Basic parameters
        * 2 - Amplify
    * - **Standard deviation**
      - ``STANDARD_DEVIATION``
-     - [number]
+     - [numeric: double]
 
        Default: 0.1
      - The standard deviation used to calculate a 5% confidence interval applied to the height threshold.
@@ -309,7 +309,7 @@ Parameters
      - Digital Terrain Model raster layer
    * - **Z factor**
      - ``Z_FACTOR``
-     - [number]
+     - [numeric: double]
 
        Default: 1.0
      - Vertical exaggeration.       
@@ -321,14 +321,14 @@ Parameters
        The default is 1 (no exaggeration).
    * - **Azimuth (horizontal angle)**
      - ``AZIMUTH``
-     - [number]
+     - [numeric: double]
 
        Default: 300.0
      - Set the horizontal angle (in degrees) of the sun (clockwise
        direction). Range: 0 to 360. 0 is north.
    * - **Vertical angle**
      - ``V_ANGLE``
-     - [number]
+     - [numeric: double]
 
        Default: 40.0
      - Set the vertical angle (in degrees) of the sun, that is the
@@ -410,7 +410,7 @@ Parameters
        to calculate hypsometric curves
    * - **Step**
      - ``STEP``
-     - [number]
+     - [numeric: double]
 
        Default: 100.0
      - Vertical distance between curves
@@ -498,7 +498,7 @@ Parameters
      - Digital Terrain Model raster layer
    * - **Z factor**
      - ``Z_FACTOR``
-     - [number]
+     - [numeric: double]
 
        Default: 1.0
      - Vertical exaggeration.       
@@ -552,7 +552,7 @@ Parameters
 
        Optional
      - ``FREQUENCY_DISTRIBUTION``
-     - [table]
+     - [vector: table]
        
        Default: ``[Skip output]``
      - Specify the CSV table for the output frequency distribution.
@@ -579,7 +579,7 @@ Outputs
      - The output relief raster layer
    * - **Frequency distribution**
      - ``OUTPUT``
-     - [table]
+     - [vector: table]
      - The output frequency distribution
 
 Python code
@@ -626,7 +626,7 @@ Parameters
      - Digital Terrain Model raster layer
    * - **Z factor**
      - ``Z_FACTOR``
-     - [number]
+     - [numeric: double]
 
        Default: 1.0
      - Vertical exaggeration.       
@@ -702,7 +702,7 @@ Parameters
      - Digital Terrain Model raster layer
    * - **Z factor**
      - ``Z_FACTOR``
-     - [number]
+     - [numeric: double]
 
        Default: 1.0
      - Vertical exaggeration.       

--- a/docs/user_manual/processing_algs/qgis/rastertools.rst
+++ b/docs/user_manual/processing_algs/qgis/rastertools.rst
@@ -68,25 +68,25 @@ Parameters
 
        Optional
      - ``CELL_SIZE_X``
-     - [number]
+     - [numeric: double]
      - Cell size in X direction to be used instead of the reference layer's
    * - **Override reference cell size Y**
 
        Optional
      - ``CELL_SIZE_Y``
-     - [number]
+     - [numeric: double]
      -  Cell size in Y direction to be used instead of the reference layer's
    * - **Override reference grid offset X**
 
        Optional
      - ``GRID_OFFSET_X``
-     - [number]
+     - [numeric: double]
      -  Offset in X direction to apply to cells grid
    * - **Override reference grid offset Y**
 
        Optional
      - ``GRID_OFFSET_Y``
-     - [number]
+     - [numeric: double]
      - Offset in Y direction to apply to cells grid
    * - **Clip to extent**
 
@@ -194,25 +194,25 @@ Parameters
 
        Optional
      - ``CELL_SIZE_X``
-     - [number]
+     - [numeric: double]
      - Cell size in X direction to be used instead of the reference layer's
    * - **Override reference cell size Y**
 
        Optional
      - ``CELL_SIZE_Y``
-     - [number]
+     - [numeric: double]
      -  Cell size in Y direction to be used instead of the reference layer's
    * - **Override reference grid offset X**
 
        Optional
      - ``GRID_OFFSET_X``
-     - [number]
+     - [numeric: double]
      -  Offset in X direction to apply to cells grid
    * - **Override reference grid offset Y**
 
        Optional
      - ``GRID_OFFSET_Y``
-     - [number]
+     - [numeric: double]
      - Offset in Y direction to apply to cells grid
    * - **Clip to extent**
 
@@ -292,32 +292,32 @@ Parameters
 
    * - **Tile size**
      - ``TILE_SIZE``
-     - [number]
-       
+     - [numeric: integer]
+
        Default: 1024
      - Size of the tile of the output raster layer. Minimum value: 64.
    * - **Map units per pixel**
      - ``MAP_UNITS_PER_PIXEL``
-     - [number]
+     - [numeric: double]
        
        Default: 100.0
      - Pixel size (in map units). Minimum value: 0.0
    * - **Make background transparent**
      - ``MAKE_BACKGROUND_TRANSPARENT``
      - [boolean]
-        
+
        Default: False
      - Allows exporting the map with a transparent background.
        Outputs an RGBA (instead of RGB) image if set to ``True``.
    * - **Map theme to render**
-       
+
        Optional
      - ``MAP_THEME``
      - [enumeration]
      - Use an existing :ref:`map theme <map_themes>` for the
        rendering.
    * - **Single layer to render**
-       
+
        Optional
      - ``LAYER``
      - [enumeration]
@@ -348,7 +348,7 @@ Outputs
      - ``OUTPUT``
      - [raster]
      - Output raster layer
-  
+
 Python code
 ...........
 
@@ -395,13 +395,13 @@ Basic parameters
      - The raster to process.
    * - **Band number**
      - ``BAND``
-     - [number]
+     - [raster band]
 
        Default: 1
      - The band of the raster
    * - **Fill value**
      - ``FILL_VALUE``
-     - [number]
+     - [numeric: double]
 
        Default: 1.0
      - Set the value to use for the NoData pixels
@@ -508,19 +508,19 @@ Basic parameters
 
    * - **Minimum zoom**
      - ``ZOOM_MIN``
-     - [number]
+     - [numeric: integer]
 
        Default: 12
      - Minimum 0, maximum 25.
    * - **Maximum zoom**
      - ``ZOOM_MAX``
-     - [number]
+     - [numeric: integer]
 
        Default: 12
      - Minimum 0, maximum 25.
    * - **DPI**
      - ``DPI``
-     - [number]
+     - [numeric: integer]
 
        Default: 96
      - Minimum 48, maximum 600.
@@ -552,7 +552,7 @@ Basic parameters
 
        Optional
      - ``QUALITY``
-     - [number]
+     - [numeric: integer]
 
        Default: 75
      - Minimum 1, maximum 100.
@@ -560,7 +560,7 @@ Basic parameters
 
        Optional
      - ``METATILESIZE``
-     - [number]
+     - [numeric: integer]
 
        Default: 4
      - Specify a custom metatile size when generating XYZ tiles.
@@ -572,7 +572,7 @@ Basic parameters
 
        Optional
      - ``TILE_WIDTH``
-     - [number]
+     - [numeric: integer]
 
        Default: 256
      - Minimum 1, maximum 4096.
@@ -580,7 +580,7 @@ Basic parameters
 
        Optional
      - ``TILE_HEIGHT``
-     - [number]
+     - [numeric: integer]
 
        Default: 256
      - Minimum 1, maximum 4096.
@@ -591,8 +591,6 @@ Basic parameters
        Default: False
      - 
    * - **Output directory**
-
-       Optional
      - ``OUTPUT_DIRECTORY``
      - [folder]
 
@@ -716,19 +714,19 @@ Parameters
 
    * - **Minimum zoom**
      - ``ZOOM_MIN``
-     - [number]
+     - [numeric: integer]
 
        Default: 12
      - Minimum 0, maximum 25.
    * - **Maximum zoom**
      - ``ZOOM_MAX``
-     - [number]
+     - [numeric: integer]
 
        Default: 12
      - Minimum 0, maximum 25.
    * - **DPI**
      - ``DPI``
-     - [number]
+     - [numeric: integer]
 
        Default: 96
      - Minimum 48, maximum 600.
@@ -760,7 +758,7 @@ Parameters
 
        Optional
      - ``QUALITY``
-     - [number]
+     - [numeric: integer]
 
        Default: 75
      - Minimum 1, maximum 100.
@@ -768,7 +766,7 @@ Parameters
 
        Optional
      - ``METATILESIZE``
-     - [number]
+     - [numeric: integer]
 
        Default: 4
      - Specify a custom metatile size when generating XYZ tiles.

--- a/docs/user_manual/processing_algs/qgis/vectoranalysis.rst
+++ b/docs/user_manual/processing_algs/qgis/vectoranalysis.rst
@@ -46,7 +46,7 @@ Parameters
 
        Optional
      - ``OUTPUT``
-     - [table]
+     - [vector: table]
 
        Default: ``[Create temporary layer]``
      - Specify the output table for the generated statistics. One of:
@@ -82,7 +82,7 @@ Outputs
      - Description
    * - **Statistics**
      - ``OUTPUT``
-     - [table]
+     - [vector: table]
      - Table containing the calculated statistics
    * - **Statistics report**
      - ``OUTPUT_HTML_FILE``
@@ -90,19 +90,19 @@ Outputs
      - HTML file with the calculated statistics
    * - **Count**
      - ``COUNT``
-     - [number]
+     - [numeric: integer]
      -
    * - **Number of unique values**
      - ``UNIQUE``
-     - [number]
+     - [numeric: integer]
      -
    * - **Number of empty (null) values**
      - ``EMPTY``
-     - [number]
+     - [numeric: integer]
      -
    * - **Number of non-empty values**
      - ``FILLED``
-     - [number]
+     - [numeric: integer]
      -
    * - **Minimum value**
      - ``MIN``
@@ -114,39 +114,39 @@ Outputs
      -
    * - **Minimum length**
      - ``MIN_LENGTH``
-     - [number]
+     - [numeric: integer]
      -
    * - **Maximum length**
      - ``MAX_LENGTH``
-     - [number]
+     - [numeric: integer]
      -
    * - **Mean length**
      - ``MEAN_LENGTH``
-     - [number]
+     - [numeric: double]
      -
    * - **Coefficient of Variation**
      - ``CV``
-     - [number]
+     - [numeric: double]
      -
    * - **Sum**
      - ``SUM``
-     - [number]
+     - [numeric: double]
      -
    * - **Mean value**
      - ``MEAN``
-     - [number]
+     - [numeric: double]
      -
    * - **Standard deviation**
      - ``STD_DEV``
-     - [number]
+     - [numeric: double]
      -
    * - **Range**
      - ``RANGE``
-     - [number]
+     - [numeric: double]
      -
    * - **Median**
      - ``MEDIAN``
-     - [number]
+     - [numeric: double]
      -
    * - **Minority (rarest occurring value)**
      - ``MINORITY``
@@ -158,15 +158,15 @@ Outputs
      -
    * - **First quartile**
      - ``FIRSTQUARTILE``
-     - [number]
+     - [numeric: double]
      -
    * - **Third quartile**
      - ``THIRDQUARTILE``
-     - [number]
+     - [numeric: double]
      -
    * - **Interquartile Range (IQR)**
      - ``IQR``
-     - [number]
+     - [numeric: double]
      -
 
 Python code
@@ -241,24 +241,22 @@ Outputs
        results from climb calculations.
    * - **Total climb**
      - ``TOTALCLIMB``
-     - [number]
+     - [numeric: double]
      - The sum of the climb for all the line geometries
        in the input layer
    * - **Total descent**
      - ``TOTALDESCENT``
-     - [number]
+     - [numeric: double]
      - The sum of the descent for all the line geometries
        in the input layer
    * - **Minimum elevation**
      - ``MINELEVATION``
-     - [number]
-     - The minimum elevation for the geometries in the
-       layer
+     - [numeric: double]
+     - The minimum elevation for the geometries in the layer
    * - **Maximum elevation**
      - ``MAXELEVATION``
-     - [number]
-     - The maximum elevation for the geometries in the
-       layer
+     - [numeric: double]
+     - The maximum elevation for the geometries in the layer
 
 Python code
 ...........
@@ -414,13 +412,13 @@ Basic parameters
      - Layer to analyze
    * - **Minimum cluster size**
      - ``MIN_SIZE``
-     - [number]
+     - [numeric: integer]
 
        Default: 5
      - Minimum number of features to generate a cluster
    * - **Maximum distance between clustered points**
      - ``EPS``
-     - [number]
+     - [numeric: double]
 
        Default: 1.0
      - Distance beyond which two features can not belong
@@ -489,7 +487,7 @@ Outputs
        field setting the cluster they belong to
    * - **Number of clusters**
      - ``NUM_CLUSTERS``
-     - [number]
+     - [numeric: integer]
      - The number of clusters discovered
 
 Python code
@@ -565,7 +563,7 @@ Parameters
          the distances to its target points.
    * - **Use only the nearest (k) target points**
      - ``NEAREST_POINTS``
-     - [number]
+     - [numeric: integer]
 
        Default: 0
      - You can choose to calculate the distance to all the
@@ -644,11 +642,11 @@ Parameters
      - Description
    * - **Source points layer**
      - ``INPUT``
-     - [vector: any]
+     - [vector: geometry]
      - Vector layer for which the nearest feature is searched
    * - **Destination hubs layer**
      - ``HUBS``
-     - [vector: any]
+     - [vector: geometry]
      - Vector layer containing the features to search for
    * - **Hub layer name attribute**
      - ``FIELD``
@@ -848,7 +846,7 @@ Basic parameters
      - Description
    * - **Hub layer**
      - ``HUBS``
-     - [vector: any]
+     - [vector: geometry]
      - Input layer
    * - **Hub ID field**
      - ``HUB_FIELD``
@@ -863,7 +861,7 @@ Basic parameters
        If no field(s) are chosen all fields are taken.
    * - **Spoke layer**
      - ``SPOKES``
-     - [vector: any]
+     - [vector: geometry]
      - Additional spoke point layer
    * - **Spoke ID field**
      - ``SPOKE_FIELD``
@@ -908,7 +906,7 @@ Advanced parameters
      - Description
    * - **Distance between vertices (geodesic lines only)**
      - ``GEODESIC_DISTANCE``
-     - [number]
+     - [numeric: double]
 
        Default: 1000.0 (kilometers)
      - Distance between consecutive vertices (in kilometers).
@@ -982,17 +980,17 @@ Parameters
      - Description
    * - **Input layer**
      - ``INPUT``
-     - [vector: any]
+     - [vector: geometry]
      - Layer to analyze
    * - **Number of clusters**
      - ``CLUSTERS``
-     - [number]
+     - [numeric: integer]
 
        Default: 5
      - Number of clusters to create with the features
    * - **Clusters**
      - ``OUTPUT``
-     - [vector: any]
+     - [vector: same as input]
 
        Default:``[Create temporary layer]``
      - Specify the output vector layer for generated the clusters.
@@ -1041,7 +1039,7 @@ Outputs
      - Description
    * - **Clusters**
      - ``OUTPUT``
-     - [vector: any]
+     - [vector: same as input]
      - Vector layer containing the original features with
        fields specifying the cluster they belong to and their number in it
 
@@ -1059,8 +1057,7 @@ Python code
 
 List unique values
 ------------------
-Lists unique values of an attribute table field and counts their
-number.
+Lists unique values of an attribute table field and counts their number.
 
 **Default menu**: :menuselection:`Vector --> Analysis Tools`
 
@@ -1081,13 +1078,13 @@ Parameters
      - Layer to analyze
    * - **Target field(s)**
      - ``FIELDS``
-     - [tablefield: any]
-     - Field to analyze
+     - [tablefield: any] [list]
+     - Field(s) to analyze
    * - **Unique values**
 
        Optional
      - ``OUTPUT``
-     - [table]
+     - [vector: table]
 
        Default:``[Create temporary layer]``
      - Specify the summary table layer with unique values. One of:
@@ -1123,7 +1120,7 @@ Outputs
      - Description
    * - **Unique values**
      - ``OUTPUT``
-     - [table]
+     - [vector: table]
      - Summary table layer with unique values
    * - **HTML report**
      - ``OUTPUT_HTML_FILE``
@@ -1132,7 +1129,7 @@ Outputs
        :menuselection:`Processing --> Results viewer`
    * - **Total unique values**
      - ``TOTAL_VALUES``
-     - [number]
+     - [numeric: integer]
      - The number of unique values in the input field
    * - **Unique values concatenated**
      - ``UNIQUE_VALUES``
@@ -1181,7 +1178,7 @@ Parameters
      - Description
    * - **Input layer**
      - ``INPUT``
-     - [vector: any]
+     - [vector: geometry]
      - Input vector layer
    * - **Weight field**
 
@@ -1191,7 +1188,7 @@ Parameters
      - Field to use if you want to perform a weighted mean
    * - **Unique ID field**
      - ``UID``
-     - [tablefield: numeric]
+     - [tablefield: any]
      - Unique field on which the calculation of the mean will
        be made
    * - **Mean coordinates**
@@ -1305,23 +1302,23 @@ Outputs
      - HTML file with the computed statistics
    * - **Observed mean distance**
      - ``OBSERVED_MD``
-     - [number]
+     - [numeric: double]
      - Observed mean distance
    * - **Expected mean distance**
      - ``EXPECTED_MD``
-     - [number]
+     - [numeric: double]
      - Expected mean distance
    * - **Nearest neighbour index**
      - ``NN_INDEX``
-     - [number]
+     - [numeric: integer]
      - Nearest neighbour index
    * - **Number of points**
      - ``POINT_COUNT``
-     - [number]
+     - [numeric: integer]
      - Number of points
    * - **Z-Score**
      - ``Z_SCORE``
-     - [number]
+     - [numeric: double]
      - Z-Score
 
 Python code
@@ -1362,11 +1359,11 @@ Basic parameters
      - Description
    * - **Input layer**
      - ``INPUT``
-     - [vector: any]
+     - [vector: polygon]
      - The input layer.
-   * - **Overlap layers**
+   * - **Overlay layers**
      - ``LAYERS``
-     - [vector: any] [list]
+     - [vector: polygon] [list]
      - The overlay layers.
    * - **Overlap**
      - ``OUTPUT``
@@ -1395,7 +1392,7 @@ Advanced parameters
 
        Optional
      - ``GRID_SIZE``
-     - [number]
+     - [numeric: double]
 
        Default: Not set
      - If provided, the input geometries are snapped to a grid of the given size,
@@ -1462,11 +1459,11 @@ Parameters
      - Description
    * - **Source layer**
      - ``SOURCE``
-     - [vector: any]
+     - [vector: geometry]
      - Origin layer for which to search for nearest neighbors
    * - **Destination layer**
      - ``DESTINATION``
-     - [vector: any]
+     - [vector: geometry]
      - Target Layer in which to search for nearest neighbors
    * - **Method**
      - ``METHOD``
@@ -1481,7 +1478,7 @@ Parameters
 
    * - **Maximum number of neighbors**
      - ``NEIGHBORS``
-     - [number]
+     - [numeric: integer]
 
        Default: 1
      - Maximum number of neighbors to look for
@@ -1489,7 +1486,7 @@ Parameters
 
        Optional
      - ``DISTANCE``
-     - [number]
+     - [numeric: double]
      - Only destination features which are closer than this distance
        will be considered.
    * - **Shortest lines**
@@ -1566,20 +1563,20 @@ Basic parameters
      - Field containing the temporal information
    * - **Minimum cluster size**
      - ``MIN_SIZE``
-     - [number]
+     - [numeric: integer]
 
        Default: 5
      - Minimum number of features to generate a cluster
    * - **Maximum distance between clustered points**
      - ``EPS``
-     - [number]
+     - [numeric: double]
 
        Default: 1.0
      - Distance beyond which two features can not belong
        to the same cluster (eps)
    * - **Maximum time duration between clustered points**
      - ``EPS2``
-     - [number]
+     - [numeric: double]
 
        Default: 0.0 (days)
      - Time duration beyond which two features can not belong
@@ -1650,7 +1647,7 @@ Outputs
        field setting the cluster they belong to
    * - **Number of clusters**
      - ``NUM_CLUSTERS``
-     - [number]
+     - [numeric: integer]
      - The number of clusters discovered
 
 Python code
@@ -1693,11 +1690,11 @@ Parameters
      - If empty only the count will be calculated
    * - **Field(s) with categories**
      - ``CATEGORIES_FIELD_NAME``
-     - [vector: any] [list]
+     - [tablefield: any] [list]
      - The fields that (combined) define the categories
    * - **Statistics by category**
      - ``OUTPUT``
-     - [table]
+     - [vector: table]
 
        Default: ``[Create temporary layer]``
      - Specify the output table for the generated statistics. One of:
@@ -1719,7 +1716,7 @@ Outputs
      - Description
    * - **Statistics by category**
      - ``OUTPUT``
-     - [table]
+     - [vector: table]
      - Table containing the statistics
 
 Depending on the type of the field being analyzed,

--- a/docs/user_manual/processing_algs/qgis/vectorcoverage.rst
+++ b/docs/user_manual/processing_algs/qgis/vectorcoverage.rst
@@ -106,13 +106,13 @@ Parameters
      - Input polygon vector layer
    * - **Tolerance**
      - ``TOLERANCE``
-     - [number]
+     - [numeric: double]
 
        Default: 0.0
      - The maximum distance (in unit of choice) between two consecutive vertices to get merged.
    * - **Preserve boundary**
      - ``PRESERVE_BOUNDARY``
-     - [number]
+     - [boolean]
 
        Default: False
      - When enabled, the outside edges of the coverage will be preserved without simplification
@@ -183,7 +183,7 @@ Parameters
      - Input polygon vector layer
    * - **Gap width**
      - ``GAP_WIDTH``
-     - [number]
+     - [numeric: double]
 
        Default: 0.0
      - The maximum width of gap to detect

--- a/docs/user_manual/processing_algs/qgis/vectorcreation.rst
+++ b/docs/user_manual/processing_algs/qgis/vectorcreation.rst
@@ -54,13 +54,13 @@ Basic parameters
      - Input line vector layer to use for the offsets.
    * - **Number of features to create**
      - ``COUNT``
-     - [number |dataDefine|]
+     - [numeric: integer] |dataDefine|
 
        Default: 10
      - Number of offset copies to generate for each feature
    * - **Offset step distance**
      - ``OFFSET``
-     - [number |dataDefine|]
+     - [numeric: double] |dataDefine|
 
        Default: 1.0
      - Distance between two consecutive offset copies
@@ -89,7 +89,7 @@ Advanced parameters
      - Description
    * - **Segments**
      - ``SEGMENTS``
-     - [number]
+     - [[numeric: double]]
 
        Default: 8
      - Number of line segments to use to approximate a quarter
@@ -113,7 +113,7 @@ Advanced parameters
           Round, miter, and bevel join styles
    * - **Miter limit**
      - ``MITER_LIMIT``
-     - [number]
+     - [numeric: double]
 
        Default: 2.0
      - Sets the maximum distance from the offset geometry to use
@@ -194,35 +194,35 @@ Parameters
      - Description
    * - **Input layer**
      - ``INPUT``
-     - [vector: any]
+     - [vector: geometry]
      - Input vector layer to translate
    * - **Number of features to create**
      - ``COUNT``
-     - [number |dataDefine|]
+     - [numeric: integer] |dataDefine|
 
        Default: 10
      - Number of copies to generate for each feature
    * - **Step distance (x-axis)**
      - ``DELTA_X``
-     - [number |dataDefine|]
+     - [numeric: double] |dataDefine|
 
        Default: 0.0
      - Displacement to apply on the X axis
    * - **Step distance (y-axis)**
      - ``DELTA_Y``
-     - [number |dataDefine|]
+     - [numeric: double] |dataDefine|
 
        Default: 0.0
      - Displacement to apply on the Y axis
    * - **Step distance (z-axis)**
      - ``DELTA_Z``
-     - [number |dataDefine|]
+     - [numeric: double] |dataDefine|
 
        Default: 0.0
      - Displacement to apply on the Z axis
    * - **Step distance (m values)**
      - ``DELTA_M``
-     - [number |dataDefine|]
+     - [numeric: double] |dataDefine|
 
        Default: 0.0
      - Displacement to apply on M
@@ -323,26 +323,26 @@ Parameters
 
    * - **Horizontal spacing**
      - ``HSPACING``
-     - [number]
+     - [numeric: double]
 
        Default: 1.0
      - Size of a grid cell on the X-axis
    * - **Vertical spacing**
      - ``VSPACING``
-     - [number]
+     - [numeric: double]
 
        Default: 1.0
      - Size of a grid cell on the Y-axis
    * - **Horizontal overlay**
      - ``HOVERLAY``
-     - [number]
+     - [numeric: double]
 
        Default: 0.0
      - Overlay distance between two consecutive grid cells on the
        X-axis
    * - **Vertical overlay**
      - ``VOVERLAY``
-     - [number]
+     - [numeric: double]
 
        Default: 0.0
      - Overlay distance between two consecutive grid cells on the
@@ -355,7 +355,7 @@ Parameters
      - Coordinate reference system to apply to the grid
    * - **Grid**
      - ``OUTPUT``
-     - [vector: any]
+     - [vector: geometry]
 
        Default: ``[Create temporary layer]``
      - Resulting vector grid layer. One of:
@@ -377,7 +377,7 @@ Outputs
      - Description
    * - **Grid**
      - ``OUTPUT``
-     - [vector: any]
+     - [vector: geometry]
      - Resulting vector grid layer. The output geometry type (point,
        line or polygon) depends on the :guilabel:`Grid type`.
        Features are created from top to bottom, left to right.
@@ -692,7 +692,7 @@ Parameters
 
        Optional
      - ``INVALID``
-     - [table]
+     - [vector: table]
 
        Default: ``[Skip output]``
      - Specify the table of unreadable or non-geotagged photos.
@@ -723,7 +723,7 @@ Outputs
 
        Optional
      - ``INVALID``
-     - [table]
+     - [vector: table]
      - Table of unreadable or non-geotagged photos can
        also be created.
 
@@ -907,13 +907,13 @@ Parameters
      - Input line vector layer
    * - **Number of points**
      - ``POINTS_NUMBER``
-     - [number]
+     - [numeric: integer]
 
        Default: 1
      - Number of points to create
    * - **Minimum distance between points**
      - ``MIN_DISTANCE``
-     - [number]
+     - [numeric: double]
 
        Default: 0.0
      - The minimum distance between points
@@ -993,13 +993,13 @@ Basic parameters
 
    * - **Number of points**
      - ``POINTS_NUMBER``
-     - [number]
+     - [numeric: integer]
 
        Default: 1
      - Number of point to create
    * - **Minimum distance between points**
      - ``MIN_DISTANCE``
-     - [number]
+     - [numeric: double]
 
        Default: 0.0
      - The minimum distance between points
@@ -1034,7 +1034,7 @@ Advanced parameters
      - Description
    * - **Maximum number of search attempts given the minimum distance**
      - ``MAX_ATTEMPTS``
-     - [number]
+     - [numeric: integer]
 
        Default: 200
      - Maximum number of attempts to place the points
@@ -1097,13 +1097,13 @@ Parameters
      - Input polygon layer defining the area
    * - **Number of points**
      - ``POINTS_NUMBER``
-     - [number]
+     - [numeric: integer]
 
        Default: 1
      - Number of points to create
    * - **Minimum distance between points**
      - ``MIN_DISTANCE``
-     - [number]
+     - [numeric: double]
 
        Default: 0.0
      - The minimum distance between points
@@ -1211,7 +1211,7 @@ Basic parameters
      - Input polygon vector layer
    * - **Number of points for each feature**
      - ``POINTS_NUMBER``
-     - [number |dataDefine|]
+     - [numeric: integer] |dataDefine|
 
        Default: 1
      - Number of points to create
@@ -1219,7 +1219,7 @@ Basic parameters
 
        Optional
      - ``MIN_DISTANCE``
-     - [number |dataDefine|]
+     - [numeric: double] |dataDefine|
 
        Default: 0.0
      - The minimum distance between points within one polygon feature
@@ -1250,7 +1250,7 @@ Advanced parameters
 
        Optional
      - ``MIN_DISTANCE_GLOBAL``
-     - [number |dataDefine|]
+     - [numeric: double] |dataDefine|
 
        Default: 0.0
      - The global minimum distance between points.
@@ -1260,7 +1260,7 @@ Advanced parameters
 
        Optional
      - ``MAX_TRIES_PER_POINT``
-     - [number |dataDefine|]
+     - [numeric: integer] |dataDefine|
 
        Default: 10
      - The maximum number of tries per point.
@@ -1270,7 +1270,7 @@ Advanced parameters
 
        Optional
      - ``SEED``
-     - [number]
+     - [numeric: integer]
 
        Default: Not set
      - The seed to use for the random number generator.
@@ -1300,20 +1300,20 @@ Outputs
      - The output random points layer.
    * - **Number of features with empty or no geometry**
      - ``FEATURES_WITH_EMPTY_OR_NO_GEOMETRY``
-     - [number]
+     - [numeric: integer]
      - 
    * - **Total number of points generated**
      - ``OUTPUT_POINTS``
-     - [number]
+     - [numeric: integer]
      - 
    * - **Number of missed points**
      - ``POINTS_MISSED``
-     - [number]
+     - [numeric: integer]
      - The number of points that could not be generated due to
        the minimum distance constraint.
    * - **Number of features with missed points**
      - ``POLYGONS_WITH_MISSED_POINTS``
-     - [number]
+     - [numeric: integer]
      - Not including features with empty or no geometry
 
 Python code
@@ -1376,14 +1376,14 @@ Parameters
 
    * - **Point count or density**
      - ``VALUE``
-     - [number |dataDefine|]
+     - [numeric: double] |dataDefine|
 
        Default: 1.0
      - The number or density of points, depending on the chosen
        :guilabel:`Sampling strategy`.
    * - **Minimum distance between points**
      - ``MIN_DISTANCE``
-     - [number]
+     - [numeric: double]
 
        Default: 0.0
      - The minimum distance between points
@@ -1491,7 +1491,7 @@ Basic parameters
      - Input line vector layer
    * - **Number of points for each feature**
      - ``POINTS_NUMBER``
-     - [number |dataDefine|]
+     - [numeric: integer] |dataDefine|
 
        Default: 1
      - Number of points to create
@@ -1499,7 +1499,7 @@ Basic parameters
 
        Optional
      - ``MIN_DISTANCE``
-     - [number |dataDefine|]
+     - [numeric: double] |dataDefine|
 
        Default: 0.0
      - The minimum distance between points within one line feature
@@ -1530,7 +1530,7 @@ Advanced parameters
 
        Optional
      - ``MIN_DISTANCE_GLOBAL``
-     - [number |dataDefine|]
+     - [numeric: double] |dataDefine|
 
        Default: 0.0
      - The global minimum distance between points.
@@ -1540,7 +1540,7 @@ Advanced parameters
 
        Optional
      - ``MAX_TRIES_PER_POINT``
-     - [number |dataDefine|]
+     - [numeric: integer] |dataDefine|
 
        Default: 10
      - The maximum number of tries per point.
@@ -1550,7 +1550,7 @@ Advanced parameters
 
        Optional
      - ``SEED``
-     - [number]
+     - [numeric: integer]
 
        Default: Not set
      - The seed to use for the random number generator.
@@ -1580,19 +1580,19 @@ Outputs
      - The output random points layer.
    * - **Number of features with empty or no geometry**
      - ``FEATURES_WITH_EMPTY_OR_NO_GEOMETRY``
-     - [number]
+     - [numeric: integer]
      - 
    * - **Number of features with missed points**
      - ``LINES_WITH_MISSED_POINTS``
-     - [number]
+     - [numeric: integer]
      - Not including features with empty or no geometry
    * - **Total number of points generated**
      - ``POINTS_GENERATED``
-     - [number]
+     - [numeric: integer]
      - 
    * - **Number of missed points**
      - ``POINTS_MISSED``
-     - [number]
+     - [numeric: integer]
      - The number of points that could not be generated due to
        the minimum distance constraint.
 
@@ -1795,14 +1795,14 @@ Parameters
 
    * - **Point spacing/count**
      - ``SPACING``
-     - [number]
+     - [numeric: integer]
 
        Default: 100
      - Spacing between the points, or the number of points, depending
        on whether ``Use point spacing`` is checked or not.
    * - **Initial inset from corner (LH side)**
      - ``INSET``
-     - [number]
+     - [numeric: double]
 
        Default: 0.0
      - Offsets the points relative to the upper left corner.

--- a/docs/user_manual/processing_algs/qgis/vectorgeneral.rst
+++ b/docs/user_manual/processing_algs/qgis/vectorgeneral.rst
@@ -40,7 +40,7 @@ Parameters
      - Description
    * - **Input layer**
      - ``INPUT``
-     - [vector: any]
+     - [vector: geometry]
      - Vector layer with wrong or missing CRS
    * - **Assigned CRS**
      - ``CRS``
@@ -219,7 +219,7 @@ Outputs
      - Description
    * - **Count of bookmarks added**
      - ``COUNT``
-     - [number]
+     - [numeric: integer]
      - 
 
 Python code
@@ -390,7 +390,7 @@ Parameters
      - Description
    * - **Input Layer**
      - ``INPUT``
-     - [vector: any]
+     - [vector: geometry]
      - Input vector layer
 
 Outputs
@@ -421,12 +421,9 @@ Python code
 
 .. _qgisdefinecurrentprojection:
 
-Define Shapefile projection
----------------------------
-Sets the CRS (projection) of an existing Shapefile format dataset to
-the provided CRS.
-It is very useful when a Shapefile format dataset is missing the
-``prj`` file and you know the correct projection.
+Define projection
+-----------------
+Sets an existing layer's projection to the provided CRS without reprojecting features.
 
 Contrary to the :ref:`qgisassignprojection` algorithm, it modifies the
 current layer and will not output a new layer.
@@ -452,7 +449,7 @@ Parameters
      - Description
    * - **Input layer**
      - ``INPUT``
-     - [vector: any]
+     - [vector: geometry]
      - Vector layer with missing projection information
    * - **CRS**
      - ``CRS``
@@ -515,7 +512,7 @@ Parameters
      - Description
    * - **Input layer**
      - ``INPUT``
-     - [vector: any]
+     - [vector: geometry]
      - The layer with duplicate geometries you want to clean
    * - **Cleaned**
      - ``OUTPUT``
@@ -541,7 +538,7 @@ Outputs
      - Description
    * - **Count of discarded duplicate records**
      - ``DUPLICATE_COUNT``
-     - [number]
+     - [numeric: integer]
      - Count of discarded duplicate records
    * - **Cleaned**
      - ``OUTPUT``
@@ -549,7 +546,7 @@ Outputs
      - The output layer without any duplicated geometries
    * - **Count of retained records**
      - ``RETAINED_COUNT``
-     - [number]
+     - [numeric: integer]
      - Count of unique records
 
 Python code
@@ -648,7 +645,7 @@ Outputs
        ``[Skip output]``).
    * - **Count of discarded duplicate records**
      - ``DUPLICATE_COUNT``
-     - [number]
+     - [numeric: integer]
      - Count of discarded duplicate records
    * - **Filtered (no duplicates)**
      - ``OUTPUT``
@@ -656,7 +653,7 @@ Outputs
      - Vector layer containing the unique features.
    * - **Count of retained records**
      - ``RETAINED_COUNT``
-     - [number]
+     - [numeric: integer]
      - Count of unique records
 
 Python code
@@ -698,11 +695,11 @@ Parameters
      - Description
    * - **Original layer**
      - ``ORIGINAL``
-     - [vector: any]
+     - [vector: geometry]
      - The vector layer considered as the original version
    * - **Revised layer**
      - ``REVISED``
-     - [vector: any]
+     - [vector: geometry]
      - The revised or modified vector layer
    * - **Attributes to consider for match**
    
@@ -787,15 +784,15 @@ Outputs
      - Vector layer containing the deleted features.
    * - **Count of unchanged features**
      - ``UNCHANGED_COUNT``
-     - [number]
+     - [numeric: integer]
      - Count of unchanged features.
    * - **Count of features added in revised layer**
      - ``ADDED_COUNT``
-     - [number]
+     - [numeric: integer]
      - Count of features added in revised layer.
    * - **Count of features deleted from original layer**
      - ``DELETED_COUNT``
-     - [number]
+     - [numeric: integer]
      - Count of features deleted from original layer.
 
 Python code
@@ -838,11 +835,11 @@ Parameters
      - Description
    * - **Input layer**
      - ``INPUT``
-     - [vector: any]
+     - [vector: geometry]
      - The input vector layer
    * - **Dropped geometries**
      - ``OUTPUT``
-     - [table]
+     - [vector: table]
      - Specify the output geometryless layer. One of:
 
        .. include:: ../algs_include.rst
@@ -862,7 +859,7 @@ Outputs
      - Description
    * - **Dropped geometries**
      - ``OUTPUT``
-     - [table]
+     - [vector: table]
      - The output geometryless layer.
        A copy of the original attribute table.
 
@@ -961,7 +958,7 @@ Parameters
      - The CRS to assign to the output layer
    * - **SQL Output**
      - ``OUTPUT``
-     - [vector: any]
+     - [vector: geometry]
 
        Default: ``[Create temporary layer]``
      - Specify the output layer created by the query. One of:
@@ -983,7 +980,7 @@ Outputs
      - Description
    * - **SQL Output**
      - ``OUTPUT``
-     - [vector: any]
+     - [vector: geometry]
      - Vector layer created by the query
 
 Python code
@@ -1019,7 +1016,7 @@ Parameters
      - Description
    * - **Input layers**
      - ``LAYERS``
-     - [vector: any] [list]
+     - [vector: geometry] [list]
      - List of input vector layers with options associated (filled as a
        :class:`QgsProcessingParameterDxfLayers
        <qgis.core.QgsProcessingParameterDxfLayers>` item ---
@@ -1029,7 +1026,7 @@ Parameters
        **Layer** [string] (``layer``)
          Full path of the input layer to export
 
-       **Output layer attribute** [number] (``attributeIndex``)
+       **Output layer attribute** [tablefield: any] (``attributeIndex``)
          Attribute index to split the input layer using unique values
 
        **Output layer name** [string] (``overriddenLayerName``)
@@ -1038,7 +1035,7 @@ Parameters
 
        **Allow data defined symbol blocks** [boolean] (``buildDataDefinedBlocks``)
 
-       **Maximum number of symbol blocks** [number] (``dataDefinedBlocksMaximumNumberOfClasses``)
+       **Maximum number of symbol blocks** [numeric: integer] (``dataDefinedBlocksMaximumNumberOfClasses``)
          ``-1`` means no limitation.
 
    * - **Symbology mode**
@@ -1228,7 +1225,7 @@ Parameters
      - Description
    * - **Input Layer**
      - ``INPUT``
-     - [vector: any]
+     - [vector: geometry]
      - ESRI Shapefile (:file:`.SHP`) Layer to extract the encoding information.
 
 Outputs
@@ -1298,7 +1295,7 @@ Parameters
      - Description
    * - **Input Layer**
      - ``INPUT``
-     - [vector: any]
+     - [vector: geometry]
      - Layer with unknown projection
    * - **Target area for layer (xmin, xmax, ymin, ymax)**
      - ``TARGET_AREA``
@@ -1311,7 +1308,7 @@ Parameters
 
    * - **CRS candidates**
      - ``OUTPUT``
-     - [table]
+     - [vector: table]
 
        Default: ``[Create temporary layer]``
      - Specify the table (geometryless layer) for the CRS
@@ -1334,7 +1331,7 @@ Outputs
      - Description
    * - **CRS candidates**
      - ``OUTPUT``
-     - [table]
+     - [vector: table]
      - A table with all the
        CRS (EPSG codes) of the matching criteria.
 
@@ -1548,7 +1545,7 @@ Outputs
      - Description
    * - **Number of joined features from input table**
      - ``JOINED_COUNT``
-     - [number]
+     - [numeric: integer]
      - 
    * - **Unjoinable features from first layer**
 
@@ -1566,7 +1563,7 @@ Outputs
 
        Optional
      - ``UNJOINABLE_COUNT``
-     - [number]
+     - [numeric: integer]
      - 
 
 Python code
@@ -1621,7 +1618,7 @@ Parameters
      - Description
    * - **Join to features in**
      - ``INPUT``
-     - [vector: any]
+     - [vector: geometry]
      - Input vector layer. The output layer will consist of
        the features of this layer with attributes from
        matching features in the second layer.
@@ -1646,7 +1643,7 @@ Parameters
        to be extracted.
    * - **By comparing to**
      - ``JOIN``
-     - [vector: any]
+     - [vector: geometry]
      - The join layer. Features of this vector layer will **add** their attributes
        to the source layer attribute table if they satisfy the spatial relationship.
    * - **Fields to add (leave empty to use all fields)**
@@ -1724,7 +1721,7 @@ Outputs
      - Description
    * - **Number of joined features from input table**
      - ``JOINED_COUNT``
-     - [number]
+     - [numeric: integer]
      - 
    * - **Unjoinable features from first layer**
 
@@ -1787,7 +1784,7 @@ Parameters
      - Description
    * - **Join to features in**
      - ``INPUT``
-     - [vector: any]
+     - [vector: geometry]
      - Input vector layer. The output layer will consist of
        the features of this layer with attributes from
        matching features in the second layer.
@@ -1812,7 +1809,7 @@ Parameters
        to be extracted.
    * - **By comparing to**
      - ``JOIN``
-     - [vector: any]
+     - [vector: geometry]
      - The join layer. Features of this vector layer will **add** summaries
        of their attributes to the source layer attribute table if
        they satisfy the spatial relationship.
@@ -1934,11 +1931,11 @@ Parameters
      - Description
    * - **Input layer**
      - ``INPUT``
-     - [vector: any]
+     - [vector: geometry]
      - The input layer.
    * - **Input layer 2**
      - ``INPUT_2``
-     - [vector: any]
+     - [vector: geometry]
      - The join layer.
    * - **Layer 2 fields to copy (leave empty to copy all fields)**
      - ``FIELDS_TO_COPY``
@@ -1958,13 +1955,13 @@ Parameters
      - Joined field prefix
    * - **Maximum nearest neighbors**
      - ``NEIGHBORS``
-     - [number]
+     - [numeric: integer]
      
        Default: 1
      - Maximum number of nearest neighbors
    * - **Maximum distance**
      - ``MAX_DISTANCE``
-     - [number]
+     - [numeric: double]
      - Maximum search distance
    * - **Joined layer**
 
@@ -2015,14 +2012,12 @@ Outputs
        could not be joined to any features in the join layer.
    * - **Number of joined features from input table**
      - ``JOINED_COUNT``
-     - [number]
-     - Number of features from the input table that have been
-       joined.
+     - [numeric: integer]
+     - Number of features from the input table that have been joined.
    * - **Number of unjoinable features from input table**
      - ``UNJOINABLE_COUNT``
-     - [number]
-     - Number of features from the input table that could not
-       be joined.
+     - [numeric: integer]
+     - Number of features from the input table that could not be joined.
 
 Python code
 ...........
@@ -2038,22 +2033,20 @@ Python code
 
 Merge vector layers
 -------------------
-Combines multiple vector layers of the **same geometry** type into a
-single one.
+Combines multiple vector layers of the **same geometry** type into a single one.
 
-The attribute table of the resulting layer will contain the fields from all
-input layers. If fields with the same name but different types are found then
+The attribute table of the resulting layer will contain the fields from all input layers.
+If fields with the same name but different types are found then
 the exported field will be automatically converted into a string type field.
 Optionally, new fields storing the original layer name and source can be added.
 
-If any input layers contain Z or M values, then the output layer will
-also contain these values.
-Similarly, if any of the input layers are multi-part, the output layer
-will also be a multi-part layer.
+If any input layers contain Z or M values,
+then the output layer will also contain these values.
+Similarly, if any of the input layers are multi-part,
+the output layer will also be a multi-part layer.
 
-Optionally, the destination coordinate reference system (CRS) for the
-merged layer can be set. If it is not set, the CRS will be taken from
-the first input layer.
+Optionally, the destination coordinate reference system (CRS) for the merged layer can be set.
+If it is not set, the CRS will be taken from the first input layer.
 All layers will be reprojected to match this CRS.
 
 .. figure:: img/merge_vector_layers.png
@@ -2080,8 +2073,7 @@ Parameters
    * - **Input Layers**
      - ``LAYERS``
      - [vector: any] [list]
-     - The layers that are to be merged into a
-       single layer.
+     - The layers that are to be merged into a single layer.
        Layers should be of the same geometry type.
    * - **Destination CRS**
 
@@ -2254,7 +2246,7 @@ Outputs
      - Description
    * - **Repaired layer**
      - ``OUTPUT``
-     - [vector: any]
+     - [vector: geometry]
      - The input vector layer with the SHX file repaired
 
 Python code
@@ -2296,7 +2288,7 @@ Basic parameters
      - Description
    * - **Input Layer**
      - ``INPUT``
-     - [vector: any]
+     - [vector: geometry]
      - Input vector layer to reproject
    * - **Target CRS**
      - ``TARGET_CRS``
@@ -2514,7 +2506,7 @@ Parameters
      - Description
    * - **Saved features**
      - ``INPUT``
-     - [vector: any]
+     - [vector: geometry]
      - Vector layer to set the encoding.
    * - **Encoding**
      - ``ENCODING``
@@ -2779,7 +2771,7 @@ Outputs
    * - **Truncated layer**
      - ``OUTPUT``
      - [folder]
-     - The truncated (empty) layer
+     - The input layer, all features deleted
 
 Python code
 ...........

--- a/docs/user_manual/processing_algs/qgis/vectorgeometry.rst
+++ b/docs/user_manual/processing_algs/qgis/vectorgeometry.rst
@@ -46,7 +46,7 @@ Parameters
      - Description
    * - **Input layer**
      - ``INPUT``
-     - [vector: any]
+     - [vector: geometry]
      - Input vector layer
    * - **Calculate using**
      - ``CALC_METHOD``
@@ -136,61 +136,61 @@ Parameters
      - Description
    * - **Input layer**
      - ``INPUT``
-     - [vector: any]
+     - [vector: geometry]
      - Input vector layer
    * - **Translation (x-axis)**
      - ``DELTA_X``
-     - [number |dataDefine|]
+     - [numeric: double] |dataDefine|
 
-       Default: 0
+       Default: 0.0
      - Displacement to apply on the X axis.
    * - **Translation (y-axis)**
      - ``DELTA_Y``
-     - [number |dataDefine|]
+     - [numeric: double] |dataDefine|
 
-       Default: 0
+       Default: 0.0
      - Displacement to apply on the Y axis.
    * - **Translation (z-axis)**
      - ``DELTA_Z``
-     - [number |dataDefine|]
+     - [numeric: double] |dataDefine|
 
-       Default: 0
+       Default: 0.0
      - Displacement to apply on the Z axis.
    * - **Translation (m-values)**
      - ``DELTA_M``
-     - [number |dataDefine|]
+     - [numeric: double] |dataDefine|
 
-       Default: 0
+       Default: 0.0
      - Offset to apply on m values.
    * - **Scale factor (x-axis)**
      - ``SCALE_X``
-     - [number |dataDefine|]
+     - [numeric: double] |dataDefine|
 
-       Default: 1
+       Default: 1.0
      - Scaling value (expansion or contraction) to apply on the X axis.
    * - **Scale factor (y-axis)**
      - ``SCALE_Y``
-     - [number |dataDefine|]
+     - [numeric: double] |dataDefine|
 
-       Default: 1
+       Default: 1.0
      - Scaling value (expansion or contraction) to apply on the Y axis.
    * - **Scale factor (z-axis)**
      - ``SCALE_Z``
-     - [number |dataDefine|]
+     - [numeric: double] |dataDefine|
 
-       Default: 1
+       Default: 1.0
      - Scaling value (expansion or contraction) to apply on the Z axis.
    * - **Scale factor (m-values)**
      - ``SCALE_M``
-     - [number |dataDefine|]
+     - [numeric: double] |dataDefine|
 
-       Default: 1
+       Default: 1.0
      - Scaling value (expansion or contraction) to apply on m values.
    * - **Rotation around z-axis (degrees counter-clockwise)**
      - ``ROTATION_Z``
-     - [number |dataDefine|]
+     - [numeric: double] |dataDefine|
 
-       Default: 0
+       Default: 0.0
      - Angle of the rotation in degrees.
 
    * - **Transformed**
@@ -348,10 +348,10 @@ Parameters
             :start-after: **vector_field_subtypes**
             :end-before: **end_vector_field_subtypes**
 
-       :guilabel:`Length` (``length``) [number]
+       :guilabel:`Length` (``length``) [numeric: integer]
          Length of the output field.
 
-       :guilabel:`Precision` (``precision``) [number]
+       :guilabel:`Precision` (``precision``) [numeric: integer]
          Precision of the output field.
 
    * - **Load fields from layer**
@@ -594,11 +594,11 @@ Basic parameters
      - Description
    * - **Input layer**
      - ``INPUT``
-     - [vector: any]
+     - [vector: geometry]
      - Input vector layer
    * - **Distance**
      - ``DISTANCE``
-     - [number |dataDefine|]
+     - [numeric: double] |dataDefine|
 
        Default: 10.0
      - Buffer distance (from the boundary of each feature).
@@ -607,7 +607,7 @@ Basic parameters
        This way you can have different radius for each feature.
    * - **Segments**
      - ``SEGMENTS``
-     - [number]
+     - [numeric: integer]
 
        Default: 5
      - Controls the number of line segments to use to approximate
@@ -649,7 +649,7 @@ Basic parameters
           Round, miter, and bevel join styles
    * - **Miter limit**
      - ``MITER_LIMIT``
-     - [number]
+     - [numeric: double]
 
        Default: 2.0
      - Sets the maximum distance from the offset geometry to use
@@ -783,11 +783,11 @@ Parameters
      - Description
    * - **Input layer**
      - ``INPUT``
-     - [vector: any]
+     - [vector: geometry]
      - Input vector layer
    * - **Create centroid for each part**
      - ``ALL_PARTS``
-     - [boolean |dataDefine|]
+     - [boolean] |dataDefine|
 
        Default: False
      - If True (checked), a centroid will be created for each part
@@ -880,7 +880,7 @@ Parameters
      - Description
    * - **Input layer**
      - ``INPUT_LAYER``
-     - [vector: any]
+     - [vector: geometry]
      - Input vector layer
    * - **Method**
      - ``METHOD``
@@ -952,7 +952,7 @@ Outputs
      - Description
    * - **Count of errors**
      - ``ERROR_COUNT``
-     - [number]
+     - [numeric: integer]
      - The number of geometries that caused errors.
    * - **Error output**
      - ``ERROR_OUTPUT``
@@ -962,7 +962,7 @@ Outputs
        the error(s) found.
    * - **Count of invalid features**
      - ``INVALID_COUNT``
-     - [number]
+     - [numeric: integer]
      - The number of invalid geometries.
    * - **Invalid output**
      - ``INVALID_OUTPUT``
@@ -972,7 +972,7 @@ Outputs
        summary of the error(s) found.
    * -  **Count of valid features**
      - ``VALID_COUNT``
-     - [number]
+     - [numeric: integer]
      - The number of valid geometries.
    * -  **Valid output**
      - ``VALID_OUTPUT``
@@ -1161,7 +1161,7 @@ Parameters
      - Description
    * - **Input layer**
      - ``INPUT``
-     - [vector: any]
+     - [vector: geometry]
      - Input vector layer
    * - **Unique ID fields**
      - ``FIELD``
@@ -1238,7 +1238,7 @@ Parameters
      - Input point vector layer
    * - **Threshold**
      - ``ALPHA``
-     - [number]
+     - [numeric: double]
 
        Default: 0.3
      - Number from 0 (maximum concave hull) to 1 (convex hull).
@@ -1323,7 +1323,7 @@ Parameters
      - Description
    * - **Input layer**
      - ``INPUT``
-     - [vector: any]
+     - [vector: geometry]
      - Input vector layer
    * - **New geometry type**
      - ``TYPE``
@@ -1341,7 +1341,7 @@ Parameters
 
    * - **Converted**
      - ``OUTPUT``
-     - [vector: any]
+     - [vector: geometry]
 
        Default: ``[Create temporary layer]``
      - Specify the output vector layer.
@@ -1365,7 +1365,7 @@ Outputs
      - Description
    * - **Converted**
      - ``OUTPUT``
-     - [vector: any]
+     - [vector: geometry]
      - Output vector layer - the type depends on the parameters
 
 Python code
@@ -1409,14 +1409,14 @@ Parameters
      - Input vector layer
    * - **Maximum distance tolerance**
      - ``DISTANCE``
-     - [number]
+     - [numeric: double]
 
        Default: 0.000001
      - The maximum distance allowed between the original location of vertices
        and where they would fall on the converted curved geometries
    * - **Maximum angle tolerance**
      - ``ANGLE``
-     - [number]
+     - [numeric: double]
 
        Default: 0.000001
      - Segments are considered as suitable for replacing with an arc
@@ -1498,7 +1498,7 @@ Parameters
      - Description
    * - **Input layer**
      - ``INPUT``
-     - [vector: any]
+     - [vector: geometry]
      - Input vector layer
    * - **Convex hull**
      - ``OUTPUT``
@@ -1714,13 +1714,13 @@ Parameters
      - Input point vector layer
    * - **Azimuth (degrees from North)**
      - ``AZIMUTH``
-     - [number |dataDefine|]
+     - [numeric: double] |dataDefine|
 
        Default: 0.0
      - Angle (in degrees) as the middle value of the wedge
    * - **Wedge width (in degrees)**
      - ``WIDTH``
-     - [number |dataDefine|]
+     - [numeric: double] |dataDefine|
 
        Default: 45.0
      - Width (in degrees) of the buffer.
@@ -1734,7 +1734,7 @@ Parameters
 
    * - **Outer radius**
      - ``OUTER_RADIUS``
-     - [number |dataDefine|]
+     - [numeric: double] |dataDefine|
 
        Default: 1.0
      - The outer *size* (length) of the wedge:
@@ -1744,7 +1744,7 @@ Parameters
 
        Optional
      - ``INNER_RADIUS``
-     - [number |dataDefine|]
+     - [numeric: double] |dataDefine|
 
        Default: 0.0
      - Inner radius value.
@@ -1819,7 +1819,7 @@ Parameters
 
        Optional
      - ``TOLERANCE``
-     - [number]
+     - [numeric: double]
 
        Default: 0.0
      - Specifies an optional snapping tolerance which can be used to improve the robustness of the triangulation.
@@ -1909,7 +1909,7 @@ Parameters
 
        Optional
      - ``MIN_AREA``
-     - [number |dataDefine|]
+     - [numeric: double] |dataDefine|
 
        Default: 0.0
      - Only holes with an area less than this threshold will be
@@ -1995,7 +1995,7 @@ Parameters
      - Input line or polygon vector layer
    * - **Vertices to add**
      - ``VERTICES``
-     - [number]
+     - [numeric: integer]
 
        Default: 1
      - Number of vertices to add to each segment
@@ -2086,7 +2086,7 @@ Parameters
      - Input line or polygon vector layer
    * - **Interval between vertices to add**
      - ``INTERVAL``
-     - [number |dataDefine|]
+     - [numeric: double] |dataDefine|
 
        Default: 1.0
      - Maximum distance between two consecutive vertices
@@ -2178,7 +2178,7 @@ Basic parameters
      - Description
    * - **Input layer**
      - ``INPUT``
-     - [vector: any]
+     - [vector: geometry]
      - Input vector layer
    * - **Dissolve field(s)**
 
@@ -2299,7 +2299,7 @@ Parameters
      - Description
    * - **Input layer**
      - ``INPUT``
-     - [vector: any]
+     - [vector: geometry]
      - Input vector layer
    * - **Raster layer**
      - ``RASTER``
@@ -2313,21 +2313,21 @@ Parameters
      - The raster band to take the Z values from
    * - **Value for NoData or non-intersecting vertices**
      - ``NODATA``
-     - [number |dataDefine|]
+     - [numeric: double] |dataDefine|
 
-       Default: 0
+       Default: 0.0
      - Value to use in case the vertex does not intersect
        (a valid pixel of) the raster
    * - **Scale factor**
      - ``SCALE``
-     - [number |dataDefine|]
+     - [numeric: double] |dataDefine|
 
        Default: 1.0
      - Scaling value: the band values are multiplied
        by this value.
    * - **Offset**
      - ``OFFSET``
-     - [number |dataDefine|]
+     - [numeric: double] |dataDefine|
 
        Default: 0.0
      - Offset value: it is algebraically added to the band
@@ -2392,7 +2392,7 @@ Parameters
      - Description
    * - **Input layer**
      - ``INPUT``
-     - [vector: any]
+     - [vector: geometry]
      - Input vector layer with M or Z values
    * - **Drop M Values**
      - ``DROP_M_VALUES``
@@ -2649,14 +2649,16 @@ Parameters
      - Input line vector layer
    * - **Start distance**
      - ``START_DISTANCE``
-     - [number |dataDefine|]
-     - Distance by which to extend the first segment of the line
-       (starting point)
+     - [numeric: double] |dataDefine|
+
+       Default: 0.0
+     - Distance by which to extend the first segment of the line (starting point)
    * - **End distance**
      - ``END_DISTANCE``
-     - [number |dataDefine|]
-     - Distance by which to extend the last segment of the line
-       (ending point)
+     - [numeric: double] |dataDefine|
+
+       Default: 0.0
+     - Distance by which to extend the last segment of the line (ending point)
    * - **Extended**
      - ``OUTPUT``
      - [vector: line]
@@ -2722,7 +2724,7 @@ Parameters
      - Description
    * - **Input layer**
      - ``INPUT``
-     - [vector: any]
+     - [vector: geometry]
      - Input vector layer
    * - **Summaries to calculate**
      - ``SUMMARIES``
@@ -2841,7 +2843,7 @@ Parameters
      - Description
    * - **Input layer**
      - ``INPUT``
-     - [vector: any]
+     - [vector: geometry]
      - Input vector layer
    * - **Vertex indices**
      - ``VERTICES``
@@ -2933,7 +2935,7 @@ Parameters
      - Description
    * - **Input layer**
      - ``INPUT``
-     - [vector: any]
+     - [vector: geometry]
      - Input vector layer
    * - **Vertices**
      - ``OUTPUT``
@@ -3002,7 +3004,7 @@ Parameters
      - Description
    * - **Input layer**
      - ``INPUT``
-     - [vector: any]
+     - [vector: geometry]
      - Input vector layer
    * - **Summaries to calculate**
      - ``SUMMARIES``
@@ -3115,14 +3117,14 @@ Parameters
      - Description
    * - **Input layer**
      - ``INPUT``
-     - [vector: any]
+     - [vector: geometry]
      - Input vector layer
        to remove vertices from
    * - **Minimum**
 
        Optional
      - ``MIN``
-     - [number |dataDefine|]
+     - [numeric: double] |dataDefine|
 
        Default: *Not set*
      - Minimum of M values allowed
@@ -3130,7 +3132,7 @@ Parameters
 
        Optional
      - ``MAX``
-     - [number |dataDefine|]
+     - [numeric: double] |dataDefine|
 
        Default: *Not set*
      - Maximum of M values allowed
@@ -3216,14 +3218,14 @@ Parameters
      - Description
    * - **Input layer**
      - ``INPUT``
-     - [vector: any]
+     - [vector: geometry]
      - Input vector layer
        to remove vertices from
    * - **Minimum**
 
        Optional
      - ``MIN``
-     - [number |dataDefine|]
+     - [numeric: double] |dataDefine|
 
        Default: *Not set*
      - Minimum of Z values allowed
@@ -3231,7 +3233,7 @@ Parameters
 
        Optional
      - ``MAX``
-     - [number |dataDefine|]
+     - [numeric: double] |dataDefine|
 
        Default: *Not set*
      - Maximum of Z values allowed
@@ -3303,7 +3305,7 @@ Parameters
      - Description
    * - **Input layer**
      - ``INPUT``
-     - [vector: any]
+     - [vector: geometry]
      - Input vector layer
    * - **Repair method**
      - ``METHOD``
@@ -3567,7 +3569,7 @@ Parameters
        with their help and guide.
    * - **Modified geometry**
      - ``OUTPUT``
-     - [vector: any]
+     - [vector: geometry]
 
        Default: ``[Create temporary layer]``
      - Specify the output vector layer. One of:
@@ -3589,7 +3591,7 @@ Outputs
      - Description
    * - **Modified geometry**
      - ``OUTPUT``
-     - [vector: any]
+     - [vector: geometry]
      - The output vector layer
 
 Python code
@@ -3642,7 +3644,7 @@ Parameters
      - Input line or polygon vector layer
    * - **Distance**
      - ``DISTANCE``
-     - [number |dataDefine|]
+     - [numeric: double] |dataDefine|
 
        Default: 0.0
      - Distance from the beginning of the line
@@ -3716,7 +3718,7 @@ Parameters
      - Input polygon vector layer
    * - **Parts to keep**
      - ``PARTS``
-     - [number]
+     - [numeric: integer] |dataDefine|
 
        Default: 1
      - Number of parts to keep. If 1, only the biggest part of the
@@ -3800,14 +3802,16 @@ Parameters
      - Input line vector layer
    * - **Start distance**
      - ``START_DISTANCE``
-     - [number |dataDefine|]
-     - Distance along the input line to the start point of
-       the output feature
+     - [numeric: double] |dataDefine|
+
+       Default: 0.0
+     - Distance along the input line to the start point of the output feature
    * - **End distance**
      - ``END_DISTANCE``
-     - [number |dataDefine|]
-     - Distance along the input line to the end point of
-       the output feature
+     - [numeric: double] |dataDefine|
+
+       Default: 1.0
+     - Distance along the input line to the end point of the output feature
    * - **Substring**
      - ``OUTPUT``
      - [vector: line]
@@ -4017,7 +4021,7 @@ Parameters
      - Description
    * - **Input layer**
      - ``INPUT``
-     - [vector: any]
+     - [vector: geometry]
      - Input vector layer
    * - **Field**
 
@@ -4108,11 +4112,11 @@ Parameters
      - Description
    * - **Input layer**
      - ``INPUT``
-     - [vector: any]
+     - [vector: geometry]
      - Input vector layer
    * - **Number of segments in circles**
      - ``SEGMENTS``
-     - [number]
+     - [numeric: integer]
 
        Default: 72
      - The number of segments used to approximate a circle.
@@ -4190,11 +4194,11 @@ Parameters
      - Description
    * - **Input layer**
      - ``INPUT``
-     - [vector: any]
+     - [vector: geometry]
      - Input vector layer
    * - **Number of rings**
      - ``RINGS``
-     - [number |dataDefine|]
+     - [numeric: integer] |dataDefine|
 
        Default: 1
      - The number of rings.
@@ -4203,7 +4207,7 @@ Parameters
        rings depends on feature values).
    * - **Distance between rings**
      - ``DISTANCE``
-     - [number |dataDefine|]
+     - [numeric: double] |dataDefine|
 
        Default: 1.0
      - Distance between the rings.
@@ -4287,7 +4291,7 @@ Parameters
      - Description
    * - **Input layer**
      - ``INPUT``
-     - [vector: any]
+     - [vector: geometry]
      - Input vector layer
    * - **Single parts**
      - ``OUTPUT``
@@ -4364,7 +4368,7 @@ Parameters
      - Input line vector layer
    * - **Distance**
      - ``DISTANCE``
-     - [number |dataDefine|]
+     - [numeric: double] |dataDefine|
 
        Default: 10.0
      - Offset distance.
@@ -4374,7 +4378,7 @@ Parameters
        (see :ref:`qgisvariabledistancebuffer`).
    * - **Segments**
      - ``SEGMENTS``
-     - [number]
+     - [numeric: integer]
 
        Default: 8
      - Controls the number of line segments to use to approximate
@@ -4399,7 +4403,7 @@ Parameters
           Round, miter, and bevel join styles
    * - **Miter limit**
      - ``MITER_LIMIT``
-     - [number]
+     - [numeric: double]
 
        Default: 2.0
      - Sets the maximum distance from the offset geometry to use
@@ -4481,7 +4485,7 @@ Parameters
      - Description
    * - **Input layer**
      - ``INPUT``
-     - [vector: any]
+     - [vector: geometry]
      - Input vector layer
    * - **Bounding boxes**
      - ``OUTPUT``
@@ -4557,9 +4561,9 @@ Parameters
      - Input line or polygon vector layer
    * - **Maximum angle tolerance (degrees)**
      - ``ANGLE_TOLERANCE``
-     - [number]
+     - [numeric: double]
 
-       Default: 15
+       Default: 15.0
      - Specify the maximum deviation from a right angle or straight
        line a vertex can have for it to be adjusted.
        Smaller tolerances mean that only vertices which are already
@@ -4568,7 +4572,7 @@ Parameters
        also be adjusted.
    * - **Maximum algorithm iterations**
      - ``MAX_ITERATIONS``
-     - [number]
+     - [numeric: integer]
 
        Default: 1000
      - Setting a larger number for the maximum number of iterations
@@ -4641,13 +4645,12 @@ Parameters
      - Description
    * - **Input layer**
      - ``INPUT``
-     - [vector: any]
+     - [vector: geometry]
      - Input vector layer
    * - **Create point on surface for each part**
      - ``ANGLE_TOLERANCE``
-     - [boolean |dataDefine|]
-     - If checked, a point will be created for each part of the
-       geometry.
+     - [boolean] |dataDefine|
+     - If checked, a point will be created for each part of the geometry.
    * - **Point**
      - ``OUTPUT``
      - [vector: point]
@@ -4725,20 +4728,20 @@ Parameters
      - Input line or polygon vector layer
    * - **Distance**
      - ``DISTANCE``
-     - [number |dataDefine|]
+     - [numeric: double] |dataDefine|
 
        Default: 1.0
      - Distance between two consecutive points along the line
    * - **Start offset**
      - ``START_OFFSET``
-     - [number |dataDefine|]
+     - [numeric: double] |dataDefine|
 
        Default: 0.0
      - Distance from the beginning of the input line, representing the
        position of the first point.
    * - **End offset**
      - ``END_OFFSET``
-     - [number |dataDefine|]
+     - [numeric: double] |dataDefine|
 
        Default: 0.0
      - Distance from the end of the input line, representing the
@@ -4808,7 +4811,7 @@ Parameters
      - Input point vector layer
    * - **Minimum distance to other points**
      - ``PROXIMITY``
-     - [number]
+     - [numeric: double]
 
        Default: 1.0
      - Distance below which point features are
@@ -4816,7 +4819,7 @@ Parameters
        Close features are distributed altogether.
    * - **Displacement distance**
      - ``DISTANCE``
-     - [number]
+     - [numeric: double]
 
        Default: 1.0
      - Radius of the circle on which close features are placed
@@ -4903,7 +4906,7 @@ Parameters
      - Input vector layer
    * - **Tolerance**
      - ``TOLERANCE``
-     - [number]
+     - [numeric: double]
 
        Default: 1.0
      - Set the tolerance for the calculation
@@ -5118,13 +5121,13 @@ Parameters
      - Input point vector layer
    * - **Bearing (degrees from North)**
      - ``BEARING``
-     - [number |dataDefine|]
+     - [numeric: double] |dataDefine|
 
        Default: 0.0
      - Clockwise angle starting from North, in degree (°) unit
    * - **Distance**
      - ``DISTANCE``
-     - [number |dataDefine|]
+     - [numeric: double] |dataDefine|
 
        Default: 1.0
      - Distance to offset geometries, in layer units
@@ -5198,7 +5201,7 @@ Parameters
      - Description
    * - **Input layer**
      - ``INPUT``
-     - [vector: any]
+     - [vector: geometry]
      - Input vector layer
    * - **Multiparts**
      - ``OUTPUT``
@@ -5279,13 +5282,13 @@ Parameters
 
    * - **Width**
      - ``WIDTH``
-     - [number |dataDefine|]
+     - [numeric: double] |dataDefine|
 
        Default: 1.0
      - Width of the buffer shape
    * - **Height**
      - ``HEIGHT``
-     - [number |dataDefine|]
+     - [numeric: double] |dataDefine|
 
        Default: 1.0
      - Height of the buffer shape
@@ -5293,13 +5296,13 @@ Parameters
 
        Optional
      - ``ROTATION``
-     - [number |dataDefine|]
+     - [numeric: double] |dataDefine|
 
-       Default: None
+       Default: 0.0
      - Rotation of the buffer shape
    * - **Number of segments**
      - ``SEGMENTS``
-     - [number]
+     - [numeric: integer]
 
        Default: 36
      - Number of segments for a full circle (*Ovals* shape)
@@ -5383,18 +5386,18 @@ Parameters
      - Description
    * - **Input layer**
      - ``INPUT``
-     - [vector: any]
+     - [vector: geometry]
      - Input vector layer
    * - **Tolerance**
      - ``TOLERANCE``
-     - [number |dataDefine|]
+     - [numeric: double] |dataDefine|
 
        Default: 0.000001
      - Vertices closer than the specified distance are considered
        duplicates
    * - **Use Z value**
      - ``USE_Z_VALUE``
-     - [boolean |dataDefine|]
+     - [boolean] |dataDefine|
 
        Default: False
      - If the :guilabel:`Use Z Value` parameter is true, then the Z
@@ -5469,7 +5472,7 @@ Parameters
      - Description
    * - **Input layer**
      - ``INPUT``
-     - [vector: any]
+     - [vector: geometry]
      - Input vector layer (with non-NULL geometries)
    * - **Also remove empty geometries**
      - ``REMOVE_EMPTY``
@@ -5628,11 +5631,11 @@ Parameters
      - Description
    * - **Input layer**
      - ``INPUT``
-     - [vector: any]
+     - [vector: geometry]
      - Input vector layer
    * - **Rotation (degrees clockwise)**
      - ``ANGLE``
-     - [number |dataDefine|]
+     - [numeric: double] |dataDefine|
 
        Default: 0.0
      - Angle of the rotation in degrees
@@ -5789,7 +5792,7 @@ Parameters
      - Input line or polygon vector layer
    * - **Maximum angle between vertices (degrees)**
      - ``ANGLE``
-     - [number |dataDefine|]
+     - [numeric: double] |dataDefine|
 
        Default: 5.0
      - Maximum allowed radius angle between vertices
@@ -5864,7 +5867,7 @@ Parameters
      - Input line or polygon vector layer
    * - **Maximum offset distance**
      - ``DISTANCE``
-     - [number |dataDefine|]
+     - [numeric: double] |dataDefine|
 
        Default: 1.0
      - Maximum allowed offset distance between the
@@ -5944,11 +5947,11 @@ Parameters
      - Description
    * - **Input layer**
      - ``INPUT``
-     - [vector: any]
+     - [vector: geometry]
      - Input vector layer
    * - **M Value**
      - ``M_VALUE``
-     - [number |dataDefine|]
+     - [numeric: double] |dataDefine|
 
        Default: 0.0
      - M value to assign to the feature geometries
@@ -6025,7 +6028,7 @@ Parameters
      - Description
    * - **Input layer**
      - ``INPUT``
-     - [vector: any]
+     - [vector: geometry]
      - Input vector layer
    * - **Raster layer**
      - ``RASTER``
@@ -6039,20 +6042,20 @@ Parameters
      - The raster band from which the M values are taken
    * - **Value for NoData or non-intersecting vertices**
      - ``NODATA``
-     - [number |dataDefine|]
+     - [numeric: double] |dataDefine|
 
        Default: 0.0
      - Value to use in case the vertex does not intersect
        (a valid pixel of) the raster
    * - **Scale factor**
      - ``SCALE``
-     - [number |dataDefine|]
+     - [numeric: double] |dataDefine|
 
        Default: 1.0
      - Scaling value: the band values are multiplied by this value.
    * - **Offset**
      - ``OFFSET``
-     - [number |dataDefine|]
+     - [numeric: double] |dataDefine|
 
        Default: 0.0
      - Offset value: it is algebraically added to the band
@@ -6131,11 +6134,11 @@ Parameters
      - Description
    * - **Input layer**
      - ``INPUT``
-     - [vector: any]
+     - [vector: geometry]
      - Input vector layer
    * - **Z Value**
      - ``Z_VALUE``
-     - [number |dataDefine|]
+     - [numeric: double] |dataDefine|
 
        Default: 0.0
      - Z value to assign to the feature geometries
@@ -6230,7 +6233,7 @@ Parameters
 
    * - **Tolerance**
      - ``TOLERANCE``
-     - [number |dataDefine|]
+     - [numeric: double] |dataDefine|
 
        Default: 1.0
      - Threshold tolerance (in units of the layer):
@@ -6309,7 +6312,7 @@ Parameters
      - Input line vector layer
    * - **Distance**
      - ``DISTANCE``
-     - [number]
+     - [numeric: double] |dataDefine|
 
        Default: 10.0
      - Buffer distance.
@@ -6326,7 +6329,7 @@ Parameters
 
    * - **Segments**
      - ``SEGMENTS``
-     - [number]
+     - [numeric: integer]
 
        Default: 8
      - Controls the number of line segments to use to approximate
@@ -6351,7 +6354,7 @@ Parameters
           Round, miter, and bevel join styles
    * - **Miter limit**
      - ``MITER_LIMIT``
-     - [number]
+     - [numeric: double]
 
        Default: 2.0
      - Sets the maximum distance from the offset geometry to use
@@ -6460,21 +6463,21 @@ Parameters
      - Input line or polygon vector layer
    * - **Iterations**
      - ``ITERATIONS``
-     - [number |dataDefine|]
+     - [numeric: integer] |dataDefine|
 
        Default: 1
      - Increasing the number of iterations will give smoother
        geometries (and more vertices).
    * - **Offset**
      - ``OFFSET``
-     - [number |dataDefine|]
+     - [numeric: double] |dataDefine|
 
        Default: 0.25
      - Increasing values will *move* the smoothed lines / boundaries
        further away from the input lines / boundaries.
    * - **Maximum node angle to smooth**
      - ``MAX_ANGLE``
-     - [number |dataDefine|]
+     - [numeric: double] |dataDefine|
 
        Default: 180.0
      - Every node below this value will be smoothed
@@ -6547,15 +6550,15 @@ Parameters
      - Description
    * - **Input layer**
      - ``INPUT``
-     - [vector: any]
+     - [vector: geometry]
      - Input vector layer
    * - **Reference layer**
      - ``REFERENCE_LAYER``
-     - [vector: any]
+     - [vector: geometry]
      - Vector layer to snap to
    * - **Tolerance**
      - ``TOLERANCE``
-     - [number]
+     - [numeric: double]
 
        Default: 10.0
      - Control how close input vertices need to be to the
@@ -6685,29 +6688,29 @@ Parameters
      - Description
    * - **Input layer**
      - ``INPUT``
-     - [vector: any]
+     - [vector: geometry]
      - Input vector layer
    * - **X Grid Spacing**
      - ``HSPACING``
-     - [number |dataDefine|]
+     - [numeric: double] |dataDefine|
 
        Default: 1.0
      - Grid spacing on the X axis
    * - **Y Grid Spacing**
      - ``VSPACING``
-     - [number |dataDefine|]
+     - [numeric: double] |dataDefine|
 
        Default: 1.0
      - Grid spacing on the Y axis
    * - **Z Grid Spacing**
      - ``ZSPACING``
-     - [number |dataDefine|]
+     - [numeric: double] |dataDefine|
 
        Default: 0.0
      - Grid spacing on the Z axis
    * - **M Grid Spacing**
      - ``MSPACING``
-     - [number |dataDefine|]
+     - [numeric: double] |dataDefine|
 
        Default: 0.0
      - Grid spacing on the M axis
@@ -6782,7 +6785,7 @@ Parameters
      - The input line vector layer
    * - **Maximum line length**
      - ``LENGTH``
-     - [number |dataDefine|]
+     - [numeric: double] |dataDefine|
 
        Default: 10.0
      - The maximum length of a line in the output.
@@ -6869,11 +6872,11 @@ Parameters
 
    * - **Input layer**
      - ``INPUT``
-     - [vector: any]
+     - [vector: geometry]
      - The input vector layer
    * - **Maximum nodes in parts**
      - ``MAX_NODES``
-     - [number |dataDefine|]
+     - [numeric: integer] |dataDefine|
 
        Default: 256
      - Maximum number of vertices each new
@@ -6947,7 +6950,7 @@ Parameters
 
    * - **Input layer**
      - ``INPUT``
-     - [vector: any]
+     - [vector: geometry]
      - The input vector layer
    * - **Swapped**
      - ``OUTPUT``
@@ -7021,21 +7024,21 @@ Parameters
      - Input line vector layer
    * - **Start width**
      - ``START_WIDTH``
-     - [number |dataDefine|]
+     - [numeric: double] |dataDefine|
 
        Default: 0.0
      - Represents the radius of the buffer applied
        at the start point of the line feature
    * - **End width**
      - ``END_WIDTH``
-     - [number |dataDefine|]
+     - [numeric: double] |dataDefine|
 
        Default: 0.0
      - Represents the radius of the buffer applied
        at the end point of the line feature.
    * - **Segments**
      - ``SEGMENTS``
-     - [number |dataDefine|]
+     - [numeric: integer] |dataDefine|
 
        Default: 16
      - Controls the number of line segments to use to approximate
@@ -7197,13 +7200,13 @@ Parameters
      - Input line vector layer
    * - **Length of the transect**
      - ``LENGTH``
-     - [number |dataDefine|]
+     - [numeric: double] |dataDefine|
 
        Default: 5.0
      - Length in map unit of the transect
    * - **Angle in degrees from the original line at the vertices**
      - ``ANGLE``
-     - [number |dataDefine|]
+     - [numeric: double] |dataDefine|
 
        Default: 90.0
      - Change the angle of the transect
@@ -7289,29 +7292,29 @@ Parameters
      - Description
    * - **Input layer**
      - ``INPUT``
-     - [vector: any]
+     - [vector: geometry]
      - Input vector layer
    * - **Offset distance (x-axis)**
      - ``DELTA_X``
-     - [number |dataDefine|]
+     - [numeric: double] |dataDefine|
 
        Default: 0.0
      - Displacement to apply on the X axis
    * - **Offset distance (y-axis)**
      - ``DELTA_Y``
-     - [number |dataDefine|]
+     - [numeric: double] |dataDefine|
 
        Default: 0.0
      - Displacement to apply on the Y axis
    * - **Offset distance (z-axis)**
      - ``DELTA_Z``
-     - [number |dataDefine|]
+     - [numeric: double] |dataDefine|
 
        Default: 0.0
      - Displacement to apply on the Z axis
    * - **Offset distance (m values)**
      - ``DELTA_M``
-     - [number |dataDefine|]
+     - [numeric: double] |dataDefine|
 
        Default: 0.0
      - Displacement to apply on the M axis
@@ -7385,7 +7388,7 @@ Parameters
      - Input line vector layer
    * - **Segments**
      - ``SEGMENTS``
-     - [number |dataDefine|]
+     - [numeric: integer] |dataDefine|
 
        Default: 16
      - Number of the buffer segments per quarter circle.
@@ -7465,7 +7468,7 @@ Parameters
      - Input point vector layer
    * - **Buffer region (% of extent)**
      - ``BUFFER``
-     - [number]
+     - [numeric: double]
 
        Default: 0.0
      - The extent of the output layer will be this much
@@ -7474,7 +7477,7 @@ Parameters
 
        Optional
      - ``TOLERANCE``
-     - [number]
+     - [numeric: double]
 
        Default: 0.0
      - Specifies an optional snapping tolerance which can be used to improve the robustness of the voronoi.

--- a/docs/user_manual/processing_algs/qgis/vectoroverlay.rst
+++ b/docs/user_manual/processing_algs/qgis/vectoroverlay.rst
@@ -53,7 +53,7 @@ Parameters
      - Description
    * - **Input layer**
      - ``INPUT``
-     - [vector: any]
+     - [vector: geometry]
      - Layer containing the features to be clipped
    * - **Overlay layer**
      - ``OVERLAY``
@@ -87,8 +87,7 @@ Outputs
    * - **Clipped**
      - ``OUTPUT``
      - [same as input]
-     - Layer containing features from the input layer split by the
-       overlay layer.
+     - Layer containing features from the input layer split by the overlay layer.
 
 Python code
 ...........
@@ -146,11 +145,11 @@ Basic parameters
      - Description
    * - **Input layer**
      - ``INPUT``
-     - [vector: any]
+     - [vector: geometry]
      - Layer to extract (parts of) features from.
    * - **Overlay layer**
      - ``OVERLAY``
-     - [vector: any]
+     - [vector: geometry]
      
      - Layer containing the geometries that will be subtracted from
        the input layer geometries.
@@ -186,7 +185,7 @@ Advanced parameters
 
        Optional
      - ``GRID_SIZE``
-     - [number]
+     - [numeric: double]
 
        Default: Not set
      - If provided, the input geometries are snapped to a grid of the given size,
@@ -260,11 +259,11 @@ Parameters
      - Description
    * - **Input layer**
      - ``INPUT``
-     - [vector: any]
+     - [vector: geometry]
      - Layer to extract (parts of) features from.
    * - **Overlay layers**
      - ``OVERLAYS``
-     - [vector: any] [list]
+     - [vector: geometry] [list]
      - List of layers containing the geometries that will be subtracted from
        the input layer geometries.
        They are expected to have at least as many dimensions (point: 0D,
@@ -346,7 +345,7 @@ Parameters
      - Description
    * - **Input layer**
      - ``INPUT``
-     - [vector: any]
+     - [vector: geometry]
      - Layer to extract (parts of) features from.
    * - **Extent (xmin, xmax, ymin, ymax)**
      - ``EXTENT``
@@ -450,11 +449,11 @@ Basic parameters
      - Description
    * - **Input layer**
      - ``INPUT``
-     - [vector: any]
+     - [vector: geometry]
      - Layer to extract (parts of) features from.
    * - **Overlay layer**
      - ``OVERLAY``
-     - [vector: any]
+     - [vector: geometry]
      - Layer containing the features to check for overlap.
        Its features' geometry is expected to have at least as many
        dimensions (point: 0D, line: 1D, polygon: 2D, volume: 3D)
@@ -515,7 +514,7 @@ Advanced parameters
 
        Optional
      - ``GRID_SIZE``
-     - [number]
+     - [numeric: double]
 
        Default: Not set
      - If provided, the input geometries are snapped to a grid of the given size,
@@ -592,11 +591,11 @@ Basic parameters
      - Description
    * - **Input layer**
      - ``INPUT``
-     - [vector: any]
+     - [vector: geometry]
      - Layer to extract (parts of) features from.
    * - **Overlay layers**
      - ``OVERLAYS``
-     - [vector: any] [list]
+     - [vector: geometry] [list]
      - Layers containing the features to check for overlap.
        The features' geometry is expected to have at least as many
        dimensions (point: 0D, line: 1D, polygon: 2D, volume: 3D)
@@ -894,11 +893,11 @@ Basic parameters
      - Description
    * - **Input layer**
      - ``INPUT``
-     - [vector: any]
+     - [vector: geometry]
      - First layer to extract (parts of) features from.
    * - **Overlay layer**
      - ``OVERLAY``
-     - [vector: any]
+     - [vector: geometry]
      - Second layer to extract (parts of) features from.
        Ideally the geometry type should be the same as input layer.
    * - **Symmetrical difference**
@@ -938,7 +937,7 @@ Advanced parameters
 
        Optional
      - ``GRID_SIZE``
-     - [number]
+     - [numeric: double]
 
        Default: Not set
      - If provided, the input geometries are snapped to a grid of the given size,
@@ -1031,13 +1030,13 @@ Basic parameters
      - Description
    * - **Input layer**
      - ``INPUT``
-     - [vector: any]
+     - [vector: geometry]
      - Input vector layer to split at any intersections.
    * - **Overlay layer**
 
        Optional
      - ``OVERLAY``
-     - [vector: any]
+     - [vector: geometry]
      - Layer that will be combined to the first one.
        Ideally the geometry type should be the same as input layer.
    * - **Union**
@@ -1076,7 +1075,7 @@ Advanced parameters
 
        Optional
      - ``GRID_SIZE``
-     - [number]
+     - [numeric: double]
 
        Default: Not set
      - If provided, the input geometries are snapped to a grid of the given size,
@@ -1168,13 +1167,13 @@ Basic parameters
      - Description
    * - **Input layer**
      - ``INPUT``
-     - [vector: any]
+     - [vector: geometry]
      - Input vector layer to split at any intersections.
    * - **Overlay layers**
 
        Optional
      - ``OVERLAYS``
-     - [vector: any] [list]
+     - [vector: geometry] [list]
      - Layers that will be combined to the first one.
        Ideally the geometry type should be the same as input layer.
    * - **Union**

--- a/docs/user_manual/processing_algs/qgis/vectorselection.rst
+++ b/docs/user_manual/processing_algs/qgis/vectorselection.rst
@@ -13,8 +13,7 @@ Vector selection
 Extract by attribute
 --------------------
 Creates two vector layers from an input layer: one will contain only
-matching features while the second will contain all the non-matching
-features.
+matching features while the second will contain all the non-matching features.
 
 The criteria for adding features to the resulting layer is based on
 the values of an attribute from the input layer.
@@ -105,13 +104,11 @@ Outputs
    * - **Extracted (attribute)**
      - ``OUTPUT``
      - [same as input]
-     - Vector layer with matching features from the input
-       layer
+     - Vector layer with matching features from the input layer
    * - **Extracted (non-matching)**
      - ``FAIL_OUTPUT``
      - [same as input]
-     - Vector layer with non-matching features from the
-       input layer
+     - Vector layer with non-matching features from the input layer
 
 Python code
 ...........
@@ -128,13 +125,10 @@ Python code
 Extract by expression
 ---------------------
 Creates two vector layers from an input layer: one will contain only
-matching features while the second will contain all the non-matching
-features.
+matching features while the second will contain all the non-matching features.
 
-The criteria for adding features to the resulting layer is based on a
-QGIS expression.
-For more information about expressions see the
-:ref:`vector_expressions`.
+The criteria for adding features to the resulting layer is based on a QGIS expression.
+For more information about expressions see the :ref:`vector_expressions`.
 
 .. seealso:: :ref:`qgisselectbyexpression`
 
@@ -218,12 +212,10 @@ Python code
 
 Extract by location
 -------------------
-Creates a new vector layer that only contains matching features from
-an input layer.
+Creates a new vector layer that only contains matching features from an input layer.
 
 The criteria for adding features to the resulting layer is based on
-the spatial relationship between each feature and the features in an
-additional layer.
+the spatial relationship between each feature and the features in an additional layer.
 
 .. seealso:: :ref:`qgisselectbylocation`, :ref:`qgisextractwithindistance`
 
@@ -248,7 +240,7 @@ Parameters
      - Description
    * - **Extract features from**
      - ``INPUT``
-     - [vector: any]
+     - [vector: geometry]
      - Input vector layer
    * - **Where the features (geometric predicate)**
      - ``PREDICATE``
@@ -268,11 +260,10 @@ Parameters
        * 7 --- cross
 
        If more than one condition is chosen, at least one
-       of them (OR operation) has to be met for a feature
-       to be extracted.
+       of them (OR operation) has to be met for a feature to be extracted.
    * - **By comparing to the features from**
      - ``INTERSECT``
-     - [vector: any]
+     - [vector: geometry]
      - Intersection vector layer
    * - **Extracted (location)**
      - ``OUTPUT``
@@ -341,17 +332,17 @@ Parameters
      - Description
    * - **Extract features from**
      - ``INPUT``
-     - [vector: any]
+     - [vector: geometry]
      - Input vector layer to copy features from
    * - **By comparing to the features from**
      - ``REFERENCE``
-     - [vector: any]
+     - [vector: geometry]
      - Vector layer whose features closeness is used
    * - **Where the features are within**
      - ``DISTANCE``
-     - [number]
+     - [numeric: double] |dataDefine|
 
-       Default: 100
+       Default: 100.0
      - The maximum distance around reference features
        to select input features within
    * - **Modify current selection by**
@@ -462,7 +453,7 @@ Outputs
 
        Optional
      - ``NO_GEOMETRY``
-     - [table]
+     - [vector: table]
      - Geometry-less vector layer
 
 Python code
@@ -519,13 +510,13 @@ Parameters
 
    * - **Number/percentage of selected features**
      - ``NUMBER``
-     - [number]
+     - [numeric: integer]
 
        Default: 10
      - Number or percentage of features to select
    * - **Extracted (random)**
      - ``OUTPUT``
-     - [vector: any]
+     - [same as input]
 
        Default: ``[Create temporary layer]``
      - Specify the output vector layer for the randomly
@@ -611,7 +602,7 @@ Parameters
 
    * - **Number/percentage of selected features**
      - ``NUMBER``
-     - [number]
+     - [numeric: integer]
 
        Default: 10
      - Number or percentage of features to select
@@ -697,7 +688,7 @@ Parameters
 
    * - **Number/percentage of selected features**
      - ``NUMBER``
-     - [number]
+     - [numeric: integer]
 
        Default: 10
      - Number or percentage of features to select
@@ -782,7 +773,7 @@ Parameters
 
    * - **Number/percentage of selected features**
      - ``NUMBER``
-     - [number]
+     - [numeric: integer]
 
        Default: 10
      - Number or percentage of features to select
@@ -1013,7 +1004,7 @@ Parameters
      - Description
    * - **Select features from**
      - ``INPUT``
-     - [vector: any]
+     - [vector: geometry]
      - Input vector layer
    * - **Where the features (geometric predicate)**
      - ``PREDICATE``
@@ -1037,7 +1028,7 @@ Parameters
        to be extracted.
    * - **By comparing to the features from**
      - ``INTERSECT``
-     - [vector: any]
+     - [vector: geometry]
      - Intersection vector layer
    * - **Modify current selection by**
      - ``METHOD``
@@ -1103,17 +1094,17 @@ Parameters
      - Description
    * - **Select features from**
      - ``INPUT``
-     - [vector: any]
+     - [vector: geometry]
      - Input vector layer to select features from
    * - **By comparing to the features from**
      - ``REFERENCE``
-     - [vector: any]
+     - [vector: geometry]
      - Vector layer whose features closeness is used
    * - **Where the features are within**
      - ``DISTANCE``
-     - [number]
+     - [numeric: double] |dataDefine|
 
-       Default: 100
+       Default: 100.0
      - The maximum distance around reference features
        to select input features
    * - **Modify current selection by**
@@ -1153,3 +1144,13 @@ Python code
 .. include:: ../algs_include.rst
   :start-after: **algorithm_code_section**
   :end-before: **end_algorithm_code_section**
+
+
+.. Substitutions definitions - AVOID EDITING PAST THIS LINE
+   This will be automatically updated by the find_set_subst.py script.
+   If you need to create a new substitution manually,
+   please add it also to the substitutions.txt file in the
+   source folder.
+
+.. |dataDefine| image:: /static/common/mIconDataDefine.png
+   :width: 1.5em

--- a/docs/user_manual/processing_algs/qgis/vectortable.rst
+++ b/docs/user_manual/processing_algs/qgis/vectortable.rst
@@ -50,7 +50,7 @@ Parameters
 
        Optional
      - ``START``
-     - [number]
+     - [numeric: integer]
 
        Default: 0
      - Choose the initial number of the incremental count
@@ -58,7 +58,7 @@ Parameters
        
        Optional
      - ``MODULUS``
-     - [number]
+     - [numeric: integer]
        
        Default: 0
      - Specifying an optional modulus value will restart the count to START
@@ -186,13 +186,13 @@ Parameters
        
    * - **Field length**
      - ``FIELD_LENGTH``
-     - [number]
+     - [numeric: integer]
        
        Default: 10
      - Length of the field
    * - **Field precision**
      - ``FIELD_PRECISION``
-     - [number]
+     - [numeric: integer]
        
        Default: 0
      - Precision of the field. Useful with Float field type.
@@ -291,7 +291,7 @@ Parameters
      - Name of the new field containing the indexes.
    * - **Layer with index field**
      - ``OUTPUT``
-     - [vector: any]
+     - [same as input]
        
        Default: ``[Create temporary layer]``
      - Vector layer with the numeric field containing indexes.
@@ -303,7 +303,7 @@ Parameters
 
    * - **Class summary**
      - ``SUMMARY_OUTPUT``
-     - [table]
+     - [vector: table]
        
        Default: ``[Skip output]``
      - Specify the table to contain the summary of the class field
@@ -331,7 +331,7 @@ Outputs
      - Vector layer with the numeric field containing indexes.
    * - **Class summary**
      - ``SUMMARY_OUTPUT``
-     - [table]
+     - [vector: table]
      - Table with summary of the class field mapped to the
        corresponding unique value.  
 
@@ -483,13 +483,13 @@ Parameters
        
    * - **Field length**
      - ``FIELD_LENGTH``
-     - [number]
+     - [numeric: integer]
        
        Default: 10
      - Length of the field
    * - **Field precision**
      - ``FIELD_PRECISION``
-     - [number]
+     - [numeric: integer]
        
        Default: 3
      - Precision of the field. Useful with Float field type.
@@ -649,7 +649,7 @@ Parameters
      - Description
    * - **Input layer**
      - ``INPUT``
-     - [vector: any]
+     - [vector: geometry]
      - Input vector layer
    * - **HStore field**
      - ``FIELD``
@@ -780,8 +780,7 @@ You can use all the supported expressions and functions.
 
 A new layer is created with the result of the expression.
 
-The field calculator is very useful when used in
-:ref:`processing.modeler`.
+The field calculator is very useful when used in :ref:`processing.modeler`.
 
 Parameters
 ..........
@@ -824,15 +823,15 @@ Parameters
        
    * - **Output field width**
      - ``FIELD_LENGTH``
-     - [number]
+     - [numeric: integer]
        
-       Default: 10
+       Default: 0
      - The length of the result field (minimum 0)
    * - **Field precision**
      - ``FIELD_PRECISION``
-     - [number]
+     - [numeric: integer]
        
-       Default: 3
+       Default: 0
      - The precision of the result field (minimum 0, maximum 15)
    * - **Create new field**
      - ``NEW_FIELD``
@@ -844,9 +843,9 @@ Parameters
      - ``FORMULA``
      - [expression]
      - The formula to use to calculate the result
-   * - **Output file**
+   * - **Calculated**
      - ``OUTPUT``
-     - [vector: any]
+     - [same as input]
        
        Default: ``[Create temporary layer]``
      - Specification of the output layer.
@@ -868,7 +867,7 @@ Outputs
      - Description
    * - **Calculated**
      - ``OUTPUT``
-     - [vector: any]
+     - [same as input]
      - Output layer with the calculated field values
 
 Python code
@@ -947,7 +946,7 @@ Parameters
        :guilabel:`Source expression` (``expression``) [expression]
          Field or expression from the input layer.
 
-       :guilabel:`Field name` (``name``) [string]
+       :guilabel:`Name` (``name``) [string]
          Name of the field in the output layer.
          By default input field name is kept.
 
@@ -975,21 +974,21 @@ Parameters
             :start-after: **vector_field_subtypes**
             :end-before: **end_vector_field_subtypes**
 
-       :guilabel:`Length` (``length``) [number]
+       :guilabel:`Length` (``length``) [numeric: integer]
          Length of the output field.
 
-       :guilabel:`Precision` (``precision``) [number]
+       :guilabel:`Precision` (``precision``) [numeric: integer]
          Precision of the output field.
 
        :guilabel:`Constraints` (``constraints``) [string]
          When using a template layer, indicates whether there are constraints
          applied to the template field. Hover over the cell to display the constraints.
 
-       :guilabel:`Field alias` (``field_alias``) [string]
+       :guilabel:`Alias` (``field_alias``) [string]
          Set a name to use as alias for the field. Not supported by all format types.
          Existing aliases are displayed and will be copied to the destination layer if supported.
 
-       :guilabel:`Field comment` (``field_comment``) [string]
+       :guilabel:`Comment` (``field_comment``) [string]
          Store a comment describing the field. Not supported by all format types.
          Existing comments are displayed and will be copied to the destination layer if supported.
 
@@ -1000,7 +999,7 @@ Parameters
 
    * - **Refactored**
      - ``OUTPUT``
-     - [vector: any]
+     - [same as input]
 
        Default: ``[Create temporary layer]``
      - Specification of the output layer.
@@ -1023,7 +1022,7 @@ Outputs
      - Description
    * - **Refactored**
      - ``OUTPUT``
-     - [vector: any]
+     - [same as input]
      - Output layer with refactored fields
 
 Python code
@@ -1073,7 +1072,7 @@ Parameters
      - The new field name
    * - **Renamed**
      - ``OUTPUT``
-     - [vector: same as input]
+     - [same as input]
 
        Default: ``[Create temporary layer]``
      - Specification of the output layer.
@@ -1096,7 +1095,7 @@ Outputs
      - Description
    * - **Renamed**
      - ``OUTPUT``
-     - [vector: same as input]
+     - [same as input]
      - Output layer with the renamed field
 
 Python code
@@ -1141,7 +1140,7 @@ Parameters
      - List of fields to keep in the layer
    * - **Retained fields**
      - ``OUTPUT``
-     - [vector: same as input]
+     - [same as input]
 
        Default: ``[Create temporary layer]``
      - Specification of the output layer.
@@ -1164,7 +1163,7 @@ Outputs
      - Description
    * - **Retained fields**
      - ``OUTPUT``
-     - [vector: same as input]
+     - [same as input]
      - Output layer with the retained fields
 
 Python code

--- a/docs/user_manual/processing_algs/qgis/vectortiles.rst
+++ b/docs/user_manual/processing_algs/qgis/vectortiles.rst
@@ -42,13 +42,13 @@ Parameters
 
    * - **Maximum zoom level to download**
      - ``MAX_ZOOM``
-     - [number]
+     - [numeric: integer]
 
        Default: 10
      - Defines how far to zoom in and fetch data from the tiles
    * - **Tile limit**
      - ``TILE_LIMIT``
-     - [number]
+     - [numeric: integer]
 
        Default: 100
      - Maximum number of tiles to download, considering the zoom levels and the extent.
@@ -117,14 +117,14 @@ Parameters
      - A list of layers to combine to generate the vector tiles
    * - **Minimum zoom level**
      - ``MIN_ZOOM``
-     - [number]
+     - [numeric: integer]
 
        Default: 0
      - The lowest zoom level for which the tileset provides data.
        Set between 0 and 24.
    * - **Maximum zoom level**
      - ``MAX_ZOOM``
-     - [number]
+     - [numeric: integer]
 
        Default: 3
      - The highest zoom level for which the tileset provides data.
@@ -244,14 +244,14 @@ Parameters
      - A list of layers to combine to generate the vector tiles
    * - **Minimum zoom level**
      - ``MIN_ZOOM``
-     - [number]
+     - [numeric: integer]
 
        Default: 0
      - The lowest zoom level for which the tileset provides data.
        Set between 0 and 24.
    * - **Maximum zoom level**
      - ``MAX_ZOOM``
-     - [number]
+     - [numeric: integer]
 
        Default: 3
      - The highest zoom level for which the tileset provides data.


### PR DESCRIPTION
refs #8852
In this PR:
- [vector: any] is used when point, line, polygon and table are supported by the parameter
- [vector: geometry] when it supports only point, line and polygon
- [table] for geometryless vector layer is now [vector: table]
- [number] has been split into [number: integer] and [number: double]

Also adjust some description, parameter name, or add missing params

These changes only cover the qgis provider for now. And not all the occurrences are fixed in this PR because a few ones raise questions and would meanwhile need a round of issues report in code repo
<!---
Include a few sentences describing the overall goals for this Pull Request.
 
A list of issues is at https://github.com/qgis/QGIS-Documentation/issues.
Add "fix #issuenumber" for each issue the PR fixes. The ticket(s) will be closed automatically.
If your PR doesn't fix entirely the ticket, only add the ticket(s) reference preceded by # character.
-->
Goal:

Ticket(s): #
<!---
Indicate whether the fix should be backported to previous release.
Replace the space between square brackets by a `x` to make it checked.
-->
- [ ] Backport to LTR documentation is requested

<!---
Reviewing is a process done by community members, mostly on a volunteer basis.
We try to keep the overhead as small as possible and appreciate if you help us.
Please read carefully and ensure you comply with our writing guidelines at
https://docs.qgis.org/testing/en/docs/documentation_guidelines/index.html.
Feel free to ask in a comment or the (qgis-community-team mailing list)
[https://lists.osgeo.org/mailman/listinfo/qgis-community-team] if you have troubles with any item.
--->
