### PR TITLE
Ensure backward compatibility for layout pages when switching from/to 3.40

### DIFF
--- a/redirects.txt
+++ b/redirects.txt
@@ -69,5 +69,23 @@ docs/user_manual/print_composer/composer_items/composer_attribute_table.rst docs
 docs/user_manual/print_composer/composer_items/composer_items_shape.rst docs/user_manual/print_composer/composer_items/composer_shapes.rst
 docs/user_manual/print_composer/print_composer.rst docs/user_manual/print_composer/index.rst
 
+docs/user_manual/print_layout/create_output.rst docs/user_manual/print_composer/create_output.rst
+docs/user_manual/print_layout/create_reports.rst docs/user_manual/print_composer/create_reports.rst
+docs/user_manual/print_layout/index.rst docs/user_manual/print_composer/index.rst
+docs/user_manual/print_layout/overview_layout.rst docs/user_manual/print_composer/overview_composer.rst
+
+docs/user_manual/print_layout/layout_items/index.rst docs/user_manual/print_composer/composer_items/index.rst
+docs/user_manual/print_layout/layout_items/layout_elevation_profile.rst docs/user_manual/print_composer/composer_items/layout_elevation_profile.rst
+docs/user_manual/print_layout/layout_items/layout_html_frame.rst docs/user_manual/print_composer/composer_items/composer_html_frame.rst
+docs/user_manual/print_layout/layout_items/layout_image.rst docs/user_manual/print_composer/composer_items/composer_image.rst
+docs/user_manual/print_layout/layout_items/layout_items_options.rst docs/user_manual/print_composer/composer_items/composer_items_options.rst
+docs/user_manual/print_layout/layout_items/layout_label.rst docs/user_manual/print_composer/composer_items/composer_label.rst
+docs/user_manual/print_layout/layout_items/layout_legend.rst docs/user_manual/print_composer/composer_items/composer_legend.rst
+docs/user_manual/print_layout/layout_items/layout_map.rst docs/user_manual/print_composer/composer_items/composer_map.rst
+docs/user_manual/print_layout/layout_items/layout_map3d.rst docs/user_manual/print_composer/composer_items/composer_map3d.rst
+docs/user_manual/print_layout/layout_items/layout_scale_bar.rst docs/user_manual/print_composer/composer_items/composer_scale_bar.rst
+docs/user_manual/print_layout/layout_items/layout_shapes.rst docs/user_manual/print_composer/composer_items/composer_shapes.rst
+docs/user_manual/print_layout/layout_items/layout_tables.rst docs/user_manual/print_composer/composer_items/composer_tables.rst
+
 ## Processing algorithm
 docs/user_manual/processing_algs/qgis/graphics.rst docs/user_manual/processing_algs/qgis/plots.rst


### PR DESCRIPTION
Allows to easily move between [this page (and alike)](https://docs.qgis.org/testing/en/docs/user_manual/print_layout/layout_items/layout_tables.html) and [this one](https://docs.qgis.org/3.40/en/docs/user_manual/print_composer/composer_items/composer_tables.html) by just changing the version number.
<!---
Include a few sentences describing the overall goals for this Pull Request.
 
A list of issues is at https://github.com/qgis/QGIS-Documentation/issues.
Add "fix #issuenumber" for each issue the PR fixes. The ticket(s) will be closed automatically.
If your PR doesn't fix entirely the ticket, only add the ticket(s) reference preceded by # character.
-->
Goal:

Ticket(s): #
<!---
Indicate whether the fix should be backported to previous release.
Replace the space between square brackets by a `x` to make it checked.
-->
- [ ] Backport to LTR documentation is requested

<!---
Reviewing is a process done by community members, mostly on a volunteer basis.
We try to keep the overhead as small as possible and appreciate if you help us.
Please read carefully and ensure you comply with our writing guidelines at
https://docs.qgis.org/testing/en/docs/documentation_guidelines/index.html.
Feel free to ask in a comment or the (qgis-community-team mailing list)
[https://lists.osgeo.org/mailman/listinfo/qgis-community-team] if you have troubles with any item.
--->
