### PR TITLE
Update default oapif endpoint

### DIFF
--- a/docs/server_manual/config.rst
+++ b/docs/server_manual/config.rst
@@ -96,7 +96,7 @@ several ways to define these variables. This is fully described in
 
    * - QGIS_SERVER_API_WFS3_ROOT_PATH
         Defines the root path component of the URL that provides the OGC API services
-     - /oapif
+     - /ogcapi
      - OAPIF/WFS3
 
    * - QGIS_SERVER_APPLICATION_NAME

--- a/docs/server_manual/development_server.rst
+++ b/docs/server_manual/development_server.rst
@@ -39,11 +39,11 @@ The default port the Development Server listens to is ``8000``. Example output:
 
     QGIS Development Server listening on http://localhost:8000
     CTRL+C to exit
-    127.0.0.1 [lun gen 20 15:16:41 2020] 5140 103ms "GET /wfs3/?MAP=/tests/testdata/qgis_server/test_project.qgs HTTP/1.1" 200
-    127.0.0.1 [lun gen 20 15:16:41 2020] 3298 2ms "GET /wfs3/static/jsonFormatter.min.js HTTP/1.1" 200
-    127.0.0.1 [lun gen 20 15:16:41 2020] 1678 3ms "GET /wfs3/static/jsonFormatter.min.css HTTP/1.1" 200
-    127.0.0.1 [lun gen 20 15:16:41 2020] 1310 5ms "GET /wfs3/static/style.css HTTP/1.1" 200
-    127.0.0.1 [lun gen 20 15:16:43 2020] 4285 13ms "GET /wfs3/collections?MAP=/tests/testdata/qgis_server/test_project.qgs HTTP/1.1" 200
+    127.0.0.1 [lun gen 20 15:16:41 2020] 5140 103ms "GET /ogcapi/?MAP=/tests/testdata/qgis_server/test_project.qgs HTTP/1.1" 200
+    127.0.0.1 [lun gen 20 15:16:41 2020] 3298 2ms "GET /ogcapi/static/jsonFormatter.min.js HTTP/1.1" 200
+    127.0.0.1 [lun gen 20 15:16:41 2020] 1678 3ms "GET /ogcapi/static/jsonFormatter.min.css HTTP/1.1" 200
+    127.0.0.1 [lun gen 20 15:16:41 2020] 1310 5ms "GET /ogcapi/static/style.css HTTP/1.1" 200
+    127.0.0.1 [lun gen 20 15:16:43 2020] 4285 13ms "GET /ogcapi/collections?MAP=/tests/testdata/qgis_server/test_project.qgs HTTP/1.1" 200
 
 The server has a few options that can be passed as command line arguments.
 You can see them all by invoking the server with ``-h``.

--- a/docs/server_manual/services/ogcapif.rst
+++ b/docs/server_manual/services/ogcapif.rst
@@ -8,7 +8,7 @@ protocols.
 It is described by the `OGC API - Features - Part 1: Core
 <https://docs.ogc.org/is/17-069r3/17-069r3.html>`_ document.
 
-The API can be reached on typical installations via ``http://localhost/qgisserver/wfs3``.
+The API can be reached on typical installations via ``http://localhost/qgisserver/ogcapi``.
 
 Here is a quick informal summary of the most important differences
 between the well known WFS protocol and OAPIF:
@@ -242,7 +242,7 @@ URL example:
 
 .. code-block:: bash
 
-    http://localhost/qgisserver/wfs3/collection_one/items.json?offset=10&limit=10
+    http://localhost/qgisserver/ogcapi/collection_one/items.json?offset=10&limit=10
 
 .. note::
 
@@ -278,21 +278,21 @@ Returns only the features with date dimension matching ``2019-01-01``
 
 .. code-block:: bash
 
-    http://localhost/qgisserver/wfs3/collection_one/items.json?datetime=2019-01-01
+    http://localhost/qgisserver/ogcapi/collection_one/items.json?datetime=2019-01-01
 
 Returns only the features with datetime dimension matching
 ``2019-01-01T01:01:01``
 
 .. code-block:: bash
 
