### PR TITLE
adding remove group action into elevation profile

### DIFF
--- a/docs/user_manual/map_views/elevation_profile.rst
+++ b/docs/user_manual/map_views/elevation_profile.rst
@@ -48,9 +48,9 @@ At the top of the :guilabel:`Elevation Profile` panel, a toolbar provides you wi
    * - |layerTree| :sup:`Show Layer Tree`
      -
      - Shows or hides a list of project layers to configure rendering in the profile view.
-   * - |removeLayer| :sup:`Remove Group Action`
+   * - |removeLayer| :sup:`Remove Group`
      - 
-     - Removes group action
+     - Removes selected group from the layer tree
    * - |captureLine| :sup:`Capture Curve`
      -
      - Draws interactively a line over the map canvas to represent the profile curve.
@@ -195,7 +195,7 @@ To create a profile view, you can:
       Clicking the |addLayer| :sup:`Add layers` button will show a filtered list of possible layers
       which can be added to the plot, but which currently aren't in the plot.
       Applying the dialog with selected layers will automatically mark them as having elevation data
-      and immediately add them to the plot. Clicking the |removeLayer| :sup:`Remove layer`
+      and immediately add them to the plot. Clicking the |removeLayer| :sup:`Remove Group`
       button will remove the selected group while keeping its child layers: the child
       layers are promoted one level up in the tree instead of being deleted.
 

--- a/substitutions.txt
+++ b/substitutions.txt
@@ -1044,8 +1044,6 @@
    :width: 1.5em
 .. |removeLayer| image:: /static/common/mActionRemoveLayer.png
    :width: 1.5em
-.. |removeGroupAction| image:: /static/common/mActionRemoveLayer.png
-   :width: 1.5em
 .. |render| image:: /static/common/render.png
    :width: 1.5em
 .. |rendering| image:: /static/common/rendering.png


### PR DESCRIPTION
<!---
Include a few sentences describing the overall goals for this Pull Request.
This PR adds the missing Remove Group action screenshot to the Elevation Profile
documentation and improves the related explanation for better clarity.

 
A list of issues is at https://github.com/qgis/QGIS-Documentation/issues.
Add "fix #issuenumber" for each issue the PR fixes. The ticket(s) will be closed automatically.
If your PR doesn't fix entirely the ticket, only add the ticket(s) reference preceded by # character.
-->
Goal:. This PR updates the Elevation Profile documentation by adding a missing screenshot
and clarifying the description of the Remove Group action.

Ticket(s):  fix  #10459 
<!---
Indicate whether the fix should be backported to previous release.
Replace the space between square brackets by a `x` to make it checked.
-->
- [x ] Backport to LTR documentation is requested

<!---
Reviewing is a process done by community members, mostly on a volunteer basis.
We try to keep the overhead as small as possible and appreciate if you help us.
Please read carefully and ensure you comply with our writing guidelines at
https://docs.qgis.org/testing/en/docs/documentation_guidelines/index.html.
Feel free to ask in a comment or the (qgis-community-team mailing list)
[https://lists.osgeo.org/mailman/listinfo/qgis-community-team] if you have troubles with any item.
--->
