### PR TITLE
Fix four dead links in the containerized deployment manual

### DIFF
--- a/docs/server_manual/containerized_deployment.rst
+++ b/docs/server_manual/containerized_deployment.rst
@@ -51,7 +51,7 @@ it. To do so create a directory :file:`qgis-server` and within its directory:
       # Add the current key for package downloading
       # Please refer to QGIS install documentation (https://www.qgis.org/fr/site/forusers/alldownloads.html#debian-ubuntu)
       && mkdir -m755 -p /etc/apt/keyrings \
-      && wget -O /etc/apt/keyrings/qgis-archive-keyring.gpg https://qgis.org/download//downloads/qgis-archive-keyring.gpg \
+      && wget -O /etc/apt/keyrings/qgis-archive-keyring.gpg https://qgis.org/downloads/qgis-archive-keyring.gpg \
       # Add repository for latest version of qgis-server
       # Please refer to QGIS repositories documentation if you want other version (https://qgis.org/resources/installation-guide/#repositories)
       && echo "deb [signed-by=/etc/apt/keyrings/qgis-archive-keyring.gpg] https://qgis.org/debian bookworm main" | tee /etc/apt/sources.list.d/qgis.list \
@@ -226,7 +226,7 @@ Swarm/docker-compose
 
 Docker now has its own orchestrator: Swarm (compatible with docker-compose
 files). You have to
-`enable it <https://docs.docker.com/guides/orchestration/#enable-docker-swarm>`_
+`enable it <https://docs.docker.com/engine/swarm/swarm-mode/>`_
 (the Mac version will also work with Linux).
 
 .. _docker-compose-file:
@@ -235,7 +235,7 @@ Stack description
 ^^^^^^^^^^^^^^^^^
 
 Now that you have Swarm working, create the service file (see
-`Deploy to Swarm <https://docs.docker.com/guides/swarm-deploy/>`_)
+`Deploy to Swarm <https://docs.docker.com/engine/swarm/stack-deploy/>`_)
 :file:`qgis-stack.yaml`:
 
 .. code-block:: yaml
@@ -306,7 +306,7 @@ Installation
 
 If you have a **Docker Desktop** installation, using Kubernetes (aka
 k8s) is pretty straight forward:
-`enable k8s <https://docs.docker.com/guides/orchestration/#turn-on-kubernetes>`_.
+`enable k8s <https://docs.docker.com/desktop/use-desktop/kubernetes/>`_.
 
 If not, follow the
 `minikube tutorial <https://kubernetes.io/docs/tutorials/hello-minikube/>`_


### PR DESCRIPTION
Goal: fix four dead links in `docs/server_manual/containerized_deployment.rst`. One of them breaks the documented Docker build.

Ticket(s): #

- [x] Backport to LTR documentation is requested

<!-- Backport requested because release_3.40 and release_3.44 both still carry the keyring URL below; I checked both branches. -->

### The build-breaking one

The Dockerfile snippet readers copy contains:

```
wget -O /etc/apt/keyrings/qgis-archive-keyring.gpg https://qgis.org/download//downloads/qgis-archive-keyring.gpg
```

That URL returns 404 — there is a stray `download/` segment before `downloads/`. So the documented image fails at the `wget` step rather than at something the reader can diagnose. `https://qgis.org/downloads/qgis-archive-keyring.gpg` serves the file (it redirects to the object storage host).

### The three Docker links

Docker retired the `guides/orchestration` and `guides/swarm-deploy` pages, and the `#enable-docker-swarm` / `#turn-on-kubernetes` anchors do not exist on any replacement:

| was | now |
| --- | --- |
| `guides/orchestration/#enable-docker-swarm` | `engine/swarm/swarm-mode/` |
| `guides/swarm-deploy/` | `engine/swarm/stack-deploy/` |
| `guides/orchestration/#turn-on-kubernetes` | `desktop/use-desktop/kubernetes/` |

All three replacements return 200. The Kubernetes one is the Docker Desktop page, matching the surrounding sentence ("If you have a **Docker Desktop** installation").

### Scope

I requested every URL in the 352 `.rst` files under `docs/`. Everything else that looks dead is a placeholder (`example.com`, `{z}/{x}/{y}`, `${TINI_VERSION}`, `SEARCH_PHRASE`), a regex artifact (`wikipedia.org/wiki/Kernel_(statistics`), or a service endpoint rather than a page. Two I checked and left alone: `exiftool.org/TagNames/EXIF.html` 404s but so does `exiftool.org/TagNames/`, so I could not establish the right target; and `tablesgenerator.com/text_tables` plus `qgistutorials.com` only appeared dead on the first pass and return 200 on a re-request.

Disclosure: prepared with AI assistance (Claude Opus 5, via Claude Code). Every URL and anchor claim above was verified with an actual request rather than inferred, and I checked the two LTR branches by hand. I did not add the `🤖🤖🤖` fast-track marker from the main QGIS repository, since this repository does not document that process.
