### PR TITLE
Identify Features tool: move vector layer specific information to the layer's page

### DIFF
--- a/docs/user_manual/introduction/general_tools.rst
+++ b/docs/user_manual/introduction/general_tools.rst
@@ -1085,6 +1085,7 @@ From bottom to top:
   and the formatting of the results; it can be set as:
 
   * **Tree**: this is the default view, and returns the results in a tree-structure
+    where the first item is the name of the layer and its children are its identified element(s).
   * **Table**: available only for raster-based layers, it allows to display the results
     as a table whose columns are ``Layer``, ``FID``, ``Attribute`` and ``Value``
   * or **Graph**: available only for raster-based layers
@@ -1109,13 +1110,23 @@ From bottom to top:
     to identify features from.
     If only a single feature is under the mouse, then the results are automatically displayed.
 
+* In the upper part, the information widget: when you identify a data in the map canvas,
+  this is the place where the :guilabel:`Identify Results` dialog will list details
+  about the clicked (or hovered over, depending on the tool in use) items.
+  Their formatting relies on the :ref:`selected view <identify_view>`.
+
+  The information displayed by the identify tool will depend on the type
+  of layer you have selected, whether it is:
+
+  * a :ref:`vector layer <identify_features_vector>` (including vector tiles
+    or point cloud data),
+  * a :ref:`raster layer <raster_identify>`,
+  * a :ref:`mesh layer <exploring_mesh>`.
 
 .. _identify_toolbar:
 
-* In the upper part of the :guilabel:`Identify Results` dialog,
-  a frame shows the :ref:`information <identified_information>` returned by features
-  as a table, a graph or a tree, depending on the :ref:`selected view <identify_view>`.
-  When in a tree view, you have a handful of tools above the results:
+* When in a tree view, the upper part also displays a handful of tools
+  above the results:
 
   * |formView| :sup:`Open Form` of the current feature
   * |expandTree| :sup:`Expand tree`
@@ -1194,74 +1205,6 @@ may greatly improve identification operations:
    uncheck the :guilabel:`Identifiable` column next to a layer
    to avoid it being queried when using the |identify| :sup:`Identify Features` tool.
    This is a handy way to return features from only layers that are of interest to you.
