### PR TITLE
Make explanation for incomplete Vector and Raster menus more visible

### DIFF
--- a/docs/user_manual/introduction/qgis_gui.rst
+++ b/docs/user_manual/introduction/qgis_gui.rst
@@ -1150,8 +1150,18 @@ When starting QGIS for the first time not all core plugins are loaded.
 Vector
 ------
 
-This is what the :guilabel:`Vector` menu looks like if all core plugins
-are enabled.
+By default, QGIS adds :ref:`Processing <sec_processing_intro>`
+algorithms to the :guilabel:`Vector` menu, grouped by sub-menus.
+This provides shortcuts for many common vector-based GIS tasks from
+different providers.
+If not all these sub-menus are available, enable the Processing plugin
+in :menuselection:`Plugins --> Manage and Install Plugins...`.
+
+Note that the list of algorithms and their menu can be modified/extended
+with any Processing algorithms (read :ref:`processing.options`) or
+some external :ref:`plugins <plugins>`.
+
+This is what the :guilabel:`Vector` menu looks like if all core plugins are enabled.
 
 .. list-table:: The Vector menu items
    :header-rows: 1
@@ -1375,9 +1385,12 @@ are enabled.
      - :ref:`qgisregularpoints`
 
 
+Raster
+------
+
 By default, QGIS adds :ref:`Processing <sec_processing_intro>`
-algorithms to the :guilabel:`Vector` menu, grouped by sub-menus.
-This provides shortcuts for many common vector-based GIS tasks from
+algorithms to the :guilabel:`Raster` menu, grouped by sub-menus.
+This provides shortcuts for many common raster-based GIS tasks from
 different providers.
 If not all these sub-menus are available, enable the Processing plugin
 in :menuselection:`Plugins --> Manage and Install Plugins...`.
@@ -1386,13 +1399,7 @@ Note that the list of algorithms and their menu can be modified/extended
 with any Processing algorithms (read :ref:`processing.options`) or
 some external :ref:`plugins <plugins>`.
 
-
-Raster
-------
-
-This is what the :guilabel:`Raster` menu looks like if all core plugins
-are enabled.
-
+This is what the :guilabel:`Raster` menu looks like if all core plugins are enabled.
 
 .. list-table:: The Raster menu items
    :header-rows: 1
@@ -1550,19 +1557,6 @@ are enabled.
      -
      -
      - :ref:`gdaltranslate`
-
-
-By default, QGIS adds :ref:`Processing <sec_processing_intro>`
-algorithms to the :guilabel:`Raster` menu, grouped by sub-menus.
-This provides a shortcut for many common raster-based GIS tasks
-from different providers.
-If not all these sub-menus are available, enable the Processing
-plugin in
-:menuselection:`Plugins --> Manage and Install Plugins...`.
-
-Note that the list of algorithms and their menu can be modified/extended
-with any Processing algorithms (read :ref:`processing.options`) or
-some external :ref:`plugins <plugins>`.
 
 
 Database


### PR DESCRIPTION
Reason why Vector and Raster menus may look incomplete at startup was instructed at the end of that long table. Not always visible, for the few ones that would have searched in the docs. Let's place it at the start of the section.

cherry-picked 67542d848 (partial backport of #10741)

<!---
Include a few sentences describing the overall goals for this Pull Request.
 
A list of issues is at https://github.com/qgis/QGIS-Documentation/issues.
Add "fix #issuenumber" for each issue the PR fixes. The ticket(s) will be closed automatically.
If your PR doesn't fix entirely the ticket, only add the ticket(s) reference preceded by # character.
-->
Goal:

Ticket(s): #
<!---
Indicate whether the fix should be backported to previous release.
Replace the space between square brackets by a `x` to make it checked.
-->
- [ ] Backport to LTR documentation is requested

<!---
Reviewing is a process done by community members, mostly on a volunteer basis.
We try to keep the overhead as small as possible and appreciate if you help us.
Please read carefully and ensure you comply with our writing guidelines at
https://docs.qgis.org/testing/en/docs/documentation_guidelines/index.html.
Feel free to ask in a comment or the (qgis-community-team mailing list)
[https://lists.osgeo.org/mailman/listinfo/qgis-community-team] if you have troubles with any item.
--->
