### PR TITLE
Add QGIS version in which a specific algorithm has been added

### DIFF
--- a/docs/documentation_guidelines/writing.rst
+++ b/docs/documentation_guidelines/writing.rst
@@ -642,6 +642,19 @@ guidelines:
 
   To find out the algorithm name you can just hover the mouse on the algorithm in
   the Processing toolbox.
+* Mention the QGIS version in which the algorithm was introduced:
+
+  .. code-block:: rst
+
+    ``Added in 3.44``
+
+  Likewise, mention if the algorithm requires a specific optional dependency (and version).
+
+  .. code-block:: rst
+
+    .. attention:: Running this algorithm requires QGIS installed with <library> >= min_value
+     (see :menuselection:`Help --> About` menu).
+
 * Avoid using "This algorithm does this and that..." as the first sentence in the
   algorithm description. Try to use more general expressions like:
 
@@ -668,8 +681,7 @@ guidelines:
 * Avoid duplicating detailed description of algorithm options. Add this information
   in the parameter description.
 * Avoid adding information about the vector geometry type in the algorithm or parameter
-  description, as this information is already available
-  in the parameter descriptions.
+  description, as this information is already available in the parameter descriptions.
 * Add the default value of the parameter, e.g.:
 
   .. code-block:: rst
@@ -681,6 +693,9 @@ guidelines:
         Default: 1
       - Number of points to create
 
+* When a parameter or a parameter's value is added to an already existing algorithm,
+  indicate the QGIS version in which it is introduced.
+  If it requires a specific library, also indicate its minimal requirements.
 * Describe the *type* of input supported the parameters. There are several types
   available you can pick one from:
 

--- a/docs/user_manual/processing_algs/gdal/miscellaneous.rst
+++ b/docs/user_manual/processing_algs/gdal/miscellaneous.rst
@@ -13,7 +13,7 @@ Miscellaneous
 
 Dataset Identification
 ----------------------
-|400|
+``Added in 4.0``
 
 Reports the name of GDAL drivers that can open files contained in a folder,
 with optional additional details, and write the result into an output vector layer.
@@ -106,12 +106,3 @@ Python code
 .. include:: ../algs_include.rst
   :start-after: **algorithm_code_section**
   :end-before: **end_algorithm_code_section**
-
-
-.. Substitutions definitions - AVOID EDITING PAST THIS LINE
-   This will be automatically updated by the find_set_subst.py script.
-   If you need to create a new substitution manually,
-   please add it also to the substitutions.txt file in the
-   source folder.
-
-.. |400| replace:: ``NEW in 4.0``

--- a/docs/user_manual/processing_algs/gdal/rasterconversion.rst
+++ b/docs/user_manual/processing_algs/gdal/rasterconversion.rst
@@ -12,6 +12,7 @@ Raster conversion
 
 Create Cloud Optimized GeoTIFF
 -------------------------------
+``Added in 4.0``
 
 Creates a Cloud Optimized GeoTIFF (COG) from the input raster layers.
 

--- a/docs/user_manual/processing_algs/gdal/rastermiscellaneous.rst
+++ b/docs/user_manual/processing_algs/gdal/rastermiscellaneous.rst
@@ -919,6 +919,8 @@ Basic parameters
        Default: Not set
      - Value to use for NoData
    * - **Handling of extent differences**
+
+       ``Added in 3.34``
      - ``EXTENT_OPT``
      - [enumeration]
 

--- a/docs/user_manual/processing_algs/gdal/vectormiscellaneous.rst
+++ b/docs/user_manual/processing_algs/gdal/vectormiscellaneous.rst
@@ -875,6 +875,8 @@ Basic parameters
      - [vector: geometry]
      - Input vector layer
    * - **Enable listing of all layers in the dataset**
+
+       ``Added in 3.40``
      - ``ALL_LAYERS``
      - [boolean]
 
@@ -913,6 +915,7 @@ Basic parameters
 
 Advanced parameters
 ^^^^^^^^^^^^^^^^^^^
+``Added in 3.40``
 
 .. list-table::
    :header-rows: 1
@@ -963,6 +966,8 @@ Python code
 
 Vector Information (JSON)
 -------------------------
+``Added in 3.40``
+
 Creates an information file that lists information about an
 OGR-supported data source.
 The output will be shown in a 'Result' window and can be written

--- a/docs/user_manual/processing_algs/qgis/3dtiles.rst
+++ b/docs/user_manual/processing_algs/qgis/3dtiles.rst
@@ -12,6 +12,7 @@
 
 Convert B3DM to GLTF
 --------------------
+``Added in 3.34``
 
 Converts files from the legacy :file:`.B3DM` format to :file:`.GLTF` or :file:`.GLB`.
 
@@ -73,6 +74,7 @@ Python code
 
 Convert GLTF to vector features
 -------------------------------
+``Added in 3.34``
 
 Converts :file:`.GLTF` or :file:`.GLB` file contents to standard vector layer formats.
 

--- a/docs/user_manual/processing_algs/qgis/cartography.rst
+++ b/docs/user_manual/processing_algs/qgis/cartography.rst
@@ -704,7 +704,7 @@ Advanced parameters
 
        * 0 - Always export text as paths (recommended)
        * 1 - Always export texts as text objects
-       * 2 - Prefer exporting texts as text objects
+       * 2 - Prefer exporting texts as text objects --- ``Added in 3.40``
    * - **Image compression**
      - ``IMAGE_COMPRESSION``
      - [enumeration]
@@ -880,7 +880,7 @@ Advanced parameters
 
        * 0 - Always export text as paths (recommended)
        * 1 - Always export texts as text objects
-       * 2 - Prefer exporting texts as text objects
+       * 2 - Prefer exporting texts as text objects --- ``Added in 3.40``
    * - **Image compression**
      - ``IMAGE_COMPRESSION``
      - [enumeration]
@@ -1137,7 +1137,7 @@ Advanced parameters
 
        * 0 - Always export text as paths (recommended)
        * 1 - Always export texts as text objects
-       * 2 - Prefer exporting texts as text objects
+       * 2 - Prefer exporting texts as text objects --- ``Added in 3.40``
    * - **Image compression**
      - ``IMAGE_COMPRESSION``
      - [enumeration]

--- a/docs/user_manual/processing_algs/qgis/checkgeometry.rst
+++ b/docs/user_manual/processing_algs/qgis/checkgeometry.rst
@@ -15,6 +15,7 @@ Check Geometry
 
 Dangle-end lines
 ----------------
+``Added in 3.42``
 
 Detects dangle-end lines in line geometries and reports them as errors.
 A dangle-end line is a line feature that terminates at a vertex connected to only one segment,
@@ -142,6 +143,7 @@ Python code
 
 Degenerate polygons
 -------------------
+``Added in 3.42``
 
 Checks the polygons with less than 3 points, which are degenerate polygons.
 Degenerate polygons are errors.
@@ -270,6 +272,7 @@ Python code
 
 Duplicated geometries
 ---------------------
+``Added in 3.42``
 
 Checks for duplicated geometries in a vector layer, and reports them as errors.
 
@@ -391,6 +394,7 @@ Python code
 
 Duplicated vertices
 -------------------
+``Added in 3.42``
 
 Checks for duplicated vertices in line or polygon geometries,
 and reports them as errors.
@@ -514,6 +518,7 @@ Python code
 
 Features inside polygon
 -----------------------
+``Added in 3.42``
 
 Checks the input geometries contained in the polygons from the polygon layers list.
 A polygon layer can be checked against itself.
@@ -646,6 +651,7 @@ Python code
 
 Holes
 ------------
+``Added in 3.42``
 
 Detects holes in polygon geometries and reports them as errors.
 
@@ -773,6 +779,7 @@ Python code
 
 Lines intersecting each other
 -----------------------------
+``Added in 3.42``
 
 Checks intersections between line geometries within a layer.
 Intersections between two different lines are errors.
@@ -897,6 +904,7 @@ Python code
 
 Lines intersecting other layer
 ------------------------------
