### PR TITLE
Replace references of Qt5 by Qt6 in docs

### DIFF
--- a/docs/developers_guide/codingstandards.rst
+++ b/docs/developers_guide/codingstandards.rst
@@ -123,7 +123,7 @@ example:
    *
    ***************************************************************************/
 
-.. note:: There is a template for Qt Creator in git repository. To use it, copy it from
+.. note:: There is a template for Qt Creator in code repository. To use it, copy it from
   :source:`qt_creator_license_template <editors/QtCreator/qt_creator_license_template>`
   to a local location, adjust the
   mail address and - if required - the name and configure QtCreator to use it:

--- a/docs/developers_guide/localization.rst
+++ b/docs/developers_guide/localization.rst
@@ -15,9 +15,8 @@ the settings.
 Another option in the settings allows to define if the
 numeric thousands separator has to be used.
 
-All these features are implemented through the
-`QLocale <https://doc.qt.io/qt-5/qlocale.html>`_
-QT class which provides a very complete support for numeric
+All these features are implemented through the `QLocale`_
+Qt class which provides a very complete support for numeric
 and date types representation.
 
 In order to make this system work a few rules need to be
@@ -32,8 +31,8 @@ For strings that are printed on the screen and visible to the users
 do not use ``QString::number()`` because it does not take locale
 options into consideration and it always uses ``C`` locale.
 
-Also do not use string interpolation unless you use the ``L`` suffix as explained in
-`QString documentation <https://doc.qt.io/qt-5/qstring.html#arg-5>`_.
+Also do not use string interpolation unless you use the ``L`` suffix
+as explained in `QString`_ documentation.
 
 Use ``QLocale().toString()`` instead.
 
@@ -91,3 +90,5 @@ independently on a string obtained from another widget (e.g., a simple
 ``QLineEdit`` widget).
 
 
+.. _QLocale: https://doc.qt.io/qt-6/qlocale.html
+.. _QString: https://doc.qt.io/qt-6/qstring.html#arg-2

--- a/docs/developers_guide/unittesting.rst
+++ b/docs/developers_guide/unittesting.rst
@@ -689,7 +689,7 @@ like any executable.
   ********* Finished testing of TestQgsDxfExport *********
 
 These tests also take `command line arguments
-<https://doc.qt.io/qt-5/qtest-overview.html#qt-test-command-line-arguments>`_.
+<https://doc.qt.io/qt-6/qtest-overview.html#qt-test-command-line-arguments>`_.
 This makes it possible to run a specific subset of tests:
 
 .. code-block:: bash

--- a/docs/documentation_guidelines/do_translations.rst
+++ b/docs/documentation_guidelines/do_translations.rst
@@ -138,8 +138,7 @@ Two different tools are currently used to do translations in QGIS:
   transparently does the process described above and pulls all the translatable
   texts in one place for the translator. Just pick the files you want and translate.
   Translated files are stored in the platform until another release is pushed.
-* `Qt Linguist <https://doc.qt.io/qt-5/qtlinguist-index.html>`_, a Qt
-  development tool, requires the translator to pull locally
+* `Qt Linguist`_, a Qt  development tool, requires the translator to pull locally
   the :file:`.po` (or :file:`.ts`) files from the source code, translate and
   then push back.
 
@@ -280,8 +279,7 @@ In the menu you see the following buttons which are convenient to use.
 * |linguist_previous_todo| The Previous Todo button, searches backward and
   jumps to the first translation item it finds that still needs a translation.
 
-For further information on the use of Qt Linguist, see
-https://doc.qt.io/qt-5/linguist-translators.html
+For further information on the use of Qt Linguist, see `linguist-translators`_.
 
 .. warning::
 
@@ -445,6 +443,9 @@ Stick to above presented rules and the translated document will look fine!
 For any question, please contact the `QGIS Community Team
 <qgis-community-team@lists.osgeo.org>`_ or the
 `QGIS Translation Team <qgis-tr@lists.osgeo.org>`_.
+
+.. _`Qt Linguist`: https://doc.qt.io/qt-6/qtlinguist-index.html
+.. _`linguist-translators`: https://doc.qt.io/qt-6/linguist-translators.html
 
 
 .. Substitutions definitions - AVOID EDITING PAST THIS LINE

--- a/docs/pyqgis_developer_cookbook/canvas.rst
+++ b/docs/pyqgis_developer_cookbook/canvas.rst
@@ -61,8 +61,7 @@ module. The implementation is based on the Qt Graphics View framework.
 This framework generally provides a surface and a view where custom graphics
 items are placed and user can interact with them.  We will assume that you are
 familiar enough with Qt to understand the concepts of the graphics scene, view
-and items. If not, please read the `overview of the framework
-<https://doc.qt.io/qt-5/graphicsview.html>`_.
+and items. If not, please read the overview of the `graphicsview`_ framework.
 
 Whenever the map has been panned, zoomed in/out (or some other action that triggers
 a refresh), the map is rendered again within the current extent. The layers are
@@ -471,3 +470,5 @@ Here is an example of a custom canvas item that draws a circle:
   item = CircleCanvasItem(iface.mapCanvas())
   item.setCenter(QgsPointXY(200,200))
   item.setSize(80)
