### PR TITLE
Update redirects for print composer and layout

### DIFF
--- a/redirects.txt
+++ b/redirects.txt
@@ -66,7 +66,6 @@ docs/user_manual/working_with_vector_tiles/vector_tiles_properties.rst docs/user
 
 ## Print Layout
 docs/user_manual/print_composer/composer_items/composer_attribute_table.rst docs/user_manual/print_layout/layout_items/layout_tables.rst
-docs/user_manual/print_composer/composer_items/composer_elevation_profile.rst docs/user_manual/print_layout/layout_items/layout_elevation_profile.rst
 docs/user_manual/print_composer/composer_items/composer_html_frame.rst docs/user_manual/print_layout/layout_items/layout_html_frame.rst
 docs/user_manual/print_composer/composer_items/composer_image.rst docs/user_manual/print_layout/layout_items/layout_image.rst
 docs/user_manual/print_composer/composer_items/composer_items_options.rst docs/user_manual/print_layout/layout_items/layout_items_options.rst
@@ -79,6 +78,7 @@ docs/user_manual/print_composer/composer_items/composer_scale_bar.rst docs/user_
 docs/user_manual/print_composer/composer_items/composer_shapes.rst docs/user_manual/print_layout/layout_items/layout_shapes.rst
 docs/user_manual/print_composer/composer_items/composer_tables.rst docs/user_manual/print_layout/layout_items/layout_tables.rst
 docs/user_manual/print_composer/composer_items/index.rst docs/user_manual/print_layout/layout_items/index.rst
+docs/user_manual/print_composer/composer_items/layout_elevation_profile.rst docs/user_manual/print_layout/layout_items/layout_elevation_profile.rst
 
 docs/user_manual/print_composer/create_output.rst docs/user_manual/print_layout/create_output.rst
 docs/user_manual/print_composer/create_reports.rst docs/user_manual/print_layout/create_reports.rst


### PR DESCRIPTION
File "composer_elevation_profile" never existed; it should be layout_elevation_profile.

<!---
Include a few sentences describing the overall goals for this Pull Request.
 
A list of issues is at https://github.com/qgis/QGIS-Documentation/issues.
Add "fix #issuenumber" for each issue the PR fixes. The ticket(s) will be closed automatically.
If your PR doesn't fix entirely the ticket, only add the ticket(s) reference preceded by # character.
-->
Goal:

Ticket(s): #
<!---
Indicate whether the fix should be backported to previous release.
Replace the space between square brackets by a `x` to make it checked.
-->
- [ ] Backport to LTR documentation is requested

<!---
Reviewing is a process done by community members, mostly on a volunteer basis.
We try to keep the overhead as small as possible and appreciate if you help us.
Please read carefully and ensure you comply with our writing guidelines at
https://docs.qgis.org/testing/en/docs/documentation_guidelines/index.html.
Feel free to ask in a comment or the (qgis-community-team mailing list)
[https://lists.osgeo.org/mailman/listinfo/qgis-community-team] if you have troubles with any item.
--->
