### PR TITLE
Remove outdated references to the supportsQt6 plugin metadata tag

### DIFF
--- a/docs/pyqgis_developer_cookbook/plugins/plugins.rst
+++ b/docs/pyqgis_developer_cookbook/plugins/plugins.rst
@@ -136,8 +136,6 @@ server                 False     boolean flag, :const:`True` or :const:`False`, 
                                  the plugin has a server interface
 hasProcessingProvider  False     boolean flag, :const:`True` or :const:`False`, determines if
                                  the plugin provides processing algorithms
-supportsQt6            False     boolean flag, :const:`True` or :const:`False`, determines if
-                                 the plugin supports Qt6 framework
 =====================  ========  =============================================================
 
 By default, plugins are placed in the :menuselection:`Plugins` menu (we will see
@@ -217,9 +215,6 @@ An example for this metadata.txt
   ; Both "MyOtherPlugin" and "YetAnotherPlugin" names come from their own metadata's
   ; name field
   plugin_dependencies=MyOtherPlugin==1.12,YetAnotherPlugin
-
-  ; whether the plugin can be run on QGIS built with Qt6 
-  supportsQt6=True
 
 
 .. index:: Plugins; Initialisation


### PR DESCRIPTION
The `supportsQt6` metadata tag was only temporarily useful when experimental Qt6 builds of late QGIS 3 versions were being produced. Now that QGIS 3 is Qt5-only and QGIS 4 is Qt6-only, the tag is not used by any official QGIS release nor on the current Plugins Webpage [1]. Removing it is therefore safe for both the QGIS 3 and QGIS 4 documentation.

[1] See: https://github.com/qgis/QGIS/issues/65169