+
+.. _`graphicsview`: https://doc.qt.io/qt-6/.html

--- a/docs/pyqgis_developer_cookbook/composer.rst
+++ b/docs/pyqgis_developer_cookbook/composer.rst
@@ -132,13 +132,13 @@ then exported to PDF, SVG, raster images or directly printed on a printer.
 The layout consists of a bunch of classes. They all belong to the core
 library. QGIS application has a convenient GUI for placement of the elements,
 though it is not available in the GUI library. If you are not familiar with
-`Qt Graphics View framework <https://doc.qt.io/qt-5/graphicsview.html>`_,
+`Qt Graphics View framework <https://doc.qt.io/qt-6/graphicsview.html>`_,
 then you are encouraged to check the documentation now, because the layout
 is based on it.
 
 The central class of the layout is the :class:`QgsLayout <qgis.core.QgsLayout>`
-class, which is derived from the Qt `QGraphicsScene <https://doc.qt.io/qt-5/qgraphicsscene.html>`_
-class. Let us create an instance of it:
+class, which is derived from the Qt `QGraphicsScene`_ class.
+Let us create an instance of it:
 
 .. testcode:: composer
 
@@ -333,7 +333,8 @@ To export a layout, the :class:`QgsLayoutExporter <qgis.core.QgsLayoutExporter>`
    exporter = QgsLayoutExporter(layout)
    exporter.exportToPdf(pdf_path, QgsLayoutExporter.PdfExportSettings())
 
-Use :meth:`exportToSvg() <qgis.core.QgsLayoutExporter.exportToSvg>` or :meth:`exportToImage() <qgis.core.QgsLayoutExporter.exportToImage>`
+Use :meth:`exportToSvg() <qgis.core.QgsLayoutExporter.exportToSvg>`
+or :meth:`exportToImage() <qgis.core.QgsLayoutExporter.exportToImage>`
 in case you want to export to respectively an SVG or image file instead of a PDF file.
 
 Exporting a layout atlas
@@ -352,3 +353,4 @@ example, the pages are exported to PNG images:
 Notice that the outputs will be saved in the base path folder, using the output
 filename expression configured on atlas.
 
+.. _`QGraphicsScene`: https://doc.qt.io/qt-6/qgraphicsscene.html

--- a/docs/pyqgis_developer_cookbook/intro.rst
+++ b/docs/pyqgis_developer_cookbook/intro.rst
@@ -417,8 +417,7 @@ Technical notes on PyQt and SIP
 ===============================
 
 We've decided for Python as it's one of the most favoured languages for
-scripting. PyQGIS bindings in QGIS 3 depend on SIP and PyQt5.
+scripting. PyQGIS bindings in QGIS depend on SIP and PyQt6.
 The reason for using SIP instead of the more widely used SWIG is that the
 QGIS code depends on Qt libraries. Python bindings for Qt (PyQt) are
-done using SIP and this allows seamless integration of PyQGIS with
-PyQt.
+done using SIP and this allows seamless integration of PyQGIS with PyQt.

--- a/docs/pyqgis_developer_cookbook/processing.rst
+++ b/docs/pyqgis_developer_cookbook/processing.rst
@@ -326,4 +326,4 @@ This is especially useful when fetching metadata or updating UI elements based o
 Always connect signals once (typically in ``__init__``) and use ``singleShot=True``
 to ensure the slot is triggered only once after a delay.
 
-.. _QTimer: https://doc.qt.io/archives/qt-5.15/qtimer.html
+.. _QTimer: https://doc.qt.io/qt-6/qtimer.html

--- a/docs/pyqgis_developer_cookbook/vector.rst
+++ b/docs/pyqgis_developer_cookbook/vector.rst
@@ -1675,8 +1675,8 @@ function becomes
 The icon can also be associated at any later time using the :meth:`setIcon()
 <qgis.core.QgsRendererAbstractMetadata.setIcon>` method
 of the metadata class. The icon can be loaded from a file (as shown above) or
-can be loaded from a `Qt resource <https://doc.qt.io/qt-5/resources.html>`_
-(PyQt5 includes .qrc compiler for Python).
+can be loaded from a `Qt resource <https://doc.qt.io/qt-6/resources.html>`_
+(PyQt6 includes .qrc compiler for Python).
 
 
 Further Topics