-
-
-.. _`identified_information`:
-
-Feature information
-...................
-
-When you identify a data in the map canvas, the :guilabel:`Identify Results` dialog will list
-information about the items clicked (or hovered over, depending on the tool in use).
-The default view is a tree view in which the first item is the name of the layer
-and its children are its identified feature(s).
-Each feature is described by the name of a field along with its value.
-This field is the one set in :menuselection:`Layer Properties --> Display`.
-All the other information about the feature follows.
-
-The feature information displayed by the identify tool will depend on the type 
-of layer you have selected, whether it is a vector layer (including vector tiles 
-or point cloud data) or raster layer. If your layer is raster, clicking on a location
-on the map canvas with identify tool will highlight the identified raster pixel.
-The Identify Results dialog can be customized to display custom fields, but by
-default it will display the following information:
-
-.. index:: Actions
-
-* The feature :ref:`display name <maptips>`;
-* **Actions**: Actions can be added to the identify feature windows.
-  The action is run by clicking on the action label. By default, only one action
-  is added, namely ``View feature form`` for editing. You can define more actions
-  in the layer's properties dialog (see :ref:`actions_menu`).
-* **Derived**: This information is calculated or derived from other information.
-  It includes:
-
-  * general information about the feature's geometry:
-
-    * depending on the geometry type, the cartesian measurements of length,
-      perimeter or area in the layer's CRS units.
-      For 3D line vectors the cartesian line length is available.
-    * depending on the geometry type and if an ellipsoid is set in the project
-      properties dialog for :guilabel:`Measurements`, the ellipsoidal values of
-      length, perimeter or area using the specified units
-    * the count of geometry parts in the feature and the number of the part
-      clicked
-    * the count of vertices in the feature
-  * coordinate information, using the project properties :guilabel:`Coordinates
-    display` settings:
-
-    * ``X`` and ``Y`` coordinate values of the point clicked
-    * the number of the closest vertex to the point clicked
-    * ``X`` and ``Y`` coordinate values of the
-      closest vertex (and ``Z``/``M`` if applicable)
-    * if you click on a curved segment,
-      the radius of that section is also displayed.
-    * if both the vector layer and the project have vertical datums set and they differ,
-      the ``Z`` value will be displayed for both datums.
-
-* **Data attributes**: This is the list of attribute fields and values for the
-  feature that has been clicked.
-* information about the related child feature if you defined a :ref:`relation <vector_relations>`:
-
-  * the name of the relation
-  * the entry in reference field, e.g. the name of the related child feature
-  * **Actions**: lists actions defined in the layer's properties dialog (see :ref:`actions_menu`)
-    and the default action is ``View feature form``.
-  * **Data attributes**: This is the list of attributes fields and values of the
-    related child feature.
-
-.. note:: Links in the feature's attributes are clickable from the :guilabel:`Identify
-   Results` panel and will open in your default web browser.
 
 
 Results contextual menu

--- a/docs/user_manual/working_with_raster/raster_properties.rst
+++ b/docs/user_manual/working_with_raster/raster_properties.rst
@@ -1170,6 +1170,7 @@ To use the |identify|:guilabel:`Identify features` tool:
 #. Select the raster layer in the Layers panel.
 #. Click on the :guilabel:`Identify features` tool in the toolbar or press :kbd:`Ctrl+Shift+I`.
 #. Click on the point in the raster layer that you want to identify.
+   The pixel will get highlighted.
 
 The Identify Results panel will open in its default ``Tree`` view
 and display information about the clicked point.

--- a/docs/user_manual/working_with_vector/attribute_table.rst
+++ b/docs/user_manual/working_with_vector/attribute_table.rst
@@ -725,35 +725,55 @@ To use the :guilabel:`Identify features` tool for vector layers, follow these st
 #. Click on the :guilabel:`Identify features` tool in the toolbar or press :kbd:`Ctrl+Shift+I`.
 #. Click on a feature in the map view.
 
+.. _figure_identify_vector:
+
+.. figure:: ../introduction/img/identify_features.png
+   :align: center
+
+   Identify Results dialog
+
 The :guilabel:`Identify results` panel will display different features information
-depending on the layer type. There are two columns in the panel, on the left side
-you can see :guilabel:`Feature` and on the right side :guilabel:`Value`.
-Under the :guilabel:`Feature` column, panel will display following information:
+in a tree view.
+There are two columns in the panel: :guilabel:`Feature` and :guilabel:`Value`.
+The first item is the name of the layer and its children are its identified feature(s).
+Each feature is identified by the :ref:`display name <maptips>` field along with its value.
+Other information about the feature follows:
 
 * **Derived** section - those are the information calculated or derived from other
   information in the layer. For example, the area of a polygon or the length of a line.
   General information that can be found in this section:
 
-  * Depending on the geometry type, cartesian measurements of length, perimeter, or area
-    in the layer's CRS units. For 3D line vectors, the cartesian line length is available.
+  * Depending on the geometry type, the cartesian measurements of length,
+    perimeter or area in the layer's CRS units.
+    For 3D line vectors, the cartesian line length is available.
   * Depending on the geometry type and if an ellipsoid is set in the :guilabel:`Project Properties`
     dialog (:menuselection:`General --> Measurements`), ellipsoidal values
     of length, perimeter, or area using the specified units.
   * The count of geometry parts in the feature and the number of the part clicked.
   * The count of vertices in the feature.
 
-  Coordinate information that can be found in this section:
-  
-  * X and Y coordinate values of the clicked point.
-  * The number of the closest vertex to the clicked point.
-  * X and Y coordinate values of the closest vertex.
-  * If you click on a curved segment, the radius of that section is also displayed.
+  * Coordinate information, using the project properties :guilabel:`Coordinates
+    display` settings:
+
+    * ``X`` and ``Y`` coordinate values of the clicked point
+    * the number of the closest vertex to the clicked point
+    * ``X`` and ``Y`` coordinate values of the closest vertex
+      (and ``Z``/``M`` if applicable)
+    * if you click on a curved segment, the radius of that section is also displayed.
+    * if both the vector layer and the project have vertical datums set and they differ,
+      the ``Z`` value will be displayed for both datums.
+
 * **Actions**: Actions can be added to the identify feature windows.
   The action is run by clicking on the action label. By default, only one action
   is added, namely ``View feature form`` for editing. You can define more actions
   in the layer's properties dialog (see :ref:`actions_menu`).
-* **Data attributes**: This is the list of attribute fields and values for the
-  feature that has been clicked.
+* **Data attributes**: This is the list of attribute fields and values
+  for the feature that has been clicked.
+
+  .. note:: Links in the feature's attributes are clickable
+   from the :guilabel:`Identify Results` panel
+   and will open in your default web browser.
+
 * When a vector layer has defined :ref:`relations <vector_relations>`,
   the :guilabel:`Identify Results` panel can display both **referenced**
   and **referencing** related features.
@@ -761,8 +781,9 @@ Under the :guilabel:`Feature` column, panel will display following information:
   is enabled in the :ref:`Identify Settings <identify_toolbar>`.
   Available information for each related feature include:
 
-  * the name of the relation
+  * the name of the relation and the linked layer
   * the entry in the referenced or referencing field, identifying the feature
+  * the activated actions
   * the list of attribute fields and values
 
   You can expand related features to explore connected records


### PR DESCRIPTION
Also add link to identify tool section in each layer type page
 refs https://github.com/qgis/QGIS-Documentation/pull/8764