### PR TITLE
fix a couple of typos in point cloud algorithm docs

### DIFF
--- a/docs/user_manual/processing_algs/qgis/pointclouddatamanagement.rst
+++ b/docs/user_manual/processing_algs/qgis/pointclouddatamanagement.rst
@@ -263,7 +263,7 @@ Outputs
      - Description
    * - **Clipped**
      - ``OUTPUT``
-     - [raster]
+     - [point cloud]
      - Output point cloud whose features are the points within the coverage polygon layer.
 
 Python code
@@ -416,7 +416,7 @@ Outputs
      - Description
    * - **Layer information**
      - ``OUTPUT``
-     - [vector]
+     - [html]
      - :file:`HTML` file to store the metadata information.
 
 Python code


### PR DESCRIPTION
There is a couple of wrongly described output data types in the PDAL algorithms documentation. E.g. `raster` output for `clip` algorithm.

Fixed them to match actual output data type.