### PR TITLE
Add output fields of Minimum bounding geometry

### DIFF
--- a/docs/user_manual/processing_algs/qgis/vectorgeometry.rst
+++ b/docs/user_manual/processing_algs/qgis/vectorgeometry.rst
@@ -3896,7 +3896,15 @@ Outputs
    * - **Bounding geometry**
      - ``OUTPUT``
      - [vector: polygon]
-     - The output (bounding) polygon vector layer.
+     - The output (bounding) polygon vector layer. 
+       It has the fields from the input layer  
+       and, depending on the selected parameter ``TYPE``,
+       the output also has the attributes:
+
+       * ``width``, ``height``, ``area`` and ``perimeter`` of the Envelope (Bounding Box)
+       * ``width``, ``height``, ``area``, ``angle`` and ``perimeter`` of the Mininum Oriented Rectangle
+       * ``radius`` and ``area`` of the Minimum Enclosing Circle
+       * ``area`` and ``perimeter`` of the Convex Hull 
 
 Python code
 ...........


### PR DESCRIPTION
Related to issue #9847 but other algorithm

<!---
Include a few sentences describing the overall goals for this Pull Request.
 
A list of issues is at https://github.com/qgis/QGIS-Documentation/issues.
Add "fix #issuenumber" for each issue the PR fixes. The ticket(s) will be closed automatically.
If your PR doesn't fix entirely the ticket, only add the ticket(s) reference preceded by # character.
-->
Goal: Add missing fields in the ouput layer of the Minimum bounding geometry algorithm (processing ; vector geometry)

Ticket(s): #
<!---
Indicate whether the fix should be backported to previous release.
Replace the space between square brackets by a `x` to make it checked.
-->
- [ ] Backport to LTR documentation is requested

<!---
Reviewing is a process done by community members, mostly on a volunteer basis.
We try to keep the overhead as small as possible and appreciate if you help us.
Please read carefully and ensure you comply with our writing guidelines at
https://docs.qgis.org/testing/en/docs/documentation_guidelines/index.html.
Feel free to ask in a comment or the (qgis-community-team mailing list)
[https://lists.osgeo.org/mailman/listinfo/qgis-community-team] if you have troubles with any item.
--->
