### PR TITLE
Make instructions more generic and not version-dependent

### DIFF
--- a/docs/user_manual/introduction/getting_started.rst
+++ b/docs/user_manual/introduction/getting_started.rst
@@ -32,19 +32,18 @@ packages (rpm and deb) or software repositories are provided for many flavors of
 GNU/Linux |nix|.
 
 For more information and instructions for your operating system check
-https://qgis.org/download/.
+the `Download page <https://qgis.org/download/>`_.
 
 Installing from source
 ----------------------
 
-If you need to build QGIS from source, please refer to the installation
-instructions. They are distributed with the QGIS source code in a file
-called :file:`INSTALL`. You can also find them online at :source:`INSTALL.md`.
-
-
-If you want to build a particular release and not the version in development,
-you should replace ``master`` with the release branch (commonly in the
-``release-X_Y`` form) in the above-mentioned link (installation instructions may differ).
+QGIS is a free and open source software subject to the GNU General Public License.
+As such, its source code is available for free, with instructions for building from source
+in the :source:`INSTALL.md` file.
+Because the code of QGIS evolves from release to release,
+these instructions are regularly updated to match the corresponding release.
+If you wish to build a version of QGIS, ensure you pick the appropriate release branch
+in the above-mentioned URL (``master`` for the development branch, or ``release-X_Y``).
 
 Installing on external media
 ----------------------------

--- a/docs/user_manual/introduction/qgis_configuration.rst
+++ b/docs/user_manual/introduction/qgis_configuration.rst
@@ -1741,7 +1741,8 @@ User Profiles` menu. You can also run QGIS with a specific user profile from the
 
    .. code-block:: bash
 
-     qgis-ltr --profile newprofilename
+     # The binary depends on the status of the version in use, e.g., qgis, qgis-ltr, qgis-dev
+     qgis --profile newprofilename
 
 .. _user_profile_setting:
 


### PR DESCRIPTION
Some of the instructions assume that the user is using a specific version of QGIS or that the docs is about a specific branch.
Let's clarify with examples so that the user easily understands what to follow depending on the context.

<!---
Include a few sentences describing the overall goals for this Pull Request.

A list of issues is at https://github.com/qgis/QGIS-Documentation/issues.
Add "fix #issuenumber" for each issue the PR fixes. The ticket(s) will be closed automatically.
If your PR doesn't fix entirely the ticket, only add the ticket(s) reference preceded by # character.
-->
Goal:

Ticket(s): #
<!---
Indicate whether the fix should be backported to previous release.
Replace the space between square brackets by a `x` to make it checked.
-->
- [ ] Backport to LTR documentation is requested

<!---
Reviewing is a process done by community members, mostly on a volunteer basis.
We try to keep the overhead as small as possible and appreciate if you help us.
Please read carefully and ensure you comply with our writing guidelines at
https://docs.qgis.org/testing/en/docs/documentation_guidelines/index.html.
Feel free to ask in a comment or the (qgis-community-team mailing list)
[https://lists.osgeo.org/mailman/listinfo/qgis-community-team] if you have troubles with any item.
--->
