### PR TITLE
loadlayers: add information to build relations from gpkg

### DIFF
--- a/docs/pyqgis_developer_cookbook/loadlayer.rst
+++ b/docs/pyqgis_developer_cookbook/loadlayer.rst
@@ -82,24 +82,6 @@ This creates a new layer and adds it to the current QGIS project (making it appe
 in the layer list) in one step. The function returns the layer instance or ``None``
 if the layer couldn't be loaded.
 
-Note that if your geopackage contains relationships between layers.
-Simply using ``addMapLayer`` does not automatically create these relationships between the layers in your QGIS project.
-To do this, you need to run the following code, which will prevent you from having to create your relationships manually from the project properties.
-
-.. testcode:: loadlayer
-
-    project = QgsProject.instance()
-    relation_manager = project.relationManager()
-    existing_relations = list(relation_manager.relations().values())
-
-    layers = [
-        layer for layer in project.mapLayers().values() if layer.type() == layer.VectorLayer
-    ]
-
-    discovered_relations = QgsRelationManager.discoverRelations(existing_relations, layers)
-    for rel in discovered_relations:
-        relation_manager.addRelation(rel)
-
 The following list shows how to access various data sources using vector data
 providers:
 
@@ -128,6 +110,26 @@ providers:
       uri = "testdata/data/data.gpkg|layername=airports"
       vlayer = QgsVectorLayer(uri, "layer_name_you_like", "ogr")
       QgsProject.instance().addMapLayer(vlayer)
+
+    Note that if your GeoPackage contains relationships between layers.
+    Simply using :meth:`addMapLayer <qgis.core.QgsProject.addMapLayer>`
+    does not automatically create these relationships between the layers in your QGIS project.
+    Add the following code to automatically find the relationships in the database
+    and add appropriate ones to the project properties.
+
+    .. testcode:: loadlayer
+
+      project = QgsProject.instance()
+      relation_manager = project.relationManager()
+      existing_relations = list(relation_manager.relations().values())
+
+      layers = [
+          layer for layer in project.mapLayers().values() if layer.type() == layer.VectorLayer
+      ]
+
+      discovered_relations = QgsRelationManager.discoverRelations(existing_relations, layers)
+      for relation in discovered_relations:
+          relation_manager.addRelation(relation)
 
   * for dxf (note the internal options in data source uri):
 

--- a/docs/pyqgis_developer_cookbook/loadlayer.rst
+++ b/docs/pyqgis_developer_cookbook/loadlayer.rst
@@ -119,6 +119,8 @@ providers:
 
     .. testcode:: loadlayer
 
+      from qgis.core import QgsRelationManager
+
       project = QgsProject.instance()
       relation_manager = project.relationManager()
       existing_relations = list(relation_manager.relations().values())

--- a/docs/pyqgis_developer_cookbook/loadlayer.rst
+++ b/docs/pyqgis_developer_cookbook/loadlayer.rst
@@ -82,6 +82,24 @@ This creates a new layer and adds it to the current QGIS project (making it appe
 in the layer list) in one step. The function returns the layer instance or ``None``
 if the layer couldn't be loaded.
 
+Note that if your geopackage contains relationships between layers.
+Simply using ``addMapLayer`` does not automatically create these relationships between the layers in your QGIS project.
+To do this, you need to run the following code, which will prevent you from having to create your relationships manually from the project properties.
+
+.. testcode:: loadlayer
+
+    project = QgsProject.instance()
+    relation_manager = project.relationManager()
+    existing_relations = list(relation_manager.relations().values())
+
+    layers = [
+        layer for layer in project.mapLayers().values() if layer.type() == layer.VectorLayer
+    ]
+
+    discovered_relations = QgsRelationManager.discoverRelations(existing_relations, layers)
+    for rel in discovered_relations:
+        relation_manager.addRelation(rel)
+
 The following list shows how to access various data sources using vector data
 providers:
 


### PR DESCRIPTION
<!---
Include a few sentences describing the overall goals for this Pull Request.
 
A list of issues is at https://github.com/qgis/QGIS-Documentation/issues.
Add "fix #issuenumber" for each issue the PR fixes. The ticket(s) will be closed automatically.
If your PR doesn't fix entirely the ticket, only add the ticket(s) reference preceded by # character.
-->
Goal: When you add a geopackage layer with `addMapLayer`, the relationships are not automatically built (unlike when this is done via the GUI). I therefore propose to explain how to do this if you want to automatically build relationships in addition to adding one or more layers from a geopackage.

<!---
Indicate whether the fix should be backported to previous release.
Replace the space between square brackets by a `x` to make it checked.
-->
- [x] Backport to LTR documentation is requested

<!---
Reviewing is a process done by community members, mostly on a volunteer basis.
We try to keep the overhead as small as possible and appreciate if you help us.
Please read carefully and ensure you comply with our writing guidelines at
https://docs.qgis.org/testing/en/docs/documentation_guidelines/index.html.
Feel free to ask in a comment or the (qgis-community-team mailing list)
[https://lists.osgeo.org/mailman/listinfo/qgis-community-team] if you have troubles with any item.
--->