+``Added in 3.42``
 
 Checks if the input line layer features intersect with the check layer features.
 An input feature that intersects with a check layer feature is an error.
@@ -1024,6 +1032,7 @@ Python code
 
 Missing vertices along borders
 ------------------------------
+``Added in 3.42``
 
 Checks for missing vertices along polygon borders.
 To be topologically correct, a vertex at the junction of two polygons
@@ -1154,6 +1163,7 @@ Python code
 
 Overlaps
 ------------------
+``Added in 3.42``
 
 Calculates overlapping areas in polygon geometries, and reports areas smaller than a given minimum as errors.
 
@@ -1282,6 +1292,7 @@ Python code
 
 Points outside lines
 --------------------
+``Added in 3.42``
 
 Checks if the points in the input layer are covered by a line in the selected line layers.
 A point not covered by a line is an error.
@@ -1393,6 +1404,7 @@ Python code
 
 Points outside polygons
 -----------------------
+``Added in 3.42``
 
 Checks if points from the input layer are in polygons from the selected polygon layers.
 Points that are not fully inside polygons are errors.
@@ -1504,6 +1516,7 @@ Python code
 
 Self-contacts
 ------------------
+``Added in 3.42``
 
 Checks if the geometry has self contact points (in line or polygon),
 i.e., a vertex that touches more than two segments of the same ring.
@@ -1640,6 +1653,7 @@ Python code
 
 Self-intersections
 ------------------
+``Added in 3.42``
 
 Detects self-intersections in line or polygon geometries, and reports them as errors.
 Self-intersections occur when the segments of a geometry cross over each other
@@ -1777,6 +1791,7 @@ Python code
 
 Sliver polygons
 ------------------
+``Added in 3.42``
 
 Detects sliver polygons in a polygon layer,
 i.e., polygons with a thinness greater than a specified value.
@@ -1934,6 +1949,7 @@ Python code
 
 Small angles
 ------------
+``Added in 3.42``
 
 Compares the angles within line or polygon geometries to a specified threshold,
 and reports as error any angle below that value.
@@ -2047,6 +2063,7 @@ Python code
 
 Small polygons
 ------------------
+``Added in 3.42``
 
 Detects polygon features whose area is below a specified value as errors.
 
@@ -2188,6 +2205,7 @@ Python code
 
 Small gaps
 ---------------------
+``Added in 3.42``
 
 Checks for gaps between polygons in the input layer.
 Gaps with an area smaller than the gap threshold are reported as errors.
@@ -2361,6 +2379,7 @@ Python code
 
 Small segments
 ---------------------
+``Added in 3.42``
 
 Calculates length of individual segments in line or polygon geometries,
 and reports segments shorter than a minimum length as errors.
@@ -2496,6 +2515,7 @@ Python code
 
 Strictly multipart
 ---------------------
+``Added in 3.42``
 
 Checks if multipart geometries have more than one part.
 Multipart geometries with only one part are errors.
@@ -2613,7 +2633,6 @@ Python code
 .. include:: ../algs_include.rst
   :start-after: **algorithm_code_section**
   :end-before: **end_algorithm_code_section**
-
 
 
 .. Substitutions definitions - AVOID EDITING PAST THIS LINE

--- a/docs/user_manual/processing_algs/qgis/filetools.rst
+++ b/docs/user_manual/processing_algs/qgis/filetools.rst
@@ -103,6 +103,8 @@ Python code
 
 HTTP(S) POST/GET request
 ------------------------
+``Added in 3.40``
+
 Performs a HTTP(S) POST/GET request and returns the HTTP status code and the reply data.
 If an error occurs then the error code and the message will be returned.
 Optionally, the result can be written to a file on the disk.

--- a/docs/user_manual/processing_algs/qgis/fixgeometry.rst
+++ b/docs/user_manual/processing_algs/qgis/fixgeometry.rst
@@ -13,6 +13,7 @@ Fix Geometry
 
 Add missing vertices along borders
 ----------------------------------
+``Added in 3.42``
 
 Adds the missing vertices along polygons borders,
 based on an error layer from the :ref:`qgischeckgeometrymissingvertex` algorithm.
@@ -163,6 +164,7 @@ Python code
 
 Convert to strictly multipart
 ------------------------------
+``Added in 3.42``
 
 Converts multipart geometries that consists of only one geometry into singlepart geometries,
 based on an error layer from the :ref:`qgischeckgeometrymultipart` algorithm.
@@ -292,6 +294,7 @@ Python code
 
 Delete duplicated vertices
 --------------------------
+``Added in 3.42``
 
 Deletes duplicated vertices from the input geometries,
 based on errors reported by the :ref:`qgischeckgeometryduplicatenodes` algorithm.
@@ -438,6 +441,7 @@ Python code
 
 Delete features
 ---------------
+``Added in 3.42``
 
 Deletes error features based on an error layer from some check geometry algorithms, such as:
 
@@ -554,6 +558,7 @@ Python code
 
 Delete overlaps
 ---------------
+``Added in 3.42``
 
 Deletes overlapping areas based on an error layer from the :ref:`qgischeckgeometryoverlap` algorithm.
 
@@ -696,6 +701,7 @@ Python code
 
 Delete small angles
 --------------------
+``Added in 3.42``
 
 Deletes vertices based on an error layer from the :ref:`qgischeckgeometryangle` algorithm.
 When deletion of a vertex results in a duplicate vertex (when a spike vertex is deleted),
@@ -850,6 +856,7 @@ Python code
 
 Fill gaps
 --------------------
+``Added in 3.42``
 
 Fills the gaps based on a gap and neighbors layer from the :ref:`qgischeckgeometrygap` algorithm.
 Three different fixing methods are available.
@@ -1005,6 +1012,7 @@ Python code
 
 Fill holes
 --------------------
+``Added in 3.42``
 
 Deletes holes in polygon geometries based on an error layer from the
 :ref:`qgischeckgeometryhole` algorithm.
@@ -1155,6 +1163,7 @@ Python code
 
 Fix small polygons
 --------------------
+``Added in 3.42``
 
 Merges neighboring polygons according to the chosen method,
 based on an error layer from the :ref:`qgischeckgeometryarea` or :ref:`qgischeckgeometrysliverpolygon` algorithm.
@@ -1326,6 +1335,7 @@ Python code
 
 Split self-intersecting geometries
 ----------------------------------
+``Added in 3.42``
 
 Splits self-intersecting geometries based on an error layer from the
 :ref:`qgischeckgeometryselfintersection` algorithm.

--- a/docs/user_manual/processing_algs/qgis/interpolation.rst
+++ b/docs/user_manual/processing_algs/qgis/interpolation.rst
@@ -471,6 +471,8 @@ Advanced parameters
    * - **Creation options**
 
        Optional
+
+       ``Added in 3.40``
      - ``CREATION_OPTIONS`` (for QGIS <= 3.42, this was ``CREATE_OPTIONS``)
      - [string]
 

--- a/docs/user_manual/processing_algs/qgis/mesh.rst
+++ b/docs/user_manual/processing_algs/qgis/mesh.rst
@@ -822,6 +822,8 @@ Advanced parameters
    * - **Creation options**
 
        Optional
+
+       ``Added in 3.40``
      - ``CREATION_OPTIONS`` (for QGIS <= 3.42, this was ``CREATE_OPTIONS``)
      - [string]
 
@@ -866,6 +868,8 @@ Python code
 
 Surface to Polygon
 ------------------
+``Added in 3.42``
+
 Exports a polygon file containing the boundary of a mesh layer.
 The resulting polygon may contain holes and may be a multi-part polygon.
 

--- a/docs/user_manual/processing_algs/qgis/metadatatools.rst
+++ b/docs/user_manual/processing_algs/qgis/metadatatools.rst
@@ -12,6 +12,7 @@ Metadata tools
 
 Add history metadata
 --------------------
+``Added in 3.42``
 
 Adds a new history entry to the layer's metadata.
 
@@ -68,6 +69,7 @@ Python code
 
 Copy Layer Metadata
 -------------------
