### PR TITLE
Fix ".. only:: html" role misalignment breaking PDF build

### DIFF
--- a/docs/user_manual/working_with_raster/raster_properties.rst
+++ b/docs/user_manual/working_with_raster/raster_properties.rst
@@ -681,7 +681,7 @@ in the :guilabel:`Custom transparency options` section:
   The button |fileOpen| :sup:`Import from file` loads your transparency
   settings and applies them to the current raster layer.
 
-    .. only:: html
+  .. only:: html
 
     .. figure:: img/tolerances_for_pixel_values.gif
        :align: center


### PR DESCRIPTION
because the expected embedded .gif file was not embedded and was then trying unsuccessfully to build in PDF

