### PR TITLE
Merge check validity algorithm example tables

### DIFF
--- a/docs/user_manual/processing_algs/qgis/vectorgeometry.rst
+++ b/docs/user_manual/processing_algs/qgis/vectorgeometry.rst
@@ -995,129 +995,86 @@ Python code
 Types of error messages and their meanings
 ..........................................
 
-.. list-table:: If the GEOS method is used the following error messages can occur:
+.. list-table:: Some examples of geometry check failures in QGIS
    :widths: 30 30 40
    :header-rows: 1
    :class: longtable
 
-   * - Error message
-     - Explanation
-     - Example
+   * - Geometry context
+     - GEOS validation and error message
+     - QGIS validation and error message
+   * - **Consecutive points on a line have the same coordinates**
 
-   * - Repeated point
-     - This error happens when a given vertex is repeated.
-     - .. figure:: img/geos_rep_point.png
+       .. figure:: img/geos_rep_point.png
           :align: center
+          
+     - |taskCancel| *Repeated point*
+     - |taskCancel| *Line a contains x duplicate node(s) at b*
+   * - **Segments of a line intersect each other**
 
-   * - Ring self-intersection
-     - This error happens when a geometry touches itself and generates
-       a ring.
-     - .. figure:: img/geos_ring_inter.png
+       .. figure:: img/qgis_seg_line_int.png
           :align: center
+          
+     -
+     - |taskCancel| *Segments a and b of line c intersect at d*
+   * - **Polygon geometry touches itself and generates a ring**
 
-   * - Self-intersection
-     - This error happens when a geometry touches itself.
-     - .. figure:: img/geos_self_inter.png
+       .. figure:: img/geos_ring_inter.png
           :align: center
+          
+     - |taskCancel| *Ring self-intersection*
+     - |taskCancel| *Ring self-intersection*
+   * - **Two rings (exterior or interior) of a
+       polygon geometry are identical**
 
-   * - Topology validation error
-     -
-     -
-
-   * - Hole lies outside shell
-     -
-     -
-
-   * - Holes are nested
-     -
-     -
-
-   * - Interior is disconnected
-     -
-     -
-
-   * - Nested shells
-     - This error happens when a polygon geometry is on top of another
-       polygon geometry.
-     - .. figure:: img/geos_nest_shell.png
+       .. figure:: img/geos_dupl_rings.png
           :align: center
+          
+     - |taskCancel| *Duplicate rings*
+     -
+   * - **Geometry touches itself**
 
-   * - Duplicate rings
-     - This error happens when two rings (exterior or interior) of a
-       polygon geometry are identical
-
-     - .. figure:: img/geos_dupl_rings.png
+       .. figure:: img/geos_self_inter.png
           :align: center
-
-   * - Too few points in geometry component
+          
+     - |taskCancel| *Self-intersection*
      -
+   * - **A polygon geometry is on top of another polygon geometry**
+
+       .. figure:: img/geos_nest_shell.png
+          :align: center
+          
+     - |taskCancel| *Nested shell*
+     -
+   * - **Part of a MultiPolygon geometry is within a hole of a MultiPolygon geometry**
+
+       .. figure:: img/qgis_poliinside_.png
+          :align: center
+          
+     -
+     - |taskCancel| *Polygon a lies inside polygon b*
+   * - Point geometry does not have a proper coordinate pair.
+       The coordinate pair does not contain a latitude value and a longitude value in that order.
+     - |taskCancel| *Invalid coordinate*
      -
 
-   * - Invalid coordinate
-     - For a point geometry, this error happens when the geometry does
-       not have a proper coordinate pair.
-       The coordinate pair does not contain a latitude value and a
-       longitude value in that order.
-     -
+.. use |success| when context is valid for a specificator
 
