### PR TITLE
Harmonize Check/Fix geometry algorithms description

### DIFF
--- a/docs/user_manual/processing_algs/qgis/checkgeometry.rst
+++ b/docs/user_manual/processing_algs/qgis/checkgeometry.rst
@@ -116,7 +116,7 @@ Outputs
        - ``gc_layername``: the name of the input layer.
        - ``gc_partidx``: the index of the feature's geometry part containing the dangle-end.
        - ``gc_ringidx``: the index of the feature's geometry ring containing the dangle-end.
-       - ``gc_vertidx``: the vertex index of the dangle-end in the feature.
+       - ``gc_vertidx``: the vertex index of the dangle-end in the feature's geometry ring.
        - ``gc_errorx``: the x coordinate of the dangle-end.
        - ``gc_errory``: the y coordinate of the dangle-end.
        - ``gc_error``
@@ -360,7 +360,7 @@ Outputs
        - ``gc_layername``: the name of the input layer.
        - ``gc_partidx``: the index of the feature's geometry part containing the duplicate vertex.
        - ``gc_ringidx``: the index of the feature's geometry ring containing the duplicate vertex.
-       - ``gc_vertidx``
+       - ``gc_vertidx``: the index of the duplicate vertex in the feature's geometry ring.
        - ``gc_errorx``: the x coordinate of the duplicate vertex.
        - ``gc_errory``: the y coordinate of the duplicate vertex.
        - ``gc_error``
@@ -1367,7 +1367,7 @@ Outputs
        - ``gc_layername``: the name of the input layer.
        - ``gc_partidx``: the index of the feature's geometry part containing the small segment.
        - ``gc_ringidx``: the index of the feature's geometry ring containing the small segment.
-       - ``gc_vertidx``: the index of the end vertex of the small segment in the input geometry.
+       - ``gc_vertidx``: the index of the end vertex of the small segment in the feature's geometry ring.
        - ``gc_errorx``: the x coordinate of the centroid of the small segment.
        - ``gc_errory``: the y coordinate of the centroid of the small segment.
        - ``gc_error``: the error segment length.

--- a/docs/user_manual/processing_algs/qgis/checkgeometry.rst
+++ b/docs/user_manual/processing_algs/qgis/checkgeometry.rst
@@ -110,8 +110,8 @@ Outputs
      - ``ERRORS``
      - [vector: point]
      - Output point layer representing the error locations and information.
-       Other than the ``UNIQUE_ID`` field, the output layer also contains the following fields:
-       
+       The output layer contains the following fields:
+
        - ``gc_layerid``: the ID of the input layer.
        - ``gc_layername``: the name of the input layer.
        - ``gc_partidx``: the index of the feature's geometry part containing the dangle-end.
@@ -120,6 +120,7 @@ Outputs
        - ``gc_errorx``: the x coordinate of the dangle-end.
        - ``gc_errory``: the y coordinate of the dangle-end.
        - ``gc_error``
+       - ``UNIQUE_ID`` field: the unique ID of the input feature with the dangle-end.
    * - **Dangle-end features**
      - ``OUTPUT``
      - [vector: line]
@@ -230,8 +231,8 @@ Outputs
      - ``ERRORS``
      - [vector: point]
      - Output point layer representing the error locations and information.
-       Other than the ``UNIQUE_ID`` field, the output layer also contains the following fields:
-       
+       The output layer contains the following fields:
+
        - ``gc_layerid``: the ID of the input layer.
        - ``gc_layername``: the name of the input layer.
        - ``gc_partidx``
@@ -240,6 +241,7 @@ Outputs
        - ``gc_errorx``: the x coordinate of the centroid of the duplicate geometry.
        - ``gc_errory``: the y coordinate of the centroid of the duplicate geometry.
        - ``gc_error``: the indices of the duplicate geometry (all except the highest index).
+       - ``UNIQUE_ID`` field: the unique ID of the input feature that is a duplicate.
    * - **Duplicate geometries**
      - ``OUTPUT``
      - [vector: same as input]
@@ -352,7 +354,7 @@ Outputs
      - ``ERRORS``
      - [vector: point]
      - Output point layer representing the error locations and information.
