### PR TITLE
Add a workaround to build the About document as PDF

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -28,14 +28,14 @@ jobs:
     - name: Harden Runner
       uses: step-security/harden-runner@0634a2670c59f64b4a01f0f96f84700a4088b9f0 # v2.12.0
       with:
-        disable-sudo: true
-        egress-policy: block
-        allowed-endpoints: >
-          files.pythonhosted.org:443
-          github.com:443
-          pypi.org:443
-          qgis.org:443
-          raw.githubusercontent.com:443
+        # disable-sudo: true
+        egress-policy: audit
+        # allowed-endpoints: >
+        #  files.pythonhosted.org:443
+        #  github.com:443
+        #  pypi.org:443
+        #  qgis.org:443
+        #  raw.githubusercontent.com:443
 
     - name: Check out repository
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/docs/about/index.rst
+++ b/docs/about/index.rst
@@ -1,0 +1,20 @@
+:orphan:
+
+.. only:: latex
+
+   .. This file is required for PDF builds
+
+   **********************************
+   About QGIS
+   **********************************
+
+   .. toctree::
+      :maxdepth: 2
+
+      preamble
+      foreword
+      conventions
+      features
+      help_and_support
+      contributors
+      license/index


### PR DESCRIPTION
Fixes #9875 
Also fix GitHub action building empty PDF, because of unavailable tools.
<!---
Include a few sentences describing the overall goals for this Pull Request.
 
A list of issues is at https://github.com/qgis/QGIS-Documentation/issues.
Add "fix #issuenumber" for each issue the PR fixes. The ticket(s) will be closed automatically.
If your PR doesn't fix entirely the ticket, only add the ticket(s) reference preceded by # character.
-->
Goal:

Ticket(s): #
<!---
Indicate whether the fix should be backported to previous release.
Replace the space between square brackets by a `x` to make it checked.
-->
- [ ] Backport to LTR documentation is requested

<!---
Reviewing is a process done by community members, mostly on a volunteer basis.
We try to keep the overhead as small as possible and appreciate if you help us.
Please read carefully and ensure you comply with our writing guidelines at
https://docs.qgis.org/testing/en/docs/documentation_guidelines/index.html.
Feel free to ask in a comment or the (qgis-community-team mailing list)
[https://lists.osgeo.org/mailman/listinfo/qgis-community-team] if you have troubles with any item.
--->
