### PR TITLE
Warn that anti-aliasing can leak the location of rendered points

### DIFF
--- a/docs/user_manual/map_views/map_view.rst
+++ b/docs/user_manual/map_views/map_view.rst
@@ -1303,6 +1303,12 @@ It's also possible to directly export the current rendering, without
 a layout.
 This quick "screenshot" of the map view has some convenient features.
 
+.. warning:: **Anti-aliasing is on by default and can leak point locations**
+
+   Be careful when exporting a map of sensitive point locations: the
+   anti-aliased edges of the symbols encode the sub-pixel position of each
+   point. See :ref:`export_privacy`.
+
 To export the map canvas with the current rendering:
 
 #. Go to :menuselection:`Project --> Import/Export`

--- a/docs/user_manual/print_layout/create_output.rst
+++ b/docs/user_manual/print_layout/create_output.rst
@@ -63,6 +63,25 @@ and that map overview items are also correctly linked to a map.
 If the checks fail, you are shown a nice warning advising you of the issue.
 
 
+.. index:: Privacy
+.. _export_privacy:
+
+Privacy of exported point locations
+-----------------------------------
+
+.. warning:: **Anti-aliasing is on by default and can leak point locations**
+
+   Anti-aliasing blends the edge of a symbol with the background to make
+   it appear smooth.
+   Studies have shown that those anti-aliasing artifacts can be exploited
+   to recover the individual locations represented by the symbols to
+   within meter precision, even on small-scale maps such as one covering
+   a whole country (`Du et al., ACM CCS 2026
+   <https://arxiv.org/abs/2609.07623>`_).
+   Be careful when publishing a map of individual-level sensitive
+   locations, such as patient residences or crime incidents.
+
+
 .. _export_layout_image:
 
 Export as Image


### PR DESCRIPTION
<!-- PR title (paste into the title field, not the body): -->
<!-- Warn that anti-aliasing can leak the location of rendered points -->

Goal:

Anti-aliasing is on by default in QGIS, and it blends the edge of a rendered point symbol with the background. Those blended pixels encode the **sub-pixel** position of the point, so an individual's location can be recovered from a published dot map even when the map is small-scale (e.g., national-scale). The paper that discovered this vulnerability was accepted to the ACM Conference on Computer and Communications Security (CCS) 2026 ([arXiv:2609.07623](https://arxiv.org/abs/2609.07623)).

This is **not** a QGIS vulnerability, and this PR does not present it as one. This PR was requested by @m-kuhn following a disclosure to security@qgis.org. 

**Changes** (+25 lines, nothing removed):

| File | Change |
| --- | --- |
| `docs/user_manual/print_layout/create_output.rst` | New subsection *Privacy of exported point locations* under **Export settings**, holding the warning and the reference. Labelled `_export_privacy`. |
| `docs/user_manual/map_views/map_view.rst` | One-sentence warning in **Exporting the map view**, cross-referencing the above. |

Documentation pages affected:

* https://docs.qgis.org/latest/en/docs/user_manual/print_layout/create_output.html#export-settings
* https://docs.qgis.org/latest/en/docs/user_manual/map_views/map_view.html#exportingmapcanvas

Notes for reviewers:

* Placement and wording are a first proposal. Please move or reword them to fit the documentation structure as you see fit.
* Verified locally: `sphinx-build -b html -nW --keep-going` and `-b latex -nW
  --keep-going` both succeed with zero warnings, and `pre-commit` passes on the
  changed files (rstcheck, doc8, codespell, trailing whitespace, image refs,
  substitutions).

Ticket(s): #
<!-- No existing issue; this originates from the security@qgis.org thread above. -->

- [x] Backport to LTR documentation is requested
<!-- The rendering behaviour is the same in the LTR, so the warning applies
     there too. Please uncheck if you would rather not carry it back. -->
