### PR TITLE
RST linting with rstcheck pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,6 +32,20 @@ repos:
         args: [-d, "{extends: relaxed, rules: {line-length: {max: 200}}}"]
         exclude: ^(locale/|_dummy/|build/)
 
+  # RST linting with rstcheck
+  - repo: https://github.com/rstcheck/rstcheck
+    rev: v6.2.0
+    hooks:
+      - id: rstcheck
+        args:
+          - --report-level=warning
+          - --ignore-directives=toctree,include,only,ifconfig,literalinclude,index,glossary,substitution-definitions,highlight,todo,todolist,deprecated,versionadded,versionchanged,seealso,productionlist,centered,testcode,testoutput,testsetup,tabs,tab,code-block,toggle
+          - --ignore-roles=menuselection,guilabel,file,kbd,ref,doc,term,command,program,option,envvar,index,abbr,dfn,numref,eq,download,py:mod,py:obj,py:class,py:meth,py:attr,py:func,py:exc,pyqgis,api,source,sup,sub,raw,math
+          - --ignore-languages=python,bash,sql,json,xml,yaml
+        exclude: ^(locale/|_dummy/|build/)
+        additional_dependencies:
+          - sphinx
+
   # - repo: local
   #   hooks:
   #     - id: find_set_subst

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,9 +39,10 @@ repos:
       - id: rstcheck
         args:
           - --report-level=warning
-          - --ignore-directives=toctree,include,only,ifconfig,literalinclude,index,glossary,substitution-definitions,highlight,todo,todolist,deprecated,versionadded,versionchanged,seealso,productionlist,centered,testcode,testoutput,testsetup,tabs,tab,code-block,toggle
+          - --ignore-directives=toctree,include,only,ifconfig,literalinclude,index,glossary,substitution-definitions,highlight,todo,todolist,deprecated,versionadded,versionchanged,seealso,productionlist,centered,testcleanup,testcode,testoutput,testsetup,tabs,tab,code-block,toggle
           - --ignore-roles=menuselection,guilabel,file,kbd,ref,doc,term,command,program,option,envvar,index,abbr,dfn,numref,eq,download,py:mod,py:obj,py:class,py:meth,py:attr,py:func,py:exc,pyqgis,api,source,sup,sub,raw,math
           - --ignore-languages=python,bash,sql,json,xml,yaml
+          - --ignore-substitutions=version,rarr,srtmFileName
         exclude: ^(locale/|_dummy/|build/)
         additional_dependencies:
           - sphinx

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -40,7 +40,7 @@ repos:
         args:
           - --report-level=warning
           - --ignore-directives=toctree,include,only,ifconfig,literalinclude,index,glossary,substitution-definitions,highlight,todo,todolist,deprecated,versionadded,versionchanged,seealso,productionlist,centered,testcleanup,testcode,testoutput,testsetup,tabs,tab,code-block,toggle
-          - --ignore-roles=menuselection,guilabel,file,kbd,ref,doc,term,command,program,option,envvar,index,abbr,dfn,numref,eq,download,py:mod,py:obj,py:class,py:meth,py:attr,py:func,py:exc,pyqgis,api,source,sup,sub,raw,math
+          - --ignore-roles=menuselection,guilabel,file,kbd,ref,doc,term,command,program,option,envvar,index,abbr,dfn,numref,eq,download,py:mod,py:obj,py:class,py:meth,py:attr,py:func,py:exc,pyqgis,api,source,sup,sub,raw,math,green,purple,blue,turquoise,kaki,slate,darkgray,midgray
           - --ignore-languages=python,bash,sql,json,xml,yaml
           - --ignore-substitutions=version,rarr,srtmFileName
         exclude: ^(locale/|_dummy/|build/)

--- a/docs/pyqgis_developer_cookbook/loadlayer.rst
+++ b/docs/pyqgis_developer_cookbook/loadlayer.rst
@@ -97,7 +97,7 @@ providers:
 
   * for ESRI Shapefile:
 
-    .. code::
+    .. code-block:: python
 
       uri = "testdata/airports.shp"
       vlayer = QgsVectorLayer(uri, "layer_name_you_like", "ogr")

--- a/docs/pyqgis_developer_cookbook/plugins/snippets.rst
+++ b/docs/pyqgis_developer_cookbook/plugins/snippets.rst
@@ -109,7 +109,7 @@ For example, to reuse the |fileOpen|
 :source:`mActionFileOpen.svg <images/themes/default/mActionFileOpen.svg>` icon available
 in the QGIS code repository:
 
