### PR TITLE
[Expressions] fixup: Better handle notes with multiple lines and a list block

### DIFF
--- a/docs/user_manual/expressions/expression_help/Date_and_Time.rst
+++ b/docs/user_manual/expressions/expression_help/Date_and_Time.rst
@@ -202,7 +202,6 @@ Formats a date type or string into a custom string format. Uses Qt date/time for
 
          These expressions may be used for the time part of the format string:
 
-
          .. csv-table::
             :header-rows: 1
             :widths: 20, 80

--- a/docs/user_manual/expressions/expression_help/GeometryGroup.rst
+++ b/docs/user_manual/expressions/expression_help/GeometryGroup.rst
@@ -2060,7 +2060,7 @@ Creates a rectangle from 3 points, the first two of which define its first side.
          * 0 (distance): The length of the second size is equal to the distance between the 2nd and 3rd points.
          * 1 (projected): The length of the second size is equal to the distance of the perpendicular projection of the 3rd point on the first segment or its extension.
 
-The second segment is always drawn on the side covering the third point.
+         The second segment is always drawn on the side covering the third point.
    * - Examples
      - * ``geom_to_wkt(make_rectangle_3points(make_point(0, 0), make_point(0,5), make_point(3, 3), 0))`` → 'Polygon ((0 0, 0 5, 3.60555128 5, 3.60555128 0, 0 0))'
        * ``geom_to_wkt(make_rectangle_3points(make_point(0, 0), make_point(0,5), make_point(3, 3), 1))`` → 'Polygon ((0 0, 0 5, 3 5, 3 0, 0 0))'

--- a/docs/user_manual/expressions/expression_help/String.rst
+++ b/docs/user_manual/expressions/expression_help/String.rst
@@ -226,7 +226,6 @@ Formats a date type or string into a custom string format. Uses Qt date/time for
 
          These expressions may be used for the time part of the format string:
 
-
          .. csv-table::
             :header-rows: 1
             :widths: 20, 80
@@ -841,12 +840,12 @@ Common use cases include normalizing text for search operations, creating ASCII-
 
 .. note:: This function is particularly useful when:
 
-* Searching or filtering data where accents should be ignored (e.g., 'Jose' matches 'José')
-* Creating URL-safe or filename-safe strings from internationalized text
-* Normalizing user input for consistent storage or comparison
-* Preparing text for systems with limited Unicode support
+   * Searching or filtering data where accents should be ignored (e.g., 'Jose' matches 'José')
+   * Creating URL-safe or filename-safe strings from internationalized text
+   * Normalizing user input for consistent storage or comparison
+   * Preparing text for systems with limited Unicode support
 
-The function uses Unicode NFC normalization internally to ensure consistent handling of composed and decomposed characters.
+   The function uses Unicode NFC normalization internally to ensure consistent handling of composed and decomposed characters.
 
 
 .. end_unaccent_section

--- a/scripts/populate_expressions_list.py
+++ b/scripts/populate_expressions_list.py
@@ -43,11 +43,15 @@ def sphynxify_html(text, base_indent=0):
     # Format paragraphs and breaks
     text = text.replace("<p>", "\n\n" + filler)
     text = text.replace("</p>", "\n")
-    text = re.sub(r"<br\s?\/?>", "\n\n" + filler, text)
+    # Ignore <br> when followed by <ul> to avoid unnecessary additional break lines
+    text = re.sub(r"\s?<br\s?\/?><ul>", "<ul>", text)
+    text = re.sub(r"\s?<br\s?\/?>", "\n\n" + filler, text)
 
     # Format unsorted lists
     text = text.replace("<ul>", "\n\n")
-    text = text.replace("</ul>", "\n")
+    # Handle indentation when there is text after a list block
+    text = re.sub("</ul>$", "\n", text)
+    text = re.sub("</ul>", "\n" + filler, text)
     text = text.replace("<li>", filler + "* ")
     text = text.replace("</li>", "\n")
 
@@ -63,7 +67,7 @@ def sphynxify_html(text, base_indent=0):
     text = text.replace("</pre>", "\n\n")
 
     # Format tables
-    text = text.replace("<table>", "\n\n" + filler + ".. csv-table::\n")
+    text = re.sub(r"\s*<table>", "\n\n" + filler + ".. csv-table::\n", text)
     text = text.replace(
         "<thead>", filler + "   :header-rows: 1\n" + filler + "   :widths: 20, 80\n\n"
     )
@@ -192,7 +196,7 @@ def format_variant(function_dict, f_name):
         v_description = ""
 
     if "notes" in function_dict:
-        notes = f"\n\n.. note:: {sphynxify_html(function_dict['notes'])}"
+        notes = f"\n\n.. note:: {sphynxify_html(function_dict['notes'], 3)}"
     else:
         notes = ""
 


### PR DESCRIPTION
Consolidate line break and indentation when a note contains mixed formatting.

[Before](https://docs.qgis.org/testing/en/docs/user_manual/expressions/functions_list.html#unaccent)
<img width="977" height="253" alt="image" src="https://github.com/user-attachments/assets/6283080e-4ffe-4b64-8b68-18f95e14c2f5" />

With PR
<img width="977" height="253" alt="image" src="https://github.com/user-attachments/assets/860ec0ee-7164-482e-980b-ff836b48b305" />