-    http://localhost/qgisserver/wfs3/collection_one/items.json?datetime=2019-01-01T01:01:01
+    http://localhost/qgisserver/ogcapi/collection_one/items.json?datetime=2019-01-01T01:01:01
 
 Returns only the features with datetime dimension in the range
 ``2019-01-01T01:01:01`` - ``2019-01-01T12:00:00``
 
 .. code-block:: bash
 
-    http://localhost/qgisserver/wfs3/collection_one/items.json?datetime=2019-01-01T01:01:01/2019-01-01T12:00:00
+    http://localhost/qgisserver/ogcapi/collection_one/items.json?datetime=2019-01-01T01:01:01/2019-01-01T12:00:00
 
 
 Bounding box filter
@@ -317,7 +317,7 @@ URL example:
 
 .. code-block:: bash
 
-    http://localhost/qgisserver/wfs3/collection_one/items.json?bbox=-180,-90,180,90
+    http://localhost/qgisserver/ogcapi/collection_one/items.json?bbox=-180,-90,180,90
 
 If the *CRS* of the bounding box is not
 `WGS 84 <https://www.opengis.net/def/crs/OGC/1.3/CRS84>`_, a different CRS can
@@ -329,7 +329,7 @@ URL example:
 
 .. code-block:: bash
 
-    http://localhost/qgisserver/wfs3/collection_one/items.json?bbox=913191,5606014,913234,5606029&bbox-crs=http://www.opengis.net/def/crs/EPSG/9.6.2/3857
+    http://localhost/qgisserver/ogcapi/collection_one/items.json?bbox=913191,5606014,913234,5606029&bbox-crs=http://www.opengis.net/def/crs/EPSG/9.6.2/3857
 
 
 Attribute filters
@@ -345,7 +345,7 @@ filters all features where attribute ``name`` equals "my value"
 
 .. code-block:: bash
 
-    http://localhost/qgisserver/wfs3/collection_one/items.json?attribute_one=my%20value
+    http://localhost/qgisserver/ogcapi/collection_one/items.json?attribute_one=my%20value
 
 
 Partial matches are also supported by using a ``*`` ("star") operator:
@@ -356,7 +356,7 @@ filters all features where attribute ``name`` ends with "value"
 
 .. code-block:: bash
 
-    http://localhost/qgisserver/wfs3/collection_one/items.json?attribute_one=*value
+    http://localhost/qgisserver/ogcapi/collection_one/items.json?attribute_one=*value
 
 Feature sorting
 ---------------
@@ -369,7 +369,7 @@ To sort the results in descending order, a boolean flag (``sortdesc``) can be se
 
 .. code-block:: bash
 
-  http://localhost/qgisserver/wfs3/collection_one/items.json?sortby=name&sortdesc=1
+  http://localhost/qgisserver/ogcapi/collection_one/items.json?sortby=name&sortdesc=1
 
 
 Attribute selection
@@ -385,7 +385,7 @@ returns only the ``name`` attribute
 
 .. code-block:: bash
 
-    http://localhost/qgisserver/wfs3/collection_one/items.json?properties=name
+    http://localhost/qgisserver/ogcapi/collection_one/items.json?properties=name
 
 
 Customize the HTML pages
@@ -412,8 +412,8 @@ Custom template functions
 - ``json_dump( )``: prints the JSON data passed to the template
 - ``static( path )``: returns the full URL to the specified static path.
   For example: "static( "/style/black.css" )" with a root path
-  "http://localhost/qgisserver/wfs3" will return
-  "http://localhost/qgisserver/wfs3/static/style/black.css".
+  "http://localhost/qgisserver/ogcapi" will return
+  "http://localhost/qgisserver/ogcapi/static/style/black.css".
 - ``links_filter( links, key, value )``: Returns filtered links from a
   link list
 - ``content_type_name( content_type )``: Returns a short name from a


### PR DESCRIPTION
Goal:

Update the default OGC Api Features endpoint. The new value is `/ogcapi`
Source: https://github.com/qgis/QGIS/blob/18b5e825726f2f0106415e8478a03fa3558da435/src/server/qgsserversettings.cpp#L223

- [x] Backport to 4.2
- [x] Backport to 4.0
