### PR TITLE
Clarify the output layer type in raster analysis algorithms

### DIFF
--- a/docs/user_manual/processing_algs/qgis/rasteranalysis.rst
+++ b/docs/user_manual/processing_algs/qgis/rasteranalysis.rst
@@ -97,7 +97,7 @@ Basic parameters
        (extent, CRS, pixel dimensions)
    * - **Output layer**
      - ``OUTPUT``
-     - [same as input]
+     - [raster]
 
        Default: ``[Save to temporary file]``
      - Specification of the output raster. :ref:`One of <output_parameter_widget>`:
@@ -276,7 +276,7 @@ Basic parameters
        (extent, CRS, pixel dimensions)
    * - **Output layer**
      - ``OUTPUT``
-     - [same as input]
+     - [raster]
 
        Default: ``[Save to temporary file]``
      - Specification of the output raster. :ref:`One of <output_parameter_widget>`:
@@ -457,7 +457,7 @@ Basic parameters
        (extent, CRS, pixel dimensions)
    * - **Output layer**
      - ``OUTPUT``
-     - [same as input]
+     - [raster]
 
        Default: ``[Save to temporary file]``
      - Specification of the output raster. :ref:`One of <output_parameter_widget>`:
@@ -643,7 +643,7 @@ Basic parameters
        from (extent, CRS, pixel dimensions)
    * - **Output layer**
      - ``OUTPUT``
-     - [same as input]
+     - [raster]
 
        Default: ``[Save to temporary file]``
      - Specification of the output raster. :ref:`One of <output_parameter_widget>`:
@@ -802,7 +802,7 @@ Basic parameters
        will result in a NoData cell in the output raster
    * - **Output layer**
      - ``OUTPUT``
-     - [same as input]
+     - [raster]
 
        Default: ``[Save to temporary file]``
      - Specification of the output raster. :ref:`One of <output_parameter_widget>`:
@@ -973,7 +973,7 @@ Basic parameters
      - Spread of the gaussian function
    * - **Fuzzified raster**
      - ``OUTPUT``
-     - [same as input]
+     - [raster]
 
        Default: ``[Save to temporary file]``
      - Specification of the output raster. :ref:`One of <output_parameter_widget>`:
@@ -1024,7 +1024,7 @@ Outputs
      - Description
    * - **Fuzzified raster**
      - ``OUTPUT``
-     - [same as input]
+     - [raster]
      - Output raster layer containing the result
    * - **CRS authority identifier**
      - ``CRS_AUTHID``
@@ -1116,7 +1116,7 @@ Basic parameters
      - Spread of the large function
    * - **Fuzzified raster**
      - ``OUTPUT``
-     - [same as input]
+     - [raster]
 
        Default: ``[Save to temporary file]``
      - Specification of the output raster. :ref:`One of <output_parameter_widget>`:
@@ -1167,7 +1167,7 @@ Outputs
      - Description
    * - **Fuzzified raster**
      - ``OUTPUT``
-     - [same as input]
+     - [raster]
      - Output raster layer containing the result
 
    * - **CRS authority identifier**
@@ -1265,7 +1265,7 @@ Basic parameters
      - High bound of the linear function
    * - **Fuzzified raster**
      - ``OUTPUT``
-     - [same as input]
+     - [raster]
 
        Default: ``[Save to temporary file]``
      - Specification of the output raster. :ref:`One of <output_parameter_widget>`:
@@ -1316,7 +1316,7 @@ Outputs
      - Description
    * - **Fuzzified raster**
      - ``OUTPUT``
-     - [same as input]
+     - [raster]
      - Output raster layer containing the result
    * - **CRS authority identifier**
      - ``CRS_AUTHID``
@@ -1408,7 +1408,7 @@ Basic parameters
      - Spread of the near function
    * - **Fuzzified raster**
      - ``OUTPUT``
-     - [same as input]
+     - [raster]
 
        Default: ``[Save to temporary file]``
      - Specification of the output raster. :ref:`One of <output_parameter_widget>`:
@@ -1459,7 +1459,7 @@ Outputs
      - Description
    * - **Fuzzified raster**
      - ``OUTPUT``
-     - [same as input]
+     - [raster]
      - Output raster layer containing the result
    * - **CRS authority identifier**
      - ``CRS_AUTHID``
@@ -1560,7 +1560,7 @@ Basic parameters
      - Exponent of the power function
    * - **Fuzzified raster**
      - ``OUTPUT``
-     - [same as input]
+     - [raster]
 
        Default: ``[Save to temporary file]``
      - Specification of the output raster. :ref:`One of <output_parameter_widget>`:
@@ -1611,7 +1611,7 @@ Outputs
      - Description
    * - **Fuzzified raster**
      - ``OUTPUT``
-     - [same as input]
+     - [raster]
      - Output raster layer containing the result
    * - **CRS authority identifier**
      - ``CRS_AUTHID``
@@ -1702,7 +1702,7 @@ Basic parameters
      - Spread of the small function
    * - **Fuzzified raster**
      - ``OUTPUT``
-     - [same as input]
+     - [raster]
 
        Default: ``[Save to temporary file]``
      - Specification of the output raster. :ref:`One of <output_parameter_widget>`:
@@ -1753,7 +1753,7 @@ Outputs
      - Description
    * - **Fuzzified raster**
      - ``OUTPUT``
-     - [same as input]
+     - [raster]
      - Output raster layer containing the result
    * - **CRS authority identifier**
      - ``CRS_AUTHID``


### PR DESCRIPTION
Replace [same as input] by [raster] as we know that these outputs are raster. "same as input" should be used when the input entry allows different types (e.g., point vs line vs polygone) and the output layer shares that same type.

<!---
Include a few sentences describing the overall goals for this Pull Request.

A list of issues is at https://github.com/qgis/QGIS-Documentation/issues.
Add "fix #issuenumber" for each issue the PR fixes. The ticket(s) will be closed automatically.
If your PR doesn't fix entirely the ticket, only add the ticket(s) reference preceded by # character.
-->
Goal:

Ticket(s): #
<!---
Indicate whether the fix should be backported to previous release.
Replace the space between square brackets by a `x` to make it checked.
-->
- [x] Backport to LTR documentation is requested

<!---
Reviewing is a process done by community members, mostly on a volunteer basis.
We try to keep the overhead as small as possible and appreciate if you help us.
Please read carefully and ensure you comply with our writing guidelines at
https://docs.qgis.org/testing/en/docs/documentation_guidelines/index.html.
Feel free to ask in a comment or the (qgis-community-team mailing list)
[https://lists.osgeo.org/mailman/listinfo/qgis-community-team] if you have troubles with any item.
--->