+``Added in 3.42``
 
 Copies metadata from a source layer to a target layer.
 Any existing metadata in the target layer will be replaced with the metadata from the source layer.
@@ -133,6 +135,7 @@ Python code
 
 Export Layer Metadata
 ---------------------
+``Added in 3.42``
 
 Exports the metadata of a layer to a QMD file.
 
@@ -195,6 +198,7 @@ Python code
 
 Set Layer Metadata
 ------------------
+``Added in 3.42``
 
 Applies metadata to a layer from a :file:`.qmd` file.
 
@@ -257,6 +261,8 @@ Python code
 
 Set Metadata Fields
 -------------------
+``Added in 3.42``
+
 Sets various metadata fields for a layer.
 
 Parameters
@@ -368,6 +374,8 @@ Python code
 
 Update Layer Metadata
 ---------------------
+``Added in 3.42``
+
 Copies all non-empty metadata fields from a source layer to a target layer.
 Leaves empty input fields unchanged in the target.
 

--- a/docs/user_manual/processing_algs/qgis/modelertools.rst
+++ b/docs/user_manual/processing_algs/qgis/modelertools.rst
@@ -18,6 +18,7 @@ Modeler tools
 
 Calculate expression
 --------------------
+``Added in 3.34``
 
 It calculates the result of a QGIS expression and eliminates
 the need to use the same expression multiple times throughout

--- a/docs/user_manual/processing_algs/qgis/networkanalysis.rst
+++ b/docs/user_manual/processing_algs/qgis/networkanalysis.rst
@@ -236,6 +236,8 @@ Basic parameters
           :end-before: **end_layer_output_types_skip**
 
    * - **Non-routable features**
+
+       ``Added in 3.38``
      - ``OUTPUT_NON_ROUTABLE``
      - [vector: point]
 
@@ -360,6 +362,8 @@ Advanced parameters
    * - **Maximum point distance from network**
 
        Optional
+
+       ``Added in 3.38``
      - ``POINT_TOLERANCE``
      - [numeric: double]
 
@@ -390,7 +394,9 @@ Outputs
      - [vector: line]
      - Line layer representing the parts of the network
        that can be serviced by the start points, for the given cost.
-   * - **Non routable features**
+   * - **Non-routable features**
+
+       ``Added in 3.38``
      - ``OUTPUT_NON_ROUTABLE``
      - [vector: point]
      - An optional output which will be used to store any input features
@@ -503,6 +509,8 @@ Advanced parameters
    * - **Maximum point distance from network**
 
        Optional
+
+       ``Added in 3.38``
      - ``POINT_TOLERANCE``
      - [numeric: double]
 
@@ -617,6 +625,8 @@ Basic parameters
    * - **Non-routable features**
 
        Optional
+
+       ``Added in 3.38``
      - ``OUTPUT_NON_ROUTABLE``
      - [vector: point]
 
@@ -642,6 +652,8 @@ Advanced parameters
    * - **Maximum point distance from network**
 
        Optional
+
+       ``Added in 3.38``
      - ``POINT_TOLERANCE``
      - [numeric: double]
 
@@ -669,7 +681,9 @@ Outputs
      - [vector: line]
      - Line layer of the shortest or fastest path
        from each of the start points to the end point
-   * - **Non routable features**
+   * - **Non-routable features**
+
+       ``Added in 3.38``
      - ``OUTPUT_NON_ROUTABLE``
      - [vector: point]
      - An optional output layer which will be used to store any input features
@@ -752,6 +766,8 @@ Basic parameters
    * - **Non-routable features**
 
        Optional
+
+       ``Added in 3.38``
      - ``OUTPUT_NON_ROUTABLE``
      - [vector: point]
 
@@ -778,6 +794,8 @@ Advanced parameters
    * - **Maximum point distance from network**
 
        Optional
+
+       ``Added in 3.38``
      - ``POINT_TOLERANCE``
      - [numeric: double]
 
@@ -805,7 +823,9 @@ Outputs
      - [vector: line]
      - Line layer of the shortest or fastest path
        from each of the start points to the end point
-   * - **Non routable features**
+   * - **Non-routable features**
+
+       ``Added in 3.38``
      - ``OUTPUT_NON_ROUTABLE``
      - [vector: point]
      - An optional output layer which will be used to store any input features
@@ -896,6 +916,8 @@ Advanced parameters
    * - **Maximum point distance from network**
 
        Optional
+
+       ``Added in 3.38``
      - ``POINT_TOLERANCE``
      - [numeric: double]
 

--- a/docs/user_manual/processing_algs/qgis/networkanalysis.rst
+++ b/docs/user_manual/processing_algs/qgis/networkanalysis.rst
@@ -11,12 +11,17 @@ Network analysis
 
 Extract network end points
 ----------------------------
+``Added in 4.0``
 
 Extracts the end points (nodes) from a network line layer.
 Two definitions are available for identifying end points:
 
-#. Nodes with only all incoming or all outgoing edges: Identifies 'Source' or 'Sink' nodes based on the direction of flow. These are nodes where flow can start (only outgoing) or stop (only incoming).
-#. Nodes connected to a single edge: Identifies topological 'dead-ends' or 'dangles', regardless of directionality. This checks if the node is connected to only one other distinct node.
+#. Nodes with only all incoming or all outgoing edges:
+   Identifies 'Source' or 'Sink' nodes based on the direction of flow.
+   These are nodes where flow can start (only outgoing) or stop (only incoming).
+#. Nodes connected to a single edge: Identifies topological 'dead-ends'
+   or 'dangles', regardless of directionality.
+   This checks if the node is connected to only one other distinct node.
 
 Parameters
 ..........
@@ -958,6 +963,7 @@ Python code
 
 Validate network
 ---------------------
+``Added in 4.0``
 
 Analyzes a network vector layer to identify data and topology errors that may affect network analysis tools (like shortest path).
 Optional checks include:

--- a/docs/user_manual/processing_algs/qgis/plots.rst
+++ b/docs/user_manual/processing_algs/qgis/plots.rst
@@ -47,6 +47,8 @@ Parameters
 
        Optional
      - ``TITLE``
+
+       ``Added in 3.42``
      - [string]
 
        Default: ""
@@ -54,6 +56,8 @@ Parameters
    * - **X-axis Title**
 
        Optional
+
+       ``Added in 3.42``
      - ``XAXIS_TITLE``
      - [string]
 
@@ -63,6 +67,8 @@ Parameters
    * - **Y-axis Title**
 
        Optional
+
+       ``Added in 3.42``
      - ``YAXIS_TITLE``
      - [string]
 
@@ -157,6 +163,8 @@ Parameters
    * - **Title**
 
        Optional
+
+       ``Added in 3.42``
      - ``TITLE``
      - [string]
 
@@ -165,6 +173,8 @@ Parameters
    * - **X-axis Title**
 
        Optional
+
+       ``Added in 3.42``
      - ``XAXIS_TITLE``
      - [string]
 
@@ -174,6 +184,8 @@ Parameters
    * - **Y-axis Title**
 
        Optional
+
+       ``Added in 3.42``
      - ``YAXIS_TITLE``
      - [string]
 
@@ -223,6 +235,7 @@ Python code
 
 Generate elevation profile image
 --------------------------------
+``Added in 3.42``
 
 Creates an elevation profile image from a list of map layers and an optional terrain layer.
 
@@ -727,6 +740,8 @@ Parameters
    * - **Hover text**
 
        Optional
+
+       ``Added in 3.42``
      - ``HOVERTEXT``
      - [expression]
 
@@ -736,6 +751,8 @@ Parameters
    * - **Title**
 
        Optional
+
+       ``Added in 3.42``
      - ``TITLE``
      - [string]
 
@@ -744,6 +761,8 @@ Parameters
    * - **X-axis Title**
 
        Optional
+
+       ``Added in 3.42``
      - ``XAXIS_TITLE``
      - [string]
 
@@ -753,6 +772,8 @@ Parameters
    * - **Y-axis Title**
 
        Optional