-       Other than the ``UNIQUE_ID`` field, the output layer also contains the following fields:
+       The output layer contains the following fields:
 
        - ``gc_layerid``: the ID of the input layer.
        - ``gc_layername``: the name of the input layer.
@@ -362,6 +364,7 @@ Outputs
        - ``gc_errorx``: the x coordinate of the duplicate vertex.
        - ``gc_errory``: the y coordinate of the duplicate vertex.
        - ``gc_error``
+       - ``UNIQUE_ID`` field: the unique ID of the input feature that has duplicate vertices.
    * - **Duplicated vertices features**
      - ``OUTPUT``
      - [vector: same as input]
@@ -483,8 +486,8 @@ Outputs
      - ``ERRORS``
      - [vector: point]
      - Output point layer representing the error locations and information.
-       Other than the ``UNIQUE_ID`` field, the output layer also contains the following fields:
-       
+       The output layer contains the following fields:
+
        - ``gc_layerid``: the ID of the input layer.
        - ``gc_layername``: the name of the input layer.
        - ``gc_partidx``
@@ -493,6 +496,7 @@ Outputs
        - ``gc_errorx``: the x coordinate of the centroid of the contained feature.
        - ``gc_errory``: the y coordinate of the centroid of the contained feature.
        - ``gc_error``: the layer name and feature ID of a polygon that contains the feature.
+       - ``UNIQUE_ID`` field: the unique ID of the input feature that is contained within another.
    * - **Contained features**
      - ``OUTPUT``
      - [vector: same as input]
@@ -608,8 +612,8 @@ Outputs
      - ``ERRORS``
      - [vector: point]
      - Output point layer representing the error locations and information.
-       Other than the ``UNIQUE_ID`` field, the output layer also contains the following fields:
-       
+       The output layer contains the following fields:
+
        - ``gc_layerid``: the ID of the input layer.
        - ``gc_layername``: the name of the input layer.
        - ``gc_partidx``: the index of the feature's geometry part containing the hole.
@@ -618,6 +622,7 @@ Outputs
        - ``gc_errorx``: the x coordinate of the centroid of the hole.
        - ``gc_errory``: the y coordinate of the centroid of the hole.
        - ``gc_error``
+       - ``UNIQUE_ID`` field: the unique ID of the input feature that has a hole.
    * - **Polygon with holes**
      - ``OUTPUT``
      - [vector: polygon]
@@ -730,8 +735,7 @@ Outputs
      - ``ERRORS``
      - [vector: point]
      - Output point layer representing the error locations and information.
-       Other than the ``UNIQUE_ID`` field referring to an intersecting input feature,
-       the output layer also contains the following fields:
+       The output layer contains the following fields:
 
        - ``gc_layerid``: the ID of the input layer.
        - ``gc_layername``: the name of the input layer.
@@ -740,6 +744,7 @@ Outputs
        - ``gc_vertidx``
        - ``gc_errorx``: the x coordinate of the intersection point.
        - ``gc_errory``: the y coordinate of the intersection point.
+       - ``UNIQUE_ID`` field: the unique ID of an intersecting input feature.
        - ``gc_error``: the layer name and index of the other intersecting feature.
    * - **Intersecting feature**
      - ``OUTPUT``
@@ -857,7 +862,7 @@ Outputs
      - ``ERRORS``
      - [vector: point]
      - Output point layer representing the error location and information.
-       Other than the ``UNIQUE_ID`` field, the output layer also contains the following fields:
+       The output layer contains the following fields:
 
        - ``gc_layerid``: the ID of the input layer.
        - ``gc_layername``: the name of the input layer.
@@ -866,6 +871,7 @@ Outputs
        - ``gc_vertidx``
        - ``gc_errorx``: the x coordinate of the intersection point.
        - ``gc_errory``: the y coordinate of the intersection point.
+       - ``UNIQUE_ID`` field: the unique ID of the intersecting input feature.
        - ``gc_error``: the index of the check layer where the intersection occurs.
    * - **Line intersecting other layer features**
      - ``OUTPUT``
@@ -988,14 +994,15 @@ Outputs
      - ``ERRORS``
      - [vector: point]
      - Output point layer representing the error locations and information.
