### PR TITLE
Add pre-commit check to update used substitutions in files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -70,19 +70,19 @@ repos:
   # Check for broken internal references (local script)
   - repo: local
     hooks:
-      # - id: find_set_subst
-      #   name: find_set_subst
-      #   entry: ./scripts/find_set_subst.py
-      #   language: system
-      #   always_run: true
-      #   pass_filenames: false
-
       - id: check-image-refs
         name: Check image references exist
         entry: ./scripts/check_image_refs.sh
         language: script
         files: \.(rst)$
         exclude: ^(locale/|_dummy/|build/)
+
+      - id: find_set_subst
+        name: Check and apply text or image substitutions
+        entry: ./scripts/find_set_subst.py
+        language: python
+        pass_filenames: false
+
 
 ci:
   autofix_prs: true


### PR DESCRIPTION
Let's automatically fill the substitutions list at the end of rst files by pre-commit

<!---
Include a few sentences describing the overall goals for this Pull Request.

A list of issues is at https://github.com/qgis/QGIS-Documentation/issues.
Add "fix #issuenumber" for each issue the PR fixes. The ticket(s) will be closed automatically.
If your PR doesn't fix entirely the ticket, only add the ticket(s) reference preceded by # character.
-->
Goal:

Ticket(s): #
<!---
Indicate whether the fix should be backported to previous release.
Replace the space between square brackets by a `x` to make it checked.
-->
- [ ] Backport to LTR documentation is requested

<!---
Reviewing is a process done by community members, mostly on a volunteer basis.
We try to keep the overhead as small as possible and appreciate if you help us.
Please read carefully and ensure you comply with our writing guidelines at
https://docs.qgis.org/testing/en/docs/documentation_guidelines/index.html.
Feel free to ask in a comment or the (qgis-community-team mailing list)
[https://lists.osgeo.org/mailman/listinfo/qgis-community-team] if you have troubles with any item.
--->
