### PR TITLE
Reinstate html_css_files parameter for handling top banner of the docs

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -163,6 +163,10 @@ html_context = {
     'isLtr': False,
 }
 
+# Add custom CSS when a top bar is needed to be shown (for testing or outdated versions)
+if html_context['isTesting'] or html_context['outdated']:
+    html_css_files = ['css/qgis_topbar.css']
+
 # Add custom tags to allow display of text based on the branch status
 if html_context['isTesting']:
     tags.add('testing')


### PR DESCRIPTION
Partial revert of 5e38721
How it should render (using an outdated docs
![IMG_20260413_143817](https://github.com/user-attachments/assets/dbf6bb53-2ee6-4bc9-9593-0007521705c8)

How it currently renders (on phone), note part of the header under the notification banner

![IMG_20260413_143908](https://github.com/user-attachments/assets/38d017e2-147e-4a59-bce4-044e2aa7e5e8)

<!---
Include a few sentences describing the overall goals for this Pull Request.
 
A list of issues is at https://github.com/qgis/QGIS-Documentation/issues.
Add "fix #issuenumber" for each issue the PR fixes. The ticket(s) will be closed automatically.
If your PR doesn't fix entirely the ticket, only add the ticket(s) reference preceded by # character.
-->
Goal:

Ticket(s): #
<!---
Indicate whether the fix should be backported to previous release.
Replace the space between square brackets by a `x` to make it checked.
-->
- [ ] Backport to LTR documentation is requested

<!---
Reviewing is a process done by community members, mostly on a volunteer basis.
We try to keep the overhead as small as possible and appreciate if you help us.
Please read carefully and ensure you comply with our writing guidelines at
https://docs.qgis.org/testing/en/docs/documentation_guidelines/index.html.
Feel free to ask in a comment or the (qgis-community-team mailing list)
[https://lists.osgeo.org/mailman/listinfo/qgis-community-team] if you have troubles with any item.
--->
