### PR TITLE
Replace references to QGIS3 in user profile stuffs by QGIS4

### DIFF
--- a/docs/pyqgis_developer_cookbook/intro.rst
+++ b/docs/pyqgis_developer_cookbook/intro.rst
@@ -155,9 +155,9 @@ is executed by the embedded Python interpreter.
 
 The path in the user's home directory usually is found under:
 
-* Linux: :file:`.local/share/QGIS/QGIS3`
-* Windows: :file:`AppData\\Roaming\\QGIS\\QGIS3`
-* macOS: :file:`Library/Application Support/QGIS/QGIS3`
+* Linux: :file:`.local/share/QGIS/QGIS4`
+* Windows: :file:`AppData\\Roaming\\QGIS\\QGIS4`
+* macOS: :file:`Library/Application Support/QGIS/QGIS4`
 
 The default system paths depend on the operating system. To find the
 paths that work for you, open the Python Console and run

--- a/docs/server_manual/config.rst
+++ b/docs/server_manual/config.rst
@@ -57,7 +57,7 @@ several ways to define these variables. This is fully described in
    * - QGIS_OPTIONS_PATH
         Specifies the path to the directory with settings. It works the same way as
         QGIS application ``--optionspath`` option. It is looking for settings file in
-        ``<QGIS_OPTIONS_PATH>/QGIS/QGIS3.ini``.
+        ``<QGIS_OPTIONS_PATH>/QGIS/QGIS4.ini``.
      - ''
      - All
 
@@ -102,7 +102,7 @@ several ways to define these variables. This is fully described in
    * - QGIS_SERVER_APPLICATION_NAME
         Name of the application to be used, for instance when connecting to a database to identify
         the QGIS server instance connected
-     - QGIS3 server
+     - QGIS4 server
      - All
 
    * - QGIS_SERVER_CACHE_DIRECTORY
@@ -380,14 +380,14 @@ For example with spawn-fcgi:
 
 .. code-block:: bash
 
- export QGIS_OPTIONS_PATH=/home/user/.local/share/QGIS/QGIS3/profiles/default/
+ export QGIS_OPTIONS_PATH=/home/user/.local/share/QGIS/QGIS4/profiles/default/
  export QGIS_SERVER_LOG_STDERR=1
  export QGIS_SERVER_LOG_LEVEL=2
  spawn-fcgi -f /usr/lib/cgi-bin/qgis_mapserv.fcgi -s /tmp/qgisserver.sock -U www-data -G www-data -n
 
   QGIS Server Settings:
 
-    - QGIS_OPTIONS_PATH / '' (Override the default path for user configuration): '/home/user/.local/share/QGIS/QGIS3/profiles/default/' (read from ENVIRONMENT_VARIABLE)
+    - QGIS_OPTIONS_PATH / '' (Override the default path for user configuration): '/home/user/.local/share/QGIS/QGIS4/profiles/default/' (read from ENVIRONMENT_VARIABLE)
 
     - QGIS_SERVER_PARALLEL_RENDERING / '/qgis/parallel_rendering' (Activate/Deactivate parallel rendering for WMS getMap request): 'true' (read from INI_FILE)
 
@@ -401,11 +401,11 @@ For example with spawn-fcgi:
 
     - MAX_CACHE_LAYERS / '' (Specify the maximum number of cached layers): '100' (read from DEFAULT_VALUE)
 
-    - QGIS_SERVER_CACHE_DIRECTORY / '/cache/directory' (Specify the cache directory): '/root/.local/share/QGIS/QGIS3/profiles/default/cache' (read from DEFAULT_VALUE)
+    - QGIS_SERVER_CACHE_DIRECTORY / '/cache/directory' (Specify the cache directory): '/root/.local/share/QGIS/QGIS4/profiles/default/cache' (read from DEFAULT_VALUE)
 
     - QGIS_SERVER_CACHE_SIZE / '/cache/size' (Specify the cache size): '52428800' (read from INI_FILE)
 
