### PR TITLE
equals/overlay_equals/force_polygon_cw/force_polygon_ccw: update references

### DIFF
--- a/docs/user_manual/expressions/functions_list.rst
+++ b/docs/user_manual/expressions/functions_list.rst
@@ -500,14 +500,16 @@ Further reading: :ref:`qgisswapxy` algorithm
    :start-after: .. end_flip_coordinates_section
    :end-before: .. end_force_polygon_ccw_section
 
-Further reading: :ref:`expression_function_GeometryGroup_force_polygon_cw`,
+Further reading: :ref:`qgisforceccw` algorithm,
+:ref:`expression_function_GeometryGroup_force_polygon_cw`,
 :ref:`expression_function_GeometryGroup_force_rhr`
 
 .. include:: expression_help/GeometryGroup.rst
    :start-after: .. end_force_polygon_ccw_section
    :end-before: .. end_force_polygon_cw_section
 
-Further reading: :ref:`expression_function_GeometryGroup_force_polygon_ccw`,
+Further reading: :ref:`qgisforcecw` algorithm,
+:ref:`expression_function_GeometryGroup_force_polygon_ccw`,
 :ref:`expression_function_GeometryGroup_force_rhr`
 
 .. include:: expression_help/GeometryGroup.rst


### PR DESCRIPTION
<!---
Include a few sentences describing the overall goals for this Pull Request.
 
A list of issues is at https://github.com/qgis/QGIS-Documentation/issues.
Add "fix #issuenumber" for each issue the PR fixes. The ticket(s) will be closed automatically.
If your PR doesn't fix entirely the ticket, only add the ticket(s) reference preceded by # character.
-->
Goal:

- overlay_equals / equals: adds reference to each other

- force_polygon_cw / force_polygon_cw: adds reference to the corresponding algorithms

- overlay_equals: I propose to remove the reference to "Select by location" processing algorithm; the "equal" predicate used by the "\* by location" algorithms behaves in a different way than the overlay_equals/equals expressions (the former is "topological", the latter is "exact"). Do you agree?
Maybe also the "Exploring spatial relations" section of the "* by location" algorithms' description could be enhanced (it incorrectly states that <<Equal Returns 1 (true) if and only if geometries are exactly the same>>).


Ticket(s): #
<!---
Indicate whether the fix should be backported to previous release.
Replace the space between square brackets by a `x` to make it checked.
-->
- [ ] Backport to LTR documentation is requested

<!---
Reviewing is a process done by community members, mostly on a volunteer basis.
We try to keep the overhead as small as possible and appreciate if you help us.
Please read carefully and ensure you comply with our writing guidelines at
https://docs.qgis.org/testing/en/docs/documentation_guidelines/index.html.
Feel free to ask in a comment or the (qgis-community-team mailing list)
[https://lists.osgeo.org/mailman/listinfo/qgis-community-team] if you have troubles with any item.
--->
