### PR TITLE
Clarify 'overlay_equals' function to check exact equality

### DIFF
--- a/docs/user_manual/expressions/expression_help/GeometryGroup.rst
+++ b/docs/user_manual/expressions/expression_help/GeometryGroup.rst
@@ -2363,11 +2363,7 @@ Read more on the underlying GEOS "Disjoint" predicate, as described in PostGIS `
 overlay_equals
 ..............
 
-Returns whether the current feature spatially equals to at least one feature from a target layer, or an array of expression-based results for the features in the target layer that are spatially equal to the current feature.
-
-
-
-Read more on the underlying GEOS "Equals" predicate, as described in PostGIS `ST_Equals <https://postgis.net/docs/ST_Equals.html>`_ function.
+Returns whether the current feature is exactly equal to at least one feature from a target layer, or an array of expression-based results for the features in the target layer that are exactly equal to the current feature. Note that the order of vertices matters.
 
 .. list-table::
    :widths: 15 85
@@ -2383,12 +2379,12 @@ Read more on the underlying GEOS "Equals" predicate, as described in PostGIS `ST
        * **limit** - an optional integer to limit the number of matching features. If not set, all the matching features will be returned.
        * **cache** - set this to true to build a local spatial index (most of the time, this is unwanted, unless you are working with a particularly slow data provider)
    * - Examples
-     - * ``overlay_equals('regions')`` → TRUE if the current feature is spatially equal to a region
-       * ``overlay_equals('regions', filter:= population > 10000)`` → TRUE if the current feature is spatially equal to a region with a population greater than 10000
-       * ``overlay_equals('regions', name)`` → an array of names, for the regions spatially equal to the current feature
-       * ``array_to_string(overlay_equals('regions', name))`` → a string as a comma separated list of names, for the regions spatially equal to the current feature
-       * ``array_sort(overlay_equals(layer:='regions', expression:="name", filter:= population > 10000))`` → an ordered array of names, for the regions spatially equal to the current feature and with a population greater than 10000
-       * ``overlay_equals(layer:='regions', expression:= geom_to_wkt(@geometry), limit:=2)`` → an array of geometries (in WKT), for up to two regions spatially equal to the current feature
+     - * ``overlay_equals('regions')`` → TRUE if the current feature is exactly equal to a region
+       * ``overlay_equals('regions', filter:= population > 10000)`` → TRUE if the current feature is exactly equal to a region with a population greater than 10000
+       * ``overlay_equals('regions', name)`` → an array of names, for the regions exactly equal to the current feature
+       * ``array_to_string(overlay_equals('regions', name))`` → a string as a comma separated list of names, for the regions exactly equal to the current feature
+       * ``array_sort(overlay_equals(layer:='regions', expression:="name", filter:= population > 10000))`` → an ordered array of names, for the regions exactly equal to the current feature and with a population greater than 10000
+       * ``overlay_equals(layer:='regions', expression:= geom_to_wkt(@geometry), limit:=2)`` → an array of geometries (in WKT), for up to two regions exactly equal to the current feature
 
 
 .. end_overlay_equals_section


### PR DESCRIPTION
While developing https://github.com/qgis/QGIS/pull/64627, I noticed that the overlay_equals function's description (https://github.com/qgis/QGIS/issues/39097) is incorrect where it states that such function is based on and behaves like the <<GEOS "Equals" predicate, as described in PostGIS `ST_Equals <https://postgis.net/docs/ST_Equals.html>`_ function.>>.

In fact, such function (unlike other overlay_* functions) is not based on the GEOS and PostGIS function having the same name: it is actually based on QgsGeometry:equals which behaves differently from GEOS “Equals” and PostGIS ST_Equals. The description would have been correct if overlay_equals had been based on QgsGeometry:isGeosEqual instead of QgsGeometry:equals.

This PR updates the description of the 'overlay_equals' function to clarify that it checks for exact equality instead of spatial equality.

Is it also possible to add some WKT examples in the description in order to make clear that e.g. the geometry represented by `'LINESTRING( 0 0, 1 1 )'` is considered different from the one represented by `'LINESTRING( 1 1, 0 0 )'` and `'POLYGON(( 0 0, 0 1, 1 1, 0 0 ))'` from `'POLYGON(( 0 0, 1 1, 0 1, 0 0 ))'`?

Fixes https://github.com/qgis/QGIS-Documentation/issues/10687.

Note that a PR introducing the corresponding `equals` function (which was missing) has been submitted: https://github.com/qgis/QGIS/pull/64627.

<!---
Include a few sentences describing the overall goals for this Pull Request.
 
A list of issues is at https://github.com/qgis/QGIS-Documentation/issues.
Add "fix #issuenumber" for each issue the PR fixes. The ticket(s) will be closed automatically.
If your PR doesn't fix entirely the ticket, only add the ticket(s) reference preceded by # character.
-->
Goal:

Ticket(s): #
<!---
Indicate whether the fix should be backported to previous release.
Replace the space between square brackets by a `x` to make it checked.
-->
- [x] Backport to LTR documentation is requested

<!---
Reviewing is a process done by community members, mostly on a volunteer basis.
We try to keep the overhead as small as possible and appreciate if you help us.
Please read carefully and ensure you comply with our writing guidelines at
https://docs.qgis.org/testing/en/docs/documentation_guidelines/index.html.
Feel free to ask in a comment or the (qgis-community-team mailing list)
[https://lists.osgeo.org/mailman/listinfo/qgis-community-team] if you have troubles with any item.
--->
