### PR TITLE
Add sphinx-tabs to flake.nix

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -51,6 +51,7 @@
             ps.sphinxext-rediraffe
             ps.sphinx-togglebutton
             ps.sphinx-copybutton
+            ps.sphinx-tabs
           ]))
           pkgs.vscode
           pkgs.transifex-cli


### PR DESCRIPTION
This PR adds the sphinx-tabs extension to the flake.nix file so that the build environment can work on NixOS.