+
+       ``Added in 3.42``
      - ``YAXIS_TITLE``
      - [string]
 
@@ -760,6 +781,9 @@ Parameters
      - If empty, the field name of the y attribute is used.
        With a single space, the axis title is not shown.
    * - **Use logarithmic scale for x-axis**
+
+       ``Added in 3.42``
+
      - ``XAXIS_LOG``
      - [boolean]
 
@@ -767,6 +791,9 @@ Parameters
      - When enabled, uses logarithmic scale for the x-axis
    * - **Use logarithmic scale for y-axis**
      - ``YAXIS_LOG``
+
+       ``Added in 3.42``
+
      - [boolean]
 
        Default: False
@@ -852,6 +879,8 @@ Parameters
    * - **Title**
 
        Optional
+
+       ``Added in 3.42``
      - ``TITLE``
      - [string]
 
@@ -860,6 +889,8 @@ Parameters
    * - **X-axis Title**
 
        Optional
+
+       ``Added in 3.42``
      - ``XAXIS_TITLE``
      - [string]
 
@@ -868,6 +899,8 @@ Parameters
    * - **Y-axis Title**
 
        Optional
+
+       ``Added in 3.42``
      - ``YAXIS_TITLE``
      - [string]
 
@@ -876,6 +909,8 @@ Parameters
    * - **Z-axis Title**
 
        Optional
+
+       ``Added in 3.42``
      - ``ZAXIS_TITLE``
      - [string]
 

--- a/docs/user_manual/processing_algs/qgis/pointcloudconversion.rst
+++ b/docs/user_manual/processing_algs/qgis/pointcloudconversion.rst
@@ -62,7 +62,7 @@ Advanced parameters
      - Description
    * - **VPC Output Format**
 
-       |400|
+       ``Added in 4.0``
      - ``VPC_OUTPUT_FORMAT``
      - [enumeration]
 
@@ -293,6 +293,8 @@ Basic parameters
    * - **Maximum triangle edge length**
 
        Optional
+
+       ``Added in 4.0``
      - ``MAX_EDGE_LENGTH``
      - [numeric: double]
      - Maximum length of triangle edges. Edges longer than this value will be ignored during interpolation.
@@ -487,12 +489,3 @@ Python code
 
 
 .. _PDAL: https://pdal.io/en/stable/
-
-
-.. Substitutions definitions - AVOID EDITING PAST THIS LINE
-   This will be automatically updated by the find_set_subst.py script.
-   If you need to create a new substitution manually,
-   please add it also to the substitutions.txt file in the
-   source folder.
-
-.. |400| replace:: ``NEW in 4.0``

--- a/docs/user_manual/processing_algs/qgis/pointcloudconversion.rst
+++ b/docs/user_manual/processing_algs/qgis/pointcloudconversion.rst
@@ -14,6 +14,7 @@ Point Cloud Conversion
 
 Convert point cloud format
 --------------------------
+``Added in 3.32``
 
 Converts a point cloud to a different file format, e.g. creates a compressed :file:`.LAZ`.
 
@@ -109,6 +110,7 @@ Python code
 
 Export point cloud to raster
 ----------------------------
+``Added in 3.32``
 
 Exports point cloud data to a 2D raster grid having cell size of given resolution,
 writing values from the specified attribute.
@@ -237,6 +239,7 @@ Python code
 
 Export point cloud to raster (using triangulation)
 --------------------------------------------------
+``Added in 3.32``
 
 Exports point cloud data to a 2D raster grid using a triangulation of points
 and then interpolating cell values from triangles.
@@ -380,6 +383,7 @@ Python code
 
 Export point cloud to vector
 -----------------------------
+``Added in 3.32``
 
 Exports point cloud data to a vector layer with 3D points (a GeoPackage),
 optionally with extra attributes.

--- a/docs/user_manual/processing_algs/qgis/pointclouddatamanagement.rst
+++ b/docs/user_manual/processing_algs/qgis/pointclouddatamanagement.rst
@@ -70,7 +70,7 @@ Advanced parameters
      - Description
    * - **VPC Output Format**
 
-       |400|
+       ``Added in 4.0``
      - ``VPC_OUTPUT_FORMAT``
      - [enumeration]
 
@@ -175,7 +175,7 @@ Parameters
        for example, for :file:`mydata.vpc`, the overview point cloud would be named :file:`mydata-overview.copc.laz`.
    * - **Convert individual files to COPC format**
 
-       |400|
+       ``Added in 4.0``
      - ``CONVERT_COPC``
      - [boolean]
 
@@ -227,7 +227,7 @@ Python code
 
 Classify ground points
 ------------------------
-|400|
+``Added in 4.0``
 
 Classifies ground points using the
 `Simple Morphological Filter (SMRF) <https://pdal.io/en/stable/stages/filters.smrf.html>`_ algorithm.
@@ -435,7 +435,7 @@ Advanced parameters
 
    * - **VPC Output Format**
 
-       |400|
+       ``Added in 4.0``
      - ``VPC_OUTPUT_FORMAT``
      - [enumeration]
 
@@ -482,8 +482,7 @@ Python code
 
 Compare point clouds
 --------------------
