### PR TITLE
Align in-place documentation

### DIFF
--- a/docs/user_manual/working_with_vector/editing_geometry_attributes.rst
+++ b/docs/user_manual/working_with_vector/editing_geometry_attributes.rst
@@ -2163,11 +2163,13 @@ To edit features in-place:
    modification will apply to the whole layer.
 #. Press the |processSelected| :sup:`Edit Features In-Place` button at the top
    of the :ref:`Processing toolbox <processing.toolbox>`. The list of algorithms
-   is filtered, showing only those compatible with in-place modifications, i.e.:
-
-   * They work at the feature source and not at the layer level.
-   * They do not change the layer structure, e.g. adding or removing fields.
-   * They do not change the geometry type, e.g. from line to point layer.
+   is filtered, showing only those supporting in-place modifications.
+   
+   .. note:: In-place editing works at the feature source level, not at the
+   layer level. It does not change the layer structure, e.g. adding or removing
+   fields.  Algorithms that usually work on layer level, e.g. ``Reproject
+   layer`` or add fields, e.g. ``Orientated minimum bounding boxes`` will not
+   do so when editing features in-place. 
 
    .. figure:: img/edit_inplace_algorithms.png
       :align: center


### PR DESCRIPTION
<!---
Include a few sentences describing the overall goals for this Pull Request.
 
A list of issues is at https://github.com/qgis/QGIS-Documentation/issues.
Add "fix #issuenumber" for each issue the PR fixes. The ticket(s) will be closed automatically.
If your PR doesn't fix entirely the ticket, only add the ticket(s) reference preceded by # character.
-->
Goal:
The former documentation and the existing implementation do not align.
This change aims to clear that up and make it more transparent to users what the algorithms do if they are used in-place.

<!---
Indicate whether the fix should be backported to previous release.
Replace the space between square brackets by a `x` to make it checked.
-->
- [x] Backport to LTR documentation is requested

<!---
Reviewing is a process done by community members, mostly on a volunteer basis.
We try to keep the overhead as small as possible and appreciate if you help us.
Please read carefully and ensure you comply with our writing guidelines at
https://docs.qgis.org/testing/en/docs/documentation_guidelines/index.html.
Feel free to ask in a comment or the (qgis-community-team mailing list)
[https://lists.osgeo.org/mailman/listinfo/qgis-community-team] if you have troubles with any item.
--->
