### PR TITLE
Fix bottom left reference to zh-Hans language

### DIFF
--- a/docs_conf.yml
+++ b/docs_conf.yml
@@ -1,4 +1,4 @@
 
 version_list: testing, latest, 3.40, 3.34, 3.28, 3.22, 3.16, 3.10, 3.4, 2.18
 # Fill this list with the languages we build for the release, space separated
-supported_languages: en cs de es fr hu it ja ko lt nl pl pt_BR pt_PT ro ru zh_Hans
+supported_languages: en cs de es fr hu it ja ko lt nl pl pt_BR pt_PT ro ru zh-Hans


### PR DESCRIPTION
Fixes #10047 
<!---
Include a few sentences describing the overall goals for this Pull Request.
 
A list of issues is at https://github.com/qgis/QGIS-Documentation/issues.
Add "fix #issuenumber" for each issue the PR fixes. The ticket(s) will be closed automatically.
If your PR doesn't fix entirely the ticket, only add the ticket(s) reference preceded by # character.
-->
Goal:

Ticket(s): #
<!---
Indicate whether the fix should be backported to previous release.
Replace the space between square brackets by a `x` to make it checked.
-->
- [ ] Backport to LTR documentation is requested

<!---
Reviewing is a process done by community members, mostly on a volunteer basis.
We try to keep the overhead as small as possible and appreciate if you help us.
Please read carefully and ensure you comply with our writing guidelines at
https://docs.qgis.org/testing/en/docs/documentation_guidelines/index.html.
Feel free to ask in a comment or the (qgis-community-team mailing list)
[https://lists.osgeo.org/mailman/listinfo/qgis-community-team] if you have troubles with any item.
--->