-
-|400|
+``Added in 4.0``
 
 Compares two point clouds using an M3C2 (Multiscale Model-to-Model Cloud Comparison)
 algorithm and outputs a subset (filtered using Poisson sampling, based on Subsampling
@@ -782,7 +781,7 @@ Advanced parameters
      - The CRS to apply to the layer
    * - **VPC Output Format**
 
-       |400|
+       ``Added in 4.0``
      - ``VPC_OUTPUT_FORMAT``
      - [enumeration]
 
@@ -829,7 +828,7 @@ Python code
 
 Filter noise
 --------------
-|400|
+``Added in 4.0``
 
 Filters noise in a point cloud using a statistical outlier removal algorithm.
 For each point, the algorithm computes the mean distance to its K nearest neighbors.
@@ -946,7 +945,7 @@ Python code
 
 Filter noise (using radius)
 -----------------------------
-|400|
+``Added in 4.0``
 
 Filters noise in a point cloud using radius algorithm.
 Points are marked as noise if they have fewer than the
@@ -1059,7 +1058,7 @@ Python code
 
 Height above ground
 -----------------------------
-|400|
+``Added in 4.0``
 
 Calculates the height of points above the ground surface in a point cloud using a nearest neighbor algorithm.
 For each point, the algorithm finds the specified number of nearest ground-classified points
@@ -1178,7 +1177,7 @@ Python code
 
 Height above ground (using triangulation)
 ----------------------------------------------
-|400|
+``Added in 4.0``
 
 Calculates the height of points above the ground surface in a point cloud using a
 `Delaunay triangulation <https://gwlucastrig.github.io/TinfourDocs/DelaunayIntro/index.html>`_ algorithm.
@@ -1534,7 +1533,7 @@ Advanced parameters
        between the origin and target systems.
    * - **VPC Output Format**
 
-       |400|
+       ``Added in 4.0``
      - ``VPC_OUTPUT_FORMAT``
      - [enumeration]
 
@@ -1662,7 +1661,7 @@ Advanced parameters
 
    * - **VPC Output Format**
 
-       |400|
+       ``Added in 4.0``
      - ``VPC_OUTPUT_FORMAT``
      - [enumeration]
 
@@ -1783,7 +1782,7 @@ Advanced parameters
 
    * - **VPC Output Format**
 
-       |400|
+       ``Added in 4.0``
      - ``VPC_OUTPUT_FORMAT``
      - [enumeration]
 
@@ -1829,7 +1828,7 @@ Python code
 
 Transform point cloud
 ------------------------
-|400|
+``Added in 4.0``
 
 Transforms point cloud coordinates using translation, rotation, and scaling operations using a 4x4 transformation matrix.
 Applies transformations in the following order: scaling, rotation (using Euler angles), then translation.
@@ -1972,12 +1971,3 @@ Python code
   :end-before: **end_algorithm_code_section**
 
 .. _PDAL: https://pdal.io/en/stable/
-
-
-.. Substitutions definitions - AVOID EDITING PAST THIS LINE
-   This will be automatically updated by the find_set_subst.py script.
-   If you need to create a new substitution manually,
-   please add it also to the substitutions.txt file in the
-   source folder.
-
-.. |400| replace:: ``NEW in 4.0``

--- a/docs/user_manual/processing_algs/qgis/pointclouddatamanagement.rst
+++ b/docs/user_manual/processing_algs/qgis/pointclouddatamanagement.rst
@@ -15,6 +15,7 @@ Point Cloud Data Management
 
 Assign projection
 -----------------
+``Added in 3.32``
 
 Assigns a Coordinate Reference System to a point cloud layer, if it is missing or wrong.
 A new layer is created.
@@ -118,6 +119,7 @@ Python code
 
 Build virtual point cloud (VPC)
 -------------------------------
+``Added in 3.32``
 
 Creates a :ref:`virtual point cloud (VPC) <virtual_point_cloud>` from input point cloud data.
 
@@ -358,6 +360,7 @@ Python code
 
 Clip point cloud
 ----------------
+``Added in 3.32``
 
 Clips a point cloud layer by a polygon layer
 so that the resulting point cloud contains only points within the polygons.
@@ -652,6 +655,7 @@ Python code
 
 Create COPC
 -----------
+``Added in 3.32``
 
 Creates the index for all the input point cloud files in a batch mode.
 
@@ -715,6 +719,7 @@ Python code
 
 Create tiles from point cloud
 -----------------------------
+``Added in 3.32``
 
 Creates tiles from input point cloud files,
 recommended for best performance (in display or analysis) with such datasets in QGIS.
@@ -1284,6 +1289,7 @@ Python code
 
 Merge point cloud
 -----------------
+``Added in 3.32``
 
 Merges multiple point cloud files into a single one.
 
@@ -1379,6 +1385,7 @@ Python code
 
 Point cloud information
 -----------------------
+``Added in 3.32``
 
 Outputs basic metadata from an input point cloud file.
 
@@ -1469,6 +1476,7 @@ Python code
 
 Reproject point cloud
 ---------------------
+``Added in 3.32``
 
 Reprojects a point cloud to a different Coordinate Reference System (CRS).
 
@@ -1573,6 +1581,7 @@ Python code
 
 Thin (by sampling radius)
 -------------------------
+``Added in 3.32``
 
 Creates a thinned version of the point cloud by performing sampling by distance point
 (reduces the number of points within a certain radius).
@@ -1700,6 +1709,7 @@ Python code
 
 Thin (by skipping points)
 -------------------------
+``Added in 3.32``
 
 Creates a thinned version of the point cloud by keeping only every N-th point
 (reduces the number of points by skipping nearby points).

--- a/docs/user_manual/processing_algs/qgis/pointcloudextraction.rst
+++ b/docs/user_manual/processing_algs/qgis/pointcloudextraction.rst
@@ -14,6 +14,7 @@ Point Cloud Extraction
 
 Boundary
 --------
+``Added in 3.32``
 
 Exports a polygon file containing point cloud layer boundary.
 It may contain holes and it may be a multi-part polygon.
@@ -126,6 +127,7 @@ Python code
 
 Filter point cloud
 ------------------
+``Added in 3.32``
 
 Extracts point from the input point cloud which match PDAL expression and/or are inside of a cropping rectangle.
 
@@ -241,6 +243,7 @@ Python code
 
 Point cloud density
 -------------------
+``Added in 3.32``
 
 Exports a raster file based on the number of points within each raster cell -
 useful for quality checking of point cloud datasets.

--- a/docs/user_manual/processing_algs/qgis/pointcloudextraction.rst
+++ b/docs/user_manual/processing_algs/qgis/pointcloudextraction.rst
@@ -195,7 +195,7 @@ Advanced parameters
      - Description
    * - **VPC Output Format**
 
-       |400|
+       ``Added in 4.0``
      - ``VPC_OUTPUT_FORMAT``
      - [enumeration]
 
@@ -366,12 +366,3 @@ Python code
 
 
 .. _PDAL: https://pdal.io/en/stable/
-
-
-.. Substitutions definitions - AVOID EDITING PAST THIS LINE
-   This will be automatically updated by the find_set_subst.py script.
-   If you need to create a new substitution manually,
-   please add it also to the substitutions.txt file in the
-   source folder.
-
-.. |400| replace:: ``NEW in 4.0``

--- a/docs/user_manual/processing_algs/qgis/rasteranalysis.rst
+++ b/docs/user_manual/processing_algs/qgis/rasteranalysis.rst
@@ -127,6 +127,8 @@ Advanced parameters
    * - **Creation options**
 
        Optional
+
+       ``Added in 3.40``
      - ``CREATION_OPTIONS`` (for QGIS <= 3.42, this was ``CREATE_OPTIONS``)
      - [string]
 
@@ -306,6 +308,8 @@ Advanced parameters
    * - **Creation options**
 
        Optional
+
+       ``Added in 3.40``
      - ``CREATION_OPTIONS`` (for QGIS <= 3.42, this was ``CREATE_OPTIONS``)
      - [string]
 
@@ -487,6 +491,8 @@ Advanced parameters
    * - **Creation options**
 
        Optional
+
+       ``Added in 3.40``
      - ``CREATION_OPTIONS`` (for QGIS <= 3.42, this was ``CREATE_OPTIONS``)
      - [string]
 
@@ -675,6 +681,8 @@ Advanced parameters
    * - **Creation options**
 
        Optional
+
+       ``Added in 3.40``
      - ``CREATION_OPTIONS`` (for QGIS <= 3.42, this was ``CREATE_OPTIONS``)
      - [string]
 
@@ -834,6 +842,8 @@ Advanced parameters
    * - **Creation options**
 
        Optional
+
+       ``Added in 3.40``
      - ``CREATION_OPTIONS`` (for QGIS <= 3.42, this was ``CREATE_OPTIONS``)
      - [string]
 
@@ -997,6 +1007,8 @@ Advanced parameters
    * - **Creation options**
 
        Optional
+
+       ``Added in 3.40``
      - ``CREATION_OPTIONS`` (for QGIS <= 3.42, this was ``CREATE_OPTIONS``)
      - [string]
 
@@ -1140,6 +1152,8 @@ Advanced parameters
    * - **Creation options**
 
        Optional
+
+       ``Added in 3.40``
      - ``CREATION_OPTIONS`` (for QGIS <= 3.42, this was ``CREATE_OPTIONS``)
      - [string]
 
@@ -1289,6 +1303,8 @@ Advanced parameters
    * - **Creation options**
 
        Optional
+
+       ``Added in 3.40``
      - ``CREATION_OPTIONS`` (for QGIS <= 3.42, this was ``CREATE_OPTIONS``)
      - [string]
 
@@ -1432,6 +1448,8 @@ Advanced parameters
    * - **Creation options**
 
        Optional
+
+       ``Added in 3.40``
      - ``CREATION_OPTIONS`` (for QGIS <= 3.42, this was ``CREATE_OPTIONS``)
      - [string]
 
@@ -1585,6 +1603,8 @@ Advanced parameters
    * - **Creation options**
 
        Optional
+
+       ``Added in 3.40``
      - ``CREATION_OPTIONS`` (for QGIS <= 3.42, this was ``CREATE_OPTIONS``)
      - [string]
 
@@ -1727,6 +1747,8 @@ Advanced parameters
    * - **Creation options**
 
        Optional
+
+       ``Added in 3.40``
      - ``CREATION_OPTIONS`` (for QGIS <= 3.42, this was ``CREATE_OPTIONS``)
      - [string]
 
@@ -2024,6 +2046,8 @@ Advanced parameters
    * - **Creation options**
 
        Optional
+
+       ``Added in 3.40``
      - ``CREATION_OPTIONS`` (for QGIS <= 3.42, this was ``CREATE_OPTIONS``)
      - [string]
 
@@ -2433,6 +2457,8 @@ Advanced parameters
    * - **Creation options**
 
        Optional
+
+       ``Added in 3.40``
      - ``CREATION_OPTIONS`` (for QGIS <= 3.42, this was ``CREATE_OPTIONS``)
      - [string]
 
@@ -2651,6 +2677,7 @@ Python code
 
 Raster calculator (virtual)
 ---------------------------
+``Added in 3.34``
 
 Performs algebraic operations using raster layers and generates in-memory result.
 
@@ -3326,7 +3353,7 @@ Python code
 
 Raster rank
 ----------------
-|344|
+``Added in 3.44``
 
 Performs a cell-by-cell analysis in which output values match
 the rank of a sorted list of overlapping cell values from input layers.
@@ -3703,6 +3730,8 @@ Advanced parameters
    * - **Creation options**
 
        Optional
+
+       ``Added in 3.40``
      - ``CREATION_OPTIONS`` (for QGIS <= 3.42, this was ``CREATE_OPTIONS``)
      - [string]
 
@@ -3848,6 +3877,8 @@ Advanced parameters
    * - **Creation options**
 
        Optional
+
+       ``Added in 3.40``
      - ``CREATION_OPTIONS`` (for QGIS <= 3.42, this was ``CREATE_OPTIONS``)
      - [string]
 
@@ -3977,6 +4008,8 @@ Advanced parameters
    * - **Creation options**
 
        Optional
+
+       ``Added in 3.40``
      - ``CREATION_OPTIONS`` (for QGIS <= 3.42, this was ``CREATE_OPTIONS``)
      - [string]
 
@@ -4116,6 +4149,8 @@ Advanced parameters
    * - **Creation options**
 
        Optional
+
+       ``Added in 3.40``
      - ``CREATION_OPTIONS`` (for QGIS <= 3.42, this was ``CREATE_OPTIONS``)
      - [string]
 
@@ -4323,6 +4358,8 @@ Python code
 
 Zonal Minimum/Maximum Point
 ---------------------------
+``Added in 3.42``
+
 Extracts point features corresponding to the minimum and maximum pixel values within polygon zones.
 
 The output will contain one point feature for the minimum and one for the maximum raster value
@@ -4647,9 +4684,6 @@ Python code
 .. include:: ../algs_include.rst
   :start-after: **algorithm_code_section**
   :end-before: **end_algorithm_code_section**
-
-
-.. |344| replace:: ``NEW in 3.44``
 
 
 .. Substitutions definitions - AVOID EDITING PAST THIS LINE

--- a/docs/user_manual/processing_algs/qgis/rasteranalysis.rst
+++ b/docs/user_manual/processing_algs/qgis/rasteranalysis.rst
@@ -2288,6 +2288,8 @@ Advanced parameters
    * - **Creation options**
 
        Optional
+
+       ``Added in 3.40``
      - ``CREATION_OPTIONS`` (for QGIS <= 3.42, this was ``CREATE_OPTIONS``)
      - [string]
 

--- a/docs/user_manual/processing_algs/qgis/rasteranalysis.rst
+++ b/docs/user_manual/processing_algs/qgis/rasteranalysis.rst
@@ -1812,6 +1812,7 @@ Python code
 
 Gaussian blur
 ----------------------
+``Added in 4.0```
 
 Applies a Gaussian blur filter to an input raster layer.
 The radius parameter controls the strength of the blur.
@@ -4534,7 +4535,7 @@ Python code
 
 Feature preserving DEM smoothing
 --------------------------------
-|400|
+``Added in 4.0``
 
 Can be used to remove surface roughness from digital elevation model without significantly altering sharp
 features such as breaks-in-slope, stream banks, or terrace scarps. This makes this algorithm superior to
@@ -4684,12 +4685,3 @@ Python code
 .. include:: ../algs_include.rst
   :start-after: **algorithm_code_section**
   :end-before: **end_algorithm_code_section**
-
-
-.. Substitutions definitions - AVOID EDITING PAST THIS LINE
-   This will be automatically updated by the find_set_subst.py script.
-   If you need to create a new substitution manually,
-   please add it also to the substitutions.txt file in the
-   source folder.
-
-.. |400| replace:: ``NEW in 4.0``

--- a/docs/user_manual/processing_algs/qgis/rastercreation.rst
+++ b/docs/user_manual/processing_algs/qgis/rastercreation.rst
@@ -103,6 +103,8 @@ Advanced parameters
    * - **Creation options**
 
        Optional
+
+       ``Added in 3.40``
      - ``CREATION_OPTIONS`` (for QGIS <= 3.42, this was ``CREATE_OPTIONS``)
      - [string]
 
@@ -246,6 +248,8 @@ Advanced parameters
    * - **Creation options**
 
        Optional
+
+       ``Added in 3.40``
      - ``CREATION_OPTIONS`` (for QGIS <= 3.42, this was ``CREATE_OPTIONS``)
      - [string]
 
@@ -378,6 +382,8 @@ Advanced parameters
    * - **Creation options**
 
        Optional
+
+       ``Added in 3.40``
      - ``CREATION_OPTIONS`` (for QGIS <= 3.42, this was ``CREATE_OPTIONS``)
      - [string]
 
@@ -516,6 +522,8 @@ Advanced parameters
    * - **Creation options**
 
        Optional
+
+       ``Added in 3.40``
      - ``CREATION_OPTIONS`` (for QGIS <= 3.42, this was ``CREATE_OPTIONS``)
      - [string]
 
@@ -653,6 +661,8 @@ Advanced parameters
    * - **Creation options**
 
        Optional
+
+       ``Added in 3.40``
      - ``CREATION_OPTIONS`` (for QGIS <= 3.42, this was ``CREATE_OPTIONS``)
      - [string]
 
@@ -796,6 +806,8 @@ Advanced parameters
    * - **Creation options**
 
        Optional
+
+       ``Added in 3.40``
      - ``CREATION_OPTIONS`` (for QGIS <= 3.42, this was ``CREATE_OPTIONS``)
      - [string]
 
@@ -934,6 +946,8 @@ Advanced parameters
    * - **Creation options**
 
        Optional
+
+       ``Added in 3.40``
      - ``CREATION_OPTIONS`` (for QGIS <= 3.42, this was ``CREATE_OPTIONS``)
      - [string]
 
@@ -1071,6 +1085,8 @@ Advanced parameters
    * - **Creation options**
 
        Optional
+
+       ``Added in 3.40``
      - ``CREATION_OPTIONS`` (for QGIS <= 3.42, this was ``CREATE_OPTIONS``)
      - [string]
 
@@ -1216,6 +1232,8 @@ Advanced parameters
    * - **Creation options**
 
        Optional
+
+       ``Added in 3.40``
      - ``CREATION_OPTIONS`` (for QGIS <= 3.42, this was ``CREATE_OPTIONS``)
      - [string]
 

--- a/docs/user_manual/processing_algs/qgis/rasterterrainanalysis.rst
+++ b/docs/user_manual/processing_algs/qgis/rasterterrainanalysis.rst
@@ -136,6 +136,7 @@ Python code
 
 DTM filter (slope-based)
 ------------------------
+``Added in 3.34``
 
 Can be used to filter a digital elevation model in order to classify its cells into ground and object (non-ground) cells.
 
@@ -256,6 +257,8 @@ Advanced parameters
    * - **Creation options**
 
        Optional
+
+       ``Added in 3.40``
      - ``CREATION_OPTIONS`` (for QGIS <= 3.42, this was ``CREATE_OPTIONS``)
      - [string]
 
@@ -304,7 +307,7 @@ Python code
 
 Fill sinks (Wang & Liu)
 ------------------------
-|344|
+``Added in 3.44``
 
 Uses a method proposed by Wang & Liu to identify and fill surface depressions in digital elevation models.
 
@@ -1181,9 +1184,6 @@ Python code
 .. include:: ../algs_include.rst
   :start-after: **algorithm_code_section**
   :end-before: **end_algorithm_code_section**
-
-
-.. |344| replace:: ``NEW in 3.44``
 
 
 .. Substitutions definitions - AVOID EDITING PAST THIS LINE

--- a/docs/user_manual/processing_algs/qgis/rasterterrainanalysis.rst
+++ b/docs/user_manual/processing_algs/qgis/rasterterrainanalysis.rst
@@ -73,7 +73,7 @@ Basic parameters
 
 Advanced parameters
 ^^^^^^^^^^^^^^^^^^^
-|400|
+``Added in 4.0``
 
 .. list-table::
    :header-rows: 1
@@ -554,7 +554,7 @@ Basic parameters
 
 Advanced parameters
 ^^^^^^^^^^^^^^^^^^^
-|400|
+``Added in 4.0``
 
 .. list-table::
    :header-rows: 1
@@ -896,7 +896,7 @@ Basic parameters
 
 Advanced parameters
 ^^^^^^^^^^^^^^^^^^^
-|400|
+``Added in 4.0``
 
 .. list-table::
    :header-rows: 1
@@ -1011,7 +1011,7 @@ Basic parameters
 
 Advanced parameters
 ^^^^^^^^^^^^^^^^^^^
-|400|
+``Added in 4.0``
 
 .. list-table::
    :header-rows: 1
@@ -1073,7 +1073,7 @@ Python code
 
 Total curvature
 ---------------
-|400|
+``Added in 4.0``
 
 Calculates the total curvature from an input raster layer. The curvature is the second
 derivative of the surface, revealing terrain features like ridges (positive curvature,
@@ -1184,12 +1184,3 @@ Python code
 .. include:: ../algs_include.rst
   :start-after: **algorithm_code_section**
   :end-before: **end_algorithm_code_section**
-
-
-.. Substitutions definitions - AVOID EDITING PAST THIS LINE
-   This will be automatically updated by the find_set_subst.py script.
-   If you need to create a new substitution manually,
-   please add it also to the substitutions.txt file in the
-   source folder.
-
-.. |400| replace:: ``NEW in 4.0``

--- a/docs/user_manual/processing_algs/qgis/rasterterrainanalysis.rst
+++ b/docs/user_manual/processing_algs/qgis/rasterterrainanalysis.rst
@@ -73,7 +73,6 @@ Basic parameters
 
 Advanced parameters
 ^^^^^^^^^^^^^^^^^^^
-``Added in 4.0``
 
 .. list-table::
    :header-rows: 1
@@ -85,6 +84,8 @@ Advanced parameters
      - Type
      - Description
    * - **Output NoData value**
+
+       ``Added in 4.0``
      - ``NODATA``
      - [numeric: double]
 
@@ -93,6 +94,8 @@ Advanced parameters
    * - **Creation options**
 
        Optional
+
+       ``Added in 4.0``
      - ``CREATION_OPTIONS``
      - [string]
 
@@ -554,7 +557,6 @@ Basic parameters
 
 Advanced parameters
 ^^^^^^^^^^^^^^^^^^^
-``Added in 4.0``
 
 .. list-table::
    :header-rows: 1
@@ -566,6 +568,8 @@ Advanced parameters
      - Type
      - Description
    * - **Output NoData value**
+
+       ``Added in 4.0``
      - ``NODATA``
      - [numeric: double]
 
@@ -574,6 +578,8 @@ Advanced parameters
    * - **Creation options**
 
        Optional
+
+       ``Added in 4.0``
      - ``CREATION_OPTIONS``
      - [string]
 
@@ -896,7 +902,6 @@ Basic parameters
 
 Advanced parameters
 ^^^^^^^^^^^^^^^^^^^
-``Added in 4.0``
 
 .. list-table::
    :header-rows: 1
@@ -908,6 +913,8 @@ Advanced parameters
      - Type
      - Description
    * - **Output NoData value**
+
+       ``Added in 4.0``
      - ``NODATA``
      - [numeric: double]
 
@@ -916,6 +923,8 @@ Advanced parameters
    * - **Creation options**
 
        Optional
+
+       ``Added in 4.0``
      - ``CREATION_OPTIONS``
      - [string]
 
@@ -1011,7 +1020,6 @@ Basic parameters
 
 Advanced parameters
 ^^^^^^^^^^^^^^^^^^^
-``Added in 4.0``
 
 .. list-table::
    :header-rows: 1
@@ -1023,6 +1031,8 @@ Advanced parameters
      - Type
      - Description
    * - **Output NoData value**
+
+       ``Added in 4.0``
      - ``NODATA``
      - [numeric: double]
 
@@ -1031,6 +1041,8 @@ Advanced parameters
    * - **Creation options**
 
        Optional
+
+       ``Added in 4.0``
      - ``CREATION_OPTIONS``
      - [string]
 

--- a/docs/user_manual/processing_algs/qgis/rastertools.rst
+++ b/docs/user_manual/processing_algs/qgis/rastertools.rst
@@ -435,6 +435,8 @@ Advanced parameters
    * - **Creation options**
 
        Optional
+
+       ``Added in 3.40``
      - ``CREATION_OPTIONS`` (for QGIS <= 3.42, this was ``CREATE_OPTIONS``)
      - [string]
 
@@ -634,6 +636,8 @@ Advanced parameters
    * - **Leaflet HTML output title**
 
        Optional
+
+       ``Added in 3.30``
      - ``HTML_TITLE``
      - [string]
 
@@ -642,6 +646,8 @@ Advanced parameters
    * - **Leaflet HTML output attribution**
 
        Optional
+
+       ``Added in 3.30``
      - ``HTML_ATTRIBUTION``
      - [string]
 
@@ -649,6 +655,8 @@ Advanced parameters
      - Custom map attribution used for the Leaflet HTML output file.
        HTML links are possible.
    * - **Include OpenStreetMap basemap in Leaflet HTML output**
+
+       ``Added in 3.30``
      - ``HTML_OSM``
      - [boolean]
 

--- a/docs/user_manual/processing_algs/qgis/vectoranalysis.rst
+++ b/docs/user_manual/processing_algs/qgis/vectoranalysis.rst
@@ -46,6 +46,8 @@ Parameters
    * - **Statistics**
 
        Optional
+
+       ``Added in 3.40``
      - ``OUTPUT``
      - [vector: table]
 
@@ -82,6 +84,8 @@ Outputs
      - Type
      - Description
    * - **Statistics**
+
+       ``Added in 3.40``
      - ``OUTPUT``
      - [vector: table]
      - Table containing the calculated statistics

--- a/docs/user_manual/processing_algs/qgis/vectoranalysis.rst
+++ b/docs/user_manual/processing_algs/qgis/vectoranalysis.rst
@@ -625,7 +625,7 @@ Python code
 
 Distance to nearest hub
 -----------------------
-|400|
+``Added in 4.0``
 
 Computes the distance between features from the source layer to the closest feature from the destination layer.
 Distance calculations are based on the feature's bounding box center.
@@ -2098,6 +2098,5 @@ Python code
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |400| replace:: ``NEW in 4.0``
 .. |checkbox| image:: /static/common/checkbox.png
    :width: 1.3em

--- a/docs/user_manual/processing_algs/qgis/vectorcoverage.rst
+++ b/docs/user_manual/processing_algs/qgis/vectorcoverage.rst
@@ -12,6 +12,7 @@ Vector coverage
 
 Dissolve coverage
 -----------------
+``Added in 3.36``
 
 Operates on a coverage (represented as a set of polygon features with exactly matching edge geometry)
 to dissolve (union) the geometries.
@@ -77,6 +78,7 @@ Python code
 
 Simplify coverage
 -----------------
+``Added in 3.36``
 
 Operates on a coverage (represented as a set of polygon features with exactly matching edge geometry)
 to apply a Visvalingam–Whyatt simplification to the edges, reducing complexity in proportion with the provided tolerance,
@@ -162,6 +164,7 @@ Python code
 
 Validate coverage
 -----------------
+``Added in 3.36``
 
 Analyzes a coverage (represented as a set of polygon features with exactly matching edge geometry)
 to find places where the assumption of exactly matching edges is not met.

--- a/docs/user_manual/processing_algs/qgis/vectorgeneral.rst
+++ b/docs/user_manual/processing_algs/qgis/vectorgeneral.rst
@@ -545,6 +545,8 @@ Parameters
    * - **Duplicates**
 
        Optional
+
+       ``Added in 4.0``
      - ``DUPLICATES``
      - [same as input]
 

--- a/docs/user_manual/processing_algs/qgis/vectorgeneral.rst
+++ b/docs/user_manual/processing_algs/qgis/vectorgeneral.rst
@@ -2121,6 +2121,9 @@ Parameters
        If not specified, the CRS of the first input
        layer is used.
    * - **Add source layer information (layer name and path)**
+
+       ``Added in 3.42``
+
      - ``ADD_SOURCE_FIELDS``
      - [boolean]
 
@@ -2340,6 +2343,8 @@ Basic parameters
        Default: ``EPSG:4326 - WGS 84``
      - Destination coordinate reference system
    * - **Convert curved geometries to straight segments**
+       ``Added in 3.32``
+
      - ``CONVERT_CURVED_GEOMETRIES``
      - [boolean]
 

--- a/docs/user_manual/processing_algs/qgis/vectorgeometry.rst
+++ b/docs/user_manual/processing_algs/qgis/vectorgeometry.rst
@@ -408,7 +408,7 @@ Python code
 
 Approximate medial axis
 -----------------------
-|400|
+``Added in 4.0``
 
 Generates a simplified skeleton of polygon geometries by approximating their
 medial axis. The output is a line layer representing the central structure
@@ -3343,8 +3343,7 @@ Python code
 
 Force polygons clockwise
 ------------------------
-
-|400|
+``Added in 4.0``
 
 Forces polygon geometries to respect the convention where the exterior ring
 is oriented in a clockwise direction and the interior rings in a counter-clockwise
@@ -3412,8 +3411,7 @@ Python code
 
 Force polygons counter-clockwise
 --------------------------------
-
-|400|
+``Added in 4.0``
 
 Forces polygon geometries to respect the convention where the exterior ring
 is oriented in a counter-clockwise direction and the interior rings in a clockwise
@@ -5730,7 +5728,7 @@ Python code
 
 Remove parts by area
 ----------------------
-|400|
+``Added in 4.0``
 
 Takes a polygon layer and removes polygons which are smaller than a specified area.
 
@@ -5813,7 +5811,7 @@ Python code
 
 Remove parts by length
 ----------------------
-|400|
+``Added in 4.0``
 
 Takes a line layer and removes lines which are shorter than a specified length.
 
@@ -8064,7 +8062,6 @@ Python code
    please add it also to the substitutions.txt file in the
    source folder.
 
-.. |400| replace:: ``NEW in 4.0``
 .. |arrowDown| image:: /static/common/mActionArrowDown.png
    :width: 1.5em
 .. |arrowUp| image:: /static/common/mActionArrowUp.png

--- a/docs/user_manual/processing_algs/qgis/vectorgeometry.rst
+++ b/docs/user_manual/processing_algs/qgis/vectorgeometry.rst
@@ -786,6 +786,8 @@ Advanced parameters
      - Type
      - Description
    * - **Keep disjoint features separate**
+
+       ``Added in 3.32``
      - ``SEPARATE_DISJOINT``
      - [boolean]
 
@@ -1736,12 +1738,16 @@ Parameters
    * - **Tolerance**
 
        Optional
+
+       ``Added in 3.34``
      - ``TOLERANCE``
      - [numeric: double]
 
        Default: 0.0
      - Specifies an optional snapping tolerance which can be used to improve the robustness of the triangulation.
    * - **Add point IDs to output**
+
+       ``Added in 3.34``
      - ``ADD_ATTRIBUTES``
      - [boolean]
 
@@ -7994,12 +8000,16 @@ Parameters
    * - **Tolerance**
 
        Optional
+
+       ``Added in 3.34``
      - ``TOLERANCE``
      - [numeric: double]
 
        Default: 0.0
      - Specifies an optional snapping tolerance which can be used to improve the robustness of the voronoi.
    * - **Copy attributes from input features**
+
+       ``Added in 3.34``
      - ``COPY_ATTRIBUTES``
      - [boolean]
 

--- a/docs/user_manual/processing_algs/qgis/vectortable.rst
+++ b/docs/user_manual/processing_algs/qgis/vectortable.rst
@@ -200,12 +200,17 @@ Parameters
    * - **Field alias**
 
        Optional
+
+       ``Added in 3.32``
      - ``FIELD_ALIAS``
      - [string]
      - Set a name to use as alias for the field. Not supported by all format types.
    * - **Field comment**
 
        Optional
+
+       ``Added in 3.32``
+
      - ``FIELD_COMMENT``
      - [string]
      - Store a comment describing the field. Not supported by all format types.
@@ -1006,11 +1011,11 @@ Parameters
          When using a template layer, indicates whether there are constraints
          applied to the template field. Hover over the cell to display the constraints.
 
-       :guilabel:`Alias` (``field_alias``) [string]
+       :guilabel:`Alias` (``field_alias``) [string] --- ``Added in 3.32``
          Set a name to use as alias for the field. Not supported by all format types.
          Existing aliases are displayed and will be copied to the destination layer if supported.
 
-       :guilabel:`Comment` (``field_comment``) [string]
+       :guilabel:`Comment` (``field_comment``) [string] --- ``Added in 3.32``
          Store a comment describing the field. Not supported by all format types.
          Existing comments are displayed and will be copied to the destination layer if supported.
 

--- a/docs/user_manual/processing_algs/qgis/vectortiles.rst
+++ b/docs/user_manual/processing_algs/qgis/vectortiles.rst
@@ -12,6 +12,7 @@ Vector Tiles
 
 Download vector tiles
 ---------------------
+``Added in 3.32``
 
 Downloads vector tiles of an input vector tile layer and saves them in a local vector tile file.
 

--- a/substitutions.txt
+++ b/substitutions.txt
@@ -5,8 +5,6 @@
    :width: 1.5em
 .. |25dSymbol| image:: /static/common/renderer25dSymbol.png
    :width: 1.5em
-.. |400| replace:: ``NEW in 4.0``
-.. |402| replace:: ``NEW in 4.2``
 .. |3d| image:: /static/common/3d.png
    :width: 1.5em
 .. |3dNavigation| image:: /static/common/mAction3DNavigation.png


### PR DESCRIPTION
or new parameters or parameter values have been added to the algorithm.

Few weeks ago, while helping to debug a model, I found that the issuer was using a QGIS version too old for a core algorithm used in the model she was trying to run. In order to find what minimal QGIS version she should use for the model, I had to browse this repo and find the issue introducing that algorithm. Not a task anyone can do. Hence this PR to add forever the QGIS version introducing a change in the Processing algs.
I browsed down to 3.30 algs (I might have missed some, of course).

Is this something it makes sense to add?
If so, is the wording OK? instead of e.g. "introduced in...", "new in ..."
<!---
Include a few sentences describing the overall goals for this Pull Request.

A list of issues is at https://github.com/qgis/QGIS-Documentation/issues.
Add "fix #issuenumber" for each issue the PR fixes. The ticket(s) will be closed automatically.
If your PR doesn't fix entirely the ticket, only add the ticket(s) reference preceded by # character.
-->
Goal:

Ticket(s): #
<!---
Indicate whether the fix should be backported to previous release.
Replace the space between square brackets by a `x` to make it checked.
-->.
- [ ] Backport to LTR documentation is requested

<!---
Reviewing is a process done by community members, mostly on a volunteer basis.
We try to keep the overhead as small as possible and appreciate if you help us.
Please read carefully and ensure you comply with our writing guidelines at
https://docs.qgis.org/testing/en/docs/documentation_guidelines/index.html.
Feel free to ask in a comment or the (qgis-community-team mailing list)
[https://lists.osgeo.org/mailman/listinfo/qgis-community-team] if you have troubles with any item.
--->
