### PR TITLE
Added "the" to sentence

### DIFF
--- a/docs/user_manual/processing_algs/qgis/vectorgeneral.rst
+++ b/docs/user_manual/processing_algs/qgis/vectorgeneral.rst
@@ -2595,7 +2595,7 @@ Parameters
      - [same as input]
        
        Default: ``Create temporary layer``
-     - Specify output vector layer. :ref:`One of <output_parameter_widget>`:
+     - Specify the output vector layer. :ref:`One of <output_parameter_widget>`:
 
        .. include:: ../algs_include.rst
           :start-after: **layer_output_types_append**


### PR DESCRIPTION
Line 2598 ; Specify output vector layer  should probably be:

                  Specify the output vector layer  for consistency reasons, the same sentence   
                                                                      occurs several times, including "the"

Goal: Deliver well formed documentation

- [x] Backport to LTR documentation is requested