-.. code:: py
+.. code-block:: python
 
     # e.g. somewhere in the initGui
     self.file_open_action = QAction(

--- a/docs/user_manual/print_layout/create_output.rst
+++ b/docs/user_manual/print_layout/create_output.rst
@@ -390,14 +390,14 @@ include expressions. Make sure that you place the expression part
 For example, for a city layer with fields ``CITY_NAME`` and ``ZIPCODE``,
 you could insert this:
 
-.. code::
+.. code-block:: text
 
    The area of [% concat( upper(CITY_NAME), ',', ZIPCODE, ' is ',
    format_number($area/1000000, 2) ) %] km2
 
 or, another combination:
 
-.. code::
+.. code-block:: text
 
    The area of [% upper(CITY_NAME)%],[%ZIPCODE%] is
    [%format_number($area/1000000,2) %] km2
@@ -440,7 +440,7 @@ field :guilabel:`Orientation`, select :guilabel:`Edit...` to open the
 :guilabel:`Expression string builder` dialog and enter the following
 expression:
 
-.. code::
+.. code-block:: text
 
    CASE WHEN bounds_width(@atlas_geometry) > bounds_height(@atlas_geometry)
    THEN 'Landscape' ELSE 'Portrait' END
@@ -451,14 +451,14 @@ reposition the location of the layout items as well. For the map item you can
 use the |dataDefine| button of its :guilabel:`Width` property to set it
 dynamic using the following expression:
 
-.. code::
+.. code-block:: text
 
    @layout_pagewidth - 20
 
 Likewise, use the |dataDefine| button of the :guilabel:`Height` property to
 provide the following expression to constrain map item size:
 
-.. code::
+.. code-block:: text
 
    @layout_pageheight - 20
 
@@ -472,7 +472,7 @@ Next move the label to the right position, choose the middle button for
 the :guilabel:`Reference point`, and provide the following expression for
 field :guilabel:`X`:
 
-.. code::
+.. code-block:: text
 
    @layout_pagewidth / 2
 
@@ -593,7 +593,7 @@ Using the JavaScript ``setFeature`` function it allows you to make flexible HTML
 which represents relations in whatever format you like (lists, tables, etc).
 In the code sample, we create a dynamic bullet list of the related child features.
 
-.. code:: html
+.. code-block:: html
 
    // Declare the two HTML div elements we will use for the parent feature id
    // and information about the children

--- a/docs/user_manual/processing_algs/qgis/rasteranalysis.rst
+++ b/docs/user_manual/processing_algs/qgis/rasteranalysis.rst
@@ -4650,6 +4650,7 @@ Python code
   :end-before: **end_algorithm_code_section**
 
 
+.. |344| replace:: ``NEW in 3.44``
 .. |gaussian_formula| image:: img/fuzzy_gaussian_formula.png
    :height: 1.5em
 .. |fuzzy_large_formula| image:: img/fuzzy_large_formula.png
@@ -4670,5 +4671,4 @@ Python code
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |344| replace:: ``NEW in 3.44``
 .. |400| replace:: ``NEW in 4.0``

--- a/docs/user_manual/processing_algs/qgis/rasterterrainanalysis.rst
+++ b/docs/user_manual/processing_algs/qgis/rasterterrainanalysis.rst
@@ -1182,11 +1182,14 @@ Python code
   :start-after: **algorithm_code_section**
   :end-before: **end_algorithm_code_section**
 
+
+.. |344| replace:: ``NEW in 3.44``
+
+
 .. Substitutions definitions - AVOID EDITING PAST THIS LINE
    This will be automatically updated by the find_set_subst.py script.
    If you need to create a new substitution manually,
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |344| replace:: ``NEW in 3.44``
 .. |400| replace:: ``NEW in 4.0``

--- a/docs/user_manual/working_with_vector/vector_properties.rst
+++ b/docs/user_manual/working_with_vector/vector_properties.rst
@@ -2615,7 +2615,7 @@ In all cases you must enter the name of the function that will be called
 
 An example is (in module MyForms.py):
 
-::
+.. code-block:: python
 
   def open(dialog,layer,feature):
       geom = feature.geometry()
@@ -3381,7 +3381,7 @@ able to make a spatial selection of localities and export these field values
 to a text file for the selected record (shown in yellow in the QGIS map area).
 Here is the action to achieve this:
 
-::
+.. code-block:: bash
 
   bash -c "echo \"%taxon_name %lat %long\" >> /tmp/species_localities.txt"
 
@@ -3389,7 +3389,7 @@ Here is the action to achieve this:
 After selecting a few localities and running the action on each one, opening
 the output file will show something like this:
 
-::
+.. code-block:: text
 
   Acacia mearnsii -34.0800000000 150.0800000000
   Acacia mearnsii -34.9000000000 150.1200000000


### PR DESCRIPTION
Continue subsecting #10856

I had to add `--ignore-substitutions=version,rarr,srtmFileName` arg because these are valid and defined substitutions but the check was keep failing without, and I couldn't find why.
