### PR TITLE
Remove expression functions and examples not available in 3.44

### DIFF
--- a/docs/user_manual/expressions/expression_help/Conversions.rst
+++ b/docs/user_manual/expressions/expression_help/Conversions.rst
@@ -6,28 +6,6 @@
    in the resources/function_help/json/ folder in the
    qgis/QGIS repository.
 
-.. _expression_function_Conversions_convert_timezone:
-
-convert_timezone
-................
-
-Converts a datetime object to a different timezone.
-
-.. list-table::
-   :widths: 15 85
-
-   * - Syntax
-     - convert_timezone(datetime, timezone)
-   * - Arguments
-     - * **datetime** - datetime value
-       * **timezone** - target timezone
-   * - Examples
-     - * ``convert_timezone(to_datetime('2012-05-04 12:50:00+3'), timezone_from_id('UTC+10'))`` → datetime 2012-05-04 19:50:00 (UTC+10)
-       * ``convert_timezone("DATE_FIELD", timezone_from_id('Australia/Darwin'))`` → Datetime from DATE_FIELD, converted to the 'Australia/Darwin' timezone
-
-
-.. end_convert_timezone_section
-
 .. _expression_function_Conversions_from_base64:
 
 from_base64
@@ -47,27 +25,6 @@ Decodes a string in the Base64 encoding into a binary value.
 
 
 .. end_from_base64_section
-
-.. _expression_function_Conversions_get_timezone:
-
-get_timezone
-............
-
-Returns the timezone object associated with a datetime value.
-
-.. list-table::
-   :widths: 15 85
-
-   * - Syntax
-     - get_timezone(datetime)
-   * - Arguments
-     - * **datetime** - datetime with timezone
-   * - Examples
-     - * ``timezone_id(get_timezone(to_datetime('2012-05-04 12:50:00+3')))`` → 'UTC+03'
-       * ``timezone_id(get_timezone("DATE_FIELD"))`` → ID of timezone associated with the DATE_FIELD value
-
-
-.. end_get_timezone_section
 
 .. _expression_function_Conversions_hash:
 
@@ -123,28 +80,6 @@ Creates a md5 hash from a string.
 
 .. end_md5_section
 
-.. _expression_function_Conversions_set_timezone:
-
-set_timezone
-............
-
-Sets the timezone object associated with a datetime value, without changing the date or time components. This function can be used to replace the timezone for a datetime.
-
-.. list-table::
-   :widths: 15 85
-
-   * - Syntax
-     - set_timezone(datetime, timezone)
-   * - Arguments
-     - * **datetime** - datetime value
-       * **timezone** - new timezone for datetime
-   * - Examples
-     - * ``set_timezone(to_datetime('2012-05-04 12:50:00+3'), timezone_from_id('UTC+10'))`` → datetime 2012-05-04 12:50:00 (UTC+10)
-       * ``set_timezone(make_datetime(2020,1,1,10,0,0), timezone_from_id('Australia/Darwin'))`` → Datetime of 2020-01-01 10:00:00 with associated timezone 'Australia/Darwin'
-
-
-.. end_set_timezone_section
-
 .. _expression_function_Conversions_sha256:
 
 sha256
@@ -164,48 +99,6 @@ Creates a sha256 hash from a string.
 
 
 .. end_sha256_section
-
-.. _expression_function_Conversions_timezone_from_id:
-
-timezone_from_id
-................
-
-Creates a timezone object from a string ID (from the IANA timezone database). The ID must be one of the available system IDs or a valid UTC-with-offset ID.
-
-.. list-table::
-   :widths: 15 85
-
-   * - Syntax
-     - timezone_from_id(id)
-   * - Arguments
-     - * **id** - string containing the time zone ID
-   * - Examples
-     - * ``timezone_from_id('Australia/Brisbane')`` → AEST timezone object
-       * ``timezone_from_id('UTC+10:30')`` → UTC+10:30 timezone object
-       * ``timezone_from_id('UTC-3')`` → UTC-03 timezone object
-
-
-.. end_timezone_from_id_section
-
-.. _expression_function_Conversions_timezone_id:
-
-timezone_id
-...........
-
-Returns the ID string for a timezone object, using IDs from the IANA timezone database.
-
-.. list-table::
-   :widths: 15 85
-
-   * - Syntax
-     - timezone_id(timezone)
-   * - Arguments
-     - * **timezone** - a valid timezone object
-   * - Examples
-     - * ``timezone_id(timezone_from_id('Australia/Brisbane'))`` → 'Australia/Brisbane'
-
-
-.. end_timezone_id_section
 
 .. _expression_function_Conversions_to_base64:
 

