### PR TITLE
Update intro.rst: fix code for standard paths

### DIFF
--- a/docs/pyqgis_developer_cookbook/intro.rst
+++ b/docs/pyqgis_developer_cookbook/intro.rst
@@ -161,7 +161,7 @@ The path in the user's home directory usually is found under:
 
 The default system paths depend on the operating system. To find the
 paths that work for you, open the Python Console and run
-``QStandardPaths.standardLocations(QStandardPaths.AppDataLocation)``
+``QStandardPaths.standardLocations(QStandardPaths.StandardLocation.AppDataLocation)``
 to see the list of default directories.
 
 The ``startup.py`` script is executed immediately upon initializing


### PR DESCRIPTION
<!---
Include a few sentences describing the overall goals for this Pull Request.

A list of issues is at https://github.com/qgis/QGIS-Documentation/issues.
Add "fix #issuenumber" for each issue the PR fixes. The ticket(s) will be closed automatically.
If your PR doesn't fix entirely the ticket, only add the ticket(s) reference preceded by # character.
-->
Goal:

With PyQt6 (thus in QGIS 4) `QStandardPaths.standardLocations(QStandardPaths.AppDataLocation)` is not valid.

`QStandardPaths.standardLocations(QStandardPaths.StandardLocation.AppDataLocation)` should be used, instead.

Anyway, `QStandardPaths.standardLocations(QStandardPaths.StandardLocation.AppDataLocation)` could be used also with PyQt5 (thus in QGIS 3).

P.S. reading the paragraph about startup.py at https://docs.qgis.org/testing/en/docs/pyqgis_developer_cookbook/intro.html#the-startup-py-file, I'm not sure it is actually correct or enough clear: what is the meaning of "user’s Python home directory". Maybe @elpaso could give some suggestions to enhance the paragraph. 

Ticket(s): #
<!---
Indicate whether the fix should be backported to previous release.
Replace the space between square brackets by a `x` to make it checked.
-->
- [ ] Backport to LTR documentation is requested

<!---
Reviewing is a process done by community members, mostly on a volunteer basis.
We try to keep the overhead as small as possible and appreciate if you help us.
Please read carefully and ensure you comply with our writing guidelines at
https://docs.qgis.org/testing/en/docs/documentation_guidelines/index.html.
Feel free to ask in a comment or the (qgis-community-team mailing list)
[https://lists.osgeo.org/mailman/listinfo/qgis-community-team] if you have troubles with any item.
--->
