### PR TITLE
List "Subsections indicator" related entries in the Elevation profile toolbar

### DIFF
--- a/docs/user_manual/map_views/elevation_profile.rst
+++ b/docs/user_manual/map_views/elevation_profile.rst
@@ -106,13 +106,14 @@ At the top of the :guilabel:`Elevation Profile` panel, a toolbar provides you wi
      - Provides access to configuration settings of the profile elevation line.
    * -  :menuselection:`-->` |unchecked| :menuselection:`Lock distance/elevation scales`
      -
-     - Keeps the current distance and elevation scales fixed when zooming or panning the plot canvas.
+     - If checked, keeps the current distance and elevation scales fixed
+       when zooming or panning the plot canvas.
        When unlocked, the ratio is automatically adjusted to fit the full extent of the current profile
        line and elevation range (similar to “zoom full”), and will change when zooming in/out.
    * -  :menuselection:`--> Scale Ratio`
      -
      - Specifies the ratio of distance to elevation units used for the profile's scale.
-   * - :menuselection:`--> Distance units`
+   * - :menuselection:`--> Distance Units`
      -
      - Allows to render distances in the profile chart with units other than the map canvas units.
    * - :menuselection:`--> Tolerance`
@@ -120,9 +121,18 @@ At the top of the :guilabel:`Elevation Profile` panel, a toolbar provides you wi
      - Sets how far from the actual profile line a feature (vector point, line or polygon, point cloud)
        can reside to be included in the results.
        Uses the map units and is ignored by other layer or geometry types.
-       For some layer types (e.g. points, lines, polygons), a custom tolerance can be set in the layer's Elevation properties tab, 
-       which replaces the global tolerance and allows more control over feature inclusion based on distance to the profile line.
-
+       For some layer types (e.g. points, lines, polygons),
+       a custom tolerance can be set in the layer's Elevation properties tab,
+       which replaces the global tolerance and allows more control over feature inclusion
+       based on distance to the profile line.
+   * - :menuselection:`-->` |unchecked|  :guilabel:`Show Subsections Indicator`
+     -
+     - Displays vertical lines at the distance of the vertices of the profile curve,
+       highlighting the position of the vertices of the curve on the Elevation Profile.
+   * - :menuselection:`--> Subsections Symbology...`
+     -
+     - Sets the :ref:`symbology <vector_line_symbols>` (color, opacity, width, style,...)
+       of the subsections indicator lines.
    * - :menuselection:`--> Rename Profile...`
      -
      - Allows to rename the profile view.
@@ -205,27 +215,27 @@ To create a profile view, you can:
 
 #. Under |options| :sup:`Options` drop-down menu, you can:
 
-   * set the :guilabel:`Tolerance` value. This value is used to create a flat buffer around the elevation profile line, 
-     visible in the main map canvas. Any visible feature (point, line, polygon, etc.) overlapping that buffer will be captured in the plot canvas.
-   * select the |checkbox| :guilabel:`Show Subsections Indicator` to display vertical lines at the distance of the vertices of the profile curve. 
-     This highlights the position of the vertices of the curve on the Elevation Profile.
-   * select the :guilabel:`Subsections Symbology` to set the color, opacity, width and style of the Subsections Indicator lines.
+   * set the :guilabel:`Tolerance` value. This value is used to create a flat buffer around the elevation profile line,
+     visible in the main map canvas. Any visible feature (point, line, polygon, etc.)
+     overlapping that buffer will be captured in the plot canvas.
 
-   .. note:: **Limitations with polygon extrusion**
+     .. note:: **Limitations with polygon extrusion**
 
-     Geometry extrusion can be set in the |elevationscale| :guilabel:`Elevation` properties of a layer,
-     and rendered in the profile view. When tolerance is enabled, it is however not trivial to render extruded polygons,
-     thus, for now, polygon extrusion is ignored.
+      Geometry extrusion can be set in the |elevationscale| :guilabel:`Elevation` properties of a layer,
+      and rendered in the profile view. When tolerance is enabled, it is however not trivial to render extruded polygons,
+      thus, for now, polygon extrusion is ignored.
 
+   * specify the ratio of distance to elevation units that is used for the profile's scale.
+     By default, the initial scale is automatically adjusted to fit the entire profile
+     in the viewer (similar to a zoom full view).
+     Setting a scale of 10:1 means that 10 units of distance are equal to 1 unit of elevation,
+     effectively exaggerating the vertical scale.
+     To freeze the distance/elevation scale ratio, check the :guilabel:`Lock Distance/Elevation Scales` option.
+     When this option is enabled, the plot maintains the defined ratio while zooming
+     or navigating within the profile view.
+   * |checkbox| :guilabel:`Show Subsections Indicator` to display vertical lines at the position of the vertices
+     of the profile curve on the Elevation Profile, and configure their symbology.
 
-   You can also specify the ratio of distance to elevation units that is
-   used for the profile's scale. By default, the initial scale is automatically adjusted to
-   fit the entire profile in the viewer (similar to a zoom full view).
-   Setting a scale of 10:1 means that 10 units of distance
-   are equal to 1 unit of elevation, effectively exaggerating the vertical scale. To freeze
-   the distance/elevation scale ratio, check the :guilabel:`Lock Distance/Elevation Scales` option.
-   When this option is enabled, the plot maintains the defined ratio while zooming
-   or navigating within the profile view.
 
 .. _`elevation_profile_interaction`:
 


### PR DESCRIPTION
and move the "lock scale ratio" step as part of configuring Options subitems
Followup to #10277 and #10408
<!---
Include a few sentences describing the overall goals for this Pull Request.
 
A list of issues is at https://github.com/qgis/QGIS-Documentation/issues.
Add "fix #issuenumber" for each issue the PR fixes. The ticket(s) will be closed automatically.
If your PR doesn't fix entirely the ticket, only add the ticket(s) reference preceded by # character.
-->
Goal:

Ticket(s): #
<!---
Indicate whether the fix should be backported to previous release.
Replace the space between square brackets by a `x` to make it checked.
-->
- [ ] Backport to LTR documentation is requested

<!---
Reviewing is a process done by community members, mostly on a volunteer basis.
We try to keep the overhead as small as possible and appreciate if you help us.
Please read carefully and ensure you comply with our writing guidelines at
https://docs.qgis.org/testing/en/docs/documentation_guidelines/index.html.
Feel free to ask in a comment or the (qgis-community-team mailing list)
[https://lists.osgeo.org/mailman/listinfo/qgis-community-team] if you have troubles with any item.
--->