--- a/docs/user_manual/expressions/expression_help/Date_and_Time.rst
+++ b/docs/user_manual/expressions/expression_help/Date_and_Time.rst
@@ -42,28 +42,6 @@ The difference is returned as an ``Interval`` and needs to be used with one of t
 
 .. end_age_section
 
-.. _expression_function_Date_and_Time_convert_timezone:
-
-convert_timezone
-................
-
-Converts a datetime object to a different timezone.
-
-.. list-table::
-   :widths: 15 85
-
-   * - Syntax
-     - convert_timezone(datetime, timezone)
-   * - Arguments
-     - * **datetime** - datetime value
-       * **timezone** - target timezone
-   * - Examples
-     - * ``convert_timezone(to_datetime('2012-05-04 12:50:00+3'), timezone_from_id('UTC+10'))`` → datetime 2012-05-04 19:50:00 (UTC+10)
-       * ``convert_timezone("DATE_FIELD", timezone_from_id('Australia/Darwin'))`` → Datetime from DATE_FIELD, converted to the 'Australia/Darwin' timezone
-
-
-.. end_convert_timezone_section
-
 .. _expression_function_Date_and_Time_datetime_from_epoch:
 
 datetime_from_epoch
@@ -231,27 +209,6 @@ Formats a date type or string into a custom string format. Uses Qt date/time for
 
 
 .. end_format_date_section
-
-.. _expression_function_Date_and_Time_get_timezone:
-
-get_timezone
-............
-
-Returns the timezone object associated with a datetime value.
-
-.. list-table::
-   :widths: 15 85
-
-   * - Syntax
-     - get_timezone(datetime)
-   * - Arguments
-     - * **datetime** - datetime with timezone
-   * - Examples
-     - * ``timezone_id(get_timezone(to_datetime('2012-05-04 12:50:00+3')))`` → 'UTC+03'
-       * ``timezone_id(get_timezone("DATE_FIELD"))`` → ID of timezone associated with the DATE_FIELD value
-
-
-.. end_get_timezone_section
 
 .. _expression_function_Date_and_Time_hour:
 
@@ -532,70 +489,6 @@ Calculates the length in seconds of an interval.
 
 
 .. end_second_section
-
-.. _expression_function_Date_and_Time_set_timezone:
-
-set_timezone
-............
-
-Sets the timezone object associated with a datetime value, without changing the date or time components. This function can be used to replace the timezone for a datetime.
-
-.. list-table::
-   :widths: 15 85
-
-   * - Syntax
-     - set_timezone(datetime, timezone)
-   * - Arguments
-     - * **datetime** - datetime value
-       * **timezone** - new timezone for datetime
-   * - Examples
-     - * ``set_timezone(to_datetime('2012-05-04 12:50:00+3'), timezone_from_id('UTC+10'))`` → datetime 2012-05-04 12:50:00 (UTC+10)
-       * ``set_timezone(make_datetime(2020,1,1,10,0,0), timezone_from_id('Australia/Darwin'))`` → Datetime of 2020-01-01 10:00:00 with associated timezone 'Australia/Darwin'
-
-
-.. end_set_timezone_section
-
-.. _expression_function_Date_and_Time_timezone_from_id:
-
-timezone_from_id
-................
-
-Creates a timezone object from a string ID (from the IANA timezone database). The ID must be one of the available system IDs or a valid UTC-with-offset ID.
-
-.. list-table::
-   :widths: 15 85
-
-   * - Syntax
-     - timezone_from_id(id)
-   * - Arguments
-     - * **id** - string containing the time zone ID
-   * - Examples
-     - * ``timezone_from_id('Australia/Brisbane')`` → AEST timezone object
-       * ``timezone_from_id('UTC+10:30')`` → UTC+10:30 timezone object
-       * ``timezone_from_id('UTC-3')`` → UTC-03 timezone object
-
-
-.. end_timezone_from_id_section
-
-.. _expression_function_Date_and_Time_timezone_id:
-
-timezone_id
-...........
-
-Returns the ID string for a timezone object, using IDs from the IANA timezone database.
-
-.. list-table::
-   :widths: 15 85
-
-   * - Syntax
-     - timezone_id(timezone)
-   * - Arguments
-     - * **timezone** - a valid timezone object
-   * - Examples
-     - * ``timezone_id(timezone_from_id('Australia/Brisbane'))`` → 'Australia/Brisbane'
-
-
-.. end_timezone_id_section
 
 .. _expression_function_Date_and_Time_to_date:
 

