### PR TITLE
Document inline legend label editing

### DIFF
--- a/docs/user_manual/introduction/general_tools.rst
+++ b/docs/user_manual/introduction/general_tools.rst
@@ -197,6 +197,11 @@ Z-ordering means that layers listed nearer the top of the legend are drawn
 over layers listed lower down in the legend.
 Also a layer or a group of layers can be dragged across several QGIS instances.
 
+To change the label of a symbol item in the legend, expand the layer, select
+the item and press :kbd:`F2`. Enter the new label and press :kbd:`Enter` to
+apply it. This updates the label in the layer's categorized, graduated or
+rule-based renderer.
+
 .. note:: The Z-ordering behavior can be overridden by the
    :ref:`Layer Order <layer_order>` panel.
 

--- a/docs/user_manual/introduction/general_tools.rst
+++ b/docs/user_manual/introduction/general_tools.rst
@@ -197,11 +197,6 @@ Z-ordering means that layers listed nearer the top of the legend are drawn
 over layers listed lower down in the legend.
 Also a layer or a group of layers can be dragged across several QGIS instances.
 
-To change the label of a symbol item in the legend, expand the layer, select
-the item and press :kbd:`F2`. Enter the new label and press :kbd:`Enter` to
-apply it. This updates the label in the layer's categorized, graduated or
-rule-based renderer.
-
 .. note:: The Z-ordering behavior can be overridden by the
    :ref:`Layer Order <layer_order>` panel.
 
@@ -459,8 +454,13 @@ When using a symbology based on features classification
 (e.g. :ref:`categorized <categorized_renderer>`, :ref:`graduated <graduated_renderer>`
 or :ref:`rule-based <rule_based_rendering>` for vector layers,
 or :ref:`classification <point_cloud_classification>` for point clouds),
-right-clicking a class entry in the :guilabel:`Layers` panels makes it possible
-to edit the visibility of the classes (and their features) and avoid (un)checking them one by one:
+class entries are listed below the layer in the :guilabel:`Layers` panel.
+
+To change the label of a class entry, select it and press :kbd:`F2`.
+Enter the new label and press :kbd:`Enter` to apply it to the layer's renderer.
+
+Right-clicking a class entry makes it possible to edit the visibility of the
+classes (and their features) and avoid (un)checking them one by one:
 
 * |toggleAllLayers| :guilabel:`Toggle Items`
 * |showAllLayers| :guilabel:`Show All Items`


### PR DESCRIPTION
## Summary

- document how to edit symbol legend labels directly from the Layers panel
- identify the categorized, graduated, and rule-based renderers supported by the QGIS 4.2 implementation

## Why

QGIS 4.2 adds inline legend-label editing, but the Layers panel documentation does not describe how to invoke or complete the edit. This adds the keyboard workflow beside the existing layer-tree interaction guidance.

## Validation

- `pre-commit run rstcheck --files docs/user_manual/introduction/general_tools.rst`
- `pre-commit run doc8 --files docs/user_manual/introduction/general_tools.rst`
- `pre-commit run codespell --files docs/user_manual/introduction/general_tools.rst`
- applicable whitespace, EOF, merge-conflict, large-file, and mixed-line-ending hooks
- `git diff --check`

Fixes #11100