-       Other than the ``UNIQUE_ID`` field, the output layer also contains the following fields:
-       
+       The output layer contains the following fields:
+
        - ``gc_layerid``: the ID of the input layer.
        - ``gc_layername``: the name of the input layer.
        - ``gc_errorx``: the x coordinate of the centroid of the overlapping area.
        - ``gc_errory``: the y coordinate of the centroid of the overlapping area.
        - ``gc_error``: the area of the overlapping geometry.
-       - ``gc_overlap_feature_{unique_id}``: the ``UNIQUE_ID`` field value for the overlapping feature.
+       - ``UNIQUE_ID`` field: the unique ID of an overlapped input feature.
+       - ``gc_overlap_feature_{unique_id}``: the ``UNIQUE_ID`` field value for the other overlapping feature.
    * - **Overlap features**
      - ``OUTPUT``
      - [vector: polygon]
@@ -1111,8 +1118,8 @@ Outputs
      - ``ERRORS``
      - [vector: point]
      - Output point layer representing the error locations and information.
-       Other than the ``UNIQUE_ID`` field, the output layer also contains the following fields:
-       
+       The output layer contains the following fields:
+
        - ``gc_layerid``: the ID of the input layer.
        - ``gc_layername``: the name of the input layer.
        - ``gc_partidx``: the index of the feature's geometry part where the self-intersection occurs.
@@ -1123,6 +1130,7 @@ Outputs
        - ``gc_error``
        - ``gc_segment_1``: the index of the first segment involved in the intersection.
        - ``gc_segment_2``: the index of the second segment involved in the intersection.
+       - ``UNIQUE_ID`` field: the unique ID of the self-intersecting input feature.
    * - **Self-intersecting features**
      - ``OUTPUT``
      - [vector: line, polygon]
@@ -1353,8 +1361,8 @@ Outputs
      - ``ERRORS``
      - [vector: point]
      - Output point layer representing the error locations and information.
-       Other than the ``UNIQUE_ID`` field, the output layer also contains the following fields:
-       
+       The output layer contains the following fields:
+
        - ``gc_layerid``: the ID of the input layer.
        - ``gc_layername``: the name of the input layer.
        - ``gc_partidx``: the index of the feature's geometry part containing the small segment.
@@ -1363,6 +1371,7 @@ Outputs
        - ``gc_errorx``: the x coordinate of the centroid of the small segment.
        - ``gc_errory``: the y coordinate of the centroid of the small segment.
        - ``gc_error``: the error segment length.
+       - ``UNIQUE_ID`` field: the unique ID of the input feature with the small segment.
    * - **Short segments features**
      - ``OUTPUT``
      - [vector: same as input]

--- a/docs/user_manual/processing_algs/qgis/checkgeometry.rst
+++ b/docs/user_manual/processing_algs/qgis/checkgeometry.rst
@@ -127,6 +127,7 @@ Outputs
      - [vector: line]
      - Output line layer containing the input dangle-end features.
        If no dangle-end features are found, the output layer will be empty.
+       Available fields are the same as in the ``ERRORS`` output.
 
 Python code
 ...........
@@ -752,7 +753,7 @@ Outputs
      - [vector: line]
      - Output layer containing, for each identified intersection, the feature (with same ``UNIQUE_ID`` value) it belongs to.
        If no intersections are found, the output layer will be empty.
-       Additional fields are available (see ``ERRORS`` output).
+       Available fields are the same as in the ``ERRORS`` output.
 
 Python code
 ...........
@@ -879,7 +880,7 @@ Outputs
      - [vector: line]
      - Output layer containing, for each identified intersection, the input feature it belongs to.
        If no intersections are found, the output layer will be empty.
-       Additional fields are available (see ``ERRORS`` output).
+       Available fields are the same as in the ``ERRORS`` output.
 
 Python code
 ...........
@@ -1008,7 +1009,7 @@ Outputs
      - ``OUTPUT``
      - [vector: polygon]
      - Output layer containing the overlapping areas.
-       Additional fields are available (see ``ERRORS`` output).
+       Available fields are the same as in the ``ERRORS`` output.
 
 Python code
 ...........
@@ -1385,7 +1386,7 @@ Outputs
      - ``OUTPUT``
      - [vector: same as input]
      - Output layer containing, for each identified short segment, the feature it belongs to.
-       Additional fields are available (see ``ERRORS`` output).
+       Available fields are the same as in the ``ERRORS`` output.
 
 Python code
 ...........

