### PR TITLE
fix #9931 add info in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,15 +94,12 @@ locale.Error: unsupported locale setting
 make: *** [html] Error 1
 ```
 
-A solution is to open the python file build.py inside venv folder with the internal pico editor.
-Use in path your installed python version, I installed python 3.10.
+A solution is to edit the Python file `build.py` inside your `venv` folder with a text editor (pico, textEdit, vscode,...).
+The file is stored at `./venv/lib/python3.10/site-packages/sphinx/cmd/build.py`
+(replace `python3.10` with your installed Python version).
 
-```sh
-pico ./venv/lib/python3.10/site-packages/sphinx/cmd/build.py
-```
-
-Goto function main, in pico use **Ctrl-W** and use: 'def main' as search string.
-Change the 1st line in function main from:
+1. Open the file in the text editor
+2. Search and replace:
 
 ```
 def main(argv: Sequence[str] = (), /) -> int:


### PR DESCRIPTION
Readme includes info how to build documentation when on a mac you can not build documentation using make html

<!---
Include a few sentences describing the overall goals for this Pull Request.
 
A list of issues is at https://github.com/qgis/QGIS-Documentation/issues.
Add "fix #issuenumber" for each issue the PR fixes. The ticket(s) will be closed automatically.
If your PR doesn't fix entirely the ticket, only add the ticket(s) reference preceded by # character.
-->
Goal: Users with a mac can build QGIS documentation locally and check how it looks before pushing changes

Ticket(s): #9931
<!---
Indicate whether the fix should be backported to previous release.
Replace the space between square brackets by a `x` to make it checked.
-->
- [ ] Backport to LTR documentation is requested

<!---
Reviewing is a process done by community members, mostly on a volunteer basis.
We try to keep the overhead as small as possible and appreciate if you help us.
Please read carefully and ensure you comply with our writing guidelines at
https://docs.qgis.org/testing/en/docs/documentation_guidelines/index.html.
Feel free to ask in a comment or the (qgis-community-team mailing list)
[https://lists.osgeo.org/mailman/listinfo/qgis-community-team] if you have troubles with any item.
--->
