### PR TITLE
Remove copy of transifexrc file in build dir in order to build docs with docker

### DIFF
--- a/docker-run.sh
+++ b/docker-run.sh
@@ -1,8 +1,0 @@
-# Run command for generating docs
-
-pwd=$(pwd)
-
-# Return release number from branch name e.g. master, 3.34
-TARGETBRANCH=`git branch --show-current | sed 's,release_,,g'`
-
-docker run -v $pwd:/build -w="/build" --rm=true --name="qgis_docs_"$TARGETBRANCH"_build" qgis/sphinx_pdf_3 make $@

--- a/docker-run.sh
+++ b/docker-run.sh
@@ -1,14 +1,8 @@
-# to be able to run the full image (including pulling from transifex)
-# you need a valid .transifexrc file with your credentials in your home dir
-# this one is temporarily copied to the project dir
-# and removed after build
-# maybe better to create a qgisdocker transifex user?
+# Run command for generating docs
 
-cp ~/.transifexrc .
 pwd=$(pwd)
 
 # Return release number from branch name e.g. master, 3.34
 TARGETBRANCH=`git branch --show-current | sed 's,release_,,g'`
 
 docker run -v $pwd:/build -w="/build" --rm=true --name="qgis_docs_"$TARGETBRANCH"_build" qgis/sphinx_pdf_3 make $@
-rm -rf .transifexrc

--- a/docker-world.sh
+++ b/docker-world.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# This script is used to build QGIS documentation to various formats and languages
+# and store them in appropriate folders on the servers.
+
 # cd to script dir
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 cd $DIR
@@ -40,7 +43,7 @@ fi;
 
 for l in $langs
   do
-    ./docker-run.sh $TARGET LANG=$l
+    docker run -v $pwd:/build -w="/build" --rm=true --name="qgis_docs_"$TARGETBRANCH"_build" qgis/sphinx_pdf_3 make $TARGET LANG =$l
     build_ok=$?
     if [[ "$build_ok" = "0" ]]; then
       echo "Build OK: syncing to web"


### PR DESCRIPTION
This is unnecessary given that we have the translated strings already in the repository and we do not download them anymore at build time. 
This then allows more simplification of the docs structure by moving the builds command in the docker-world.sh file and remove the docker-run.sh one. 

<!---
Include a few sentences describing the overall goals for this Pull Request.
 
A list of issues is at https://github.com/qgis/QGIS-Documentation/issues.
Add "fix #issuenumber" for each issue the PR fixes. The ticket(s) will be closed automatically.
If your PR doesn't fix entirely the ticket, only add the ticket(s) reference preceded by # character.
-->
Goal:

Ticket(s): #
<!---
Indicate whether the fix should be backported to previous release.
Replace the space between square brackets by a `x` to make it checked.
-->
- [ ] Backport to LTR documentation is requested

<!---
Reviewing is a process done by community members, mostly on a volunteer basis.
We try to keep the overhead as small as possible and appreciate if you help us.
Please read carefully and ensure you comply with our writing guidelines at
https://docs.qgis.org/testing/en/docs/documentation_guidelines/index.html.
Feel free to ask in a comment or the (qgis-community-team mailing list)
[https://lists.osgeo.org/mailman/listinfo/qgis-community-team] if you have troubles with any item.
--->
