### PR TITLE
Adjust misplaced punctuation in *equals_exact functions help text

### DIFF
--- a/docs/user_manual/expressions/expression_help/GeometryGroup.rst
+++ b/docs/user_manual/expressions/expression_help/GeometryGroup.rst
@@ -775,9 +775,9 @@ Tests whether two geometries are point-by-point exactly equal. Note that the ord
        * **backend** - Geometry backend implementation: 'QGIS' or 'GEOS'. Both internal implementation uses fuzzy comparison with very low (1e-8) tolerance.
 
          * 'QGIS' works on 2D, 3D and 4D
-         * 'GEOS' works only on 2D components (Z or M components are ignored)
+         * 'GEOS' works only on 2D components (Z or M components are ignored).
 
-.
+
    * - Examples
      - * ``equals_exact( geom_from_wkt( 'POINT( 0 0 )' ), geom_from_wkt( 'POINT( 0 0 )' ), 'GEOS' )`` → TRUE
 
@@ -2572,9 +2572,9 @@ Returns whether the current feature's geometry is point-by-point exactly equal t
        * **backend** - Geometry backend implementation: 'QGIS' or 'GEOS'. Both internal implementation uses fuzzy comparison with very low (1e-8) tolerance.
 
          * 'QGIS' works on 2D, 3D and 4D
-         * 'GEOS' works only on 2D components (Z or M components are ignored)
+         * 'GEOS' works only on 2D components (Z or M components are ignored).
 
-.
+
    * - Examples
      - * ``overlay_equals_exact('regions')`` → TRUE if the current feature's geometry is exactly the same as the geometry of a region
        * ``overlay_equals_exact('regions', filter:= population > 10000)`` → TRUE if the current feature's geometry is exactly the same as the geometry of a region whose population is greater than 10000

--- a/docs/user_manual/expressions/expression_help/Operators.rst
+++ b/docs/user_manual/expressions/expression_help/Operators.rst
@@ -490,7 +490,7 @@ Returns TRUE if a is not the same as b.
 LIKE
 ....
 
-Returns TRUE if the first parameter matches the supplied pattern. Works with numbers also.
+Returns TRUE if the first parameter matches case-sensitive the supplied pattern. ILIKE can be used instead of LIKE to make the match case-insensitive. Works with numbers also.
 
 .. list-table::
    :widths: 15 85


### PR DESCRIPTION
fixing wrong formatting of the examples row in their docs (refs https://github.com/qgis/QGIS/pull/66004)
Also update LIKE operator help text.
<!---
Include a few sentences describing the overall goals for this Pull Request.

A list of issues is at https://github.com/qgis/QGIS-Documentation/issues.
Add "fix #issuenumber" for each issue the PR fixes. The ticket(s) will be closed automatically.
If your PR doesn't fix entirely the ticket, only add the ticket(s) reference preceded by # character.
-->
Goal:

Ticket(s): #
<!---
Indicate whether the fix should be backported to previous release.
Replace the space between square brackets by a `x` to make it checked.
-->
- [ ] Backport to LTR documentation is requested

<!---
Reviewing is a process done by community members, mostly on a volunteer basis.
We try to keep the overhead as small as possible and appreciate if you help us.
Please read carefully and ensure you comply with our writing guidelines at
https://docs.qgis.org/testing/en/docs/documentation_guidelines/index.html.
Feel free to ask in a comment or the (qgis-community-team mailing list)
[https://lists.osgeo.org/mailman/listinfo/qgis-community-team] if you have troubles with any item.
--->
