### PR TITLE
Remove wrong figure reference

### DIFF
--- a/docs/user_manual/map_views/map_view.rst
+++ b/docs/user_manual/map_views/map_view.rst
@@ -1037,7 +1037,7 @@ menu or from the :guilabel:`Annotations Toolbar`:
 * |htmlAnnotation| :sup:`HTML Annotation` to display a HTML-formatted string
   or a whole :file:`HTML` file as an annotation.
 * |formAnnotation| :sup:`Form Annotation`: useful to display attributes
-  of a vector layer in a customized :file:`ui` file (see :numref:`figure_custom_annotation`).
+  of a vector layer in a customized :file:`.ui` file.
   This is similar to the :ref:`custom attribute forms <provide_ui_file>`,
   but displayed in an annotation item.
 


### PR DESCRIPTION
The figure (just below) doesn't show a form annotation, but a HTML one

<!---
Include a few sentences describing the overall goals for this Pull Request.
 
A list of issues is at https://github.com/qgis/QGIS-Documentation/issues.
Add "fix #issuenumber" for each issue the PR fixes. The ticket(s) will be closed automatically.
If your PR doesn't fix entirely the ticket, only add the ticket(s) reference preceded by # character.
-->
Goal:

Ticket(s): #
<!---
Indicate whether the fix should be backported to previous release.
Replace the space between square brackets by a `x` to make it checked.
-->
- [ ] Backport to LTR documentation is requested

<!---
Reviewing is a process done by community members, mostly on a volunteer basis.
We try to keep the overhead as small as possible and appreciate if you help us.
Please read carefully and ensure you comply with our writing guidelines at
https://docs.qgis.org/testing/en/docs/documentation_guidelines/index.html.
Feel free to ask in a comment or the (qgis-community-team mailing list)
[https://lists.osgeo.org/mailman/listinfo/qgis-community-team] if you have troubles with any item.
--->