-  Ini file used to initialize settings: /home/user/.local/share/QGIS/QGIS3/profiles/default/QGIS/QGIS3.ini
+  Ini file used to initialize settings: /home/user/.local/share/QGIS/QGIS4/profiles/default/QGIS/QGIS4.ini
 
 In this particular case, we know that **QGIS_SERVER_MAX_THREADS** and
 **QGIS_SERVER_PARALLEL_RENDERING** values are read from the ini file found in

--- a/docs/user_manual/expressions/expression.rst
+++ b/docs/user_manual/expressions/expression.rst
@@ -303,7 +303,7 @@ Using the |fileSave| :sup:`Add current expression to user expressions` button
 above the expression editor frame, you can save important expressions you want
 to have quick access to. These are available from the **User expressions** group
 in the middle panel. They are saved under the :ref:`user profile <user_profiles>`
-(:file:`<userprofile>/QGIS/QGIS3.ini` file) and available in all expression
+(:file:`<userprofile>/QGIS/QGIS4.ini` file) and available in all expression
 dialogs inside all projects of the current user profile.
 
 A set of tools available above the expression editor frame helps you manage
@@ -318,7 +318,7 @@ the user expressions:
 * |sharingImport| :sup:`Import user expressions` from a ``.json`` file
   into the active user profile folder
 * |sharingExport| :sup:`Export user expressions` as a ``.json`` file;
-  all the user expressions in the user profile :file:`QGIS3.ini` file are
+  all the user expressions in the user profile :file:`QGIS4.ini` file are
   shared
 
 

--- a/docs/user_manual/introduction/qgis_configuration.rst
+++ b/docs/user_manual/introduction/qgis_configuration.rst
@@ -1641,7 +1641,7 @@ Advanced settings
 
 All the settings related to QGIS (UI, tools, data providers, Processing
 configurations, default values and paths, plugins options, expressions,
-geometry checks...) are saved in a :file:`QGIS/QGIS3.ini` file under the active
+geometry checks...) are saved in a :file:`QGIS/QGIS4.ini` file under the active
 :ref:`user profile <user_profiles>` directory.
 Configurations can be shared by copying this file to other installations.
 
@@ -1650,8 +1650,8 @@ settings through the :guilabel:`Advanced Settings Editor`.
 After you promise to be careful, the widget is populated with a tree of all
 the existing settings, and you can edit their value.
 Right-click over a setting or a group and you can delete it
-(to add a setting or group, you have to edit the :file:`QGIS3.ini` file).
-Changes are automatically saved in the :file:`QGIS3.ini` file.
+(to add a setting or group, you have to edit the :file:`QGIS4.ini` file).
+Changes are automatically saved in the :file:`QGIS4.ini` file.
 
 .. warning:: **Avoid using the Advanced tab settings blindly**
 
@@ -1692,9 +1692,9 @@ But you can create as many user profiles as you want:
      something like :file:`C:\\Users\\<username>`.
    * and ``<UserProfiles>`` represents the main profiles folder, i.e.:
 
-     * |nix| :file:`.local/share/QGIS/QGIS3/profiles/`
-     * |win| :file:`%AppData%\\Roaming\\QGIS\\QGIS3\\profiles\\`
-     * |osx| :file:`Library/Application Support/QGIS/QGIS3/profiles/`
+     * |nix| :file:`.local/share/QGIS/QGIS4/profiles/`
+     * |win| :file:`%AppData%\\Roaming\\QGIS\\QGIS4\\profiles\\`
+     * |osx| :file:`Library/Application Support/QGIS/QGIS4/profiles/`
 
    The user profile folder can be opened from within QGIS using the
    :guilabel:`Open Active Profile Folder`.