--- a/docs/user_manual/processing_algs/qgis/checkgeometry.rst
+++ b/docs/user_manual/processing_algs/qgis/checkgeometry.rst
@@ -1239,10 +1239,18 @@ Outputs
    * - **Small angle errors**
      - ``ERRORS``
      - [vector: point]
-     - Output point layer representing the error locations and information
-       (the ID and name of the input layer, the ID, geometry part,
-       ring and vertex index of the erroneous feature,
-       x and y coordinates of the error and the value of the erroneous angle).
+     - Output point layer representing the error locations and information.
+       The output layer contains the following fields:
+
+       - ``gc_layerid``: the ID of the input layer.
+       - ``gc_layername``: the name of the input layer.
+       - ``gc_partidx``: the index of the feature's geometry part containing the small angle.
+       - ``gc_ringidx``: the index of the feature's geometry ring containing the small angle.
+       - ``gc_vertidx``: the index of the vertex with the small angle in the feature's geometry ring.
+       - ``gc_errorx``: the x coordinate of the vertex with the small angle.
+       - ``gc_errory``: the y coordinate of the vertex with the small angle.
+       - ``gc_error``: the error angle value.
+       - ``UNIQUE_ID`` field: the unique ID of the input feature with the small angle.
 
 Python code
 ...........

--- a/docs/user_manual/processing_algs/qgis/checkgeometry.rst
+++ b/docs/user_manual/processing_algs/qgis/checkgeometry.rst
@@ -23,7 +23,8 @@ resulting in an endpoint without a proper connection.
 .. figure:: img/check_geometry_dangleendlines.png
    :align: center
 
-   Errors for dangle-end lines are reported on line features, and entire features with dangling ends are highlighted in red for clarity.
+   Errors for dangle-end lines are reported on line features,
+   and entire features with dangling ends are highlighted in red for clarity.
 
 Parameters
 ..........
@@ -927,7 +928,7 @@ Basic parameters
      - ``UNIQUE_ID``
      - [tablefield: any]
      - Field storing unique values for feature identification.
-   * - **Min overlap area**
+   * - **Minimum overlap area**
      - ``MIN_OVERLAP_AREA``
      - [numeric: double]
      - Minimum area of the overlap to be reported as an error.

--- a/docs/user_manual/processing_algs/qgis/fixgeometry.rst
+++ b/docs/user_manual/processing_algs/qgis/fixgeometry.rst
@@ -143,6 +143,7 @@ Outputs
      - ``OUTPUT``
      - [vector: same as input]
      - Output layer with the geometry fix applied to the input features.
+       The layer contains the same fields as in the input layer.
 
 Python code
 ...........
@@ -253,6 +254,7 @@ Outputs
      - ``OUTPUT``
      - [vector: same as input]
      - Output layer with features removed based on detected errors.
+       The layer contains the same fields as in the input layer.
 
 Python code
 ...........
@@ -390,6 +392,7 @@ Outputs
      - [vector: polygon]
      - Output layer with input features edited.
        Overlapping areas reported as errors are removed.
+       The layer contains the same fields as in the input layer.
 
 Python code
 ...........
@@ -545,6 +548,7 @@ Outputs
      - ``OUTPUT``
      - [same as input]
      - Output layer with the geometry fix applied to the input features
+       The layer contains the same fields as in the input layer.
 
 Python code
 ...........
@@ -694,6 +698,7 @@ Outputs
      - ``OUTPUT``
      - [vector: polygon]
      - Output layer of polygons without holes.
+       The layer contains the same fields as in the input layer.
 
 Python code
 ...........
@@ -868,6 +873,7 @@ Outputs
      - ``OUTPUT``
      - [vector: same as input]
      - Output layer with the geometry fix applied to the input features.
+       The layer contains the same fields as in the input layer.
 
 Python code
 ...........

--- a/docs/user_manual/processing_algs/qgis/fixgeometry.rst
+++ b/docs/user_manual/processing_algs/qgis/fixgeometry.rst
@@ -126,8 +126,8 @@ Outputs
      - ``REPORT``
      - [vector: point]
      - Output point layer representing the error locations and fix applied.
