### PR TITLE
Clarify Planetary Computer authentication method

### DIFF
--- a/docs/user_manual/auth_system/auth_overview.rst
+++ b/docs/user_manual/auth_system/auth_overview.rst
@@ -356,13 +356,13 @@ containing both the certificate and private key, with an optional passphrase for
 
    PKI PKCS#12 file paths authentication configs
 
-Planetary Computer Authentication
-.................................
+Microsoft Planetary Computer Authentication
+...........................................
 
 The Microsoft Planetary Computer authentication method allows QGIS to access Microsoft Planetary Computer data. It supports two modes:
 
 * `Open Planetary Computer <https://planetarycomputer.microsoft.com/>`_ - uses SAS tokens to sign assets for access.
-* `Microsoft Planetary Computer Pro <https://learn.microsoft.com/azure/planetary-computer/configure-qgis>`_ - requires SAS signing plus OAuth2 authentication.
+* `Planetary Computer Pro <https://learn.microsoft.com/azure/planetary-computer/configure-qgis>`_ - requires SAS signing plus OAuth2 authentication.
 
 .. _figure_authmethod_planetary:
 


### PR DESCRIPTION
Updated the authentication method description for clarity and added links.

<!---
Fix typos and add links to Microsoft Planetary Computer Pro Authentication section
-->
Goal:
Fix instructions and point to additional information. 

Ticket(s): #
<!---
Indicate whether the fix should be backported to previous release.
Replace the space between square brackets by a `x` to make it checked.
-->
- [ ] Backport to LTR documentation is requested

<!---
Reviewing is a process done by community members, mostly on a volunteer basis.
We try to keep the overhead as small as possible and appreciate if you help us.
Please read carefully and ensure you comply with our writing guidelines at
https://docs.qgis.org/testing/en/docs/documentation_guidelines/index.html.
Feel free to ask in a comment or the (qgis-community-team mailing list)
[https://lists.osgeo.org/mailman/listinfo/qgis-community-team] if you have troubles with any item.
--->
