### PR TITLE
Fix text formatting

### DIFF
--- a/docs/developers_guide/processingtesting.rst
+++ b/docs/developers_guide/processingtesting.rst
@@ -173,7 +173,7 @@ properties to define how a layer is compared.
 To deal with a certain tolerance for output values you can specify a ``compare``
 property for an output. The compare property can contain sub-properties for
 ``fields``. This contains information about how precisely a certain field is
-compared (``precision``) or a field can even entirely be ``skip``ed. There is a
+compared (``precision``) or a field can even entirely be ignored (``skip``). There is a
 special field name ``__all__`` which will apply a certain tolerance to all fields.
 There is another property ``geometry`` which also accepts a ``precision`` which is
 applied to each vertex.


### PR DESCRIPTION
Avoids this wrongly formatted due to missing space (and not easy to translate)

<img width="503" height="23" alt="image" src="https://github.com/user-attachments/assets/a97c9c15-e94d-48ca-8052-31308e40360d" />


<!---
Indicate whether the fix should be backported to previous release.
Replace the space between square brackets by a `x` to make it checked.
-->
- [x] Backport to LTR documentation is requested

<!---
Reviewing is a process done by community members, mostly on a volunteer basis.
We try to keep the overhead as small as possible and appreciate if you help us.
Please read carefully and ensure you comply with our writing guidelines at
https://docs.qgis.org/testing/en/docs/documentation_guidelines/index.html.
Feel free to ask in a comment or the (qgis-community-team mailing list)
[https://lists.osgeo.org/mailman/listinfo/qgis-community-team] if you have troubles with any item.
--->
