### PR TITLE
Document custom naming for temporary processing outputs

### DIFF
--- a/docs/user_manual/processing/toolbox.rst
+++ b/docs/user_manual/processing/toolbox.rst
@@ -445,8 +445,9 @@ and a drop-down :menuselection:`...` button for additional options
 (the availability depends on the algorithm you run):
 
 * :guilabel:`Skip Output`: if you are not interested in a given output of the algorithm
-* :guilabel:`Create Temporary Layer` (``TEMPORARY_OUTPUT``):
-  the output is stored in a vector :ref:`temporary scratch layer <vector_new_scratch_layer>`.
+* :guilabel:`Create Temporary Layer` (``TEMPORARY_OUTPUT``):The output is stored in a vector :ref:`temporary scratch layer`. 
+  Users can assign a custom name to the temporary output layer directly from the output widget while keeping the output temporary. 
+  The layer is not permanently saved to disk.
 * :guilabel:`Save to File…`: you will be prompted with a save file dialog,
   where you can select the desired file path.
   Supported file extensions are shown in the file format selector of the dialog,

--- a/docs/user_manual/processing/toolbox.rst
+++ b/docs/user_manual/processing/toolbox.rst
@@ -445,7 +445,7 @@ and a drop-down :menuselection:`...` button for additional options
 (the availability depends on the algorithm you run):
 
 * :guilabel:`Skip Output`: if you are not interested in a given output of the algorithm
-* :guilabel:`Create Temporary Layer` (``TEMPORARY_OUTPUT``):The output is stored in a vector :ref:`temporary scratch layer`. 
+* :guilabel:`Create Temporary Layer` (``TEMPORARY_OUTPUT``): the output is stored in a vector :ref:`temporary scratch layer <vector_new_scratch_layer>`.
   Users can assign a custom name to the temporary output layer directly from the output widget while keeping the output temporary. 
   The layer is not permanently saved to disk.
 * :guilabel:`Save to File…`: you will be prompted with a save file dialog,

--- a/docs/user_manual/processing/toolbox.rst
+++ b/docs/user_manual/processing/toolbox.rst
@@ -446,7 +446,7 @@ and a drop-down :menuselection:`...` button for additional options
 
 * :guilabel:`Skip Output`: if you are not interested in a given output of the algorithm
 * :guilabel:`Create Temporary Layer` (``TEMPORARY_OUTPUT``): the output is stored in a vector :ref:`temporary scratch layer <vector_new_scratch_layer>`.
-  Users can assign a custom name to the temporary output layer directly from the output widget while keeping the output temporary. 
+  Users can assign a custom name to the temporary output layer directly from the output widget while keeping the output temporary.
   The layer is not permanently saved to disk.
 * :guilabel:`Save to File…`: you will be prompted with a save file dialog,
   where you can select the desired file path.


### PR DESCRIPTION
<!---
Include a few sentences describing the overall goals for this Pull Request.

A list of issues is at https://github.com/qgis/QGIS-Documentation/issues.
Add "fix #issuenumber" for each issue the PR fixes. The ticket(s) will be closed automatically.
If your PR doesn't fix entirely the ticket, only add the ticket(s) reference preceded by # character.
-->
Goal: The documentation clarifies that the layer remains temporary and is not permanently saved to disk, while QGIS visually marks it with the temporary layer icon.

Ticket(s): Fix #10864
<!---
Indicate whether the fix should be backported to previous release.
Replace the space between square brackets by a `x` to make it checked.
-->
- [ ] Backport to LTR documentation is requested

<!---
Reviewing is a process done by community members, mostly on a volunteer basis.
We try to keep the overhead as small as possible and appreciate if you help us.
Please read carefully and ensure you comply with our writing guidelines at
https://docs.qgis.org/testing/en/docs/documentation_guidelines/index.html.
Feel free to ask in a comment or the (qgis-community-team mailing list)
[https://lists.osgeo.org/mailman/listinfo/qgis-community-team] if you have troubles with any item.
--->
