### PR TITLE
Deduplicate mention of related features in Identify Results

### DIFF
--- a/docs/user_manual/introduction/general_tools.rst
+++ b/docs/user_manual/introduction/general_tools.rst
@@ -1109,6 +1109,9 @@ From bottom to top:
     to identify features from.
     If only a single feature is under the mouse, then the results are automatically displayed.
 
+
+.. _identify_toolbar:
+
 * In the upper part of the :guilabel:`Identify Results` dialog,
   a frame shows the :ref:`information <identified_information>` returned by features
   as a table, a graph or a tree, depending on the :ref:`selected view <identify_view>`.

--- a/docs/user_manual/working_with_vector/attribute_table.rst
+++ b/docs/user_manual/working_with_vector/attribute_table.rst
@@ -754,25 +754,26 @@ Under the :guilabel:`Feature` column, panel will display following information:
   in the layer's properties dialog (see :ref:`actions_menu`).
 * **Data attributes**: This is the list of attribute fields and values for the
   feature that has been clicked.
-* information about the related child feature if you defined a :ref:`relation <vector_relations>`:
+* When a vector layer has defined :ref:`relations <vector_relations>`,
+  the :guilabel:`Identify Results` panel can display both **referenced**
+  and **referencing** related features.
+  To view these relations, ensure that the :guilabel:`Show relations` option
+  is enabled in the :ref:`Identify Settings <identify_toolbar>`.
+  Available information for each related feature include:
 
   * the name of the relation
-  * the entry in reference field, e.g. the name of the related child feature
-  * **Data attributes**: This is the list of attributes fields and values of the
-    related child feature.
+  * the entry in the referenced or referencing field, identifying the feature
+  * the list of attribute fields and values
 
-When a vector layer has defined :ref:`relations <vector_relations>`, the :guilabel:`Identify Results` panel
-can display both **referenced** and **referencing** related features. 
-To view these relations, ensure that the :guilabel:`Show relations` option is enabled in the :ref:`Identify Settings <identify_view>`.
+  You can expand related features to explore connected records
+  through multiple levels, including many-to-many (n:m) and polymorphic relations.
+  Only nodes you explicitly expand are loaded, preventing excessive nesting.
 
-You can expand related features to explore connected records through multiple levels,
-including many-to-many (n:m) and polymorphic relations.
-Only nodes you explicitly expand are loaded, preventing excessive nesting.
-
-To focus on a specific related record, right-click it and choose :guilabel:`Identify Feature`. 
-This re-centers the identify results on the selected feature, starting a new identification tree from it 
-and effectively limiting the visible nesting depth. 
-Features already shown in ancestor nodes are automatically omitted to avoid duplicates or circular relations.
+  To focus on a specific related record, right-click it and choose :guilabel:`Identify Feature`.
+  This re-centers the identify results on the selected feature,
+  starting a new identification tree from it and effectively limiting the visible nesting depth.
+  Features already shown in ancestor nodes are automatically omitted
+  to avoid duplicates or circular relations.
 
 
 .. index:: External Storage, WebDAV


### PR DESCRIPTION
There was already a section relative to referenced feature, so let's merge with referencing features instead of a new paragraph about both

<!---
Include a few sentences describing the overall goals for this Pull Request.
 
A list of issues is at https://github.com/qgis/QGIS-Documentation/issues.
Add "fix #issuenumber" for each issue the PR fixes. The ticket(s) will be closed automatically.
If your PR doesn't fix entirely the ticket, only add the ticket(s) reference preceded by # character.
-->
Goal:

Ticket(s): #
<!---
Indicate whether the fix should be backported to previous release.
Replace the space between square brackets by a `x` to make it checked.
-->
- [ ] Backport to LTR documentation is requested

<!---
Reviewing is a process done by community members, mostly on a volunteer basis.
We try to keep the overhead as small as possible and appreciate if you help us.
Please read carefully and ensure you comply with our writing guidelines at
https://docs.qgis.org/testing/en/docs/documentation_guidelines/index.html.
Feel free to ask in a comment or the (qgis-community-team mailing list)
[https://lists.osgeo.org/mailman/listinfo/qgis-community-team] if you have troubles with any item.
--->
