### PR TITLE
Remove the unused isonum.txt include

### DIFF
--- a/docs/pyqgis_developer_cookbook/server.rst
+++ b/docs/pyqgis_developer_cookbook/server.rst
@@ -1,7 +1,5 @@
 .. index:: Server plugins; Developing, Python; Developing server plugins
 
-.. include:: <isonum.txt>
-
 .. highlight:: python
    :linenothreshold: 5
 


### PR DESCRIPTION
pre-commit is failing due to missing [isonum.txt](https://docutils.sourceforge.io/docs/ref/rst/definitions.html) file defined by docutils, a dependency of Sphinx. I suspect this to be a network issue, since I can't find anything that helps think this was removed downstream (recently). However I can't find what use we do have for this file so let's remove it, and see...

<!---
Include a few sentences describing the overall goals for this Pull Request.

A list of issues is at https://github.com/qgis/QGIS-Documentation/issues.
Add "fix #issuenumber" for each issue the PR fixes. The ticket(s) will be closed automatically.
If your PR doesn't fix entirely the ticket, only add the ticket(s) reference preceded by # character.
-->
Goal:

Ticket(s): #
<!---
Indicate whether the fix should be backported to previous release.
Replace the space between square brackets by a `x` to make it checked.
-->
- [ ] Backport to LTR documentation is requested

<!---
Reviewing is a process done by community members, mostly on a volunteer basis.
We try to keep the overhead as small as possible and appreciate if you help us.
Please read carefully and ensure you comply with our writing guidelines at
https://docs.qgis.org/testing/en/docs/documentation_guidelines/index.html.
Feel free to ask in a comment or the (qgis-community-team mailing list)
[https://lists.osgeo.org/mailman/listinfo/qgis-community-team] if you have troubles with any item.
--->