--- a/docs/user_manual/expressions/expression_help/GeometryGroup.rst
+++ b/docs/user_manual/expressions/expression_help/GeometryGroup.rst
@@ -126,8 +126,7 @@ Returns the area of a geometry polygon object. Calculations are always planimetr
    * - Arguments
      - * **geometry** - polygon geometry object
    * - Examples
-     - * ``area(@geometry)`` → area of the current feature's geometry
-       * ``area(geom_from_wkt('POLYGON((0 0, 4 0, 4 2, 0 2, 0 0))'))`` → 8.0
+     - * ``area(geom_from_wkt('POLYGON((0 0, 4 0, 4 2, 0 2, 0 0))'))`` → 8.0
 
 
 .. end_area_section
@@ -195,8 +194,7 @@ Returns the closure of the combinatorial boundary of the geometry (ie the topolo
    * - Arguments
      - * **geometry** - a geometry
    * - Examples
-     - * ``boundary(@geometry)`` → boundary of the current feature's geometry
-       * ``geom_to_wkt(boundary(geom_from_wkt('Polygon((1 1, 0 0, -1 1, 1 1))')))`` → 'LineString(1 1,0 0,-1 1,1 1)'
+     - * ``geom_to_wkt(boundary(geom_from_wkt('Polygon((1 1, 0 0, -1 1, 1 1))')))`` → 'LineString(1 1,0 0,-1 1,1 1)'
        * ``geom_to_wkt(boundary(geom_from_wkt('LineString(1 1,0 0,-1 1)')))`` → 'MultiPoint ((1 1),(-1 1))'
 
 
@@ -529,8 +527,7 @@ Returns the convex hull of a geometry. It represents the minimum convex geometry
    * - Arguments
      - * **geometry** - a geometry
    * - Examples
-     - * ``convex_hull(@geometry)`` → convex hull of the current feature's geometry
-       * ``geom_to_wkt( convex_hull( geom_from_wkt( 'LINESTRING(3 3, 4 4, 4 10)' ) ) )`` → 'POLYGON((3 3, 4 10, 4 4, 3 3))'
+     - * ``geom_to_wkt( convex_hull( geom_from_wkt( 'LINESTRING(3 3, 4 4, 4 10)' ) ) )`` → 'POLYGON((3 3, 4 10, 4 4, 3 3))'
 
 
 .. figure:: /docs/user_manual/processing_algs/qgis/img/convex_hull.png
@@ -719,8 +716,7 @@ Returns the last node from a geometry.
    * - Arguments
      - * **geometry** - geometry object
    * - Examples
-     - * ``end_point(@geometry)`` → end point of the current feature's geometry
-       * ``geom_to_wkt(end_point(geom_from_wkt('LINESTRING(4 0, 4 2, 0 2)')))`` → 'Point (0 2)'
+     - * ``geom_to_wkt(end_point(geom_from_wkt('LINESTRING(4 0, 4 2, 0 2)')))`` → 'Point (0 2)'
 
 
 .. figure:: /docs/user_manual/expressions/expression_help/img/end_point.*
@@ -987,7 +983,7 @@ Returns the Well-Known Binary (WKB) representation of a geometry
    * - Arguments
      - * **geometry** - a geometry
    * - Examples
-     - * ``geom_to_wkb( @geometry )`` → binary blob of the current feature's geometry
+     - * ``geom_to_wkb( @geometry )`` → binary blob containing a geometry object
 
 
 .. end_geom_to_wkb_section
@@ -1010,8 +1006,7 @@ Returns the Well-Known Text (WKT) representation of the geometry without SRID me
      - * **geometry** - a geometry
        * **precision** - numeric precision
    * - Examples
-     - * ``geom_to_wkt(@geometry)`` → well-known text representation of the current feature's geometry
-       * ``geom_to_wkt( make_point(6, 50) )`` → 'POINT(6 50)'
+     - * ``geom_to_wkt( make_point(6, 50) )`` → 'POINT(6 50)'
        * ``geom_to_wkt(centroid(geom_from_wkt('Polygon((1 1, 0 0, -1 1, 1 1))')))`` → 'POINT(0 0.66666667)'
        * ``geom_to_wkt(centroid(geom_from_wkt('Polygon((1 1, 0 0, -1 1, 1 1))')), 2)`` → 'POINT(0 0.67)'
 
@@ -1339,8 +1334,7 @@ Returns TRUE if the geometry is of Multi type.
    * - Arguments
      - * **geometry** - a geometry
    * - Examples
-     - * ``is_multipart(@geometry)`` → checks if the current feature's geometry is multipart
-       * ``is_multipart(geom_from_wkt('MULTIPOINT ((0 0),(1 1),(2 2))'))`` → TRUE
+     - * ``is_multipart(geom_from_wkt('MULTIPOINT ((0 0),(1 1),(2 2))'))`` → TRUE
        * ``is_multipart(geom_from_wkt('POINT (0 0)'))`` → FALSE
 
 
@@ -1361,8 +1355,7 @@ Returns TRUE if a geometry is valid; if it is well-formed in 2D according to the
    * - Arguments
      - * **geometry** - a geometry
    * - Examples
-     - * ``is_valid(@geometry)`` → checks if the current feature's geometry is valid
-       * ``is_valid(geom_from_wkt('LINESTRING(0 0, 1 1, 2 2, 0 0)'))`` → TRUE
+     - * ``is_valid(geom_from_wkt('LINESTRING(0 0, 1 1, 2 2, 0 0)'))`` → TRUE
        * ``is_valid(geom_from_wkt('LINESTRING(0 0)'))`` → FALSE
 
 
@@ -1420,8 +1413,7 @@ Calculate the length of a geometry line object. Calculations are always planimet
    * - Arguments
      - * **geometry** - line geometry object
    * - Examples
-     - * ``length(@geometry)`` → length of the current feature's geometry
-       * ``length(geom_from_wkt('LINESTRING(0 0, 4 0)'))`` → 4.0
+     - * ``length(geom_from_wkt('LINESTRING(0 0, 4 0)'))`` → 4.0
 
 
 .. end_length_section
@@ -1441,8 +1433,7 @@ Calculates the 3D length of a geometry line object. If the geometry is not a 3D 
    * - Arguments
      - * **geometry** - line geometry object
    * - Examples
-     - * ``length3D(@geometry)`` → 3D length of the current feature's geometry
-       * ``length3D(geom_from_wkt('LINESTRINGZ(0 0 0, 3 0 4)'))`` → 5.0
+     - * ``length3D(geom_from_wkt('LINESTRINGZ(0 0 0, 3 0 4)'))`` → 5.0
 
 
 .. end_length3D_section
@@ -2582,8 +2573,7 @@ Returns the perimeter of a geometry polygon object. Calculations are always plan
    * - Arguments
      - * **geometry** - polygon geometry object
    * - Examples
-     - * ``perimeter(@geometry)`` → perimeter of the current feature's geometry
-       * ``perimeter(geom_from_wkt('POLYGON((0 0, 4 0, 4 2, 0 2, 0 0))'))`` → 12.0
+     - * ``perimeter(geom_from_wkt('POLYGON((0 0, 4 0, 4 2, 0 2, 0 0))'))`` → 12.0
 
 
 .. end_perimeter_section
@@ -3563,8 +3553,7 @@ Returns the maximum x coordinate of a geometry. Calculations are in the spatial 
    * - Arguments
      - * **geometry** - a geometry
    * - Examples
-     - * ``x_max(@geometry)`` → the maximum x coordinate of the current feature's geometry
-       * ``x_max( geom_from_wkt( 'LINESTRING(2 5, 3 6, 4 8)') )`` → 4
+     - * ``x_max( geom_from_wkt( 'LINESTRING(2 5, 3 6, 4 8)') )`` → 4
 
 
 .. end_x_max_section
@@ -3584,8 +3573,7 @@ Returns the minimum x coordinate of a geometry. Calculations are in the spatial 
    * - Arguments
      - * **geometry** - a geometry
    * - Examples
-     - * ``x_min(@geometry)`` → the minimum x coordinate of the current feature's geometry
-       * ``x_min( geom_from_wkt( 'LINESTRING(2 5, 3 6, 4 8)') )`` → 2
+     - * ``x_min( geom_from_wkt( 'LINESTRING(2 5, 3 6, 4 8)') )`` → 2
 
 
 .. end_x_min_section
@@ -3685,8 +3673,7 @@ Returns the maximum y coordinate of a geometry. Calculations are in the spatial 
    * - Arguments
      - * **geometry** - a geometry
    * - Examples
-     - * ``y_max(@geometry)`` → the maximum y coordinate of the current feature's geometry
-       * ``y_max( geom_from_wkt( 'LINESTRING(2 5, 3 6, 4 8)') )`` → 8
+     - * ``y_max( geom_from_wkt( 'LINESTRING(2 5, 3 6, 4 8)') )`` → 8
 
 
 .. end_y_max_section
@@ -3706,8 +3693,7 @@ Returns the minimum y coordinate of a geometry. Calculations are in the spatial 
    * - Arguments
      - * **geometry** - a geometry
    * - Examples
-     - * ``y_min(@geometry)`` → the minimum y coordinate of the current feature's geometry
-       * ``y_min( geom_from_wkt( 'LINESTRING(2 5, 3 6, 4 8)') )`` → 5
+     - * ``y_min( geom_from_wkt( 'LINESTRING(2 5, 3 6, 4 8)') )`` → 5
 
 
 .. end_y_min_section

--- a/docs/user_manual/expressions/expression_help/Math.rst
+++ b/docs/user_manual/expressions/expression_help/Math.rst
@@ -438,7 +438,7 @@ Returns a random float within the range specified by the minimum and maximum arg
 round
 .....
 
-Rounds a number to number of decimal places. The rounding is done to the nearest number. The ceil or floor functions can be used if rounding up or down is required.
+Rounds a number to number of decimal places.
 
 .. list-table::
    :widths: 15 85
@@ -449,12 +449,11 @@ Rounds a number to number of decimal places. The rounding is done to the nearest
        [] marks optional arguments
    * - Arguments
      - * **value** - decimal number to be rounded
-       * **places** - Optional integer representing number of places to round decimals to. For negative integers the rounding is done to the left of the decimal point.
+       * **places** - Optional integer representing number of places to round decimals to. Can be negative.
    * - Examples
      - * ``round(1234.567, 2)`` → 1234.57
        * ``round(1234.567)`` → 1235
        * ``round(1234.567, -1)`` → 1230
-       * ``round(1234.567, -2)`` → 1200
 
 
 .. end_round_section

--- a/docs/user_manual/expressions/expression_help/String.rst
+++ b/docs/user_manual/expressions/expression_help/String.rst
@@ -240,8 +240,7 @@ Calculate the length of a geometry line object. Calculations are always planimet
    * - Arguments
      - * **geometry** - line geometry object
    * - Examples
-     - * ``length(@geometry)`` → length of the current feature's geometry
-       * ``length(geom_from_wkt('LINESTRING(0 0, 4 0)'))`` → 4.0
+     - * ``length(geom_from_wkt('LINESTRING(0 0, 4 0)'))`` → 4.0
 
 
 .. end_length_section


### PR DESCRIPTION
This is due to me having run the command against the wrong branch (master instead of 3.44)

<!---
Include a few sentences describing the overall goals for this Pull Request.
 
A list of issues is at https://github.com/qgis/QGIS-Documentation/issues.
Add "fix #issuenumber" for each issue the PR fixes. The ticket(s) will be closed automatically.
If your PR doesn't fix entirely the ticket, only add the ticket(s) reference preceded by # character.
-->
Goal:

Ticket(s): #
<!---
Indicate whether the fix should be backported to previous release.
Replace the space between square brackets by a `x` to make it checked.
-->
- [ ] Backport to LTR documentation is requested

<!---
Reviewing is a process done by community members, mostly on a volunteer basis.
We try to keep the overhead as small as possible and appreciate if you help us.
Please read carefully and ensure you comply with our writing guidelines at
https://docs.qgis.org/testing/en/docs/documentation_guidelines/index.html.
Feel free to ask in a comment or the (qgis-community-team mailing list)
[https://lists.osgeo.org/mailman/listinfo/qgis-community-team] if you have troubles with any item.
--->