-       Other than the ``UNIQUE_ID`` field, the output layer also contains the following fields:
-       
+       The output layer contains the following fields:
+
        - ``gc_layerid``: the ID of the input layer.
        - ``gc_layername``: the name of the input layer.
        - ``gc_partidx``: the index of the feature's geometry part containing the duplicate vertex.
@@ -138,6 +138,7 @@ Outputs
        - ``gc_error``
        - ``report``: a text field describing the fix applied.
        - ``error_fixed``: a boolean field indicating whether the error was fixed.
+       - ``UNIQUE_ID`` field: the unique ID of the input feature that has duplicate vertices.
    * - **Fixed duplicate vertices layer**
      - ``OUTPUT``
      - [vector: same as input]
@@ -235,8 +236,8 @@ Outputs
      - ``REPORT``
      - [vector: point]
      - Output point layer representing the error locations and fix applied.
-       Other than the ``UNIQUE_ID`` field, the output layer also contains the following fields:
-       
+       The output layer contains the following fields:
+
        - ``gc_layerid``: the ID of the input layer.
        - ``gc_layername``: the name of the input layer.
        - ``gc_partidx``
@@ -247,6 +248,7 @@ Outputs
        - ``gc_error``: the index of the feature where the error belongs.
        - ``report``: a text field describing the fix applied.
        - ``error_fixed``: a boolean field indicating whether the error was fixed.
+       - ``UNIQUE_ID`` field: the unique ID of the input feature with the error.
    * - **Cleaned layer**
      - ``OUTPUT``
      - [vector: same as input]
@@ -372,15 +374,16 @@ Outputs
      - ``REPORT``
      - [vector: point]
      - Output point layer representing the error locations and fix applied.
-       Other than the ``UNIQUE_ID`` field, the output layer also contains the following fields:
-       
+       The output layer contains the following fields:
+
        - ``gc_layerid``: the ID of the input layer.
        - ``gc_layername``: the name of the input layer.
        - ``gc_errorx``: the x coordinate of the centroid of the overlapping area.
        - ``gc_errory``: the y coordinate of the centroid of the overlapping area.
        - ``gc_error``: the area of the overlapping geometry.
-       - ``gc_overlap_feature_{unique_id}``: the ``UNIQUE_ID`` field value for the overlapping feature.
        - ``report``: a text field describing the fix applied.
+       - ``UNIQUE_ID`` field: the unique ID of the unique ID of an overlapped input feature.
+       - ``gc_overlap_feature_{unique_id}``: the ``UNIQUE_ID`` field value for the other overlapping feature.
        - ``error_fixed``: a boolean field indicating whether the error was fixed.
    * - **No-overlap layer**
      - ``OUTPUT``
@@ -822,8 +825,8 @@ Outputs
      - ``REPORT``
      - [vector: point]
      - Output point layer representing the error locations and fix applied.
-       Other than the ``UNIQUE_ID`` field, the output layer also contains the following fields:
-       
+       The output layer contains the following fields:
+
        - ``gc_layerid``: the ID of the input layer.
        - ``gc_layername``: the name of the input layer.
        - ``gc_partidx``: the index of the feature's geometry part where the self-intersection occurs.
@@ -834,6 +837,7 @@ Outputs
        - ``gc_error``
        - ``gc_segment_1``: the index of the first segment involved in the intersection.
        - ``gc_segment_2``: the index of the second segment involved in the intersection.
+       - ``UNIQUE_ID`` field: the unique ID of the self-intersecting input feature.
        - ``report``: a text field describing the fix applied.
        - ``error_fixed``: a boolean field indicating whether the error was fixed.
    * - **Self-intersections fixed layer**

--- a/docs/user_manual/processing_algs/qgis/fixgeometry.rst
+++ b/docs/user_manual/processing_algs/qgis/fixgeometry.rst
@@ -526,9 +526,21 @@ Outputs
    * - **Report layer from fixing small angles**
      - ``REPORT``
      - [vector: point]