-   * - Ring is not closed
-     -
-     -
-
-
-.. list-table:: If the QGIS method is used the following error messages can occur:
-   :widths: 50 50 50
-   :header-rows: 1
-   :class: longtable
-
-   * - Error message
-     - Explanation
-     - Example
-
-   * - Segment %1 of ring %2 of polygon %3 intersects segment %4
+.. to do list:
+     GEOS:
+     - Topology validation error
+     - Hole lies outside shell
+     - Holes are nested
+     - Interior is disconnected
+     - Ring is not closed
+     - Too few points in geometry component
+     QGIS:
+     - Segment %1 of ring %2 of polygon %3 intersects segment %4
        of ring %5 of polygon %6 at %7
-     -
-     -
-
-   * - Ring %1 with less than four points
-     -
-     -
-
-   * - Ring %1 not closed
-     -
-     -
-
-   * - Line %1 with less than two points
-     -
-     -
-
-   * - Line %1 contains %n duplicate node(s) at %2
-     - This error happens when consecutive points on a line have the
-       same coordinates.
-     - .. figure:: img/geos_rep_point.png
-          :align: center
-
-   * - Segments %1 and %2 of line %3 intersect at %4
-     - This error happens when a line self intersects (two segments
-       of the line intersect each other).
-     - .. figure:: img/qgis_seg_line_int.png
-          :align: center
-
-   * - Ring self-intersection
-     - This error happens when an outer or inner (island) ring /
-       boundary of a polygon geometry intersects itself.
-     - .. figure:: img/geos_ring_inter.png
-          :align: center
-
-   * - Ring %1 of polygon %2 not in exterior ring
-     -
-     -
-
-   * - Polygon %1 lies inside polygon %2
-     - This error happens when a part of a MultiPolygon geometry is
-       inside a hole of a MultiPolygon geometry.
-     - .. figure:: img/qgis_poliinside_.png
-          :align: center
+     - Ring %1 with less than four points
+     - Ring %1 not closed
+     - Line %1 with less than two points
+     - Ring %1 of polygon %2 not in exterior ring
 
 
 .. _qgiscollect:
@@ -7544,4 +7501,10 @@ Python code
 .. |identify| image:: /static/common/mActionIdentify.png
    :width: 1.5em
 .. |newAttribute| image:: /static/common/mActionNewAttribute.png
+   :width: 1.5em
+.. |remove| image:: /static/common/mActionRemove.png
+   :width: 1.5em
+.. |success| image:: /static/common/mIconSuccess.png
+   :width: 1em
+.. |taskCancel| image:: /static/common/mTaskCancel.png
    :width: 1.5em


### PR DESCRIPTION
into a single one, allowing comparison between GEOS and QGIS methods
In [check validity alg](https://docs.qgis.org/3.40/en/docs/user_manual/processing_algs/qgis/vectorgeometry.html#types-of-error-messages-and-their-meanings), we have tables showing examples or error ad meanings using either GEOS or QGIS method. This PR proposes to merge them into a single table to provide a quick overview of what is valid/invalid for each method.

This PR simply transcribes existing materials, hence the empty cells. I don't really plan to go further.
There were also listed errors without examples in old tables, they are moved to writer comments

https://github.com/user-attachments/assets/6a4c9190-44d0-4167-9cd8-eb95abce05c8

<!---
Include a few sentences describing the overall goals for this Pull Request.
 
A list of issues is at https://github.com/qgis/QGIS-Documentation/issues.
Add "fix #issuenumber" for each issue the PR fixes. The ticket(s) will be closed automatically.
If your PR doesn't fix entirely the ticket, only add the ticket(s) reference preceded by # character.
-->
Goal:

Ticket(s): #
<!---
Indicate whether the fix should be backported to previous release.
Replace the space between square brackets by a `x` to make it checked.
-->
- [ ] Backport to LTR documentation is requested

<!---
Reviewing is a process done by community members, mostly on a volunteer basis.
We try to keep the overhead as small as possible and appreciate if you help us.
Please read carefully and ensure you comply with our writing guidelines at
https://docs.qgis.org/testing/en/docs/documentation_guidelines/index.html.
Feel free to ask in a comment or the (qgis-community-team mailing list)
[https://lists.osgeo.org/mailman/listinfo/qgis-community-team] if you have troubles with any item.
--->
