### PR TITLE
Make the top "Edit on Github" button actually switch file to edit mode instead of simply display the file

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -120,6 +120,10 @@ html_theme_options = {
     # Toc options
     # titles_only: When enabled, page subheadings are not included in the navigation. Default: False
     # 'titles_only': False,
+    # vcs_pageview_mode: changes how to view files when using ``display_github``, ``display_gitlab``, etc.
+    # When using GitHub or GitLab this can be: ``blob`` (default), ``edit``, or ``raw``.
+    # On Bitbucket, this can be either: ``view`` (default) or ``edit``.
+    'vcs_pageview_mode': 'edit',
 }
 
 # Add any paths that contain custom themes here, relative to this directory.

--- a/docs/documentation_guidelines/first_contribution.rst
+++ b/docs/documentation_guidelines/first_contribution.rst
@@ -89,9 +89,11 @@ without any harm.
 Alternative 1: Use the ``Edit on GitHub`` shortcut
 ..................................................
 
-Pages on the QGIS documentation website can be edited quickly and easily by clicking on the
-``Edit on GitHub`` link at the top right of each page,
-or in the drop-down menu at the bottom of the left sidebar.
+Pages on the QGIS documentation website can be edited quickly and easily
+by clicking on the ``Edit on GitHub`` link:
+
+* at the top right of each page,
+* or in the drop-down menu at the bottom of the left sidebar.
 
 #. This will open the file in the ``qgis:master`` branch with a message at the
    top of the page telling you that you don't have write access to this repo


### PR DESCRIPTION
It is expected to behave the same as the one in the bottom left menu