### PR TITLE
Georeferencer: "Create world file only" is available for both Linear and Helmert transformation types

### DIFF
--- a/docs/user_manual/managing_data_source/georeferencer.rst
+++ b/docs/user_manual/managing_data_source/georeferencer.rst
@@ -248,7 +248,7 @@ There are several options that need to be defined for the georeferenced output
 raster.
 
 * The |checkbox| :guilabel:`Create world file` checkbox is only available if you
-  decide to use the linear transformation type, because this means that the
+  decide to use the Linear or Helmert transformation type, because this means that the
   raster image actually won't be transformed. In this case, the
   :guilabel:`Output raster` field is not activated, because only a new world file will
   be created.


### PR DESCRIPTION
See https://github.com/qgis/QGIS/commit/4e035e686bc33c64b183fe21648f2e1dac1a6d9d.

<!---
Include a few sentences describing the overall goals for this Pull Request.

A list of issues is at https://github.com/qgis/QGIS-Documentation/issues.
Add "fix #issuenumber" for each issue the PR fixes. The ticket(s) will be closed automatically.
If your PR doesn't fix entirely the ticket, only add the ticket(s) reference preceded by # character.
-->
Goal:

Ticket(s): #
<!---
Indicate whether the fix should be backported to previous release.
Replace the space between square brackets by a `x` to make it checked.
-->
- [x] Backport to LTR documentation is requested

<!---
Reviewing is a process done by community members, mostly on a volunteer basis.
We try to keep the overhead as small as possible and appreciate if you help us.
Please read carefully and ensure you comply with our writing guidelines at
https://docs.qgis.org/testing/en/docs/documentation_guidelines/index.html.
Feel free to ask in a comment or the (qgis-community-team mailing list)
[https://lists.osgeo.org/mailman/listinfo/qgis-community-team] if you have troubles with any item.
--->