-     - Output point layer representing the error locations and fix applied
-       (the ID and name of the input layer, the ID, geometry part, ring and vertex index of the erroneous feature,
-       x and y coordinates and value of the erroneous angle, the applied fix and its successfulness).
+     - Output point layer representing the error locations and fix applied.
+       The output layer contains the following fields:
+
+       - ``gc_layerid``: the ID of the input layer.
+       - ``gc_layername``: the name of the input layer.
+       - ``gc_partidx``: the index of the feature's geometry part containing the small angle.
+       - ``gc_ringidx``: the index of the feature's geometry ring containing the small angle.
+       - ``gc_vertidx``: the index of the vertex with the small angle in the feature's geometry ring.
+       - ``gc_errorx``: the x coordinate of the vertex with the small angle.
+       - ``gc_errory``: the y coordinate of the vertex with the small angle.
+       - ``gc_error``: the error angle value.
+       - ``UNIQUE_ID`` field: the unique ID of the input feature with the small angle.
+       - ``report``: a text field describing the fix applied or justifying the failure.
+       - ``error_fixed``: a boolean field indicating whether the error was fixed.
+
    * - **Small angle fixed layer**
      - ``OUTPUT``
      - [same as input]
@@ -663,9 +675,21 @@ Outputs
    * - **Report layer from fixing holes**
      - ``REPORT``
      - [vector: point]
-     - Output point layer representing the error locations and fix applied
-       (the ID and name of the input layer, the geometry part, ring and vertex index of the erroneous feature,
-       x and y coordinates of the error, the applied fix and its successfulness).
+     - Output point layer representing the error locations and fix applied.
+       The output layer contains the following fields:
+
+       - ``gc_layerid``: the ID of the input layer.
+       - ``gc_layername``: the name of the input layer.
+       - ``gc_partidx``: the index of the feature's geometry part containing the hole.
+       - ``gc_ringidx``: the index of the feature's geometry ring containing the hole.
+       - ``gc_vertidx``
+       - ``gc_errorx``: the x coordinate of the centroid of the hole.
+       - ``gc_errory``: the y coordinate of the centroid of the hole.
+       - ``gc_error``
+       - ``UNIQUE_ID`` field: the unique ID of the input feature that has a hole.
+       - ``report``: a text field describing the fix applied or justifying the failure.
+       - ``error_fixed``: a boolean field indicating whether the error was fixed.
+
    * - **Holes-filled layer**
      - ``OUTPUT``
      - [vector: polygon]

--- a/docs/user_manual/processing_algs/qgis/fixgeometry.rst
+++ b/docs/user_manual/processing_algs/qgis/fixgeometry.rst
@@ -383,9 +383,13 @@ Outputs
        - ``gc_errorx``: the x coordinate of the centroid of the overlapping area.
        - ``gc_errory``: the y coordinate of the centroid of the overlapping area.
        - ``gc_error``: the area of the overlapping geometry.
-       - ``report``: a text field describing the fix applied.
        - ``UNIQUE_ID`` field: the unique ID of the unique ID of an overlapped input feature.
        - ``gc_overlap_feature_{unique_id}``: the ``UNIQUE_ID`` field value for the other overlapping feature.
+       - ``report``: a text field describing the fix applied or justifying the failure.
+         Possible values are:
+
+         * Remove overlapping area from neighboring polygon with shortest shared edge
+         * Error is obsolete
        - ``error_fixed``: a boolean field indicating whether the error was fixed.
    * - **No-overlap layer**
      - ``OUTPUT``

--- a/docs/user_manual/processing_algs/qgis/fixgeometry.rst
+++ b/docs/user_manual/processing_algs/qgis/fixgeometry.rst
@@ -132,7 +132,7 @@ Outputs
        - ``gc_layername``: the name of the input layer.
        - ``gc_partidx``: the index of the feature's geometry part containing the duplicate vertex.
        - ``gc_ringidx``: the index of the feature's geometry ring containing the duplicate vertex.
-       - ``gc_vertidx``: the index of the duplicate vertex in the feature.
+       - ``gc_vertidx``: the index of the duplicate vertex in the feature's geometry ring.
        - ``gc_errorx``: the x coordinate of the duplicate vertex.
        - ``gc_errory``: the y coordinate of the duplicate vertex.
        - ``gc_error``


### PR DESCRIPTION
This PR contains different changes and tries to harmonize literal description of the algs outputs, namely:
- Mention the UNIQUE_ID field as part of the output layer fields
- Clarify what the vertex index value actually refers to
- apply same formatting to all algs outputs
- Mention that output layers from check algs have the same fields
- Mention that `OUTPUT` layer from fix alg has same fields as `INPUT` layer