### PR TITLE
Remove Plugin creation instructions with obsolete Plugin Builder

### DIFF
--- a/docs/pyqgis_developer_cookbook/processing.rst
+++ b/docs/pyqgis_developer_cookbook/processing.rst
@@ -31,19 +31,6 @@ To distribute those algorithms, you should create a new plugin that adds them to
 Processing Toolbox. The plugin should contain an algorithm provider, which has to be
 registered when the plugin is instantiated.
 
-Creating from scratch
-=====================
-
-To create a plugin from scratch which contains an algorithm provider, you can
-follow these steps using the Plugin Builder:
-
-#. Install the **Plugin Builder** plugin
-#. Create a new plugin using the Plugin Builder. When the Plugin Builder asks you for
-   the template to use, select "Processing provider".
-#. The created plugin contains a provider with a single algorithm. Both the provider
-   file and the algorithm file are fully commented and contain information about how to
-   modify the provider and add additional algorithms. Refer to them for more information.
-
 Updating a plugin
 =================
 


### PR DESCRIPTION
Removed instructions for creating a plugin from scratch using Plugin Builder, since [Plugin Builder](https://github.com/g-sherman/Qgis-Plugin-Builder) is not maintained (last updated 7 years ago) and with the switch to Qgis 4.0 it will be obsolete.

<!---
Include a few sentences describing the overall goals for this Pull Request.
 
A list of issues is at https://github.com/qgis/QGIS-Documentation/issues.
Add "fix #issuenumber" for each issue the PR fixes. The ticket(s) will be closed automatically.
If your PR doesn't fix entirely the ticket, only add the ticket(s) reference preceded by # character.
-->
Goal:
keep the plugin creation documentation up to date with qt6 compatible options.
<!---
Indicate whether the fix should be backported to previous release.
Replace the space between square brackets by a `x` to make it checked.
-->
- [ ] Backport to LTR documentation is requested

<!---
Reviewing is a process done by community members, mostly on a volunteer basis.
We try to keep the overhead as small as possible and appreciate if you help us.
Please read carefully and ensure you comply with our writing guidelines at
https://docs.qgis.org/testing/en/docs/documentation_guidelines/index.html.
Feel free to ask in a comment or the (qgis-community-team mailing list)
[https://lists.osgeo.org/mailman/listinfo/qgis-community-team] if you have troubles with any item.
--->