--- a/docs/user_manual/introduction/qgis_configuration.rst
+++ b/docs/user_manual/introduction/qgis_configuration.rst
@@ -1235,8 +1235,7 @@ Excluding some URLs can be added to the text box below the proxy settings (see
 the string listed in this text box.
 
 If you need more detailed information about the different proxy settings,
-please refer to the manual of the underlying QT library documentation at
-https://doc.qt.io/archives/qt-5.9/qnetworkproxy.html#ProxyType-enum
+please refer to the manual of the underlying QT library documentation at `ProxyType-enum`_.
 
 .. tip:: **Using Proxies**
 
@@ -2856,6 +2855,7 @@ in the QGIS user profile.
 * Project templates must be deployed in the :file:`project_templates` directory.
 * Custom Python macros must be deployed in the :file:`python` directory.
 
+.. _`ProxyType-enum`: https://doc.qt.io/qt-6/qnetworkproxy.html#ProxyType-enum
 .. _`PROJ 8.0`: https://proj.org/en/8.0/
 .. _Qt: https://doc.qt.io/qt-6.8/
 

--- a/docs/user_manual/map_views/3d_map_view.rst
+++ b/docs/user_manual/map_views/3d_map_view.rst
@@ -466,8 +466,7 @@ To create an animation:
 #. Click the |play| button to preview the animation. QGIS will generate scenes using
    the camera positions/rotations at set times, and interpolating them in between
    these keyframes. Various :guilabel:`Interpolation` modes for animations are
-   available (eg, linear, inQuad, outQuad, inCirc... -- more details at
-   https://doc.qt.io/qt-5/qeasingcurve.html#EasingFunction-typedef).
+   available (eg, linear, inQuad, outQuad, inCirc... -- more details at `QEasingCurve`_.
 
    The animation can also be previewed by moving the time slider.
    Keeping the :guilabel:`Loop` box checked will repeatedly run the
@@ -486,6 +485,8 @@ view by checking :guilabel:`Enable 3D Renderer` in the
 :guilabel:`3D View` section of the vector layer properties.
 A number of options are available for controlling the rendering of
 the 3D vector layer.
+
+.. _`QEasingCurve`: https://doc.qt.io/qt-6/qeasingcurve.html#EasingFunction-typedef).
 
 
 .. Substitutions definitions - AVOID EDITING PAST THIS LINE

--- a/docs/user_manual/plugins/python_console.rst
+++ b/docs/user_manual/plugins/python_console.rst
@@ -73,7 +73,7 @@ The Console input area main features are:
 
   * Python
   * PyQGIS
-  * PyQt5
+  * PyQt6
   * QScintilla2
   * osgeo-gdal-ogr
 

--- a/docs/user_manual/print_layout/create_output.rst
+++ b/docs/user_manual/print_layout/create_output.rst
@@ -239,8 +239,7 @@ To export a layout as PDF:
    
      * :guilabel:`Lossy (JPEG)`, which is the default compression mode
      * or :guilabel:`Lossless`, which creates bigger files in most cases, but is
-       much more suitable for printing outputs or for post-production in external
-       applications (requires Qt 5.13 or later).
+       much more suitable for printing outputs or for post-production in external applications.
    * |unchecked| :guilabel:`Create Geospatial PDF`:
      Generate a georeferenced PDF file.
    * |unchecked| :guilabel:`Disable tiled raster layer exports`: When exporting

--- a/docs/user_manual/style_library/label_settings.rst
+++ b/docs/user_manual/style_library/label_settings.rst
@@ -180,7 +180,7 @@ Use whitespaces instead of tabs for any kind of indentation.
 The expression is parsed and any supported HTML tag overrides its corresponding setting in the labels properties.
 Because it is impossible to list and detail every HTML tag and CSS property that QGIS currently supports,
 we invite you to explore and test in your labels
-`the ones supported <https://doc.qt.io/qt-5/richtext-html-subset.html>`_ by the underlying Qt library.
+`the ones supported <https://doc.qt.io/qt-6/richtext-html-subset.html>`_ by the underlying Qt library.
 
 **Examples of supported HTML tags:**
 

--- a/docs/user_manual/working_with_vector/vector_properties.rst
+++ b/docs/user_manual/working_with_vector/vector_properties.rst
@@ -2532,7 +2532,7 @@ They can be used to enhance the appearance of the form or to display dynamically
   and may contain the result of dynamically calculated expressions.
 * :guilabel:`Spacer Widget`: inserts an empty transparent rectangle, increasing the vertical distance between two widgets.
 
-.. _QML: https://doc.qt.io/qt-5/qtqml-syntax-basics.html
+.. _QML: https://doc.qt.io/qt-6/qtqml-syntax-basics.html
 
 .. tip:: **Display Dynamic Content**
 


### PR DESCRIPTION
Also, wherever possible without a risk of misleading translators, hide the URL behind a reference (to avoid breaking again translation in the future)

<!---
Include a few sentences describing the overall goals for this Pull Request.
 
A list of issues is at https://github.com/qgis/QGIS-Documentation/issues.
Add "fix #issuenumber" for each issue the PR fixes. The ticket(s) will be closed automatically.
If your PR doesn't fix entirely the ticket, only add the ticket(s) reference preceded by # character.
-->
Goal:

Ticket(s): #
<!---
Indicate whether the fix should be backported to previous release.
Replace the space between square brackets by a `x` to make it checked.
-->
- [ ] Backport to LTR documentation is requested

<!---
Reviewing is a process done by community members, mostly on a volunteer basis.
We try to keep the overhead as small as possible and appreciate if you help us.
Please read carefully and ensure you comply with our writing guidelines at
https://docs.qgis.org/testing/en/docs/documentation_guidelines/index.html.
Feel free to ask in a comment or the (qgis-community-team mailing list)
[https://lists.osgeo.org/mailman/listinfo/qgis-community-team] if you have troubles with any item.
--->
