### PR TITLE
Fix Latex syntax warning when building docs

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -319,13 +319,13 @@ latex_elements = {
     \\newunicodechar{Ț}{\\cb{T}}
     \\newunicodechar{ț}{\\cb{t}}
     \\newunicodechar{≠}{$\\neq$}
-    \\newunicodechar{≥}{$\geq$}
-    \\newunicodechar{≤}{$\leq$}
-    \\newunicodechar{π}{$\pi$}
+    \\newunicodechar{≥}{$\\geq$}
+    \\newunicodechar{≤}{$\\leq$}
+    \\newunicodechar{π}{$\\pi$}
     \\newunicodechar{㎡}{$m^2$}
     \\newunicodechar{\u25BA}{$\u25BA$}
-    \\newunicodechar{′}{\ensuremath{^{\prime}}}
-    \\newunicodechar{″}{\ensuremath{^{\prime\prime}}}
+    \\newunicodechar{′}{\\ensuremath{^{\\prime}}}
+    \\newunicodechar{″}{\\ensuremath{^{\\prime\\prime}}}
     \\newunicodechar{​}{ }''',
 
     # Latex figure float alignment
@@ -341,7 +341,7 @@ if tags.has('ko'):
         'preamble': '''
         \\usepackage{fontspec}
         \\usepackage[space]{xeCJK}
-        \\renewcommand\CJKglue{}
+        \\renewcommand\\CJKglue{}
         \\setCJKmainfont{NanumMyeongjo}''',
     }
 


### PR DESCRIPTION
Backport #9431
<!---
Include a few sentences describing the overall goals for this Pull Request.
 
A list of issues is at https://github.com/qgis/QGIS-Documentation/issues.
Add "fix #issuenumber" for each issue the PR fixes. The ticket(s) will be closed automatically.
If your PR doesn't fix entirely the ticket, only add the ticket(s) reference preceded by # character.
-->
Goal:

Ticket(s): #
<!---
Indicate whether the fix should be backported to previous release.
Replace the space between square brackets by a `x` to make it checked.
-->
- [ ] Backport to LTR documentation is requested

<!---
Reviewing is a process done by community members, mostly on a volunteer basis.
We try to keep the overhead as small as possible and appreciate if you help us.
Please read carefully and ensure you comply with our writing guidelines at
https://docs.qgis.org/testing/en/docs/documentation_guidelines/index.html.
Feel free to ask in a comment or the (qgis-community-team mailing list)
[https://lists.osgeo.org/mailman/listinfo/qgis-community-team] if you have troubles with any item.
--->
