### PR TITLE
fix: Keep showing the docs version in the left side bar

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -108,7 +108,8 @@ html_theme_options = {
     # canonical_url: This will specify a canonical URL meta link element to tell search engines which URL should be ranked as the primary URL for your documentation. This is important if you have multiple URLs that your documentation is available through. The URL points to the root path of the documentation and requires a trailing slash.
     "canonical_url": "https://docs.qgis.org/latest/en/",
     # display_version: If True, the version number is shown at the top of the sidebar. Default: True,
-    "display_version": True,
+    # Unsupported for now for self-hosted builds, see https://github.com/readthedocs/sphinx_rtd_theme/issues/1624
+    # "display_version": True,
     # logo_only: Only display the logo image, do not display the project name at the top of the sidebar. Default: False,
     "logo_only": False,
     # prev_next_buttons_location': Location to display Next and Previous buttons. This can be either bottom, top, both , or None. Default: 'bottom',

--- a/themes/rtd_qgis/layout.html
+++ b/themes/rtd_qgis/layout.html
@@ -41,6 +41,23 @@
  {% endblock extrabody %}
 
  {% block sidebartitle %}
-   {{ super() }}
+   <!-- Workaround switch to version selector in sphinx_rtd_theme hosted docs -->
+   {# the logo helper function was removed in Sphinx 6 and deprecated since Sphinx 4 #}
+   {# the master_doc variable was renamed to root_doc in Sphinx 4 (master_doc still exists in later Sphinx versions) #}
+   {%- set _logo_url = logo_url|default(pathto('_static/' + (logo or ""), 1)) %}
+   {%- set _root_doc = root_doc|default(master_doc) %}
+   <a href="{{ pathto(_root_doc) }}"{% if not theme_logo_only %} class="icon icon-home"{% endif %}>
+     {% if not theme_logo_only %}{{ project }}{% endif %}
+     {%- if logo or logo_url %}
+       <img src="{{ _logo_url }}" class="logo" alt="{{ _('Logo') }}"/>
+     {%- endif %}
+   </a>
+   {%- set nav_version = version %}
+   {%- if nav_version %}
+     <div class="version">
+       {{ nav_version }}
+     </div>
+   {%- endif %}
+   {%- include "searchbox.html" %}
    <a href= "{{pathto('genindex.html', 1)}}">{{ _('Index') }}</a>
  {% endblock sidebartitle %}

--- a/themes/rtd_qgis/static/css/qgis_docs.css
+++ b/themes/rtd_qgis/static/css/qgis_docs.css
@@ -9,6 +9,13 @@
 /* adds scrollbar to side navigator and keep showing the top title block */
 .wy-side-nav-search {
   margin-bottom: 0;
+  /* Format custom display of version in the navigation side bar */
+  >div.version {
+    margin-top: -.4045em;
+    margin-bottom: .809em;
+    font-weight: 400;
+    color: hsla(0, 0%, 100%, .3);
+  }
 }
 
 .wy-side-scroll {


### PR DESCRIPTION
readthedocs theme replaces version display in the left panel with a version drop-down menu only available for the docs they hosted, deprecating the display_version theme option (https://github.com/readthedocs/sphinx_rtd_theme/issues/1624). This commit allows to still display the version by overriding their template.
A first step toward Sphinx version upgrade (refs #10943)

<!---
Include a few sentences describing the overall goals for this Pull Request.

A list of issues is at https://github.com/qgis/QGIS-Documentation/issues.
Add "fix #issuenumber" for each issue the PR fixes. The ticket(s) will be closed automatically.
If your PR doesn't fix entirely the ticket, only add the ticket(s) reference preceded by # character.
-->
Goal:

Ticket(s): #
<!---
Indicate whether the fix should be backported to previous release.
Replace the space between square brackets by a `x` to make it checked.
-->
- [ ] Backport to LTR documentation is requested

<!---
Reviewing is a process done by community members, mostly on a volunteer basis.
We try to keep the overhead as small as possible and appreciate if you help us.
Please read carefully and ensure you comply with our writing guidelines at
https://docs.qgis.org/testing/en/docs/documentation_guidelines/index.html.
Feel free to ask in a comment or the (qgis-community-team mailing list)
[https://lists.osgeo.org/mailman/listinfo/qgis-community-team] if you have troubles with any item.
--->
