### PR TITLE
Update qgis_configuration.rst: fix AppData mentions (Windows)

### DIFF
--- a/docs/user_manual/introduction/qgis_configuration.rst
+++ b/docs/user_manual/introduction/qgis_configuration.rst
@@ -1714,7 +1714,7 @@ But you can create as many user profiles as you want:
    * and ``<UserProfiles>`` represents the main profiles folder, i.e.:
 
      * |nix| :file:`.local/share/QGIS/QGIS4/profiles/`
-     * |win| :file:`%AppData%\\Roaming\\QGIS\\QGIS4\\profiles\\`
+     * |win| :file:`AppData\\Roaming\\QGIS\\QGIS4\\profiles\\`
      * |osx| :file:`Library/Application Support/QGIS/QGIS4/profiles/`
 
    The user profile folder can be opened from within QGIS using the
@@ -2717,7 +2717,7 @@ only the first found file will be used:
   or settings environment variable. Depending on the OS, it is:
 
   * |nix| :file:`$HOME/.local/share/QGIS/QGIS4/`
-  * |win| :file:`C:\\Users\\<username>\\%AppData%\\Roaming\\QGIS\\QGIS4\\`
+  * |win| :file:`C:\\Users\\<username>\\AppData\\Roaming\\QGIS\\QGIS4\\`
   * |osx| :file:`$HOME/Library/Application Support/QGIS/QGIS4/`
 * the installation directory, i.e., :file:`your_QGIS_package_path/resources/qgis_global_settings.ini`.
 


### PR DESCRIPTION
<!---
Include a few sentences describing the overall goals for this Pull Request.

A list of issues is at https://github.com/qgis/QGIS-Documentation/issues.
Add "fix #issuenumber" for each issue the PR fixes. The ticket(s) will be closed automatically.
If your PR doesn't fix entirely the ticket, only add the ticket(s) reference preceded by # character.
-->
Goal:

On Windows systems, the `%AppData%` env var contains the value `C:\Users\<username>\AppData\Roaming`, thus a path like `C:\Users\<username>\%AppData%\Roaming\QGIS\QGIS4\` is incorrect. Either we use `%AppData%\QGIS\QGIS4\` or `C:\Users\<username>\AppData\Roaming\QGIS\QGIS4\`.



Ticket(s): #
<!---
Indicate whether the fix should be backported to previous release.
Replace the space between square brackets by a `x` to make it checked.
-->
- [x] Backport to LTR documentation is requested

<!---
Reviewing is a process done by community members, mostly on a volunteer basis.
We try to keep the overhead as small as possible and appreciate if you help us.
Please read carefully and ensure you comply with our writing guidelines at
https://docs.qgis.org/testing/en/docs/documentation_guidelines/index.html.
Feel free to ask in a comment or the (qgis-community-team mailing list)
[https://lists.osgeo.org/mailman/listinfo/qgis-community-team] if you have troubles with any item.
--->
