### PR TITLE
Document escape function in ogcapif.rst

### DIFF
--- a/docs/server_manual/services/ogcapif.rst
+++ b/docs/server_manual/services/ogcapif.rst
@@ -405,6 +405,7 @@ the template:
 Custom template functions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+- ``escape( string )``: escapes XHTML tag angle brackets
 - ``path_append( path )``: appends a directory path to the current url
 - ``path_chomp( n )``: removes the specified number "n" of directory
   components from the current url path


### PR DESCRIPTION
Added description for the escape function in custom template functions.

<!---
Include a few sentences describing the overall goals for this Pull Request.

A list of issues is at https://github.com/qgis/QGIS-Documentation/issues.
Add "fix #issuenumber" for each issue the PR fixes. The ticket(s) will be closed automatically.
If your PR doesn't fix entirely the ticket, only add the ticket(s) reference preceded by # character.
-->
Goal:

Ticket(s): #
<!---
Indicate whether the fix should be backported to previous release.
Replace the space between square brackets by a `x` to make it checked.
-->
- [ ] Backport to LTR documentation is requested

<!---
Reviewing is a process done by community members, mostly on a volunteer basis.
We try to keep the overhead as small as possible and appreciate if you help us.
Please read carefully and ensure you comply with our writing guidelines at
https://docs.qgis.org/testing/en/docs/documentation_guidelines/index.html.
Feel free to ask in a comment or the (qgis-community-team mailing list)
[https://lists.osgeo.org/mailman/listinfo/qgis-community-team] if you have troubles with any item.
--->
