### PR TITLE
Ignore substitutions voluntarily not defined in substitutions.txt file

### DIFF
--- a/docs/about/translation_stats.rst
+++ b/docs/about/translation_stats.rst
@@ -6,7 +6,7 @@
 Statistics of translation
 ===========================
 
-*Last update:* |today|
+*Last update:* |stats_today|
 
 .. list-table::
    :widths: auto
@@ -14,9 +14,9 @@ Statistics of translation
    * - Number of strings
      - Number of target languages
      - Overall Translation ratio
-   * - |total_strings|
-     - |nb_languages|
-     - |global_percentage|
+   * - |stats_total_strings|
+     - |stats_nb_languages|
+     - |stats_global_percentage|
 
 
 
@@ -159,10 +159,10 @@ Statistics of translation
 
 .. list of substitutions for the statistics:
 
-.. |today| replace:: *2026-04-21*
-.. |total_strings| replace:: **32848**
-.. |nb_languages| replace:: **61**
-.. |global_percentage| replace:: **15.64%**
+.. |stats_today| replace:: *2026-04-21*
+.. |stats_total_strings| replace:: **32848**
+.. |stats_nb_languages| replace:: **61**
+.. |stats_global_percentage| replace:: **15.64%**
 
 .. |stats_ar| replace:: 3.36
 .. |stats_az| replace:: 0.1
@@ -225,4 +225,3 @@ Statistics of translation
 .. |stats_vi| replace:: 1.65
 .. |stats_zh-Hans| replace:: 26.32
 .. |stats_zh-Hant| replace:: 2.81
-

--- a/scripts/find_set_subst.py
+++ b/scripts/find_set_subst.py
@@ -78,9 +78,15 @@ def get_subst_definition(subst_list, s_dict):
                                                              s['unicode'])
             s_count += 1
         else:
-            print("\033[91m\033[1m|{}|\033[0m is not available in "
-                  "substitution.txt file, please add it before use it in "
-                  "\033[93m\033[1m{}\033[0m".format(subst, path.relpath(file)))
+            # |version| is a Sphinx global substitution undefined in substitutions.txt,
+            # |stats_...| are custom dynamically generated substitutions for Transifex stats
+            # They are unknown in substitutions.txt file so we want the script to ignore them
+            if subst == 'version' or subst.startswith('stats_'):
+                continue
+            else:
+                print("\033[91m\033[1m|{}|\033[0m is not available in "
+                    "substitution.txt file, please add it before use it in "
+                    "\033[93m\033[1m{}\033[0m".format(subst, path.relpath(file)))
     if s_count == 0:
     # No substitution found in dict
         s_def = None

--- a/scripts/load_tx_stats.py
+++ b/scripts/load_tx_stats.py
@@ -207,10 +207,10 @@ def load_lang_substitutions(target_langs):
     """
 
     text = (f".. list of substitutions for the statistics:\n\n"
-            f".. |today| replace:: *{date.today()}*\n"
-            f".. |total_strings| replace:: **{target_langs['en']['total_strings']}**\n"
-            f".. |nb_languages| replace:: **{target_langs['en']['nb_languages']}**\n"
-            f".. |global_percentage| replace:: **{target_langs['en']['percentage']}%**\n\n"
+            f".. |stats_today| replace:: *{date.today()}*\n"
+            f".. |stats_total_strings| replace:: **{target_langs['en']['total_strings']}**\n"
+            f".. |stats_nb_languages| replace:: **{target_langs['en']['nb_languages']}**\n"
+            f".. |stats_global_percentage| replace:: **{target_langs['en']['percentage']}%**\n\n"
             )
 
     for lang in sorted(target_langs):


### PR DESCRIPTION
Other than the substitutions we list in the substitutions.txt file, there are particular substitutions:

- |version|, a Sphinx global substitution available everywhere in the docs (so no need to reference it in each file)
- substitutions starting with "stats_": they are dynamically generated by the load_tx_stats script and are available only in the generated translation stats file. Thus unknown from substitutions.txt.

These substitutions are always guaranteed to be available where they are loaded so we can ignore them in the script checking substitutions existence.

This PR completes #10936, leading to 0 warning when the find_set_subst script is run. Ready to enable that script as pre-commit hook.