### PR TITLE
Update list of properties tabs accessible from Layer Styling panel

### DIFF
--- a/docs/user_manual/introduction/general_tools.rst
+++ b/docs/user_manual/introduction/general_tools.rst
@@ -501,12 +501,17 @@ From a drop-down list of current layers in the layer panel, select an item and:
     :guilabel:`Mask` and |3d| :guilabel:`3D View` properties for vector layer.
     These options are the same as in the :ref:`vector_properties_dialog`
     and can be extended by custom properties introduced by third-party plugins.
-  * |symbology| :guilabel:`Symbology` and |3d| :guilabel:`3D View` properties
+  * |symbology| :guilabel:`Symbology`, |labelingSingle| :guilabel:`Labels` and |3d| :guilabel:`3D View` properties
     for mesh layer.
     These options are the same as in the :ref:`label_meshproperties`.
   * |symbology| :guilabel:`Symbology`, |3d| :guilabel:`3D View`
-    and |elevationscale| :guilabel:`Elevation` properties for point cloud layer.
-    These options are the same as in the :ref:`point_clouds_properties`.
+    and |elevationscale| :guilabel:`Elevation` properties for point cloud or 3D Tiles layer.
+    These options are the same as in the :ref:`point_clouds_properties` or :ref:`3dtiles_properties`.
+  * |symbology| :guilabel:`Symbology` and |labelingSingle| :guilabel:`Labels` properties for vector tiles layer.
+    These options are the same as in the :ref:`vectortiles_properties`.
+  * |symbology| :guilabel:`Symbology` and |3d| :guilabel:`3D View` properties for annotations layer.
+    These options are the same as in the :ref:`feature annotation properties <annotation_layer>`.
+
 * Enable and configure :ref:`global map shading <global_map_shading>` properties
 * Manage the associated style(s) in the |stylePreset| :guilabel:`Style Manager`
   (more details at :ref:`manage_custom_style`).


### PR DESCRIPTION
- [ ] to do: remove mention of 3D tab for annotations when backporting to 3.44
<!---
Include a few sentences describing the overall goals for this Pull Request.
 
A list of issues is at https://github.com/qgis/QGIS-Documentation/issues.
Add "fix #issuenumber" for each issue the PR fixes. The ticket(s) will be closed automatically.
If your PR doesn't fix entirely the ticket, only add the ticket(s) reference preceded by # character.
-->
Goal:

Ticket(s): #
<!---
Indicate whether the fix should be backported to previous release.
Replace the space between square brackets by a `x` to make it checked.
-->
- [ ] Backport to LTR documentation is requested

<!---
Reviewing is a process done by community members, mostly on a volunteer basis.
We try to keep the overhead as small as possible and appreciate if you help us.
Please read carefully and ensure you comply with our writing guidelines at
https://docs.qgis.org/testing/en/docs/documentation_guidelines/index.html.
Feel free to ask in a comment or the (qgis-community-team mailing list)
[https://lists.osgeo.org/mailman/listinfo/qgis-community-team] if you have troubles with any item.
--->
