### PR TITLE
Remove file extension from expression functions anchor

### DIFF
--- a/scripts/populate_expressions_list.py
+++ b/scripts/populate_expressions_list.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 
+from pathlib import Path
 from os import path, walk
 import glob
 from sys import argv
@@ -238,7 +239,7 @@ for file in filenames:
     with open(filepath) as f:
         data = json.load(f)
     #print(data)
-    data['filename'] = file.replace('op_', '')
+    data['filename'] = Path(filepath).stem.replace('op_', '')
     if data['type'] == 'group':
         groups[data['name']] = {'description': data['description'], 'func_list': {}}
     elif data['type'] in ['function', 'expression', 'operator', 'value']:


### PR DESCRIPTION
qgis/QGIS#65674 introduces extension to function file names in code repo and we don't want to keep these in the generated anchor for the function

<!---
Include a few sentences describing the overall goals for this Pull Request.

A list of issues is at https://github.com/qgis/QGIS-Documentation/issues.
Add "fix #issuenumber" for each issue the PR fixes. The ticket(s) will be closed automatically.
If your PR doesn't fix entirely the ticket, only add the ticket(s) reference preceded by # character.
-->
Goal:

Ticket(s): #
<!---
Indicate whether the fix should be backported to previous release.
Replace the space between square brackets by a `x` to make it checked.
-->
- [ ] Backport to LTR documentation is requested

<!---
Reviewing is a process done by community members, mostly on a volunteer basis.
We try to keep the overhead as small as possible and appreciate if you help us.
Please read carefully and ensure you comply with our writing guidelines at
https://docs.qgis.org/testing/en/docs/documentation_guidelines/index.html.
Feel free to ask in a comment or the (qgis-community-team mailing list)
[https://lists.osgeo.org/mailman/listinfo/qgis-community-team] if you have troubles with any item.
--->
