### PR TITLE
Refrased

### DIFF
--- a/docs/user_manual/processing_algs/qgis/vectoranalysis.rst
+++ b/docs/user_manual/processing_algs/qgis/vectoranalysis.rst
@@ -993,7 +993,7 @@ Parameters
      - [vector: same as input]
 
        Default:``[Create temporary layer]``
-     - Specify the output vector layer for generated the clusters.
+     - Specify the output vector layer for the generated clusters.
        :ref:`One of <output_parameter_widget>`:
 
        .. include:: ../algs_include.rst


### PR DESCRIPTION
for generated the clusters.  should probably be
for the generated clusters.

Goal: Deliver well formed documentation

- [x] Backport to LTR documentation is requested
