### PR TITLE
Mention drop-down tools in the vector attribute table toolbar

### DIFF
--- a/docs/user_manual/working_with_vector/attribute_table.rst
+++ b/docs/user_manual/working_with_vector/attribute_table.rst
@@ -80,8 +80,8 @@ following functionality:
    "|saveEdits|", "Save Edits", "Save current modifications"
    "|refresh|", "Reload the table"
    "|newTableRow| :menuselection:`-->` ([1]_)", "Add feature", "Add new geometryless feature"
-   ":menuselection:`-->` |newTableRow|", "Add feature via attribute table", "Creates a new geometryless feature using the table view"
-   ":menuselection:`-->` |formSelect|", "Add feature via attribute form", "Creates a new geometryless feature using the form view"
+   ":menuselection:`-->` |newTableRow|", "Add feature via attribute table", "Inserts a new empty row in the attribute table to be filled in"
+   ":menuselection:`-->` |formSelect|", "Add feature via attribute form", "Opens the feature attributes form for data entry"
    "|deleteSelectedFeatures|", "Delete selected features", "Remove selected features from the layer"
    "|editCut|", "Cut selected features to clipboard", "", ":kbd:`Ctrl+X`"
    "|copySelected|", "Copy selected features to clipboard", "", ":kbd:`Ctrl+C`"
@@ -102,8 +102,7 @@ following functionality:
    "|dock|", "Dock attribute table", "Allows to dock/undock the attribute table"
    "|actionRun|", "Actions", "Lists the actions related to the layer"
 
-.. [1] Pressing and holding the button helps you switch between table and form view
-  for adding new features. 
+.. [1] Press and hold to select whether to add the feature via the attribute table or form.
 
 .. attention:: Depending on the format of the data and the GDAL library built with
    your QGIS version, some tools may not be available.


### PR DESCRIPTION
I've never noticed there was a menu in the "Add feature" button until https://github.com/qgis/QGIS/pull/65131
I'm unsatisfied by the way this is mentioned, so any suggestion is more than welcome...

<!---
Include a few sentences describing the overall goals for this Pull Request.
 
A list of issues is at https://github.com/qgis/QGIS-Documentation/issues.
Add "fix #issuenumber" for each issue the PR fixes. The ticket(s) will be closed automatically.
If your PR doesn't fix entirely the ticket, only add the ticket(s) reference preceded by # character.
-->
Goal:

Ticket(s): #
<!---
Indicate whether the fix should be backported to previous release.
Replace the space between square brackets by a `x` to make it checked.
-->
- [ ] Backport to LTR documentation is requested

<!---
Reviewing is a process done by community members, mostly on a volunteer basis.
We try to keep the overhead as small as possible and appreciate if you help us.
Please read carefully and ensure you comply with our writing guidelines at
https://docs.qgis.org/testing/en/docs/documentation_guidelines/index.html.
Feel free to ask in a comment or the (qgis-community-team mailing list)
[https://lists.osgeo.org/mailman/listinfo/qgis-community-team] if you have troubles with any item.
--->
