### PR TITLE
Remove unused parameter from Polar Plot processing algorithm

### DIFF
--- a/docs/user_manual/processing_algs/qgis/plots.rst
+++ b/docs/user_manual/processing_algs/qgis/plots.rst
@@ -437,7 +437,7 @@ Python code
 
 Polar plot
 ----------
-Generates a polar plot based on the value of an input vector layer.
+Generates a polar bar plot based on the value of an input vector layer.
 
 Parameters
 ..........


### PR DESCRIPTION
<!---
Include a few sentences describing the overall goals for this Pull Request.
 
A list of issues is at https://github.com/qgis/QGIS-Documentation/issues.
Add "fix #issuenumber" for each issue the PR fixes. The ticket(s) will be closed automatically.
If your PR doesn't fix entirely the ticket, only add the ticket(s) reference preceded by # character.
-->
Goal: fix #10544

This PR simply removes the unnecessary parameter (NAME_FIELD) from the parameter table.

I also made a slight change to the short description to specify that the algorithm produces a "polar *bar* chart," since `plotly` can also generate other kinds of [polar charts](https://plotly.com/python/polar-chart/) (e.g. line or scatter).


Ticket(s): #
<!---
Indicate whether the fix should be backported to previous release.
Replace the space between square brackets by a `x` to make it checked.
-->
- [ ] Backport to LTR documentation is requested

<!---
Reviewing is a process done by community members, mostly on a volunteer basis.
We try to keep the overhead as small as possible and appreciate if you help us.
Please read carefully and ensure you comply with our writing guidelines at
https://docs.qgis.org/testing/en/docs/documentation_guidelines/index.html.
Feel free to ask in a comment or the (qgis-community-team mailing list)
[https://lists.osgeo.org/mailman/listinfo/qgis-community-team] if you have troubles with any item.
--->
