### PR TITLE
Introduce pre-commit as a GitHub automated action

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -47,33 +47,8 @@ jobs:
       - name: Install pre-commit
         run: pip install pre-commit
 
+      - name: Install pre-commit
+        run: pip install pre-commit
+
       - name: Run pre-commit checks
-        run: |
-            if [ "${{ github.event_name }}" == "pull_request" ]; then
-              git fetch origin ${GITHUB_EVENT_PULL_REQUEST_BASE_REF}
-              git fetch origin pull/${{ github.event.pull_request.number }}/head:pr-head
-              git checkout pr-head
-              MERGE_BASE=$(git merge-base origin/${GITHUB_EVENT_PULL_REQUEST_BASE_REF} pr-head)
-              MODIFIED_FILES=($(git diff --name-only $MERGE_BASE pr-head))
-            elif [ "${{ github.event_name }}" == "push" ]; then
-              MODIFIED_FILES=($(git diff --name-only ${{ github.event.before }} ${{ github.sha }}))
-            else
-              echo "Unsupported event: ${{ github.event_name }}"
-              exit 1
-            fi
-            echo "Modified files: ${MODIFIED_FILES[@]}"
-            pre-commit run --files ${MODIFIED_FILES[@]} || (echo "Differences:" && git diff && echo "pre-commit failed. Attempting to auto-fix..." && exit 1)
-        env:
-          GITHUB_EVENT_PULL_REQUEST_BASE_REF: ${{ github.event.pull_request.base.ref }}
-
-      - name: Commit fixes
-        if: failure()
-        run: |
-            git config --global user.name "github-actions[bot]"
-            git config --global user.email "github-actions[bot]@users.noreply.github.com"
-            git add .
-            git commit -m "auto-fix pre-commit issues" || echo "No changes to commit"
-
-      - name: Auto-commit fixes
-        if: failure() && github.event_name == 'push'
-        run: git push || echo "Failed to push changes. Please check permissions or conflicts."
+        run: pre-commit run --all-files

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,0 +1,79 @@
+name:  Pre-commit Checks
+
+on:
+  push:
+  pull_request:
+    branches:
+      - master
+      - release_*
+    paths-ignore:
+      - 'locale/**'
+
+  # Allow manual trigger
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  # ============================================================================
+  # Pre-commit checks (linting, formatting, etc.)
+  # ============================================================================
+  pre-commit:
+    name: Pre-commit Checks
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      contents: write
+      issues: write 
+
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1
+        with:
+          egress-policy: audit
+
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 200
+          persist-credentials: true  # We need to persist credentials because of later git push
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+            python-version: '3.12'
+
+      - name: Install pre-commit
+        run: pip install pre-commit
+
+      - name: Run pre-commit checks
+        run: |
+            if [ "${{ github.event_name }}" == "pull_request" ]; then
+              git fetch origin ${GITHUB_EVENT_PULL_REQUEST_BASE_REF}
+              git fetch origin pull/${{ github.event.pull_request.number }}/head:pr-head
+              git checkout pr-head
+              MERGE_BASE=$(git merge-base origin/${GITHUB_EVENT_PULL_REQUEST_BASE_REF} pr-head)
+              MODIFIED_FILES=($(git diff --name-only $MERGE_BASE pr-head))
+            elif [ "${{ github.event_name }}" == "push" ]; then
+              MODIFIED_FILES=($(git diff --name-only ${{ github.event.before }} ${{ github.sha }}))
+            else
+              echo "Unsupported event: ${{ github.event_name }}"
+              exit 1
+            fi
+            echo "Modified files: ${MODIFIED_FILES[@]}"
+            pre-commit run --files ${MODIFIED_FILES[@]} || (echo "Differences:" && git diff && echo "pre-commit failed. Attempting to auto-fix..." && exit 1)
+        env:
+          GITHUB_EVENT_PULL_REQUEST_BASE_REF: ${{ github.event.pull_request.base.ref }}
+
+      - name: Commit fixes
+        if: failure()
+        run: |
+            git config --global user.name "github-actions[bot]"
+            git config --global user.email "github-actions[bot]@users.noreply.github.com"
+            git add .
+            git commit -m "auto-fix pre-commit issues" || echo "No changes to commit"
+
+      - name: Auto-commit fixes
+        if: failure() && github.event_name == 'push'
+        run: git push || echo "Failed to push changes. Please check permissions or conflicts."

--- a/docs/documentation_guidelines/substitutions.rst
+++ b/docs/documentation_guidelines/substitutions.rst
@@ -193,6 +193,8 @@ Identify result
   |identifyByFreehand|            ``|identifyByFreehand|``            |identifyByRadius|              ``|identifyByRadius|``
   ==============================  ==================================  ==============================  ==================================
 
+testing if sone checks 
+work corectly
 
 Digitizing and Advanced Digitizing
 ..................................


### PR DESCRIPTION
This is an attempt to instaure the pre-commit checks in Github actions and ensure that we catch errors from any contributors.

The content is highly inspired by the one in [code repo](https://github.com/qgis/QGIS/blob/master/.github/workflows/pre-commit.yaml) and I must confess that I do not understand the whole logic. I just know that it quite works well there so let's try here also. I also picked some formatting from #10856.

@timlinux @3nids May I request your review please ? I don't know if there are additional things to set at the repo level e.g.. Thanks.