### PR TITLE
Add the difference expression function screenshot to the help

### DIFF
--- a/docs/user_manual/expressions/expression_help/GeometryGroup.rst
+++ b/docs/user_manual/expressions/expression_help/GeometryGroup.rst
@@ -630,6 +630,11 @@ Returns a geometry that represents that part of geometry1 that does not intersec
      - * ``geom_to_wkt( difference( geom_from_wkt( 'LINESTRING(3 3, 4 4, 5 5)' ), geom_from_wkt( 'LINESTRING(3 3, 4 4)' ) ) )`` → 'LINESTRING(4 4, 5 5)'
 
 
+.. figure:: /docs/user_manual/processing_algs/qgis/img/difference.png
+   :align: center
+
+   Difference operation between a two-features input layer ‘a’ and a single feature overlay layer ‘b’ (left) - resulting in a new layer with the modified ‘a’ features (right)
+
 .. end_difference_section
 
 .. _expression_function_GeometryGroup_disjoint:


### PR DESCRIPTION
Complements #9951
@bsaglio2001 we forgot to do the last step, I.e., regenerate the difference function help with the image, either running the Python function or, like done here, copy-paste a figure block and adapt filename and caption

<!---
Include a few sentences describing the overall goals for this Pull Request.
 
A list of issues is at https://github.com/qgis/QGIS-Documentation/issues.
Add "fix #issuenumber" for each issue the PR fixes. The ticket(s) will be closed automatically.
If your PR doesn't fix entirely the ticket, only add the ticket(s) reference preceded by # character.
-->
Goal:

Ticket(s): #
<!---
Indicate whether the fix should be backported to previous release.
Replace the space between square brackets by a `x` to make it checked.
-->
- [ ] Backport to LTR documentation is requested

<!---
Reviewing is a process done by community members, mostly on a volunteer basis.
We try to keep the overhead as small as possible and appreciate if you help us.
Please read carefully and ensure you comply with our writing guidelines at
https://docs.qgis.org/testing/en/docs/documentation_guidelines/index.html.
Feel free to ask in a comment or the (qgis-community-team mailing list)
[https://lists.osgeo.org/mailman/listinfo/qgis-community-team] if you have troubles with any item.
--->
