### PR TITLE
Mention somehow that Oracle Spatial curve geometries can be edited and saved as curved

### DIFF
--- a/docs/user_manual/managing_data_source/supported_data.rst
+++ b/docs/user_manual/managing_data_source/supported_data.rst
@@ -49,14 +49,14 @@ Vector Data
 ===========
 
 Many of the features and tools available in QGIS work the same,
-regardless the vector data source.
+regardless of the vector data source.
 However, because of the differences in format specifications
 (GeoPackage, ESRI Shapefile, MapInfo and MicroStation file formats,
 AutoCAD DXF, PostgreSQL, SpatiaLite, Oracle Spatial, MS SQL Server,
 SAP HANA Spatial databases and many more), QGIS may handle some of
 their properties differently. Support is provided by the
 `GDAL vector drivers <https://gdal.org/en/latest/drivers/vector/index.html>`_.
-This section describes how to work with these specifics.
+This section describes how to work with some of these specifics.
 
 .. note::
 

--- a/docs/user_manual/working_with_vector/editing_geometry_attributes.rst
+++ b/docs/user_manual/working_with_vector/editing_geometry_attributes.rst
@@ -1669,10 +1669,10 @@ on the curve and a radius:
 
 .. note:: **Curved geometries are stored as such only in compatible data provider**
 
-   Although QGIS allows to digitize curved geometries within any editable
-   data format, you need to be using a data provider (e.g. PostgreSQL, memory
-   layer, GML or WFS) that supports curves to have features stored as
-   curved, otherwise QGIS segmentizes the circular arcs.
+   Although QGIS allows to digitize curved geometries within any editable data format,
+   you need to be using a data provider (e.g. PostgreSQL, Oracle Spatial, memory layer,
+   GML or WFS) that supports curves to have features stored as curved,
+   otherwise QGIS segmentizes the circular arcs.
 
 .. index:: Draw circle
 .. _draw_circles:


### PR DESCRIPTION
Fixes #4780
There is no specific place in the docs we mention what geometry types can be edited depending on the data provider but this PR kind of adds Oracle among the ones with curved geometry support.
