### PR TITLE
Approximate medial axis algorithm

### DIFF
--- a/docs/user_manual/processing_algs/qgis/vectorgeometry.rst
+++ b/docs/user_manual/processing_algs/qgis/vectorgeometry.rst
@@ -416,10 +416,8 @@ of each polygon, preserving main topology while ignoring small variations.
 Z values are ignored; the medial axis is calculated from the 2D projection
 of input geometries.
 
-.. note:: `SFCGAL <https://www.osgeo.org/projects/sfcgal/>`_ support is disabled by default. To enable it when building QGIS, you need to:
-
-   * Install the SFCGAL development packages on your system.
-   * Enable SFCGAL in the CMake configuration using the ``WITH_SFCGAL`` flag.
+.. attention:: This algorithm is not available by default in QGIS. It requires `SFCGAL <https://sfcgal.gitlab.io/SFCGAL/>`_ 
+  library to be installed.
 
 Parameters
 ..........


### PR DESCRIPTION
fixes #10235 

NOTE: I was not able to test this algorithm because my current QGIS builds do not include SFCGAL support. See [this report](https://github.com/qgis/QGIS/issues/63563)