@@ -1720,7 +1720,7 @@ User Profiles` menu. You can also run QGIS with a specific user profile from the
  If the bug prevents you to create a new user profile from within the :menuselection:`Settings --> User Profiles` menu,
  you can either:
 
- * Rename in the file explorer, the "broken" user profile folder in the :file:`QGIS3/profiles` folder
+ * Rename in the file explorer, the "broken" user profile folder in the :file:`QGIS4/profiles` folder
    and restart QGIS.
    A new ``default`` user profile will be created and executed.
  * Start QGIS from the command line, using the new :ref:`profile name <profile_commandline>` argument:
@@ -2683,9 +2683,9 @@ only the first found file will be used:
   and does not require any additional setup like passing commandline parameters
   or settings environment variable. Depending on the OS, it is:
 
-  * |nix| :file:`$HOME/.local/share/QGIS/QGIS3/`
-  * |win| :file:`C:\\Users\\<username>\\%AppData%\\Roaming\\QGIS\\QGIS3\\`
-  * |osx| :file:`$HOME/Library/Application Support/QGIS/QGIS3/`
+  * |nix| :file:`$HOME/.local/share/QGIS/QGIS4/`
+  * |win| :file:`C:\\Users\\<username>\\%AppData%\\Roaming\\QGIS\\QGIS4\\`
+  * |osx| :file:`$HOME/Library/Application Support/QGIS/QGIS4/`
 * the installation directory, i.e., :file:`your_QGIS_package_path/resources/qgis_global_settings.ini`.
 
 Presently, there's no way to specify a file to write settings to; therefore,

--- a/docs/user_manual/managing_data_source/create_layers.rst
+++ b/docs/user_manual/managing_data_source/create_layers.rst
@@ -686,7 +686,7 @@ to create, store and manipulate your queries:
 * As previously mentioned, queries can be saved as an :file:`.sql` file stored on disk.
   Using the |storedqueries| :sup:`Store Current Query` button, they can also be stored:
 
-  * In the active :guilabel:`User Profile`, in the associated :file:`QGIS3.ini` file,
+  * In the active :guilabel:`User Profile`, in the associated :file:`QGIS4.ini` file,
     thus accessible in subsequent projects
   * or as part of the :guilabel:`Current Project`.
 

--- a/docs/user_manual/processing/3rdParty.rst
+++ b/docs/user_manual/processing/3rdParty.rst
@@ -200,14 +200,14 @@ Perform the following steps to load and enable them using the
 
       * On Ubuntu, set the path to (or, better, include in the path):
 
-          /home/<user>/.local/share/QGIS/QGIS3/profiles/default/resource_sharing/repositories/github.com/qgis/QGIS-Resources/collections/rscripts
+          /home/<user>/.local/share/QGIS/QGIS4/profiles/default/resource_sharing/repositories/github.com/qgis/QGIS-Resources/collections/rscripts
 
         .. figure:: img/rscript_folder.png
            :align: center
 
       * On Windows, set the path to (or, better, include in the path):
 
-          C:\\Users\\<user>\\AppData\\Roaming\\QGIS\\QGIS3\\profiles\\default\\resource_sharing\\repositories\\github.com\\qgis\\QGIS-Resources\\collections\\rscripts
+          C:\\Users\\<user>\\AppData\\Roaming\\QGIS\\QGIS4\\profiles\\default\\resource_sharing\\repositories\\github.com\\qgis\\QGIS-Resources\\collections\\rscripts
 
       To edit, double-click. You can then choose to just paste / type
       the path, or you can navigate to the directory by using the
@@ -434,7 +434,7 @@ If these two packages are not installed, R may try to load and install them
 (and all the libraries that they depend on).
 
 The following R libraries end up in
-:file:`~/.local/share/QGIS/QGIS3/profiles/default/processing/rscripts`
+:file:`~/.local/share/QGIS/QGIS4/profiles/default/processing/rscripts`
 after ``sf_test`` has been run from the Processing Toolbox on Ubuntu with
 version 2.0 of the *Processing R Provider* plugin and a fresh install of
 *R* 3.4.4 (*apt* package ``r-base-core`` only):


### PR DESCRIPTION
Fixes #10836

I found some external URLs in PyQGIS Cookbook related to QGIS3:
* https://www.opengis.ch/2018/06/22/threads-in-pyqgis3/ in [Tasks](https://docs.qgis.org/testing/en/docs/pyqgis_developer_cookbook/tasks.html#task-from-a-processing-algorithm)
* https://github.com/elpaso/qgis3-server-vagrant/tree/master/resources/web/plugins in [Writing a server plugin](https://docs.qgis.org/testing/en/docs/pyqgis_developer_cookbook/server.html#writing-a-server-plugin)

@elpaso @m-kuhn Do you know if those links and instructions are still relevant for QGIS 4 (and worth keeping) or if any better reference exists? Thanks.
